### PR TITLE
refactor: align coredata return contract with persisted state (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - 근처 사용자 익명 핫스팟 명세 v1: `docs/nearby-anonymous-hotspot-v1.md`
 - Feature Flag/롤아웃 모니터링 명세 v1: `docs/feature-flag-rollout-monitoring-v1.md`
 - ViewModel 현대화 리팩토링 명세 v1: `docs/viewmodel-modernization-v1.md`
+- CoreData 반환 계약 정리 v1: `docs/coredata-return-contract-v1.md`
 
 ## 강아지들의 영역 표시
 

--- a/docs/coredata-return-contract-v1.md
+++ b/docs/coredata-return-contract-v1.md
@@ -1,0 +1,24 @@
+# CoreData Return Contract v1
+
+## 1. 목적
+- `savePolygon` / `deletePolygon` 호출 직후 UI 상태와 영속 데이터가 항상 동일하도록 반환 계약을 통일한다.
+
+## 2. 계약
+- `fetchPolygons()`:
+  - CoreData 기준 전체 목록을 반환한다.
+  - `createdAt` 오름차순으로 정렬된 결과를 반환한다.
+- `savePolygon(polygon:)`:
+  - 저장 시도 후 최신 `fetchPolygons()` 결과 전체 목록을 반환한다.
+  - 저장 실패 시에도 현재 영속 상태(`fetchPolygons()`)를 반환한다.
+- `deletePolygon(id:)`:
+  - 삭제 시도 후 최신 `fetchPolygons()` 결과 전체 목록을 반환한다.
+  - 대상이 없어도 현재 영속 상태(`fetchPolygons()`)를 반환한다.
+
+## 3. 호출부 규칙(MapViewModel)
+- save/delete 호출 뒤 별도 fetch를 중복 호출하지 않는다.
+- 반환 목록을 단일 진실원으로 사용해 `polygonList`를 즉시 갱신한다.
+- Heatmap 갱신은 `polygonList` 갱신 직후 수행한다.
+
+## 4. 완료 기준
+- 저장/삭제 직후 UI 목록과 CoreData 데이터가 일치한다.
+- save/delete/fetch의 반환 의미가 문서-코드에서 동일하다.

--- a/dogArea/Source/CoreDataProtocol.swift
+++ b/dogArea/Source/CoreDataProtocol.swift
@@ -25,6 +25,7 @@ extension CoreDataProtocol {
     }
     var fetchRequest: NSFetchRequest<PolygonEntity> {
         let request = NSFetchRequest<PolygonEntity>(entityName: "PolygonEntity")
+        request.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: true)]
         return request
     }
     var fetchAreaRequest: NSFetchRequest<AreaEntity> {
@@ -57,7 +58,6 @@ extension CoreDataProtocol {
     }
     func savePolygon (polygon : Polygon) -> [Polygon] {
         let polygons = PolygonEntity(context: context)
-        var polygonList = [Polygon]()
         polygons.uuid = polygon.id
         polygons.walkingArea = polygon.walkingArea
         polygons.walkingTime = polygon.walkingTime
@@ -73,13 +73,10 @@ extension CoreDataProtocol {
         }
         do {
             try context.save()
-            polygonList.append(polygon)
-//            print("Saved successfully!")
-            return polygonList
-            
+            return fetchPolygons()
         } catch let error as NSError {
             print("Could not save. \(error), \(error.userInfo)")
-            return polygonList
+            return fetchPolygons()
         }
     }
     func fetchPolygons() -> [Polygon] {
@@ -97,29 +94,21 @@ extension CoreDataProtocol {
         }
     }
     func deletePolygon(id: UUID) -> [Polygon] {
-        // Set the predicate to filter by id
-        var polygonList = [Polygon]()
-        let predicate = NSPredicate(format: "uuid == %@", id as CVarArg)
-        fetchRequest.predicate = predicate
+        let request = fetchRequest
+        request.predicate = NSPredicate(format: "uuid == %@", id as CVarArg)
         do {
-            // Perform the fetch request
-            let polygons = try context.fetch(fetchRequest)
-            
+            let polygons = try context.fetch(request)
             if let polygonToDelete = polygons.first {
-                // Delete the found PolygonEntity from the context
                 context.delete(polygonToDelete)
-                
-                // Save changes in the context
                 try context.save()
                 print("Deleted successfully!")
-                polygonList.removeAll(where: {$0.id == id})
             } else {
                 print("No PolygonEntity found with createdAt \(id)")
             }
-            return polygonList
+            return fetchPolygons()
         } catch let error as NSError {
             print("Could not delete. \(error), \(error.userInfo)")
-            return polygonList
+            return fetchPolygons()
         }
     }
 

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -92,12 +92,17 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         nearbyTickTimer?.invalidate()
     }
 
