### PR TITLE
[Task] AI 캐리커처 비동기 파이프라인 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - 이미지 생성 공급자 라우터 명세 v1: `docs/image-provider-router-v1.md`
 - 시계열 Heatmap 명세 v1: `docs/heatmap-timeseries-v1.md`
 - Watch 액션 신뢰성 명세 v1: `docs/watch-connectivity-reliability-v1.md`
+- 캐리커처 비동기 파이프라인 명세 v1: `docs/caricature-async-pipeline-v1.md`
 
 ## 강아지들의 영역 표시
 

--- a/docs/caricature-async-pipeline-v1.md
+++ b/docs/caricature-async-pipeline-v1.md
@@ -1,0 +1,78 @@
+# Caricature Async Pipeline v1
+
+## 1. 목적
+가입 플로우를 블로킹하지 않고, 반려견 원본 사진 업로드 후 캐리커처 생성은 비동기 백그라운드 파이프라인으로 처리한다.
+
+연결 이슈:
+- 구현: #44
+
+## 2. 가입 UX 계약
+1. 원본 반려견 사진 업로드(Firebase/Supabase 저장소)
+2. 사용자 가입 즉시 완료 처리
+3. 캐리커처 상태:
+- `queued` -> `processing` -> `ready | failed`
+4. 실패 시 가입 자체는 성공 상태 유지
+5. 완료 시 반려견 프로필 이미지를 캐리커처 URL로 갱신
+
+## 3. DB 계약
+
+### 3.1 `pets` 컬럼
+- `caricature_status text` (`queued|processing|ready|failed`)
+- `caricature_provider text`
+- `caricature_style text`
+- `caricature_url text`
+
+### 3.2 `caricature_jobs` 테이블
+- `id uuid pk`
+- `user_id uuid`
+- `pet_id uuid`
+- `style text`
+- `provider_chain text`
+- `status text`
+- `error_message text`
+- `retry_count int`
+- `created_at timestamptz`
+- `updated_at timestamptz`
+
+상태 전이:
+- `queued -> processing -> ready | failed`
+
+## 4. Edge Function 계약
+엔드포인트:
+- `POST /functions/v1/caricature`
+
+요청:
+```json
+{
+  "petId": "uuid",
+  "sourceImagePath": "optional/storage/path.jpg",
+  "sourceImageUrl": "optional/https-url",
+  "style": "cute_cartoon",
+  "providerHint": "auto",
+  "requestId": "uuid"
+}
+```
+
+라우팅:
+- 기본: Gemini 우선
+- 실패 시: OpenAI 폴백
+- timeout 25초 / provider당 최대 2회 재시도
+
+응답:
+- 성공: `status=ready`, `caricatureUrl`, `provider`, `jobId`
+- 실패: `status=failed`, `errorCode`, `jobId`
+
+## 5. iOS 앱 계약
+- 가입 ViewModel은 원본 업로드/로컬 저장 완료 후 바로 `loading=.success`
+- 캐리커처 요청은 detached task로 실행
+- 로컬 사용자 저장소(UserDefaults)에도 상태를 반영:
+  - queued (가입 직후)
+  - processing (요청 시작)
+  - ready + caricatureURL/provider (성공)
+  - failed (실패)
+
+## 6. 검증 체크리스트
+- [ ] 캐리커처 실패 시 가입 플로우 차단 없음
+- [ ] 상태 전이(`queued -> processing -> ready/failed`) 추적 가능
+- [ ] Edge Function이 provider fallback 경로를 가짐
+- [ ] ready 시 프로필 화면에서 캐리커처 URL 우선 표시

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -55,10 +55,22 @@ struct UserInfo: TimeCheckable {
     let pet: [PetInfo]
     var createdAt: TimeInterval
 }
