### PR TITLE
refactor: modernize viewmodels and remove env coupling (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - 캐리커처 비동기 파이프라인 명세 v1: `docs/caricature-async-pipeline-v1.md`
 - 근처 사용자 익명 핫스팟 명세 v1: `docs/nearby-anonymous-hotspot-v1.md`
 - Feature Flag/롤아웃 모니터링 명세 v1: `docs/feature-flag-rollout-monitoring-v1.md`
+- ViewModel 현대화 리팩토링 명세 v1: `docs/viewmodel-modernization-v1.md`
 
 ## 강아지들의 영역 표시
 

--- a/docs/viewmodel-modernization-v1.md
+++ b/docs/viewmodel-modernization-v1.md
@@ -1,0 +1,35 @@
+# ViewModel Modernization v1
+
+## 1. 목적
+- ViewModel에서 View 전용 `@Environment` 의존을 제거한다.
+- 상태 갱신 경로를 단일화해 중복/불일치를 줄인다.
+- watch action 처리 책임을 분리해 가독성과 테스트 가능성을 높인다.
+
+## 2. 범위
+- `MapViewModel`
+- `SettingViewModel`
+- `WalkListViewModel`
+
+## 3. 변경 원칙
+- ViewModel은 `@Environment`를 직접 사용하지 않는다.
+- 동일 상태(`polygonList`, `heatmapCells`)를 갱신하는 코드는 한 경로로 모은다.
+- 메시지 파싱과 상태 변경 로직을 분리한다.
+
+## 4. 적용 내용
+1. 불필요 `@Environment` 제거
+- 세 ViewModel에서 `@Environment(\.managedObjectContext)` 제거
+- CoreData 접근은 `CoreDataProtocol` 기본 구현으로 유지
+
+2. 상태 갱신 경로 단일화
+- `MapViewModel`에 `reloadPolygonState()` 추가
+- 산책 종료/삭제/초기 로딩 등에서 중복된 fetch+refresh 코드를 통합
+
+3. watch action 책임 분리
+- 문자열 switch 직접 처리 대신 `WatchIncomingAction` 타입으로 파싱
+- `handleWatchPayload`는 입력 검증/중복 판단/metric 기록만 수행
+- 실제 상태 변경은 `applyWatchAction(_:)`에서 담당
+
+## 5. 완료 기준
+- ViewModel 내부의 불필요 `@Environment` 선언 제거
+- 상태 갱신 중복 코드 감소
+- 기존 watch 동작(start/add/end) 기능 회귀 없음

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -14,7 +14,6 @@ import Combine
 import WatchConnectivity
 import CryptoKit
 class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreDataProtocol, WCSessionDelegate {
-    @Environment(\.managedObjectContext) private var viewContext
     private let locationManager = CLLocationManager()
     private var timer: Timer? = nil
     @Published var time: TimeInterval = 0.0
@@ -57,6 +56,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     private let locationSharingKey = "nearby.locationSharingEnabled"
     private let nearbyHotspotEnabledKey = "nearby.hotspotEnabled"
     private let nearbyPresenceUserIdKey = "nearby.presenceUserId"
+
+    private enum WatchIncomingAction: String {
+        case startWalk
+        case addPoint
+        case endWalk
+    }
+
     override init() {
         super.init()
         self.locationManager.delegate = self
@@ -64,9 +70,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         self.locationManager.desiredAccuracy = kCLLocationAccuracyBest // 정확도 설정
         self.locationManager.requestWhenInUseAuthorization() // 권한 요청
         self.locationManager.startUpdatingLocation() // 위치 업데이트 시작
-        self.polygonList = self.fetchPolygons()
-        self.polygon = lastPolygon() ?? Polygon(walkingTime: 0.0, walkingArea: 0.0)
-        self.refreshHeatmap()
+        self.reloadPolygonState(restoreLatestPolygon: true)
         self.loadProcessedWatchActions()
 
         let storedHeatmapEnabled = UserDefaults.standard.object(forKey: heatmapEnabledKey) as? Bool ?? true
@@ -87,9 +91,17 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         timer?.invalidate()
         nearbyTickTimer?.invalidate()
     }
-    func fetchPolygonList() {
+
+    private func reloadPolygonState(restoreLatestPolygon: Bool = false) {
         self.polygonList = self.fetchPolygons()
+        if restoreLatestPolygon {
+            self.polygon = lastPolygon() ?? Polygon(walkingTime: 0.0, walkingArea: 0.0)
+        }
         self.refreshHeatmap()
+    }
+
+    func fetchPolygonList() {
+        self.reloadPolygonState()
     }
     func fetchSelectedPolygonList(for clusters: Cluster) {
         if clusters.sumLocs.count == self.selectedPolygonList.count {
@@ -122,8 +134,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
             polygon.removeAt(locationID)
             if polygon.locations.count<3 {
                 _ = deletePolygon(id: self.polygon.id)
-                self.polygonList = self.fetchPolygons()
-                self.refreshHeatmap()
+                self.reloadPolygonState()
             }
         }
     }
@@ -143,8 +154,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
                         featureKey: .heatmapV1,
                         payload: ["pointCount": "\(self.polygon.locations.count)"]
                     )
-                    self.polygonList = self.fetchPolygons()
-                    self.refreshHeatmap()
+                    self.reloadPolygonState()
                 }
             time = 0.0
         }
