### PR TITLE
[Task] watchOS 액션 신뢰성 강화(dedupe + queue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - 명소 넓이 데이터 거버넌스 v1: `docs/area-references-data-governance.md`
 - 이미지 생성 공급자 라우터 명세 v1: `docs/image-provider-router-v1.md`
 - 시계열 Heatmap 명세 v1: `docs/heatmap-timeseries-v1.md`
+- Watch 액션 신뢰성 명세 v1: `docs/watch-connectivity-reliability-v1.md`
 
 ## 강아지들의 영역 표시
 

--- a/docs/watch-connectivity-reliability-v1.md
+++ b/docs/watch-connectivity-reliability-v1.md
@@ -1,0 +1,61 @@
+# Watch Connectivity Reliability v1
+
+## 1. 목적
+watchOS 액션 전달에서 중복 적용과 유실을 줄이기 위한 신뢰성 규약을 고정한다.
+
+연결 이슈:
+- 구현: #43
+
+## 2. 액션 계약
+iPhone <- Watch payload:
+
+```json
+{
+  "action": "startWalk | addPoint | endWalk",
+  "action_id": "uuid",
+  "sent_at": 1770000000.0
+}
+```
+
+필드 규칙:
+- `action`: watch 사용자 의도
+- `action_id`: 멱등키(중복 제거 기준)
+- `sent_at`: watch 발생 시각(epoch seconds)
+
+## 3. 수신 측(iPhone) 처리
+- `action_id`를 최근 N개(기본 500) 캐시
+- 이미 처리된 `action_id`는 무시
+- 액션 적용:
+  - `startWalk`: 산책이 꺼져 있으면 시작
+  - `addPoint`: 산책 중일 때만 포인트 추가
+  - `endWalk`: 산책 중일 때만 종료
+
+## 4. 송신 측(Watch) 처리
+- 즉시 전송 경로:
+  - `session.isReachable == true`이면 `sendMessage` 시도
+- 비연결/실패 경로:
+  - 로컬 큐(UserDefaults)에 저장
+  - 세션 활성화 후 `transferUserInfo`로 재전송
+- 큐는 전송 등록 후 비움(전송 보장은 `transferUserInfo`가 담당)
+
+## 5. 컨텍스트 동기화
+iPhone -> Watch application context:
+
+```json
+{
+  "isWalking": true,
+  "time": 123.0,
+  "area": 45.6,
+  "last_sync_at": 1770000000.0
+}
+```
+
+목적:
+- Watch UI 상태 표시(연동 상태/시간/면적)
+- 로컬 액션 시점 판단 보조
+
+## 6. 검증 시나리오
+- [ ] 동일 `action_id`를 2회 보내도 1회만 적용
+- [ ] watch 오프라인에서 액션 누적 후 연결 복구 시 반영
+- [ ] 산책 중이 아닐 때 `addPoint`가 무시됨
+- [ ] `startWalk -> addPoint -> endWalk` 순서가 iPhone에 반영

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -12,7 +12,7 @@ import CoreLocation
 import CoreData
 import Combine
 import WatchConnectivity
-class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreDataProtocol{
+class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreDataProtocol, WCSessionDelegate {
     @Environment(\.managedObjectContext) private var viewContext
     private let locationManager = CLLocationManager()
     private var timer: Timer? = nil
@@ -37,6 +37,12 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     @Published var showOnlyOne: Bool = true
     @Published var heatmapEnabled: Bool = true
     @Published var heatmapCells: [HeatmapCellDTO] = []
+    private let watchSession = WCSession.isSupported() ? WCSession.default : nil
+    private var processedWatchActionIds: Set<String> = []
+    private var processedWatchActionOrder: [String] = []
+    private let maxProcessedWatchActions = 500
+    private var lastWatchContextSyncAt: Date = .distantPast
+    private let processedWatchActionStorageKey = "watch.processedActionIds"
     override init() {
         super.init()
         self.locationManager.delegate = self
@@ -47,6 +53,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         self.polygonList = self.fetchPolygons()
         self.polygon = lastPolygon() ?? Polygon(walkingTime: 0.0, walkingArea: 0.0)
         self.refreshHeatmap()
+        self.loadProcessedWatchActions()
+        self.setupWatchConnectivity()
     }
     func fetchPolygonList() {
         self.polygonList = self.fetchPolygons()
@@ -75,6 +83,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     func addLocation(){
         if let location = self.location{
             polygon.addPoint(.init(coordinate: location.coordinate))
+            self.syncWatchContext(force: true)
         }
     }
     func removeLocation(_ locationID : UUID){
@@ -110,6 +119,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         withAnimation{ [weak self] in
             self?.isWalking.toggle()
         }
+        self.syncWatchContext(force: true)
     }
     func setTrackingMode() {
         guard let location = self.location else {
@@ -162,6 +172,86 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         }
     }
 
+    private func setupWatchConnectivity() {
+        guard let watchSession else { return }
+        watchSession.delegate = self
+        watchSession.activate()
+        self.syncWatchContext(force: true)
+    }
+
+    private func syncWatchContext(force: Bool = false) {
+        guard let watchSession, watchSession.activationState == .activated else { return }
+
+        let now = Date()
+        if force == false, now.timeIntervalSince(lastWatchContextSyncAt) < 1.0 {
+            return
+        }
+
+        let context: [String: Any] = [
+            "isWalking": self.isWalking,
+            "time": self.time,
+            "area": self.polygon.walkingArea,
+            "last_sync_at": now.timeIntervalSince1970
+        ]
+
+        do {
+            try watchSession.updateApplicationContext(context)
+            self.lastWatchContextSyncAt = now
+        } catch {
+            print("watch context update failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func loadProcessedWatchActions() {
+        let stored = UserDefaults.standard.stringArray(forKey: processedWatchActionStorageKey) ?? []
+        self.processedWatchActionOrder = stored
+        self.processedWatchActionIds = Set(stored)
+    }
+
+    private func persistProcessedWatchActions() {
+        UserDefaults.standard.set(self.processedWatchActionOrder, forKey: processedWatchActionStorageKey)
+    }
+
+    private func shouldProcessWatchAction(actionId: String) -> Bool {
+        guard processedWatchActionIds.contains(actionId) == false else {
+            return false
+        }
+        processedWatchActionIds.insert(actionId)
+        processedWatchActionOrder.append(actionId)
+        if processedWatchActionOrder.count > maxProcessedWatchActions {
+            let overflow = processedWatchActionOrder.count - maxProcessedWatchActions
+            let removed = Array(processedWatchActionOrder.prefix(overflow))
+            processedWatchActionOrder.removeFirst(overflow)
+            removed.forEach { processedWatchActionIds.remove($0) }
+        }
+        persistProcessedWatchActions()
+        return true
+    }
+
+    private func handleWatchPayload(_ payload: [String: Any]) {
+        guard let action = payload["action"] as? String else { return }
+        let actionId = payload["action_id"] as? String ?? UUID().uuidString
+        if shouldProcessWatchAction(actionId: actionId) == false {
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            switch action {
+            case "startWalk":
+                if self.isWalking == false { self.endWalk() }
+            case "addPoint":
+                if self.isWalking {
+                    self.addLocation()
+                    self.syncWatchContext(force: true)
+                }
+            case "endWalk":
+                if self.isWalking { self.endWalk() }
+            default:
+                break
+            }
+        }
+    }
+
 }
 //MARK: - 넓이와 시간로직
 extension MapViewModel {
@@ -169,6 +259,7 @@ extension MapViewModel {
         timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) {[weak self] t in
             guard let self = self else {return}
             self.time += t.timeInterval
+            self.syncWatchContext()
             if self.time > 3600 {
                 self.forceQuit()
             }
@@ -310,5 +401,39 @@ extension MapViewModel {
             i += 1
         }
         return tempClusters
+    }
+}
+
+// MARK: - WatchConnectivity
+extension MapViewModel {
+    func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        if let error {
+            print("watch activation failed: \(error.localizedDescription)")
+            return
+        }
+        self.syncWatchContext(force: true)
+    }
+
+    #if os(iOS)
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+    func sessionDidDeactivate(_ session: WCSession) {
+        session.activate()
+    }
+    #endif
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        self.syncWatchContext(force: true)
+    }
+
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
+        self.handleWatchPayload(message)
+    }
+
+    func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any]) {
+        self.handleWatchPayload(userInfo)
     }
 }