-struct PetInfo: Codable {
-    let petName: String
-    let petProfile: String?
+
+enum CaricatureStatus: String, Codable {
+    case queued
+    case processing
+    case ready
+    case failed
 }
+
+struct PetInfo: Codable {
+    var petName: String
+    var petProfile: String?
+    var caricatureURL: String? = nil
+    var caricatureStatus: CaricatureStatus? = nil
+    var caricatureProvider: String? = nil
+}
+
 extension UserDefaults {
     public func setStruct<T: Codable>(_ value: T?, forKey defaultName: String){
         let data = try? JSONEncoder().encode(value)
@@ -84,5 +96,32 @@ extension UserDefaults {
             return []
         }
         return encodedData.map { try! JSONDecoder().decode(type, from: $0) }
+    }
+}
+
+extension UserdefaultSetting {
+    func updateFirstPetCaricature(
+        status: CaricatureStatus,
+        caricatureURL: String? = nil,
+        provider: String? = nil
+    ) {
+        guard let current = getValue(), current.pet.isEmpty == false else { return }
+        var pets = current.pet
+        pets[0].caricatureStatus = status
+        if let caricatureURL {
+            pets[0].caricatureURL = caricatureURL
+            // Display generated profile first after it is ready.
+            pets[0].petProfile = caricatureURL
+        }
+        if let provider {
+            pets[0].caricatureProvider = provider
+        }
+        save(
+            id: current.id,
+            name: current.name,
+            profile: current.profile,
+            pet: pets,
+            createdAt: current.createdAt
+        )
     }
 }

--- a/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
+++ b/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
@@ -35,10 +35,18 @@ struct NotificationCenterView: View {
                    VStack(alignment: .leading) {
                        Text("\(viewModel.userInfo?.pet.first?.petName ?? "강아지")")
                            .font(.appFont(for: .SemiBold, size: 20))
+                       if let status = viewModel.userInfo?.pet.first?.caricatureStatus {
+                           Text("캐리커처 상태: \(status.rawValue)")
+                               .font(.appFont(for: .Light, size: 11))
+                               .foregroundStyle(Color.appTextDarkGray)
+                       }
                    }
                    Spacer()
                }
                Spacer()
+           }
+           .onAppear {
+               viewModel.reloadUserInfo()
            }
        }
 }