-    private func reloadPolygonState(restoreLatestPolygon: Bool = false) {
-        self.polygonList = self.fetchPolygons()
+    private func applyPolygonList(_ polygons: [Polygon], restoreLatestPolygon: Bool = false) {
+        self.polygonList = polygons
         if restoreLatestPolygon {
-            self.polygon = lastPolygon() ?? Polygon(walkingTime: 0.0, walkingArea: 0.0)
+            self.polygon = polygons.last ?? Polygon(walkingTime: 0.0, walkingArea: 0.0)
         }
         self.refreshHeatmap()
+    }
+
+    private func reloadPolygonState(restoreLatestPolygon: Bool = false) {
+        let latest = self.fetchPolygons()
+        self.applyPolygonList(latest, restoreLatestPolygon: restoreLatestPolygon)
     }
 
     func fetchPolygonList() {
@@ -120,9 +125,6 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
             }
         }
     }
-    private func lastPolygon() -> Polygon? {
-        return polygonList.last
-    }
     func addLocation(){
         if let location = self.location{
             polygon.addPoint(.init(coordinate: location.coordinate))
@@ -133,8 +135,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         if polygon.locations.firstIndex(where:{ $0.id == locationID}) != nil {
             polygon.removeAt(locationID)
             if polygon.locations.count<3 {
-                _ = deletePolygon(id: self.polygon.id)
-                self.reloadPolygonState()
+                let updated = deletePolygon(id: self.polygon.id)
+                self.applyPolygonList(updated)
             }
         }
     }
@@ -147,14 +149,15 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         if isWalking {
                 if self.polygon.locations.count > 2{
                     polygon.makePolygon(walkArea: calculateArea(), walkTime: self.time, img: img)
-                    let saved = savePolygon(polygon: self.polygon).isEmpty == false
+                    let updated = savePolygon(polygon: self.polygon)
+                    let saved = updated.contains(where: { $0.id == self.polygon.id })
                     metricTracker.track(
                         saved ? .walkSaveSuccess : .walkSaveFailed,
                         userKey: currentMetricUserId(),
                         featureKey: .heatmapV1,
                         payload: ["pointCount": "\(self.polygon.locations.count)"]
                     )
-                    self.reloadPolygonState()
+                    self.applyPolygonList(updated)
                 }
             time = 0.0
         }
@@ -190,8 +193,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     }
 
     func deletePolygonAndRefresh(_ id: UUID) {
-        _ = deletePolygon(id: id)
-        self.reloadPolygonState()
+        let updated = deletePolygon(id: id)
+        self.applyPolygonList(updated)
     }
 
     func refreshHeatmap(now: Date = Date()) {

--- a/scripts/coredata_contract_unit_check.swift
+++ b/scripts/coredata_contract_unit_check.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let coreDataProtocol = load("dogArea/Source/CoreDataProtocol.swift")
+let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
+
+assertTrue(coreDataProtocol.contains("request.sortDescriptors = [NSSortDescriptor(key: \"createdAt\", ascending: true)]"), "fetchRequest should have createdAt sort descriptor")
+assertTrue(coreDataProtocol.contains("func savePolygon (polygon : Polygon) -> [Polygon]"), "savePolygon signature should return polygon array")
+assertTrue(coreDataProtocol.contains("return fetchPolygons()"), "save/delete should return latest fetch result")
+assertTrue(coreDataProtocol.contains("let request = fetchRequest"), "deletePolygon should use isolated fetch request with predicate")
+
+assertTrue(mapViewModel.contains("private func applyPolygonList"), "MapViewModel should apply returned polygon list directly")
+assertTrue(mapViewModel.contains("let updated = savePolygon(polygon: self.polygon)"), "save call site should use returned list")
+assertTrue(mapViewModel.contains("let updated = deletePolygon(id: id)"), "delete call site should use returned list")
+
+print("PASS: coredata return contract unit checks")


### PR DESCRIPTION
## Summary
- add CoreData return contract spec and README link
- align `CoreDataProtocol` return behavior with persisted state
  - `savePolygon`: returns latest `fetchPolygons()` result after save attempt
  - `deletePolygon`: returns latest `fetchPolygons()` result after delete attempt
  - `fetchRequest` sorted by `createdAt ASC` for stable list ordering
- update `MapViewModel` call sites to use returned list directly
  - introduce `applyPolygonList(_:)`
  - remove redundant post-save/post-delete fetch path

## Test
- `swift scripts/heatmap_unit_check.swift`
- `swift scripts/watch_reliability_unit_check.swift`
- `swift scripts/caricature_pipeline_unit_check.swift`
- `swift scripts/nearby_hotspot_unit_check.swift`
- `swift scripts/feature_flag_rollout_unit_check.swift`
- `swift scripts/viewmodel_modernization_unit_check.swift`
- `swift scripts/coredata_contract_unit_check.swift`
