### PR TITLE
docs: add release regression checklist and report (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 - ViewModel 현대화 리팩토링 명세 v1: `docs/viewmodel-modernization-v1.md`
 - CoreData 반환 계약 정리 v1: `docs/coredata-return-contract-v1.md`
 - Swift 안정화(강제 언래핑/타이머 수명) v1: `docs/swift-stability-hardening-v1.md`
+- 릴리즈 회귀 체크리스트 v1: `docs/release-regression-checklist-v1.md`
+- 릴리즈 회귀 실행 리포트(2026-02-26): `docs/release-regression-report-2026-02-26.md`
 
 ## 강아지들의 영역 표시
 

--- a/docs/release-regression-checklist-v1.md
+++ b/docs/release-regression-checklist-v1.md
@@ -1,0 +1,65 @@
+# Release Regression Checklist v1
+
+## 1. 목적
+고도화 이후 핵심 경로(iOS/watchOS 빌드, 로그인/산책/저장/목록, DB 마이그레이션)의 회귀 여부를 릴리즈 전 표준 절차로 점검한다.
+
+## 2. 사전 준비
+- [ ] `OpenAIConfiguration.xcconfig` 존재 및 유효 키 설정
+- [ ] `supabase link` 완료(원격 project ref 연결)
+- [ ] 네트워크 정상 및 패키지 의존성 resolve 완료
+
+## 3. 빌드 체크
+### 3.1 iOS
+- 명령: `xcodebuild -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
+- 기대 결과: `** BUILD SUCCEEDED **`
+
+### 3.2 watchOS
+- 명령: `xcodebuild -project dogArea.xcodeproj -scheme 'dogAreaWatch Watch App' -configuration Debug -destination 'generic/platform=watchOS' CODE_SIGNING_ALLOWED=NO build`
+- 기대 결과: `** BUILD SUCCEEDED **`
+
+## 4. 핵심 시나리오 체크
+### 4.1 로그인
+- [ ] Apple 로그인 성공
+- [ ] 기존 사용자/신규 사용자 분기 정상 동작
+
+### 4.2 산책/기록
+- [ ] 산책 시작 -> 포인트 추가 -> 종료 플로우 정상
+- [ ] 저장 후 지도/목록 데이터 일치
+
+### 4.3 목록/상세
+- [ ] 산책 목록 로딩 정상
+- [ ] 상세 진입/이미지 저장 동작 정상
+
+## 5. 마이그레이션 검증 시나리오
+### 5.1 상태 확인
+- 명령: `npx --yes supabase migration list`
+- 기대 결과: linked 프로젝트 기준 migration state 확인 가능
+
+### 5.2 SQL 변경 검토
+- [ ] 신규 migration 파일 존재 확인
+- [ ] DDL/RLS/함수 변경사항 문서와 일치
+
+## 6. 결과 기록 템플릿
+- 실행 일시:
+- 실행자:
+- 대상 브랜치/커밋:
+
+### 6.1 빌드
+- iOS: `PASS | FAIL | BLOCKED`
+- watchOS: `PASS | FAIL | BLOCKED`
+- 근거 로그:
+
+### 6.2 핵심 시나리오
+- 로그인: `PASS | FAIL | BLOCKED`
+- 산책/저장: `PASS | FAIL | BLOCKED`
+- 목록/상세: `PASS | FAIL | BLOCKED`
+- 근거:
+
+### 6.3 마이그레이션
+- migration list: `PASS | FAIL | BLOCKED`
+- SQL 검토: `PASS | FAIL | BLOCKED`
+- 근거:
+
+### 6.4 종합 판단
+- 릴리즈 가능 여부: `GO | NO-GO`
+- 잔여 이슈/액션:

--- a/docs/release-regression-report-2026-02-26.md
+++ b/docs/release-regression-report-2026-02-26.md
@@ -1,0 +1,61 @@
+# Release Regression Report
+
+- 실행 일시: 2026-02-26
+- 실행자: Codex
+- 대상 커밋: `a6045fa` (cycle 시작 시점)
+
+## 1. 빌드 체크 결과
+
+### 1.1 iOS build
+- 명령:
+  - `xcodebuild -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
+- 결과: `FAIL`
+- 근거:
+  - `Unable to open base configuration reference file '/tmp/dogArea-cycle28/OpenAIConfiguration.xcconfig'`
+
+### 1.2 watchOS build
+- 명령:
+  - `xcodebuild -project dogArea.xcodeproj -scheme 'dogAreaWatch Watch App' -configuration Debug -destination 'generic/platform=watchOS' CODE_SIGNING_ALLOWED=NO build`
+- 결과: `FAIL`
+- 근거:
+  - 동일하게 `OpenAIConfiguration.xcconfig` 부재로 build fail
+
+## 2. 핵심 시나리오 점검 결과
+
+### 2.1 로그인/산책/저장/목록
+- 결과: `BLOCKED (수동 디바이스 QA 미실행)`
+- 근거:
+  - CLI 환경에서 UI 수동 시나리오(Apple 로그인, 지도 상호작용, 저장 후 화면 검증) 직접 수행 불가
+
+### 2.2 보완 근거 (자동 스크립트)
+- `swift scripts/heatmap_unit_check.swift` -> PASS
+- `swift scripts/watch_reliability_unit_check.swift` -> PASS
+- `swift scripts/caricature_pipeline_unit_check.swift` -> PASS
+- `swift scripts/nearby_hotspot_unit_check.swift` -> PASS
+- `swift scripts/feature_flag_rollout_unit_check.swift` -> PASS
+- `swift scripts/viewmodel_modernization_unit_check.swift` -> PASS
+- `swift scripts/coredata_contract_unit_check.swift` -> PASS
+- `swift scripts/swift_stability_unit_check.swift` -> PASS
+
+## 3. 마이그레이션 검증 결과
+
+### 3.1 migration list
+- 명령: `npx --yes supabase migration list`
+- 결과: `BLOCKED`
+- 근거:
+  - `Cannot find project ref. Have you run supabase link?`
+
+### 3.2 SQL 변경 점검
+- 결과: `PASS`
+- 근거:
+  - migration 파일 존재 확인:
+    - `supabase/migrations/20260226093000_caricature_async_pipeline.sql`
+    - `supabase/migrations/20260226095500_nearby_hotspots.sql`
+    - `supabase/migrations/20260226103000_feature_flags_and_metrics.sql`
+
+## 4. 종합 판단
+- 릴리즈 가능 여부: `NO-GO`
+- 선행 조치:
+  1. `OpenAIConfiguration.xcconfig`를 CI/로컬 빌드 환경에 주입
+  2. Supabase 프로젝트를 `supabase link`로 연결
+  3. 실기기/시뮬레이터에서 로그인/산책/저장/목록 수동 QA 수행

--- a/scripts/release_regression_checklist_unit_check.swift
+++ b/scripts/release_regression_checklist_unit_check.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let checklist = load("docs/release-regression-checklist-v1.md")
+let report = load("docs/release-regression-report-2026-02-26.md")
+
+assertTrue(checklist.contains("## 3. 빌드 체크"), "checklist must include build check section")
+assertTrue(checklist.contains("## 4. 핵심 시나리오 체크"), "checklist must include scenario check section")
+assertTrue(checklist.contains("## 5. 마이그레이션 검증 시나리오"), "checklist must include migration section")
+assertTrue(checklist.contains("## 6. 결과 기록 템플릿"), "checklist must include result template")
+
+assertTrue(report.contains("## 1. 빌드 체크 결과"), "report must include build results")
+assertTrue(report.contains("## 2. 핵심 시나리오 점검 결과"), "report must include scenario results")
+assertTrue(report.contains("## 3. 마이그레이션 검증 결과"), "report must include migration results")
+assertTrue(report.contains("릴리즈 가능 여부"), "report must include GO/NO-GO decision")
+
+print("PASS: release regression checklist unit checks")


### PR DESCRIPTION
## Summary
- add release regression checklist document
- add 2026-02-26 execution report with recorded results (build/scenario/migration)
- add README links for checklist and report
- add checklist unit check script to keep required sections consistent

## Validation executed
### Build check
- iOS build command executed -> FAIL
  - reason: missing `OpenAIConfiguration.xcconfig`
- watchOS build command executed -> FAIL
  - reason: missing `OpenAIConfiguration.xcconfig`

### Migration check
- `npx --yes supabase migration list` executed -> BLOCKED
  - reason: project ref not linked (`supabase link` required)

### Script checks
- `swift scripts/heatmap_unit_check.swift` PASS
- `swift scripts/watch_reliability_unit_check.swift` PASS
- `swift scripts/caricature_pipeline_unit_check.swift` PASS
- `swift scripts/nearby_hotspot_unit_check.swift` PASS
- `swift scripts/feature_flag_rollout_unit_check.swift` PASS
- `swift scripts/viewmodel_modernization_unit_check.swift` PASS
- `swift scripts/coredata_contract_unit_check.swift` PASS
- `swift scripts/swift_stability_unit_check.swift` PASS
- `swift scripts/release_regression_checklist_unit_check.swift` PASS