--- a/dogAreaWatch Watch App/ContentView.swift
+++ b/dogAreaWatch Watch App/ContentView.swift
@@ -6,19 +6,40 @@
 //
 
 import SwiftUI
-import WatchConnectivity
 
 struct ContentView: View {
+    @StateObject private var viewModel = ContentsViewModel()
+
+    private var durationText: String {
+        let total = Int(viewModel.walkingTime)
+        let min = total / 60
+        let sec = total % 60
+        return String(format: "%02d:%02d", min, sec)
+    }
+
     var body: some View {
         VStack {
-            Text("산책 중")
-            Button(action: {},
-                   label: {
-                Text("영역 추가하기")
-                    
-            }).frame(maxWidth: .infinity,
-                     maxHeight: .infinity)
-            
+            Text(viewModel.isWalking ? "산책 중" : "대기 중")
+            Text("시간 \(durationText)")
+                .font(.footnote)
+            Text(String(format: "넓이 %.1f㎡", viewModel.walkingArea))
+                .font(.footnote)
+            Text(viewModel.isReachable ? "연결됨" : "오프라인 큐")
+                .font(.caption2)
+                .foregroundStyle(viewModel.isReachable ? .green : .orange)
+
+            if viewModel.isWalking {
+                Button("영역 표시하기") {
+                    viewModel.sendAction(.addPoint)
+                }
+                Button("산책 종료") {
+                    viewModel.sendAction(.endWalk)
+                }
+            } else {
+                Button("산책 시작") {
+                    viewModel.sendAction(.startWalk)
+                }
+            }
         }
         .padding()
     }

--- a/dogAreaWatch Watch App/ContentsViewModel.swift
+++ b/dogAreaWatch Watch App/ContentsViewModel.swift
@@ -8,15 +8,136 @@
 import Foundation
 import WatchConnectivity
 
-class ContentsViewModel: ObservableObject {
-    @Published var receiveData = WCSession.default.receivedApplicationContext
-    func fetchData() {
-        if receiveData.isEmpty == false {
-            DispatchQueue.main.async {
-                if let  data = self.receiveData.values.first as? TimeInterval {
-                    
-                }
+struct WatchActionDTO: Codable, Equatable {
+    let action: String
+    let actionId: String
+    let sentAt: TimeInterval
+
+    var payload: [String: Any] {
+        [
+            "action": action,
+            "action_id": actionId,
+            "sent_at": sentAt
+        ]
+    }
+}
+
+enum WatchActionType: String {
+    case startWalk = "startWalk"
+    case addPoint = "addPoint"
+    case endWalk = "endWalk"
+}
+
+final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
+    @Published var isWalking = false
+    @Published var walkingTime: TimeInterval = 0
+    @Published var walkingArea: Double = 0
+    @Published var isReachable = false
+    @Published var lastSyncAt: TimeInterval = 0
+
+    private let actionQueueStorageKey = "watch.pendingActions.v1"
+    private var pendingActions: [WatchActionDTO] = []
+    private let session = WCSession.default
+
+    override init() {
+        super.init()
+        loadPendingActions()
+        activateSession()
+    }
+
+    private func activateSession() {
+        guard WCSession.isSupported() else { return }
+        session.delegate = self
+        session.activate()
+    }
+
+    func sendAction(_ action: WatchActionType) {
+        let dto = WatchActionDTO(
+            action: action.rawValue,
+            actionId: UUID().uuidString,
+            sentAt: Date().timeIntervalSince1970
+        )
+
+        if session.activationState == .activated, session.isReachable {
+            session.sendMessage(dto.payload, replyHandler: nil) { [weak self] _ in
+                self?.enqueue(dto)
+                self?.flushPendingActions()
             }
+            return
         }
+
+        enqueue(dto)
+        flushPendingActions()
+    }
+
+    private func enqueue(_ action: WatchActionDTO) {
+        pendingActions.append(action)
+        persistPendingActions()
+    }
+
+    private func loadPendingActions() {
+        guard let data = UserDefaults.standard.data(forKey: actionQueueStorageKey),
+              let decoded = try? JSONDecoder().decode([WatchActionDTO].self, from: data) else {
+            pendingActions = []
+            return
+        }
+        pendingActions = decoded
+    }
+
+    private func persistPendingActions() {
+        guard let data = try? JSONEncoder().encode(pendingActions) else { return }
+        UserDefaults.standard.set(data, forKey: actionQueueStorageKey)
+    }
+
+    private func flushPendingActions() {
+        guard session.activationState == .activated,
+              session.isReachable,
+              pendingActions.isEmpty == false else { return }
+
+        // Flush queued actions when the connection is restored.
+        pendingActions.forEach { session.transferUserInfo($0.payload) }
+        pendingActions.removeAll()
+        persistPendingActions()
+    }
+
+    private func applyContext(_ context: [String: Any]) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isWalking = context["isWalking"] as? Bool ?? false
+            self.walkingTime = context["time"] as? TimeInterval ?? 0
+            self.walkingArea = context["area"] as? Double ?? 0
+            self.lastSyncAt = context["last_sync_at"] as? TimeInterval ?? 0
+        }
+    }
+
+    func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        if let error {
+            print("watch session activation failed: \(error.localizedDescription)")
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            self?.isReachable = session.isReachable
+        }
+        applyContext(session.receivedApplicationContext)
+        if session.isReachable {
+            flushPendingActions()
+        }
+    }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        DispatchQueue.main.async { [weak self] in
+            self?.isReachable = session.isReachable
+        }
+        if session.isReachable {
+            flushPendingActions()
+        }
+    }
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        applyContext(applicationContext)
     }
 }