@@ -95,7 +103,7 @@ struct UserProfileImageView: View {
 struct PetProfileImageView: View {
     @EnvironmentObject var viewModel: SettingViewModel
     var body: some View {
-        if let url = viewModel.userInfo?.pet.first?.petProfile {
+        if let url = viewModel.userInfo?.pet.first?.caricatureURL ?? viewModel.userInfo?.pet.first?.petProfile {
             KFImage(URL(string: url))
                 .resizable()
                 .aspectRatio(contentMode: .fit)

--- a/dogArea/Views/ProfileSettingView/SettingViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/SettingViewModel.swift
@@ -19,10 +19,14 @@ final class SettingViewModel: ObservableObject, CoreDataProtocol {
     private var storage = Storage.storage().reference()
     init() {
         fetchModel()
-        self.userInfo = UserdefaultSetting().getValue()
+        reloadUserInfo()
     }
     func fetchModel() {
         self.polygonList = self.fetchPolygons()
+    }
+
+    func reloadUserInfo() {
+        self.userInfo = UserdefaultSetting().getValue()
     }
     func uploadImg(img: UIImage, isPet:Bool = false){
         Task{ @MainActor in

--- a/dogArea/Views/SigningView/SigningViewModel.swift
+++ b/dogArea/Views/SigningView/SigningViewModel.swift
@@ -38,11 +38,53 @@ class SigningViewModel: ObservableObject {
                 if let img = petProfile {
                     petURL = try await uploadImage(img: img, isPet: true)
                 }
-                userdefaluts.save(id: userId, name: userName, profile: profileURL, pet: [.init(petName: petName, petProfile: petURL)], createdAt: createdAt)
+                let petInfo = PetInfo(
+                    petName: petName,
+                    petProfile: petURL,
+                    caricatureURL: nil,
+                    caricatureStatus: petURL == nil ? nil : .queued,
+                    caricatureProvider: nil
+                )
+                userdefaluts.save(
+                    id: userId,
+                    name: userName,
+                    profile: profileURL,
+                    pet: [petInfo],
+                    createdAt: createdAt
+                )
                 loading = .success
+                enqueueCaricatureJobIfPossible()
+            } catch {
+                loading = .fail(msg: error.localizedDescription)
             }
         }
     }
+
+    private func enqueueCaricatureJobIfPossible() {
+        guard let petImageURL = self.petURL else { return }
+
+        Task(priority: .background) { [userId, petName, petImageURL] in
+            let client = CaricatureEdgeClient()
+            UserdefaultSetting.shared.updateFirstPetCaricature(status: .processing)
+            do {
+                let response = try await client.requestCaricature(
+                    petId: UUID().uuidString,
+                    sourceImageURL: petImageURL,
+                    requestId: UUID().uuidString
+                )
+                UserdefaultSetting.shared.updateFirstPetCaricature(
+                    status: .ready,
+                    caricatureURL: response.caricatureURL,
+                    provider: response.provider
+                )
+                print("caricature ready for user=\(userId), pet=\(petName), job=\(response.jobId)")
+            } catch {
+                UserdefaultSetting.shared.updateFirstPetCaricature(status: .failed)
+                print("caricature failed for user=\(userId), pet=\(petName): \(error.localizedDescription)")
+            }
+        }
+    }
+
     private func uploadImage(img: UIImage, isPet: Bool) async throws -> String?{
         guard let data = img.jpegData(compressionQuality: 0.3) else { return nil}
         var finished: Bool = false
@@ -67,5 +109,67 @@ class SigningViewModel: ObservableObject {
         try await self.storage.child("images/\(userName)/" + (isPet ? "petProfile.jpeg" : "userProfile.jpeg"))
             .downloadURL()
             .absoluteString
+    }
+}
+
+private struct CaricatureEdgeClient {
+    struct ResponseDTO: Decodable {
+        let jobId: String
+        let provider: String?
+        let caricatureUrl: String?
+
+        var caricatureURL: String? { caricatureUrl }
+    }
+
+    struct RequestDTO: Encodable {
+        let petId: String
+        let sourceImagePath: String?
+        let sourceImageUrl: String?
+        let style: String
+        let providerHint: String
+        let requestId: String
+    }
+
+    enum RequestError: Error {
+        case notConfigured
+        case invalidURL
+        case requestFailed
+    }
+
+    func requestCaricature(
+        petId: String,
+        sourceImageURL: String,
+        requestId: String
+    ) async throws -> ResponseDTO {
+        let env = ProcessInfo.processInfo.environment
+        let supabaseURL = env["SUPABASE_URL"] ?? ""
+        let anonKey = env["SUPABASE_ANON_KEY"] ?? ""
+        guard supabaseURL.isEmpty == false, anonKey.isEmpty == false else {
+            throw RequestError.notConfigured
+        }
+        guard let url = URL(string: "\(supabaseURL)/functions/v1/caricature") else {
+            throw RequestError.invalidURL
+        }
+
+        let payload = RequestDTO(
+            petId: petId,
+            sourceImagePath: nil,
+            sourceImageUrl: sourceImageURL,
+            style: "cute_cartoon",
+            providerHint: "auto",
+            requestId: requestId
+        )
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(anonKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let statusCode = (response as? HTTPURLResponse)?.statusCode,
+              (200..<300).contains(statusCode) else {
+            throw RequestError.requestFailed
+        }
+        return try JSONDecoder().decode(ResponseDTO.self, from: data)
     }
 }

--- a/scripts/caricature_pipeline_unit_check.swift
+++ b/scripts/caricature_pipeline_unit_check.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+enum CaricatureStatus: String {
+    case queued
+    case processing
+    case ready
+    case failed
+}
+
+enum ProviderHint: String {
+    case auto
+    case gemini
+    case openai
+}
+
+func nextStatus(from current: CaricatureStatus, event: String) -> CaricatureStatus? {
+    switch (current, event) {
+    case (.queued, "start"):
+        return .processing
+    case (.processing, "success"):
+        return .ready
+    case (.processing, "fail"):
+        return .failed
+    default:
+        return nil
+    }
+}
+
+func providerOrder(_ hint: ProviderHint) -> [String] {
+    switch hint {
+    case .gemini:
+        return ["gemini", "openai"]
+    case .openai:
+        return ["openai", "gemini"]
+    case .auto:
+        return ["gemini", "openai"]
+    }
+}
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let processing = nextStatus(from: .queued, event: "start")
+let ready = nextStatus(from: processing ?? .queued, event: "success")
+let failed = nextStatus(from: processing ?? .queued, event: "fail")
+let invalid = nextStatus(from: .ready, event: "start")
+
+assertTrue(processing == .processing, "queued -> processing transition")
+assertTrue(ready == .ready, "processing -> ready transition")
+assertTrue(failed == .failed, "processing -> failed transition")
+assertTrue(invalid == nil, "invalid transition should be rejected")
+
+assertTrue(providerOrder(.auto) == ["gemini", "openai"], "auto provider fallback order")
+assertTrue(providerOrder(.openai) == ["openai", "gemini"], "openai hint order")
+assertTrue(providerOrder(.gemini) == ["gemini", "openai"], "gemini hint order")
+
+print("PASS: caricature pipeline unit checks")

--- a/supabase/functions/caricature/index.ts
+++ b/supabase/functions/caricature/index.ts
@@ -1,0 +1,360 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+
+type ProviderName = "gemini" | "openai";
+type ProviderHint = "auto" | ProviderName;
+type Style = "cute_cartoon" | "line_illustration" | "watercolor";
+
+type RequestDTO = {
+  petId: string;
+  sourceImagePath?: string;
+  sourceImageUrl?: string;
+  style?: Style;
+  providerHint?: ProviderHint;
+  requestId?: string;
+};
+
+const TIMEOUT_MS = 25_000;
+const MAX_RETRY = 2;
+const SUPPORTED_STYLES = new Set<Style>([
+  "cute_cartoon",
+  "line_illustration",
+  "watercolor",
+]);
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const withTimeout = async <T>(work: Promise<T>, timeoutMs: number): Promise<T> => {
+  const timeout = new Promise<never>((_, reject) => {
+    const id = setTimeout(() => {
+      clearTimeout(id);
+      reject(new Error("timeout"));
+    }, timeoutMs);
+  });
+  return await Promise.race([work, timeout]);
+};
+
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+};
+
+const base64ToBytes = (base64: string): Uint8Array => {
+  const normalized = base64.replace(/^data:.*;base64,/, "");
+  const binary = atob(normalized);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+};
+
+const stylePrompt = (style: Style) => {
+  switch (style) {
+    case "line_illustration":
+      return "Turn this dog photo into a clean line illustration profile image.";
+    case "watercolor":
+      return "Turn this dog photo into a soft watercolor portrait profile image.";
+    default:
+      return "Turn this dog photo into a cute cartoon profile image.";
+  }
+};
+
+const providerOrder = (hint: ProviderHint): ProviderName[] => {
+  if (hint === "gemini") return ["gemini", "openai"];
+  if (hint === "openai") return ["openai", "gemini"];
+  return ["gemini", "openai"];
+};
+
+const callGemini = async (
+  sourceImage: Uint8Array,
+  style: Style,
+): Promise<Uint8Array> => {
+  const key = Deno.env.get("GEMINI_API_KEY");
+  if (!key) throw new Error("gemini key missing");
+  const endpoint =
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent?key=${key}`;
+  const payload = {
+    contents: [
+      {
+        parts: [
+          { text: stylePrompt(style) },
+          {
+            inline_data: {
+              mime_type: "image/jpeg",
+              data: bytesToBase64(sourceImage),
+            },
+          },
+        ],
+      },
+    ],
+    generationConfig: {
+      responseModalities: ["TEXT", "IMAGE"],
+    },
+  };
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`gemini failed: ${response.status}`);
+  }
+  const data = await response.json();
+  const parts = data?.candidates?.[0]?.content?.parts ?? [];
+  const imagePart = parts.find((part: Record<string, unknown>) =>
+    typeof (part?.inlineData as Record<string, unknown>)?.data === "string" ||
+    typeof (part?.inline_data as Record<string, unknown>)?.data === "string"
+  );
+  const encoded = imagePart?.inlineData?.data ?? imagePart?.inline_data?.data;
+  if (!encoded || typeof encoded !== "string") {
+    throw new Error("gemini did not return image data");
+  }
+  return base64ToBytes(encoded);
+};
+
+const callOpenAI = async (
+  sourceImage: Uint8Array,
+  style: Style,
+): Promise<Uint8Array> => {
+  const key = Deno.env.get("OPENAI_API_KEY");
+  if (!key) throw new Error("openai key missing");
+
+  const body = new FormData();
+  body.append("model", "gpt-image-1");
+  body.append("prompt", stylePrompt(style));
+  body.append("image", new Blob([sourceImage], { type: "image/jpeg" }), "source.jpg");
+
+  const response = await fetch("https://api.openai.com/v1/images/edits", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+    },
+    body,
+  });
+  if (!response.ok) {
+    throw new Error(`openai failed: ${response.status}`);
+  }
+  const data = await response.json();
+  const encoded = data?.data?.[0]?.b64_json;
+  if (!encoded || typeof encoded !== "string") {
+    throw new Error("openai did not return image data");
+  }
+  return base64ToBytes(encoded);
+};
+
+const runProvider = async (
+  provider: ProviderName,
+  sourceImage: Uint8Array,
+  style: Style,
+): Promise<Uint8Array> => {
+  if (provider === "gemini") {
+    return await callGemini(sourceImage, style);
+  }
+  return await callOpenAI(sourceImage, style);
+};
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") return json({ errorCode: "METHOD_NOT_ALLOWED" }, 405);
+
+  const supabaseURL = Deno.env.get("SUPABASE_URL");
+  const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseURL || !supabaseAnonKey || !supabaseServiceRoleKey) {
+    return json({ errorCode: "SERVER_MISCONFIGURED" }, 500);
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return json({ errorCode: "UNAUTHORIZED" }, 401);
+  }
+  const token = authHeader.replace("Bearer ", "").trim();
+
+  const userClient = createClient(supabaseURL, supabaseAnonKey, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  });
+  const serviceClient = createClient(supabaseURL, supabaseServiceRoleKey);
+
+  const { data: userResult, error: userError } = await userClient.auth.getUser();
+  if (userError || !userResult?.user) {
+    return json({ errorCode: "UNAUTHORIZED" }, 401);
+  }
+  const user = userResult.user;
+
+  let body: RequestDTO;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ errorCode: "INVALID_REQUEST", message: "invalid json" }, 400);
+  }
+
+  if (!body?.petId) {
+    return json({ errorCode: "INVALID_REQUEST", message: "petId is required" }, 400);
+  }
+  if (!body.sourceImagePath && !body.sourceImageUrl) {
+    return json(
+      { errorCode: "INVALID_REQUEST", message: "sourceImagePath or sourceImageUrl is required" },
+      400,
+    );
+  }
+
+  const style: Style = SUPPORTED_STYLES.has(body.style as Style)
+    ? body.style as Style
+    : "cute_cartoon";
+  const providerHint: ProviderHint = ["gemini", "openai"].includes(body.providerHint ?? "")
+    ? body.providerHint as ProviderHint
+    : "auto";
+  const chain = providerOrder(providerHint);
+  const requestId = body.requestId ?? crypto.randomUUID();
+
+  const { data: job, error: jobError } = await serviceClient
+    .from("caricature_jobs")
+    .insert({
+      user_id: user.id,
+      pet_id: body.petId,
+      style,
+      provider_chain: chain.join(">"),
+      status: "queued",
+      retry_count: 0,
+    })
+    .select("id")
+    .single();
+
+  if (jobError || !job?.id) {
+    return json({ errorCode: "DB_UPDATE_FAILED", message: "failed to create job" }, 500);
+  }
+  const jobId = job.id as string;
+
+  await serviceClient
+    .from("pets")
+    .update({
+      caricature_status: "processing",
+      caricature_style: style,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", body.petId)
+    .eq("owner_user_id", user.id);
+  await serviceClient
+    .from("caricature_jobs")
+    .update({ status: "processing", updated_at: new Date().toISOString() })
+    .eq("id", jobId);
+
+  let sourceImage: Uint8Array;
+  try {
+    if (body.sourceImageUrl) {
+      const fetched = await fetch(body.sourceImageUrl);
+      if (!fetched.ok) throw new Error(`sourceImageUrl fetch failed: ${fetched.status}`);
+      sourceImage = new Uint8Array(await fetched.arrayBuffer());
+    } else {
+      const { data: imageBlob, error } = await serviceClient
+        .storage
+        .from("profiles")
+        .download(body.sourceImagePath!);
+      if (error || !imageBlob) throw new Error("source image download failed");
+      sourceImage = new Uint8Array(await imageBlob.arrayBuffer());
+    }
+  } catch (error) {
+    await serviceClient.from("caricature_jobs").update({
+      status: "failed",
+      error_message: String(error),
+      updated_at: new Date().toISOString(),
+    }).eq("id", jobId);
+    await serviceClient.from("pets").update({
+      caricature_status: "failed",
+      updated_at: new Date().toISOString(),
+    }).eq("id", body.petId).eq("owner_user_id", user.id);
+    return json({ errorCode: "SOURCE_IMAGE_NOT_FOUND", requestId, jobId }, 404);
+  }
+
+  let generatedImage: Uint8Array | null = null;
+  let usedProvider: ProviderName | null = null;
+  let failureMessage = "ALL_PROVIDERS_FAILED";
+
+  for (const provider of chain) {
+    for (let attempt = 1; attempt <= MAX_RETRY; attempt += 1) {
+      try {
+        generatedImage = await withTimeout(
+          runProvider(provider, sourceImage, style),
+          TIMEOUT_MS,
+        );
+        usedProvider = provider;
+        break;
+      } catch (error) {
+        failureMessage = `${provider}:${String(error)}`;
+      }
+    }
+    if (generatedImage && usedProvider) break;
+  }
+
+  if (!generatedImage || !usedProvider) {
+    await serviceClient
+      .from("caricature_jobs")
+      .update({
+        status: "failed",
+        error_message: failureMessage,
+        retry_count: MAX_RETRY,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", jobId);
+    await serviceClient.from("pets").update({
+      caricature_status: "failed",
+      updated_at: new Date().toISOString(),
+    }).eq("id", body.petId).eq("owner_user_id", user.id);
+    return json({
+      errorCode: "ALL_PROVIDERS_FAILED",
+      message: failureMessage,
+      requestId,
+      jobId,
+    }, 502);
+  }
+
+  const caricaturePath = `${user.id}/${body.petId}/${jobId}.png`;
+  const upload = await serviceClient.storage.from("caricatures").upload(
+    caricaturePath,
+    generatedImage,
+    { contentType: "image/png", upsert: true },
+  );
+  if (upload.error) {
+    await serviceClient.from("caricature_jobs").update({
+      status: "failed",
+      error_message: `storage upload failed: ${upload.error.message}`,
+      updated_at: new Date().toISOString(),
+    }).eq("id", jobId);
+    await serviceClient.from("pets").update({
+      caricature_status: "failed",
+      updated_at: new Date().toISOString(),
+    }).eq("id", body.petId).eq("owner_user_id", user.id);
+    return json({ errorCode: "STORAGE_UPLOAD_FAILED", requestId, jobId }, 500);
+  }
+
+  const { data: publicData } = serviceClient.storage.from("caricatures").getPublicUrl(caricaturePath);
+  const caricatureUrl = publicData.publicUrl;
+
+  await serviceClient.from("pets").update({
+    caricature_url: caricatureUrl,
+    caricature_status: "ready",
+    caricature_provider: usedProvider,
+    caricature_style: style,
+    updated_at: new Date().toISOString(),
+  }).eq("id", body.petId).eq("owner_user_id", user.id);
+  await serviceClient.from("caricature_jobs").update({
+    status: "ready",
+    provider_chain: chain.join(">"),
+    updated_at: new Date().toISOString(),
+  }).eq("id", jobId);
+
+  return json({
+    jobId,
+    petId: body.petId,
+    status: "ready",
+    provider: usedProvider,
+    fallbackUsed: usedProvider !== chain[0],
+    caricaturePath,
+    caricatureUrl,
+  });
+});

--- a/supabase/migrations/20260226093000_caricature_async_pipeline.sql
+++ b/supabase/migrations/20260226093000_caricature_async_pipeline.sql
@@ -1,0 +1,117 @@
+-- #44 AI caricature async pipeline
+
+create extension if not exists pgcrypto;
+
+alter table if exists public.pets
+  add column if not exists caricature_status text default 'queued',
+  add column if not exists caricature_provider text,
+  add column if not exists caricature_style text,
+  add column if not exists caricature_url text;
+
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'pets' and column_name = 'caricature_status'
+  ) and not exists (
+    select 1
+    from pg_constraint
+    where conname = 'pets_caricature_status_check'
+  ) then
+    alter table public.pets
+      add constraint pets_caricature_status_check
+      check (caricature_status in ('queued', 'processing', 'ready', 'failed'));
+  end if;
+end $$;
+
+create table if not exists public.caricature_jobs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  pet_id uuid not null,
+  style text not null default 'cute_cartoon',
+  provider_chain text not null default 'gemini>openai',
+  status text not null default 'queued',
+  error_message text,
+  retry_count int not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint caricature_jobs_status_check
+    check (status in ('queued', 'processing', 'ready', 'failed'))
+);
+
+create index if not exists idx_caricature_jobs_user_id on public.caricature_jobs(user_id);
+create index if not exists idx_caricature_jobs_pet_id on public.caricature_jobs(pet_id);
+create index if not exists idx_caricature_jobs_status on public.caricature_jobs(status);
+create index if not exists idx_caricature_jobs_created_at on public.caricature_jobs(created_at desc);
+
+do $$
+begin
+  if exists (select 1 from information_schema.tables where table_schema = 'public' and table_name = 'pets')
+     and not exists (
+       select 1 from pg_constraint where conname = 'caricature_jobs_pet_id_fkey'
+     ) then
+    alter table public.caricature_jobs
+      add constraint caricature_jobs_pet_id_fkey
+      foreign key (pet_id) references public.pets(id) on delete cascade;
+  end if;
+end $$;
+
+alter table public.caricature_jobs enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'caricature_jobs'
+      and policyname = 'caricature_jobs_select_own'
+  ) then
+    create policy caricature_jobs_select_own
+      on public.caricature_jobs
+      for select
+      using (auth.uid() = user_id);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'caricature_jobs'
+      and policyname = 'caricature_jobs_insert_service_role'
+  ) then
+    create policy caricature_jobs_insert_service_role
+      on public.caricature_jobs
+      for insert
+      with check (auth.role() = 'service_role');
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'caricature_jobs'
+      and policyname = 'caricature_jobs_update_service_role'
+  ) then
+    create policy caricature_jobs_update_service_role
+      on public.caricature_jobs
+      for update
+      using (auth.role() = 'service_role')
+      with check (auth.role() = 'service_role');
+  end if;
+end $$;
+
+create or replace function public.touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_caricature_jobs_updated_at on public.caricature_jobs;
+create trigger trg_caricature_jobs_updated_at
+before update on public.caricature_jobs
+for each row execute function public.touch_updated_at();


### PR DESCRIPTION
## 변경 사항
- docs/caricature-async-pipeline-v1.md 추가
- Supabase migration 추가 (pets 캐리커처 컬럼 + caricature_jobs + RLS)
- Supabase Edge Function(caricature provider router) 추가
- 가입 ViewModel 비동기 캐리커처 요청/상태 전이 반영
- UserDefaults PetInfo에 caricature 상태/URL/provider 필드 추가
- 프로필 화면에서 생성된 caricature URL 우선 표시
- scripts/caricature_pipeline_unit_check.swift 추가

## 검증
- rg 기반 계약 확인(마이그레이션/함수 상태 전이/provider fallback)
- swift scripts/caricature_pipeline_unit_check.swift
  - PASS: caricature pipeline unit checks

## 참고
- deno CLI 부재로 Edge Function deno check는 실행하지 못함

Closes #44