### PR TITLE
refactor: harden swift stability and timer lifecycle (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - Feature Flag/롤아웃 모니터링 명세 v1: `docs/feature-flag-rollout-monitoring-v1.md`
 - ViewModel 현대화 리팩토링 명세 v1: `docs/viewmodel-modernization-v1.md`
 - CoreData 반환 계약 정리 v1: `docs/coredata-return-contract-v1.md`
+- Swift 안정화(강제 언래핑/타이머 수명) v1: `docs/swift-stability-hardening-v1.md`
 
 ## 강아지들의 영역 표시
 

--- a/docs/swift-stability-hardening-v1.md
+++ b/docs/swift-stability-hardening-v1.md
@@ -1,0 +1,19 @@
+# Swift Stability Hardening v1
+
+## 1. 목표
+- 강제 언래핑(`!`, `try!`) 기반 잠재 크래시 경로를 줄인다.
+- modal 카운트다운 타이머의 수명 주기를 명확히 관리한다.
+
+## 2. 적용 범위
+- `SignInView` Apple 로그인 토큰 처리
+- `StartModalView` 카운트다운 timer
+- 기타 force unwrap 빈발 지점의 안전화
+
+## 3. 구현 원칙
+- 외부 입력(Apple credential, UserDefaults decode, CoreData 변환)은 `guard`/`if let`/`compactMap`으로 처리한다.
+- Timer는 `onAppear` 생성, `onDisappear` 무효화, 종료 시점 정리를 보장한다.
+
+## 4. 완료 기준
+- identityToken/authorizationCode 강제 언래핑 제거
+- StartModalView 타이머 무효화 + dismiss 흐름 정상화
+- 주요 force unwrap 지점 정리 후 기존 동작 회귀 없음

--- a/dogArea/Source/Cluster.swift
+++ b/dogArea/Source/Cluster.swift
@@ -37,8 +37,10 @@ final class Hiarachical: Operation {
     init(polygons: [Polygon], distance: Double) {
         self.polygons = polygons
         self.distance = distance
-        self.clusters = polygons.filter{!$0.polygon.isNil}
-            .map{Cluster(center: $0.polygon!.coordinate, id: $0.id)}
+        self.clusters = polygons.compactMap { polygon in
+            guard let mapPolygon = polygon.polygon else { return nil }
+            return Cluster(center: mapPolygon.coordinate, id: polygon.id)
+        }
     }
     override var isAsynchronous: Bool {
         return true

--- a/dogArea/Source/CoreDataProtocol.swift
+++ b/dogArea/Source/CoreDataProtocol.swift
@@ -49,7 +49,7 @@ extension CoreDataProtocol {
     func fetchArea() -> [AreaMeterDTO] {
         do {
             let areaList = try context.fetch(fetchAreaRequest)
-            let temp = areaList.map{$0.toArea()}.filter{!$0.isNil}.map{$0!}
+            let temp = areaList.compactMap { $0.toArea() }
             return temp
         } catch let error as NSError {
             print("Could not fetch. \(error), \(error.userInfo)")
@@ -84,7 +84,7 @@ extension CoreDataProtocol {
         do {
             // Perform the fetch request
             let polygons = try context.fetch(fetchRequest)
-            let temp = polygons.map{$0.toPolygon()}.filter{!$0.isNil}.map{$0!}
+            let temp = polygons.compactMap { $0.toPolygon() }
             polygonList = temp
             return polygonList
         } catch let error as NSError {

--- a/dogArea/Source/TimeCheckable.swift
+++ b/dogArea/Source/TimeCheckable.swift
@@ -45,7 +45,9 @@ extension Array where Element: TimeCheckable {
         }
         let thisWeek = self.filter{e in
             let date = Date(timeIntervalSince1970: e.createdAt)
-            let roundedDate = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: date)!
+            guard let roundedDate = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: date) else {
+                return false
+            }
             return roundedDate > startOfWeek
         }
         return thisWeek
@@ -57,4 +59,3 @@ extension Array where Element: TimeCheckable {
         return result
     }
 }
-

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -82,8 +82,7 @@ extension UserDefaults {
         guard let encodedData = data(forKey: defaultName) else {
             return nil
         }
-        
-        return try! JSONDecoder().decode(type, from: encodedData)
+        return try? JSONDecoder().decode(type, from: encodedData)
     }
     
     public func setStructArray<T: Codable>(_ value: [T], forKey defaultName: String){
@@ -96,7 +95,7 @@ extension UserDefaults {
         guard let encodedData = array(forKey: defaultName) as? [Data] else {
             return []
         }
-        return encodedData.map { try! JSONDecoder().decode(type, from: $0) }
+        return encodedData.compactMap { try? JSONDecoder().decode(type, from: $0) }
     }
 }
 

--- a/dogArea/Source/ViewUtility.swift
+++ b/dogArea/Source/ViewUtility.swift
@@ -73,7 +73,7 @@ extension View {
         self.modifier(RenderImageModifier(rendered: rendered))
     }
     func asUiImage() -> UIImage {
-        var uiImage = UIImage(systemName: "exclamationmark.triangle.fill")!
+        var uiImage = UIImage(systemName: "exclamationmark.triangle.fill") ?? UIImage()
         let controller = UIHostingController(rootView: self)
        
         if let view = controller.view {
@@ -95,6 +95,6 @@ extension View {
 //MARK: - default empty image
 extension UIImage {
     static var emptyImage: UIImage {
-        .init(named: "emptyImg")!
+        .init(named: "emptyImg") ?? UIImage()
     }
 }

--- a/dogArea/Views/GlobalViews/TitleTextView.swift
+++ b/dogArea/Views/GlobalViews/TitleTextView.swift
@@ -18,8 +18,8 @@ struct TitleTextView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     Text(title)
                         .font(.appFont(for: .SemiBold, size: 40))
-                    if subTitle != nil {
-                        Text(subTitle!)
+                    if let subTitle {
+                        Text(subTitle)
                             .font(.appFont(for: .Light, size: 15))
                             .foregroundStyle(Color.appTextDarkGray)
                     }
@@ -28,8 +28,8 @@ struct TitleTextView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     Text(title)
                         .font(.appFont(for: .SemiBold, size: 25))
-                    if subTitle != nil {
-                        Text(subTitle!)
+                    if let subTitle {
+                        Text(subTitle)
                             .font(.appFont(for: .Light, size: 11))
                             .foregroundStyle(Color.appTextDarkGray)
                     }

--- a/dogArea/Views/HomeView/AreaMeters.swift
+++ b/dogArea/Views/HomeView/AreaMeters.swift
@@ -273,11 +273,10 @@ struct AreaMeterCollection {
         return areas.first{$0.area < myarea}
     }
     func nearistArea(since: AreaMeterDTO? = nil, from myarea: Double) -> [AreaMeter] {
-        if since.isNil {
-            return areas.filter{$0.area < myarea}
-        } else {
-            return areas.filter{$0.area < myarea && $0.area > since!.area}
+        guard let since else {
+            return areas.filter { $0.area < myarea }
         }
+        return areas.filter { $0.area < myarea && $0.area > since.area }
     }
     func closeArea(of myarea: Double) -> AreaMeter? {
         return areas.last{$0.area > myarea}

--- a/dogArea/Views/HomeView/HomeSubView/Calender.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Calender.swift
@@ -87,7 +87,7 @@ struct CalenderView: View {
                         let sunday = index % 7 == 0
                         let saturday = index % 7 == 6
                         let clicked = clickedDates.filter{$0 == date}
-                        let today = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: Date())!
+                        let today = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: Date()) ?? Date()
                         CellView(day: day, clickedCount: clicked.count, sun: sunday, sat: saturday, today: today == date)
                     }
                 }
@@ -144,14 +144,14 @@ private struct CellView: View {
 private extension CalenderView {
     /// 특정 해당 날짜
     private func getDate(for day: Int) -> Date {
-        var date = Calendar.current.date(byAdding: .day, value: day, to: startOfMonth())!
-        return Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: date)!
+        let date = Calendar.current.date(byAdding: .day, value: day, to: startOfMonth()) ?? startOfMonth()
+        return Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: date) ?? date
     }
     
     /// 해당 월의 시작 날짜
     func startOfMonth() -> Date {
         let components = Calendar.current.dateComponents([.year, .month], from: month)
-        return Calendar.current.date(from: components)!
+        return Calendar.current.date(from: components) ?? month
     }
     
     /// 해당 월에 존재하는 일자 수
@@ -162,7 +162,7 @@ private extension CalenderView {
     /// 해당 월의 첫 날짜가 갖는 해당 주의 몇번째 요일
     func firstWeekdayOfMonth(in date: Date) -> Int {
         let components = Calendar.current.dateComponents([.year, .month], from: date)
-        let firstDayOfMonth = Calendar.current.date(from: components)!
+        let firstDayOfMonth = Calendar.current.date(from: components) ?? date
         
         return Calendar.current.component(.weekday, from: firstDayOfMonth)
     }

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -55,10 +55,11 @@ struct HomeView: View {
                         .padding(.trailing)
                 }
                 HStack {
+                    let petNameWithYi = viewModel.userInfo?.pet.first?.petName.addYi() ?? "강아지"
                     VStack(alignment: .leading, spacing: 0) {
-                        Text("\(viewModel.userInfo!.pet.first!.petName.addYi())의 영역")
+                        Text("\(petNameWithYi)의 영역")
                             .font(.appFont(for: .SemiBold, size: 40))
-                        Text("\(viewModel.userInfo!.pet.first!.petName.addYi())가 정복한 영역을 확인해보세요!")
+                        Text("\(petNameWithYi)가 정복한 영역을 확인해보세요!")
                             .font(.appFont(for: .Light, size: 15))
                             .foregroundStyle(Color.appTextDarkGray)
                     }.padding()
@@ -167,4 +168,3 @@ struct HomeView: View {
 #Preview {
     HomeView()
 }
-

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -78,7 +78,7 @@ final class HomeViewModel: ObservableObject, CoreDataProtocol {
     }
     func walkedDates() -> Array<Date> {
         let dateArr = polygonList.map{Date(timeIntervalSince1970:$0.createdAt)}
-            .map{Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: $0)!}
+            .compactMap { Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: $0) }
         return dateArr
     }
     func walkedAreaforWeek() -> Double {

--- a/dogArea/Views/MapView/MapSubViews/MapCapture.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapCapture.swift
@@ -63,7 +63,12 @@ class MapImageProvider: ObservableObject {
                     UIGraphicsBeginImageContextWithOptions(snapshotImage.size, true, snapshotImage.scale)
                     snapshotImage.draw(at: .zero)
 
-                    let context = UIGraphicsGetCurrentContext()!
+                    guard let context = UIGraphicsGetCurrentContext() else {
+                        let drawnImage = UIGraphicsGetImageFromCurrentImageContext()
+                        UIGraphicsEndImageContext()
+                        promise(.success(drawnImage))
+                        return
+                    }
 
                     let pointCount = polygon.pointCount
                     let points = polygon.points()
@@ -94,4 +99,3 @@ class MapImageProvider: ObservableObject {
         }
     }
 }
-

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -579,12 +579,7 @@ extension MapViewModel {
         return abs(area)
     }
     func calculatedAreaString(areaSize: Double? = nil , isPyong: Bool = false) -> String {
-        var area = 0.0
-        if areaSize == nil {
-            area = calculateArea()
-        } else {
-            area = areaSize!
-        }
+        let area = areaSize ?? calculateArea()
         var str = String(format: "%.2f" , area) + "㎡"
         if area > 10000.0 {
             str = String(format: "%.2f" , area/10000) + "만 ㎡"
@@ -661,9 +656,10 @@ extension MapViewModel {
 
     }
     private func initialClusterByPolygon() async -> [Cluster] {
-        return self.polygonList
-            .filter{!$0.polygon.isNil}
-            .map{Cluster(center: $0.polygon!.coordinate, id: $0.id)}
+        return self.polygonList.compactMap { polygon in
+            guard let mapPolygon = polygon.polygon else { return nil }
+            return Cluster(center: mapPolygon.coordinate, id: polygon.id)
+        }
     }
     private func cluster(distance: Double) async -> [Cluster] {
         let startCluster = await initialClusterByPolygon()

--- a/dogArea/Views/MapView/StartModalView.swift
+++ b/dogArea/Views/MapView/StartModalView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct StartModalView: View {
     @Environment(\.dismiss) var dismiss
     @State var time: TimeInterval = 3
+    @State private var countdownTimer: Timer? = nil
     var body: some View {
         VStack {
             if Int(time) < 1 {
@@ -19,11 +20,30 @@ struct StartModalView: View {
                 Text("\(Int(time))")
                     .font(.appFont(for: .Black, size: 72))
             }
-        }.onAppear() {
-            Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { t in
-                self.time -= t.timeInterval
-            })
         }
+        .onAppear {
+            startCountdown()
+        }
+        .onDisappear {
+            invalidateCountdown()
+        }
+    }
+
+    private func startCountdown() {
+        invalidateCountdown()
+        countdownTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+            self.time = max(0, self.time - timer.timeInterval)
+            if self.time <= 0 {
+                timer.invalidate()
+                self.countdownTimer = nil
+                dismiss()
+            }
+        }
+    }
+
+    private func invalidateCountdown() {
+        countdownTimer?.invalidate()
+        countdownTimer = nil
     }
 }
 

--- a/dogArea/Views/SigningView/SignInView.swift
+++ b/dogArea/Views/SigningView/SignInView.swift
@@ -46,21 +46,27 @@ struct AppleSigninButton : View{
                     switch authResults.credential{
                     case let appleIDCredential as ASAuthorizationAppleIDCredential:
                         // 계정 정보 가져오기
-                        var userInfo = UserdefaultSetting().getValue()
+                        let userInfo = UserdefaultSetting().getValue()
                         let UserIdentifier = appleIDCredential.user
                         let fullName = appleIDCredential.fullName
                         let name =  (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
-                        let IdentityToken = String(data: appleIDCredential.identityToken!, encoding: .utf8)
-                        let AuthorizationCode = String(data: appleIDCredential.authorizationCode!, encoding: .utf8)
                         if userInfo?.name == UserIdentifier {
-                            guard let info = userInfo else { return }
+                            guard userInfo != nil else { return }
                             isLogined.toggle()
                             // 첫 가입 아님(이미 가입함)
                         } else {
+                            guard let identityTokenData = appleIDCredential.identityToken,
+                                  let identityToken = String(data: identityTokenData, encoding: .utf8) else {
+                                print("identity token missing")
+                                return
+                            }
+                            if appleIDCredential.authorizationCode == nil {
+                                print("authorization code missing")
+                            }
                             let credential = OAuthProvider.credential(withProviderID: "apple.com",
-                                                                      idToken: IdentityToken!,
+                                                                      idToken: identityToken,
                                                                       rawNonce: nil)
-                            Auth.auth().signIn(with: credential){ result, error in
+                            Auth.auth().signIn(with: credential){ _, error in
                                 guard error == nil else {
                                     print(error?.localizedDescription)
                                     return

--- a/dogArea/Views/WalkListView/WalkListDetailView.swift
+++ b/dogArea/Views/WalkListView/WalkListDetailView.swift
@@ -107,7 +107,9 @@ struct WalkListDetailView: View {
             ).navigationBarBackButtonHidden()
         }.padding(.top, 20)
         .onAppear {
-            imageRenderer.captureMapImage(for: model.toPolygon().polygon!)
+            if let polygon = model.toPolygon().polygon {
+                imageRenderer.captureMapImage(for: polygon)
+            }
 
             tabStatus.hide()
         }.safeAreaPadding(.top, 20)

--- a/scripts/swift_stability_unit_check.swift
+++ b/scripts/swift_stability_unit_check.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let signInView = load("dogArea/Views/SigningView/SignInView.swift")
+let startModalView = load("dogArea/Views/MapView/StartModalView.swift")
+let userDefaultsSource = load("dogArea/Source/UserdefaultSetting.swift")
+let titleTextView = load("dogArea/Views/GlobalViews/TitleTextView.swift")
+let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let homeViewModel = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let walkListDetailView = load("dogArea/Views/WalkListView/WalkListDetailView.swift")
+let areaMeters = load("dogArea/Views/HomeView/AreaMeters.swift")
+let mapCapture = load("dogArea/Views/MapView/MapSubViews/MapCapture.swift")
+let viewUtility = load("dogArea/Source/ViewUtility.swift")
+let timeCheckable = load("dogArea/Source/TimeCheckable.swift")
+let calendarView = load("dogArea/Views/HomeView/HomeSubView/Calender.swift")
+
+assertTrue(!signInView.contains("identityToken!"), "SignInView should not force unwrap identityToken")
+assertTrue(!signInView.contains("authorizationCode!"), "SignInView should not force unwrap authorizationCode")
+assertTrue(signInView.contains("guard let identityTokenData"), "SignInView should guard identity token")
+
+assertTrue(startModalView.contains("@State private var countdownTimer"), "StartModalView should keep timer state")
+assertTrue(startModalView.contains(".onDisappear"), "StartModalView should handle disappear lifecycle")
+assertTrue(startModalView.contains("invalidateCountdown()"), "StartModalView should invalidate timer")
+
+assertTrue(!userDefaultsSource.contains("try! JSONDecoder"), "UserdefaultSetting decode should avoid try!")
+assertTrue(!titleTextView.contains("subTitle!"), "TitleTextView should avoid subtitle force unwrap")
+assertTrue(!homeView.contains("userInfo!"), "HomeView should avoid force unwrap userInfo")
+assertTrue(
+    !homeViewModel.contains("date(bySettingHour: 0, minute: 0, second: 0, of: $0)!"),
+    "HomeViewModel walkedDates should avoid force unwrap date rounding"
+)
+assertTrue(!walkListDetailView.contains("polygon!"), "WalkListDetailView should avoid force unwrap polygon")
+assertTrue(!areaMeters.contains("since!"), "AreaMeters should avoid force unwrap optional since")
+assertTrue(!mapCapture.contains("UIGraphicsGetCurrentContext()!"), "MapCapture should avoid force unwrap graphics context")
+assertTrue(!viewUtility.contains("UIImage(systemName: \"exclamationmark.triangle.fill\")!"), "ViewUtility should avoid force unwrap system image")
+assertTrue(!viewUtility.contains(".init(named: \"emptyImg\")!"), "ViewUtility should avoid force unwrap asset image")
+assertTrue(!timeCheckable.contains("date(bySettingHour: 0, minute: 0, second: 0, of: date)!"), "TimeCheckable should avoid force unwrap date rounding")
+assertTrue(!calendarView.contains("bySettingHour: 0, minute: 0, second: 0, of: Date())!"), "Calendar view should avoid force unwrap today")
+
+print("PASS: swift stability unit checks")


### PR DESCRIPTION
## Summary
- add Swift stability hardening doc and README link
- remove force unwrap in Apple sign-in token path (`SignInView`)
- fix `StartModalView` timer lifecycle
  - keep timer state
  - invalidate on disappear
  - dismiss at countdown completion
- harden additional force unwrap hotspots
  - `TitleTextView`, `HomeView`, `HomeViewModel`, `WalkListDetailView`
  - `UserdefaultSetting` decode (`try!` -> safe decode)
  - `CoreDataProtocol` conversion (`compactMap`)
  - `Cluster`, `MapViewModel` polygon access (`compactMap`)
  - `TimeCheckable`, `Calender`, `AreaMeters`, `MapCapture`, `ViewUtility`

## Test
- `swift scripts/heatmap_unit_check.swift`
- `swift scripts/watch_reliability_unit_check.swift`
- `swift scripts/caricature_pipeline_unit_check.swift`
- `swift scripts/nearby_hotspot_unit_check.swift`
- `swift scripts/feature_flag_rollout_unit_check.swift`
- `swift scripts/viewmodel_modernization_unit_check.swift`
- `swift scripts/coredata_contract_unit_check.swift`
- `swift scripts/swift_stability_unit_check.swift`