@@ -181,7 +191,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
 
     func deletePolygonAndRefresh(_ id: UUID) {
         _ = deletePolygon(id: id)
-        self.fetchPolygonList()
+        self.reloadPolygonState()
     }
 
     func refreshHeatmap(now: Date = Date()) {
@@ -472,47 +482,55 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     }
 
     private func handleWatchPayload(_ payload: [String: Any]) {
-        guard let action = payload["action"] as? String else { return }
+        guard let action = parseWatchAction(from: payload) else { return }
+        let actionName = action.rawValue
         metricTracker.track(
             .watchActionReceived,
             userKey: currentMetricUserId(),
-            payload: ["action": action]
+            payload: ["action": actionName]
         )
         let actionId = payload["action_id"] as? String ?? UUID().uuidString
         if shouldProcessWatchAction(actionId: actionId) == false {
             metricTracker.track(
                 .watchActionDuplicate,
                 userKey: currentMetricUserId(),
-                payload: ["action": action]
+                payload: ["action": actionName]
             )
             return
         }
         metricTracker.track(
             .watchActionProcessed,
             userKey: currentMetricUserId(),
-            payload: ["action": action]
+            payload: ["action": actionName]
         )
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            switch action {
-            case "startWalk":
-                if self.isWalking == false {
-                    self.endWalk()
-                    self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action])
-                }
-            case "addPoint":
-                if self.isWalking {
-                    self.addLocation()
-                    self.syncWatchContext(force: true)
-                    self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action])
-                }
-            case "endWalk":
-                if self.isWalking {
-                    self.endWalk()
-                    self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action])
-                }
-            default:
-                break
+            self.applyWatchAction(action)
+        }
+    }
+
+    private func parseWatchAction(from payload: [String: Any]) -> WatchIncomingAction? {
+        guard let rawAction = payload["action"] as? String else { return nil }
+        return WatchIncomingAction(rawValue: rawAction)
+    }
+
+    private func applyWatchAction(_ action: WatchIncomingAction) {
+        switch action {
+        case .startWalk:
+            if self.isWalking == false {
+                self.endWalk()
+                self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action.rawValue])
+            }
+        case .addPoint:
+            if self.isWalking {
+                self.addLocation()
+                self.syncWatchContext(force: true)
+                self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action.rawValue])
+            }
+        case .endWalk:
+            if self.isWalking {
+                self.endWalk()
+                self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action.rawValue])
             }
         }
     }

--- a/dogArea/Views/ProfileSettingView/SettingViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/SettingViewModel.swift
@@ -6,10 +6,10 @@
 //
 
 import Foundation
-import SwiftUI
+import Combine
+import UIKit
 import FirebaseStorage
 final class SettingViewModel: ObservableObject, CoreDataProtocol {
-    @Environment(\.managedObjectContext) private var viewContext
     @Published var polygonList: [Polygon] = []
     @Published var userName: String? = nil
     @Published var petName: String? = nil

--- a/dogArea/Views/WalkListView/WalkListViewModel.swift
+++ b/dogArea/Views/WalkListView/WalkListViewModel.swift
@@ -6,10 +6,8 @@
 //
 
 import Foundation
-import SwiftUI
-import CoreData
+import Combine
 final class WalkListViewModel: ObservableObject, CoreDataProtocol {
-    @Environment(\.managedObjectContext) private var viewContext
     @Published var walkingDatas: [WalkDataModel] = []
     func fetchModel() {
         self.walkingDatas = self.fetchPolygons().map{

--- a/scripts/viewmodel_modernization_unit_check.swift
+++ b/scripts/viewmodel_modernization_unit_check.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let mapVM = load("dogArea/Views/MapView/MapViewModel.swift")
+let settingVM = load("dogArea/Views/ProfileSettingView/SettingViewModel.swift")
+let walkListVM = load("dogArea/Views/WalkListView/WalkListViewModel.swift")
+
+assertTrue(mapVM.contains("private func reloadPolygonState"), "MapViewModel should centralize polygon state updates")
+assertTrue(mapVM.contains("private enum WatchIncomingAction"), "MapViewModel should use typed watch action")
+assertTrue(!mapVM.contains("@Environment(\\.managedObjectContext)"), "MapViewModel should not use @Environment managedObjectContext")
+assertTrue(!settingVM.contains("@Environment(\\.managedObjectContext)"), "SettingViewModel should not use @Environment managedObjectContext")
+assertTrue(!walkListVM.contains("@Environment(\\.managedObjectContext)"), "WalkListViewModel should not use @Environment managedObjectContext")
+
+print("PASS: viewmodel modernization unit checks")


### PR DESCRIPTION
## Summary
- add ViewModel modernization spec document and README link
- remove unnecessary `@Environment(\.managedObjectContext)` from ViewModels
  - `MapViewModel`
  - `SettingViewModel`
  - `WalkListViewModel`
- reduce MapViewModel responsibility overlap
  - centralize polygon/heatmap state update with `reloadPolygonState()`
  - split watch payload parsing and state transition (`WatchIncomingAction`, `applyWatchAction`)
- add `scripts/viewmodel_modernization_unit_check.swift`

## Test
- `swift scripts/heatmap_unit_check.swift`
- `swift scripts/watch_reliability_unit_check.swift`
- `swift scripts/caricature_pipeline_unit_check.swift`
- `swift scripts/nearby_hotspot_unit_check.swift`
- `swift scripts/feature_flag_rollout_unit_check.swift`
- `swift scripts/viewmodel_modernization_unit_check.swift`
