### PR TITLE
feat: feature flag + rollout monitoring stack (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - Watch 액션 신뢰성 명세 v1: `docs/watch-connectivity-reliability-v1.md`
 - 캐리커처 비동기 파이프라인 명세 v1: `docs/caricature-async-pipeline-v1.md`
 - 근처 사용자 익명 핫스팟 명세 v1: `docs/nearby-anonymous-hotspot-v1.md`
+- Feature Flag/롤아웃 모니터링 명세 v1: `docs/feature-flag-rollout-monitoring-v1.md`
 
 ## 강아지들의 영역 표시
 

--- a/docs/feature-flag-rollout-monitoring-v1.md
+++ b/docs/feature-flag-rollout-monitoring-v1.md
@@ -1,0 +1,55 @@
+# Feature Flag + Rollout Monitoring v1
+
+## 1. 목표
+- 기능별 ON/OFF 제어를 런타임에서 수행한다.
+- 단계별 릴리즈(내부 -> 10% -> 50% -> 100%)를 체크리스트 기반으로 운영한다.
+- 1차 KPI를 서버 지표로 수집하고, 릴리즈 단계 승급/중단 기준으로 사용한다.
+
+## 2. 대상 플래그
+- `ff_heatmap_v1`
+- `ff_caricature_async_v1`
+- `ff_nearby_hotspot_v1`
+
+## 3. 런타임 제어 모델
+- 앱 시작 후 원격 플래그를 조회하고 로컬 캐시에 저장한다.
+- 각 플래그는 `is_enabled` + `rollout_percent(0~100)` 조합으로 최종 활성 여부를 계산한다.
+- `rollout_percent`는 `app_instance_id + flag_key` 해시 버킷(0~99)에 의해 결정한다.
+- 원격 조회 실패 시 마지막 캐시값을 사용한다.
+
+## 4. 운영 체크리스트
+
+### 4.1 사전 점검
+- [ ] `feature_flags` 테이블에 3개 플래그가 존재한다.
+- [ ] 기본값(`is_enabled=true`, `rollout_percent=100`)이 설정되어 있다.
+- [ ] `feature-control` Edge Function 배포 완료.
+- [ ] 앱에서 플래그별 ON/OFF 반영 동작 확인.
+
+### 4.2 단계별 롤아웃
+- [ ] 내부 테스트: `rollout_percent=100` (내부 사용자만)
+- [ ] 10%: 크래시/핵심 KPI 이상치 없음
+- [ ] 50%: p95 지연 및 실패율 기준 충족
+- [ ] 100%: 24시간 이상 안정성 확인
+
+### 4.3 롤백 기준
+- [ ] 산책 저장 성공률 95% 미만
+- [ ] watch action 유실률 2% 초과
+- [ ] 캐리커처 성공률 90% 미만
+- [ ] nearby opt-in 비율 급락(직전 대비 30% 이상 하락)
+
+## 5. KPI 수집 이벤트
+- `walk_save_success`, `walk_save_failed`
+- `watch_action_received`, `watch_action_processed`, `watch_action_applied`, `watch_action_duplicate`
+- `caricature_success`, `caricature_failed`
+- `nearby_opt_in_enabled`, `nearby_opt_in_disabled`
+
+## 6. KPI 집계 뷰
+`view_rollout_kpis_24h`에서 최근 24시간 지표를 조회한다.
+
+- `walk_save_success_rate`
+- `watch_action_loss_rate` (`1 - applied / processed`)
+- `caricature_success_rate`
+- `nearby_opt_in_ratio`
+
+## 7. 릴리즈 게이트
+- 단계 승급은 `view_rollout_kpis_24h` + QA 체크리스트를 함께 통과해야 한다.
+- 하나라도 실패 시 즉시 해당 플래그 `rollout_percent`를 직전 단계로 되돌린다.

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CryptoKit
 class UserdefaultSetting {
     enum keyValue: String {
         case userId = "userId"
@@ -123,5 +124,226 @@ extension UserdefaultSetting {
             pet: pets,
             createdAt: current.createdAt
         )
+    }
+}
+
+enum AppFeatureFlagKey: String, CaseIterable {
+    case heatmapV1 = "ff_heatmap_v1"
+    case caricatureAsyncV1 = "ff_caricature_async_v1"
+    case nearbyHotspotV1 = "ff_nearby_hotspot_v1"
+}
+
+enum AppMetricEvent: String {
+    case walkSaveSuccess = "walk_save_success"
+    case walkSaveFailed = "walk_save_failed"
+    case watchActionReceived = "watch_action_received"
+    case watchActionProcessed = "watch_action_processed"
+    case watchActionApplied = "watch_action_applied"
+    case watchActionDuplicate = "watch_action_duplicate"
+    case caricatureSuccess = "caricature_success"
+    case caricatureFailed = "caricature_failed"
+    case nearbyOptInEnabled = "nearby_opt_in_enabled"
+    case nearbyOptInDisabled = "nearby_opt_in_disabled"
+}
+
+final class FeatureFlagStore {
+    static let shared = FeatureFlagStore()
+
+    private struct FeatureFlagValue: Codable, Equatable {
+        let isEnabled: Bool
+        let rolloutPercent: Int
+        let updatedAt: String?
+    }
+
+    private struct FeatureFlagRowDTO: Decodable {
+        let key: String
+        let isEnabled: Bool
+        let rolloutPercent: Int
+        let updatedAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case key
+            case isEnabled = "is_enabled"
+            case rolloutPercent = "rollout_percent"
+            case updatedAt = "updated_at"
+        }
+    }
+
+    private struct FeatureFlagEnvelope: Decodable {
+        let flags: [FeatureFlagRowDTO]
+    }
+
+    private let lock = NSLock()
+    private let cacheStorageKey = "feature.flags.cache.v1"
+    private let appInstanceStorageKey = "feature.flags.appInstance.v1"
+    private var cached: [String: FeatureFlagValue] = [:]
+    private lazy var appInstance: String = {
+        if let existing = UserDefaults.standard.string(forKey: appInstanceStorageKey), existing.isEmpty == false {
+            return existing
+        }
+        let generated = UUID().uuidString.lowercased()
+        UserDefaults.standard.set(generated, forKey: appInstanceStorageKey)
+        return generated
+    }()
+
+    private let defaults: [String: FeatureFlagValue] = [
+        AppFeatureFlagKey.heatmapV1.rawValue: .init(isEnabled: true, rolloutPercent: 100, updatedAt: nil),
+        AppFeatureFlagKey.caricatureAsyncV1.rawValue: .init(isEnabled: true, rolloutPercent: 100, updatedAt: nil),
+        AppFeatureFlagKey.nearbyHotspotV1.rawValue: .init(isEnabled: true, rolloutPercent: 100, updatedAt: nil),
+    ]
+
+    private init() {
+        loadCachedFlags()
+    }
+
+    var appInstanceId: String { appInstance }
+
+    func isEnabled(_ key: AppFeatureFlagKey) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let flag = cached[key.rawValue] ?? defaults[key.rawValue] ?? .init(isEnabled: true, rolloutPercent: 100, updatedAt: nil)
+        return isEnabled(flag: flag, key: key.rawValue)
+    }
+
+    @discardableResult
+    func refresh() async -> Bool {
+        do {
+            let data = try await FeatureControlService.shared.post(payload: [
+                "action": "get_flags",
+                "keys": AppFeatureFlagKey.allCases.map(\.rawValue)
+            ])
+            let decoded = try JSONDecoder().decode(FeatureFlagEnvelope.self, from: data)
+            let newValues = Dictionary(uniqueKeysWithValues: decoded.flags.map {
+                ($0.key, FeatureFlagValue(isEnabled: $0.isEnabled, rolloutPercent: $0.rolloutPercent, updatedAt: $0.updatedAt))
+            })
+            lock.lock()
+            cached.merge(newValues) { _, latest in latest }
+            persistCachedFlags()
+            lock.unlock()
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func isEnabled(flag: FeatureFlagValue, key: String) -> Bool {
+        guard flag.isEnabled else { return false }
+        let percent = max(0, min(100, flag.rolloutPercent))
+        if percent >= 100 { return true }
+        if percent <= 0 { return false }
+        return rolloutBucket(for: key) < percent
+    }
+
+    private func rolloutBucket(for key: String) -> Int {
+        let seed = "\(appInstance):\(key)"
+        let digest = SHA256.hash(data: Data(seed.utf8))
+        guard let first = Array(digest).first else { return 0 }
+        return Int(first) % 100
+    }
+
+    private func loadCachedFlags() {
+        guard let data = UserDefaults.standard.data(forKey: cacheStorageKey) else {
+            cached = defaults
+            return
+        }
+        guard let decoded = try? JSONDecoder().decode([String: FeatureFlagValue].self, from: data) else {
+            cached = defaults
+            return
+        }
+        cached = defaults.merging(decoded) { _, saved in saved }
+    }
+
+    private func persistCachedFlags() {
+        guard let data = try? JSONEncoder().encode(cached) else { return }
+        UserDefaults.standard.set(data, forKey: cacheStorageKey)
+    }
+}
+
+final class AppMetricTracker {
+    static let shared = AppMetricTracker()
+
+    private init() {}
+
+    func track(
+        _ event: AppMetricEvent,
+        userKey: String? = nil,
+        featureKey: AppFeatureFlagKey? = nil,
+        eventValue: Double? = nil,
+        payload: [String: String] = [:]
+    ) {
+        var body: [String: Any] = [
+            "action": "track_metric",
+            "eventName": event.rawValue,
+            "appInstanceId": FeatureFlagStore.shared.appInstanceId
+        ]
+        if let userKey, userKey.isEmpty == false {
+            body["userKey"] = userKey
+        }
+        if let featureKey {
+            body["featureKey"] = featureKey.rawValue
+        }
+        if let eventValue {
+            body["eventValue"] = eventValue
+        }
+        if payload.isEmpty == false {
+            body["payload"] = payload
+        }
+        FeatureControlService.shared.postFireAndForget(payload: body)
+    }
+}
+
+private struct FeatureControlService {
+    static let shared = FeatureControlService()
+
+    private enum ServiceError: Error {
+        case notConfigured
+        case invalidURL
+        case badResponse
+    }
+
+    private func endpointURL() throws -> URL {
+        let env = ProcessInfo.processInfo.environment
+        guard let raw = env["SUPABASE_URL"], raw.isEmpty == false else {
+            throw ServiceError.notConfigured
+        }
+        guard let url = URL(string: raw + "/functions/v1/feature-control") else {
+            throw ServiceError.invalidURL
+        }
+        return url
+    }
+
+    private func bearerToken() -> String {
+        ProcessInfo.processInfo.environment["SUPABASE_ANON_KEY"] ?? ""
+    }
+
+    func post(payload: [String: Any]) async throws -> Data {
+        let url = try endpointURL()
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let token = bearerToken()
+        if token.isEmpty == false {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let code = (response as? HTTPURLResponse)?.statusCode, (200..<300).contains(code) else {
+            throw ServiceError.badResponse
+        }
+        return data
+    }
+
+    func postFireAndForget(payload: [String: Any]) {
+        guard let url = try? endpointURL() else { return }
+        guard let body = try? JSONSerialization.data(withJSONObject: payload) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let token = bearerToken()
+        if token.isEmpty == false {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = body
+        URLSession.shared.dataTask(with: request).resume()
     }
 }

--- a/dogArea/Views/MapView/MapSubViews/MapSettingView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapSettingView.swift
@@ -27,11 +27,11 @@ struct MapSettingView: View {
               Text("Heatmap")
                   .font(.bold14)
                   .onTapGesture {
-                      viewModel.heatmapEnabled.toggle()
+                      viewModel.toggleHeatmapEnabled()
                   }
                   .padding(.horizontal, 10)
                   .padding(.vertical, 5)
-                  .background(viewModel.heatmapEnabled ? Color.appYellow : Color.appTextLightGray)
+                  .background((viewModel.isHeatmapFeatureAvailable && viewModel.heatmapEnabled) ? Color.appYellow : Color.appTextLightGray)
                   .cornerRadius(5)
               Text("근처 핫스팟")
                   .font(.bold14)
@@ -40,7 +40,7 @@ struct MapSettingView: View {
                   }
                   .padding(.horizontal, 10)
                   .padding(.vertical, 5)
-                  .background(viewModel.nearbyHotspotEnabled ? Color.appYellowPale : Color.appTextLightGray)
+                  .background((viewModel.isNearbyHotspotFeatureAvailable && viewModel.nearbyHotspotEnabled) ? Color.appYellowPale : Color.appTextLightGray)
                   .cornerRadius(5)
               Text("위치 공유")
                   .font(.bold14)
@@ -49,7 +49,7 @@ struct MapSettingView: View {
                   }
                   .padding(.horizontal, 10)
                   .padding(.vertical, 5)
-                  .background(viewModel.locationSharingEnabled ? Color.appGreen : Color.appTextLightGray)
+                  .background((viewModel.isNearbyHotspotFeatureAvailable && viewModel.locationSharingEnabled) ? Color.appGreen : Color.appTextLightGray)
                   .cornerRadius(5)
           }.padding(.horizontal)
         Spacer()

--- a/dogArea/Views/MapView/MapSubViews/MapSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapSubView.swift
@@ -23,7 +23,7 @@ struct MapSubView: View {
                         .shadow(radius: 5)
                 }
             }
-            if !viewModel.isWalking && !viewModel.showOnlyOne && viewModel.heatmapEnabled {
+            if !viewModel.isWalking && !viewModel.showOnlyOne && viewModel.isHeatmapFeatureAvailable && viewModel.heatmapEnabled {
                 ForEach(viewModel.heatmapCells) { cell in
                     MapCircle(center: cell.centerCoordinate, radius: 75)
                         .foregroundStyle(
@@ -32,7 +32,7 @@ struct MapSubView: View {
                         )
                 }
             }
-            if viewModel.nearbyHotspotEnabled {
+            if viewModel.isNearbyHotspotFeatureAvailable && viewModel.nearbyHotspotEnabled {
                 ForEach(viewModel.nearbyHotspots) { spot in
                     MapCircle(center: spot.centerCoordinate, radius: 100)
                         .foregroundStyle(

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -42,6 +42,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     @Published var locationSharingEnabled: Bool = false
     @Published var nearbyHotspots: [NearbyHotspotDTO] = []
     private let watchSession = WCSession.isSupported() ? WCSession.default : nil
+    private let featureFlags = FeatureFlagStore.shared
+    private let metricTracker = AppMetricTracker.shared
     private let nearbyService = NearbyPresenceService()
     private var nearbyTickTimer: Timer? = nil
     private var lastPresenceSentAt: Date = .distantPast
@@ -51,6 +53,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     private let maxProcessedWatchActions = 500
     private var lastWatchContextSyncAt: Date = .distantPast
     private let processedWatchActionStorageKey = "watch.processedActionIds"
+    private let heatmapEnabledKey = "heatmap.enabled"
     private let locationSharingKey = "nearby.locationSharingEnabled"
     private let nearbyHotspotEnabledKey = "nearby.hotspotEnabled"
     private let nearbyPresenceUserIdKey = "nearby.presenceUserId"
@@ -65,11 +68,19 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         self.polygon = lastPolygon() ?? Polygon(walkingTime: 0.0, walkingArea: 0.0)
         self.refreshHeatmap()
         self.loadProcessedWatchActions()
-        self.locationSharingEnabled = UserDefaults.standard.bool(forKey: locationSharingKey)
-        self.nearbyHotspotEnabled = UserDefaults.standard.object(forKey: nearbyHotspotEnabledKey) as? Bool ?? true
+
+        let storedHeatmapEnabled = UserDefaults.standard.object(forKey: heatmapEnabledKey) as? Bool ?? true
+        let storedNearbyHotspotEnabled = UserDefaults.standard.object(forKey: nearbyHotspotEnabledKey) as? Bool ?? true
+        let storedLocationSharingEnabled = UserDefaults.standard.bool(forKey: locationSharingKey)
+
+        self.heatmapEnabled = featureFlags.isEnabled(.heatmapV1) ? storedHeatmapEnabled : false
+        let nearbyFeatureOn = featureFlags.isEnabled(.nearbyHotspotV1)
+        self.nearbyHotspotEnabled = nearbyFeatureOn ? storedNearbyHotspotEnabled : false
+        self.locationSharingEnabled = nearbyFeatureOn ? storedLocationSharingEnabled : false
         self.setupWatchConnectivity()
         self.startNearbyTicker()
         self.syncVisibilitySettingIfNeeded()
+        self.refreshFeatureFlagsFromRemote()
     }
 
     deinit {
@@ -125,7 +136,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         if isWalking {
                 if self.polygon.locations.count > 2{
                     polygon.makePolygon(walkArea: calculateArea(), walkTime: self.time, img: img)
-                    _ = savePolygon(polygon: self.polygon)
+                    let saved = savePolygon(polygon: self.polygon).isEmpty == false
+                    metricTracker.track(
+                        saved ? .walkSaveSuccess : .walkSaveFailed,
+                        userKey: currentMetricUserId(),
+                        featureKey: .heatmapV1,
+                        payload: ["pointCount": "\(self.polygon.locations.count)"]
+                    )
                     self.polygonList = self.fetchPolygons()
                     self.refreshHeatmap()
                 }
@@ -168,8 +185,20 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     }
 
     func refreshHeatmap(now: Date = Date()) {
+        guard isHeatmapFeatureAvailable else {
+            self.heatmapCells = []
+            return
+        }
         let points = self.polygonList.flatMap { $0.locations }
         self.heatmapCells = HeatmapEngine.aggregate(points: points, now: now, precision: 7)
+    }
+
+    var isHeatmapFeatureAvailable: Bool {
+        featureFlags.isEnabled(.heatmapV1)
+    }
+
+    var isNearbyHotspotFeatureAvailable: Bool {
+        featureFlags.isEnabled(.nearbyHotspotV1)
     }
 
     func heatmapColor(for score: Double) -> Color {
@@ -212,13 +241,45 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         }
     }
 
+    func toggleHeatmapEnabled() {
+        guard isHeatmapFeatureAvailable else {
+            self.heatmapEnabled = false
+            self.heatmapCells = []
+            return
+        }
+        self.heatmapEnabled.toggle()
+        UserDefaults.standard.set(self.heatmapEnabled, forKey: heatmapEnabledKey)
+        if self.heatmapEnabled {
+            refreshHeatmap()
+        } else {
+            self.heatmapCells = []
+        }
+    }
+
     func toggleLocationSharing() {
+        guard isNearbyHotspotFeatureAvailable else {
+            self.locationSharingEnabled = false
+            UserDefaults.standard.set(false, forKey: locationSharingKey)
+            self.syncVisibilitySettingIfNeeded()
+            return
+        }
         self.locationSharingEnabled.toggle()
         UserDefaults.standard.set(self.locationSharingEnabled, forKey: locationSharingKey)
+        metricTracker.track(
+            self.locationSharingEnabled ? .nearbyOptInEnabled : .nearbyOptInDisabled,
+            userKey: currentMetricUserId(),
+            featureKey: .nearbyHotspotV1
+        )
         self.syncVisibilitySettingIfNeeded()
     }
 
     func toggleNearbyHotspotEnabled() {
+        guard isNearbyHotspotFeatureAvailable else {
+            self.nearbyHotspotEnabled = false
+            self.nearbyHotspots = []
+            UserDefaults.standard.set(false, forKey: nearbyHotspotEnabledKey)
+            return
+        }
         self.nearbyHotspotEnabled.toggle()
         UserDefaults.standard.set(self.nearbyHotspotEnabled, forKey: nearbyHotspotEnabledKey)
         if nearbyHotspotEnabled == false {
@@ -237,12 +298,12 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         guard let location else { return }
         let now = Date()
 
-        if locationSharingEnabled && isWalking && now.timeIntervalSince(lastPresenceSentAt) >= 30 {
+        if isNearbyHotspotFeatureAvailable && locationSharingEnabled && isWalking && now.timeIntervalSince(lastPresenceSentAt) >= 30 {
             lastPresenceSentAt = now
             sendPresence(location: location.coordinate)
         }
 
-        if nearbyHotspotEnabled && now.timeIntervalSince(lastNearbyFetchedAt) >= 10 {
+        if isNearbyHotspotFeatureAvailable && nearbyHotspotEnabled && now.timeIntervalSince(lastNearbyFetchedAt) >= 10 {
             lastNearbyFetchedAt = now
             fetchNearbyHotspots(center: location.coordinate)
         }
@@ -284,7 +345,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
 
     private func syncVisibilitySettingIfNeeded() {
         guard let userId = currentPresenceUserId() else { return }
-        let enabled = self.locationSharingEnabled
+        let enabled = isNearbyHotspotFeatureAvailable ? self.locationSharingEnabled : false
         Task { [weak self] in
             guard let self else { return }
             do {
@@ -300,6 +361,40 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         }
     }
 
+    private func refreshFeatureFlagsFromRemote() {
+        Task { [weak self] in
+            guard let self else { return }
+            _ = await self.featureFlags.refresh()
+            await MainActor.run {
+                self.applyFeatureFlags()
+            }
+        }
+    }
+
+    private func applyFeatureFlags() {
+        let heatmapAllowed = featureFlags.isEnabled(.heatmapV1)
+        let nearbyAllowed = featureFlags.isEnabled(.nearbyHotspotV1)
+        let heatmapPreference = UserDefaults.standard.object(forKey: heatmapEnabledKey) as? Bool ?? true
+        let nearbyPreference = UserDefaults.standard.object(forKey: nearbyHotspotEnabledKey) as? Bool ?? true
+        let sharingPreference = UserDefaults.standard.bool(forKey: locationSharingKey)
+
+        self.heatmapEnabled = heatmapAllowed ? heatmapPreference : false
+        self.nearbyHotspotEnabled = nearbyAllowed ? nearbyPreference : false
+        self.locationSharingEnabled = nearbyAllowed ? sharingPreference : false
+
+        if heatmapAllowed {
+            self.refreshHeatmap()
+        } else {
+            self.heatmapCells = []
+        }
+
+        if nearbyAllowed == false {
+            self.nearbyHotspots = []
+            UserDefaults.standard.set(false, forKey: locationSharingKey)
+            self.syncVisibilitySettingIfNeeded()
+        }
+    }
+
     private func currentPresenceUserId() -> String? {
         if let existing = UserDefaults.standard.string(forKey: nearbyPresenceUserIdKey) {
             return existing
@@ -311,6 +406,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         let stable = raw.stableUUIDString
         UserDefaults.standard.set(stable, forKey: nearbyPresenceUserIdKey)
         return stable
+    }
+
+    private func currentMetricUserId() -> String? {
+        guard let raw = UserdefaultSetting.shared.getValue()?.id, raw.isEmpty == false else {
+            return nil
+        }
+        return raw
     }
 
     private func setupWatchConnectivity() {
@@ -371,22 +473,44 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
 
     private func handleWatchPayload(_ payload: [String: Any]) {
         guard let action = payload["action"] as? String else { return }
+        metricTracker.track(
+            .watchActionReceived,
+            userKey: currentMetricUserId(),
+            payload: ["action": action]
+        )
         let actionId = payload["action_id"] as? String ?? UUID().uuidString
         if shouldProcessWatchAction(actionId: actionId) == false {
+            metricTracker.track(
+                .watchActionDuplicate,
+                userKey: currentMetricUserId(),
+                payload: ["action": action]
+            )
             return
         }
+        metricTracker.track(
+            .watchActionProcessed,
+            userKey: currentMetricUserId(),
+            payload: ["action": action]
+        )
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             switch action {
             case "startWalk":
-                if self.isWalking == false { self.endWalk() }
+                if self.isWalking == false {
+                    self.endWalk()
+                    self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action])
+                }
             case "addPoint":
                 if self.isWalking {
                     self.addLocation()
                     self.syncWatchContext(force: true)
+                    self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action])
                 }
             case "endWalk":
-                if self.isWalking { self.endWalk() }
+                if self.isWalking {
+                    self.endWalk()
+                    self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action])
+                }
             default:
                 break
             }

--- a/dogArea/Views/SigningView/SigningViewModel.swift
+++ b/dogArea/Views/SigningView/SigningViewModel.swift
@@ -22,11 +22,16 @@ class SigningViewModel: ObservableObject {
     private var createdAt: Double
     private var storage = Storage.storage().reference()
     private let userdefaluts = UserdefaultSetting()
+    private let featureFlags = FeatureFlagStore.shared
+    private let metricTracker = AppMetricTracker.shared
     init(info: AppleUserInfo) {
         self.appleInfo = info
         self.userName = info.name ?? ""
         self.userId = info.id
         self.createdAt = info.createdAt
+        Task {
+            _ = await FeatureFlagStore.shared.refresh()
+        }
     }
     func setValue(){
         loading = .loading
@@ -38,11 +43,12 @@ class SigningViewModel: ObservableObject {
                 if let img = petProfile {
                     petURL = try await uploadImage(img: img, isPet: true)
                 }
+                let caricatureEnabled = featureFlags.isEnabled(.caricatureAsyncV1)
                 let petInfo = PetInfo(
                     petName: petName,
                     petProfile: petURL,
                     caricatureURL: nil,
-                    caricatureStatus: petURL == nil ? nil : .queued,
+                    caricatureStatus: (caricatureEnabled && petURL != nil) ? .queued : nil,
                     caricatureProvider: nil
                 )
                 userdefaluts.save(
@@ -53,7 +59,9 @@ class SigningViewModel: ObservableObject {
                     createdAt: createdAt
                 )
                 loading = .success
-                enqueueCaricatureJobIfPossible()
+                if caricatureEnabled {
+                    enqueueCaricatureJobIfPossible()
+                }
             } catch {
                 loading = .fail(msg: error.localizedDescription)
             }
@@ -77,9 +85,21 @@ class SigningViewModel: ObservableObject {
                     caricatureURL: response.caricatureURL,
                     provider: response.provider
                 )
+                self.metricTracker.track(
+                    .caricatureSuccess,
+                    userKey: userId,
+                    featureKey: .caricatureAsyncV1,
+                    payload: ["provider": response.provider ?? "unknown"]
+                )
                 print("caricature ready for user=\(userId), pet=\(petName), job=\(response.jobId)")
             } catch {
                 UserdefaultSetting.shared.updateFirstPetCaricature(status: .failed)
+                self.metricTracker.track(
+                    .caricatureFailed,
+                    userKey: userId,
+                    featureKey: .caricatureAsyncV1,
+                    payload: ["error": error.localizedDescription]
+                )
                 print("caricature failed for user=\(userId), pet=\(petName): \(error.localizedDescription)")
             }
         }

--- a/scripts/feature_flag_rollout_unit_check.swift
+++ b/scripts/feature_flag_rollout_unit_check.swift
@@ -1,0 +1,87 @@
+import Foundation
+import CryptoKit
+
+struct FlagState {
+    let enabled: Bool
+    let rolloutPercent: Int
+}
+
+func rolloutBucket(appInstanceId: String, key: String) -> Int {
+    let seed = "\(appInstanceId):\(key)"
+    let digest = SHA256.hash(data: Data(seed.utf8))
+    guard let first = Array(digest).first else { return 0 }
+    return Int(first) % 100
+}
+
+func isEnabled(_ state: FlagState, appInstanceId: String, key: String) -> Bool {
+    guard state.enabled else { return false }
+    let percent = max(0, min(100, state.rolloutPercent))
+    if percent >= 100 { return true }
+    if percent <= 0 { return false }
+    return rolloutBucket(appInstanceId: appInstanceId, key: key) < percent
+}
+
+struct KPIInput {
+    let walkSuccess: Double
+    let walkFailed: Double
+    let watchProcessed: Double
+    let watchApplied: Double
+    let caricatureSuccess: Double
+    let caricatureFailed: Double
+    let nearbyOptInUsers: Double
+    let nearbyOptInTouchedUsers: Double
+}
+
+func kpiRates(_ input: KPIInput) -> (walk: Double?, watchLoss: Double?, caricature: Double?, nearby: Double?) {
+    let walkDenominator = input.walkSuccess + input.walkFailed
+    let walkRate = walkDenominator == 0 ? nil : input.walkSuccess / walkDenominator
+
+    let watchLossRate = input.watchProcessed == 0
+    ? nil
+    : 1 - (input.watchApplied / input.watchProcessed)
+
+    let caricatureDenominator = input.caricatureSuccess + input.caricatureFailed
+    let caricatureRate = caricatureDenominator == 0 ? nil : input.caricatureSuccess / caricatureDenominator
+
+    let nearbyRate = input.nearbyOptInTouchedUsers == 0
+    ? nil
+    : input.nearbyOptInUsers / input.nearbyOptInTouchedUsers
+
+    return (walkRate, watchLossRate, caricatureRate, nearbyRate)
+}
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let appId = "app-instance-a"
+let key = "ff_heatmap_v1"
+let bucket = rolloutBucket(appInstanceId: appId, key: key)
+assertTrue(bucket >= 0 && bucket < 100, "bucket must be 0...99")
+assertTrue(rolloutBucket(appInstanceId: appId, key: key) == bucket, "bucket must be deterministic")
+
+assertTrue(isEnabled(.init(enabled: false, rolloutPercent: 100), appInstanceId: appId, key: key) == false, "disabled flag should be false")
+assertTrue(isEnabled(.init(enabled: true, rolloutPercent: 0), appInstanceId: appId, key: key) == false, "0 percent rollout should be false")
+assertTrue(isEnabled(.init(enabled: true, rolloutPercent: 100), appInstanceId: appId, key: key) == true, "100 percent rollout should be true")
+
+let rates = kpiRates(.init(
+    walkSuccess: 96,
+    walkFailed: 4,
+    watchProcessed: 100,
+    watchApplied: 98,
+    caricatureSuccess: 45,
+    caricatureFailed: 5,
+    nearbyOptInUsers: 40,
+    nearbyOptInTouchedUsers: 100
+))
+
+assertTrue(abs((rates.walk ?? 0) - 0.96) < 0.0001, "walk success rate")
+assertTrue(abs((rates.watchLoss ?? 0) - 0.02) < 0.0001, "watch loss rate")
+assertTrue(abs((rates.caricature ?? 0) - 0.9) < 0.0001, "caricature success rate")
+assertTrue(abs((rates.nearby ?? 0) - 0.4) < 0.0001, "nearby opt-in ratio")
+
+print("PASS: feature flag rollout unit checks")

--- a/supabase/functions/feature-control/index.ts
+++ b/supabase/functions/feature-control/index.ts
@@ -1,0 +1,92 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+
+type Action = "get_flags" | "track_metric" | "get_rollout_kpis";
+
+type RequestDTO = {
+  action: Action;
+  keys?: string[];
+  eventName?: string;
+  featureKey?: string;
+  eventValue?: number;
+  appInstanceId?: string;
+  userKey?: string;
+  payload?: Record<string, unknown>;
+};
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") return json({ error: "METHOD_NOT_ALLOWED" }, 405);
+
+  const supabaseURL = Deno.env.get("SUPABASE_URL");
+  const serviceRole = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseURL || !serviceRole) {
+    return json({ error: "SERVER_MISCONFIGURED" }, 500);
+  }
+
+  const client = createClient(supabaseURL, serviceRole);
+
+  let body: RequestDTO;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "INVALID_JSON" }, 400);
+  }
+
+  if (!body.action) return json({ error: "ACTION_REQUIRED" }, 400);
+
+  if (body.action === "get_flags") {
+    const keys = (body.keys ?? []).filter((key) => key.startsWith("ff_"));
+    let query = client
+      .from("feature_flags")
+      .select("key,is_enabled,rollout_percent,updated_at")
+      .order("key", { ascending: true });
+
+    if (keys.length > 0) {
+      query = query.in("key", keys);
+    }
+
+    const { data, error } = await query;
+    if (error) return json({ error: error.message }, 500);
+    return json({ flags: data ?? [] });
+  }
+
+  if (body.action === "track_metric") {
+    if (!body.eventName || !body.appInstanceId) {
+      return json({ error: "INVALID_PAYLOAD" }, 400);
+    }
+
+    const payload = body.payload && typeof body.payload === "object"
+      ? body.payload
+      : {};
+
+    const { error } = await client.from("app_metric_events").insert({
+      event_name: body.eventName,
+      feature_key: body.featureKey ?? null,
+      event_value: typeof body.eventValue === "number" ? body.eventValue : null,
+      app_instance_id: body.appInstanceId,
+      user_key: body.userKey ?? null,
+      payload,
+    });
+
+    if (error) return json({ error: error.message }, 500);
+    return json({ ok: true });
+  }
+
+  if (body.action === "get_rollout_kpis") {
+    const { data, error } = await client
+      .from("view_rollout_kpis_24h")
+      .select("*")
+      .limit(1)
+      .maybeSingle();
+
+    if (error) return json({ error: error.message }, 500);
+    return json({ kpis: data ?? null });
+  }
+
+  return json({ error: "UNSUPPORTED_ACTION" }, 400);
+});

--- a/supabase/migrations/20260226103000_feature_flags_and_metrics.sql
+++ b/supabase/migrations/20260226103000_feature_flags_and_metrics.sql
@@ -1,0 +1,116 @@
+-- #46 feature flag + rollout monitoring
+
+create table if not exists public.feature_flags (
+  key text primary key,
+  is_enabled boolean not null default false,
+  rollout_percent integer not null default 0 check (rollout_percent >= 0 and rollout_percent <= 100),
+  description text,
+  updated_at timestamptz not null default now()
+);
+
+insert into public.feature_flags (key, is_enabled, rollout_percent, description)
+values
+  ('ff_heatmap_v1', true, 100, 'Heatmap overlay v1'),
+  ('ff_caricature_async_v1', true, 100, 'Caricature async pipeline v1'),
+  ('ff_nearby_hotspot_v1', true, 100, 'Nearby anonymous hotspot v1')
+on conflict (key) do nothing;
+
+create table if not exists public.app_metric_events (
+  id bigint generated always as identity primary key,
+  event_name text not null,
+  feature_key text,
+  event_value double precision,
+  app_instance_id text not null,
+  user_key text,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_app_metric_events_created_at
+  on public.app_metric_events(created_at desc);
+create index if not exists idx_app_metric_events_event_name_created_at
+  on public.app_metric_events(event_name, created_at desc);
+create index if not exists idx_app_metric_events_feature_key
+  on public.app_metric_events(feature_key);
+
+create or replace function public.touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_feature_flags_updated_at on public.feature_flags;
+create trigger trg_feature_flags_updated_at
+before update on public.feature_flags
+for each row execute function public.touch_updated_at();
+
+alter table public.feature_flags enable row level security;
+alter table public.app_metric_events enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'feature_flags'
+      and policyname = 'feature_flags_select_all'
+  ) then
+    create policy feature_flags_select_all
+      on public.feature_flags
+      for select
+      to anon, authenticated
+      using (true);
+  end if;
+end $$;
+
+create or replace view public.view_rollout_kpis_24h as
+with metrics as (
+  select event_name, user_key
+  from public.app_metric_events
+  where created_at >= now() - interval '24 hours'
+),
+agg as (
+  select
+    count(*) filter (where event_name = 'walk_save_success')::double precision as walk_success,
+    count(*) filter (where event_name = 'walk_save_failed')::double precision as walk_failed,
+    count(*) filter (where event_name = 'watch_action_processed')::double precision as watch_processed,
+    count(*) filter (where event_name = 'watch_action_applied')::double precision as watch_applied,
+    count(*) filter (where event_name = 'caricature_success')::double precision as caricature_success,
+    count(*) filter (where event_name = 'caricature_failed')::double precision as caricature_failed,
+    count(distinct user_key) filter (where event_name = 'nearby_opt_in_enabled')::double precision as nearby_opt_in_users,
+    count(distinct user_key) filter (where event_name in ('nearby_opt_in_enabled', 'nearby_opt_in_disabled'))::double precision as nearby_opt_in_touched_users
+  from metrics
+)
+select
+  now() as calculated_at,
+  case
+    when (walk_success + walk_failed) = 0 then null
+    else walk_success / nullif(walk_success + walk_failed, 0)
+  end as walk_save_success_rate,
+  case
+    when watch_processed = 0 then null
+    else 1 - (watch_applied / nullif(watch_processed, 0))
+  end as watch_action_loss_rate,
+  case
+    when (caricature_success + caricature_failed) = 0 then null
+    else caricature_success / nullif(caricature_success + caricature_failed, 0)
+  end as caricature_success_rate,
+  case
+    when nearby_opt_in_touched_users = 0 then null
+    else nearby_opt_in_users / nullif(nearby_opt_in_touched_users, 0)
+  end as nearby_opt_in_ratio,
+  walk_success::bigint as walk_success_count,
+  walk_failed::bigint as walk_failed_count,
+  watch_processed::bigint as watch_processed_count,
+  watch_applied::bigint as watch_applied_count,
+  caricature_success::bigint as caricature_success_count,
+  caricature_failed::bigint as caricature_failed_count,
+  nearby_opt_in_users::bigint as nearby_opt_in_users,
+  nearby_opt_in_touched_users::bigint as nearby_opt_in_touched_users
+from agg;
+
+grant select on public.feature_flags to anon, authenticated;
+grant select on public.view_rollout_kpis_24h to anon, authenticated;


### PR DESCRIPTION
## Summary
- add rollout monitoring documentation and README link for #46
- add Supabase migration for `feature_flags` and `app_metric_events` with `view_rollout_kpis_24h`
- add `feature-control` edge function for remote flags + metric tracking + KPI 조회
- wire iOS runtime feature flag gate + metric tracker into `MapViewModel` and `SigningViewModel`
- add unit check script for rollout bucket and KPI formula

## Test
- `swift scripts/heatmap_unit_check.swift`
- `swift scripts/watch_reliability_unit_check.swift`
- `swift scripts/caricature_pipeline_unit_check.swift`
- `swift scripts/nearby_hotspot_unit_check.swift`
- `swift scripts/feature_flag_rollout_unit_check.swift`

## Note
- `supabase db push --linked` from this worktree failed because `supabase/config.toml` is not tracked on `origin/main` branch, so linked project ref was unavailable in this isolated worktree.