--- a/scripts/watch_reliability_unit_check.swift
+++ b/scripts/watch_reliability_unit_check.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+struct WatchActionDTO: Equatable {
+    let action: String
+    let actionId: String
+    let sentAt: TimeInterval
+}
+
+final class WatchDedupeStore {
+    private let maxCount: Int
+    private var order: [String] = []
+    private var ids: Set<String> = []
+
+    init(maxCount: Int = 500) {
+        self.maxCount = maxCount
+    }
+
+    func shouldProcess(_ actionId: String) -> Bool {
+        guard ids.contains(actionId) == false else { return false }
+        ids.insert(actionId)
+        order.append(actionId)
+        if order.count > maxCount {
+            let overflow = order.count - maxCount
+            let removed = Array(order.prefix(overflow))
+            order.removeFirst(overflow)
+            removed.forEach { ids.remove($0) }
+        }
+        return true
+    }
+}
+
+final class WatchQueueStore {
+    private(set) var pending: [WatchActionDTO] = []
+
+    func enqueue(_ action: WatchActionDTO) {
+        pending.append(action)
+    }
+
+    func flush(isReachable: Bool) -> [WatchActionDTO] {
+        guard isReachable else { return [] }
+        let flushed = pending
+        pending.removeAll()
+        return flushed
+    }
+}
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let dedupe = WatchDedupeStore(maxCount: 3)
+assertTrue(dedupe.shouldProcess("a1"), "first action should be processed")
+assertTrue(dedupe.shouldProcess("a1") == false, "duplicate action must be ignored")
+assertTrue(dedupe.shouldProcess("a2"), "new action should be processed")
+assertTrue(dedupe.shouldProcess("a3"), "new action should be processed")
+assertTrue(dedupe.shouldProcess("a4"), "new action should be processed")
+assertTrue(dedupe.shouldProcess("a1"), "evicted old id should be processable again")
+
+let queue = WatchQueueStore()
+queue.enqueue(.init(action: "addPoint", actionId: "q1", sentAt: 1))
+queue.enqueue(.init(action: "addPoint", actionId: "q2", sentAt: 2))
+assertTrue(queue.pending.count == 2, "queue should store offline actions")
+
+let offlineFlush = queue.flush(isReachable: false)
+assertTrue(offlineFlush.isEmpty, "offline flush should not send actions")
+assertTrue(queue.pending.count == 2, "offline flush should keep queue")
+
+let onlineFlush = queue.flush(isReachable: true)
+assertTrue(onlineFlush.count == 2, "online flush should send all queued actions")
+assertTrue(queue.pending.isEmpty, "queue should be empty after successful flush")
+
+print("PASS: watch reliability unit checks")


### PR DESCRIPTION
## 변경 사항
- docs/watch-connectivity-reliability-v1.md 추가
- README 문서 섹션 링크 추가
- iPhone(MapViewModel) WatchConnectivity 수신/중복제거/상태동기화 구현
- Watch(ContentsViewModel) action queue 저장/재전송 구현
- Watch UI(ContentView) start/addPoint/end 버튼 연동
- scripts/watch_reliability_unit_check.swift 추가

## 검증
- swift scripts/watch_reliability_unit_check.swift
  - PASS: watch reliability unit checks

Closes #43