### PR TITLE
feat: guest->member 전환 UX 표준화 (#77)

### DIFF
--- a/docs/guest-upgrade-ux-v1.md
+++ b/docs/guest-upgrade-ux-v1.md
@@ -1,0 +1,42 @@
+# Guest to Member Upgrade UX v1
+
+## Scope
+- Issue: #77
+- Goal: 비회원(게스트) 사용 중 회원 전환 UX를 공통화하고, 로그인 후 원래 화면으로 복귀시키는 흐름을 고정한다.
+
+## Implemented Behavior
+1. 앱 첫 진입 분기
+- `바로 시작`: 게스트 모드로 진입
+- `로그인하고 동기화`: 즉시 로그인 플로우 진입
+
+2. 공통 잠금 UX
+- 회원 전용 동작에서 동일한 바텀시트(`MemberUpgradeSheetView`) 노출
+- 메시지/버튼 카피를 공통으로 사용
+- `나중에` 선택 시 현재 화면 유지
+
+3. 로그인 후 복귀
+- 기존 `RootView` 재생성(fullScreenCover) 제거
+- 콜백 기반(`onAuthenticated`)으로 현재 컨텍스트 복귀
+
+4. 적용 지점
+- 산책 시작 버튼(`walk_start`)
+- 텍스트-이미지 생성(`image_generator`)
+- 산책 목록 동기화 유도(`walk_history`)
+- 지도 상 백업 유도 배너(`walk_backup`)
+
+## State Contract
+- `AuthFlowCoordinator`
+  - `shouldShowEntryChoice`
+  - `shouldShowSignIn`
+  - `pendingUpgradeRequest`
+  - `isGuestMode`
+- persisted keys
+  - `auth.guest_mode.v1`
+  - `auth.entry_choice_completed.v1`
+
+## QA Checklist
+- [ ] 첫 실행에서 진입 선택 시트가 1회 노출되는가
+- [ ] 게스트로 시작 후 회원 전용 액션에서 공통 시트가 뜨는가
+- [ ] 로그인 성공 시 기존 화면 컨텍스트가 유지되는가
+- [ ] `나중에` 선택 시 강제 이동/앱 종료가 없는가
+- [ ] 지도/목록/이미지 생성 진입에서 카피가 일관적인가

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CryptoKit
+import SwiftUI
 class UserdefaultSetting {
     enum keyValue: String {
         case userId = "userId"
@@ -878,5 +879,173 @@ struct SupabaseSyncOutboxTransport: SyncOutboxTransporting {
         } catch {
             return .retryable(.unknown)
         }
+    }
+}
+
+enum MemberUpgradeTrigger: String {
+    case walkStart = "walk_start"
+    case imageGenerator = "image_generator"
+    case walkHistory = "walk_history"
+    case walkBackup = "walk_backup"
+
+    var title: String {
+        switch self {
+        case .walkStart:
+            return "회원 전환 후 산책 기록"
+        case .imageGenerator:
+            return "회원 전환 후 이미지 생성"
+        case .walkHistory:
+            return "회원 전환 후 기록 동기화"
+        case .walkBackup:
+            return "로그인하고 산책 백업"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .walkStart:
+            return "산책 기록은 계정과 연결되어야 안전하게 저장되고 기기 간 동기화됩니다."
+        case .imageGenerator:
+            return "AI 이미지 생성 결과를 안정적으로 저장하려면 계정 연동이 필요합니다."
+        case .walkHistory:
+            return "지금 로그인하면 현재 기기의 산책 기록을 계정에 백업하고 다른 기기에서도 볼 수 있어요."
+        case .walkBackup:
+            return "게스트 모드 기록은 기기 삭제 시 유실될 수 있어요. 로그인 후 자동 백업을 켜세요."
+        }
+    }
+}
+
+struct MemberUpgradeRequest: Identifiable {
+    let id = UUID()
+    let trigger: MemberUpgradeTrigger
+}
+
+@MainActor
+final class AuthFlowCoordinator: ObservableObject {
+    @Published var shouldShowEntryChoice: Bool = false
+    @Published var shouldShowSignIn: Bool = false
+    @Published var pendingUpgradeRequest: MemberUpgradeRequest? = nil
+
+    private let guestModeKey = "auth.guest_mode.v1"
+    private let entryChoiceCompletedKey = "auth.entry_choice_completed.v1"
+    private var onAuthenticated: (() -> Void)?
+
+    var isLoggedIn: Bool {
+        guard let id = UserdefaultSetting.shared.getValue()?.id else { return false }
+        return id.isEmpty == false
+    }
+
+    var isGuestMode: Bool {
+        isLoggedIn == false && UserDefaults.standard.bool(forKey: guestModeKey)
+    }
+
+    func refresh() {
+        if isLoggedIn {
+            UserDefaults.standard.set(false, forKey: guestModeKey)
+            UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
+            shouldShowEntryChoice = false
+            shouldShowSignIn = false
+            pendingUpgradeRequest = nil
+            return
+        }
+        let didChooseEntryPath = UserDefaults.standard.bool(forKey: entryChoiceCompletedKey)
+        shouldShowEntryChoice = !didChooseEntryPath
+    }
+
+    func continueAsGuest() {
+        UserDefaults.standard.set(true, forKey: guestModeKey)
+        UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
+        shouldShowEntryChoice = false
+    }
+
+    func chooseSignInFromEntry() {
+        UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
+        shouldShowEntryChoice = false
+        shouldShowSignIn = true
+    }
+
+    @discardableResult
+    func requireMember(trigger: MemberUpgradeTrigger, onAuthenticated: (() -> Void)? = nil) -> Bool {
+        if isLoggedIn {
+            onAuthenticated?()
+            return true
+        }
+        self.onAuthenticated = onAuthenticated
+        pendingUpgradeRequest = MemberUpgradeRequest(trigger: trigger)
+        return false
+    }
+
+    func proceedToSignIn() {
+        pendingUpgradeRequest = nil
+        shouldShowSignIn = true
+    }
+
+    func dismissUpgradeRequest() {
+        pendingUpgradeRequest = nil
+        onAuthenticated = nil
+    }
+
+    func dismissSignIn() {
+        shouldShowSignIn = false
+        if isLoggedIn == false {
+            UserDefaults.standard.set(true, forKey: guestModeKey)
+        }
+        onAuthenticated = nil
+    }
+
+    func completeSignIn() {
+        UserDefaults.standard.set(false, forKey: guestModeKey)
+        UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
+        shouldShowSignIn = false
+        shouldShowEntryChoice = false
+        pendingUpgradeRequest = nil
+        let completion = onAuthenticated
+        onAuthenticated = nil
+        completion?()
+    }
+}
+
+struct MemberUpgradeSheetView: View {
+    let request: MemberUpgradeRequest
+    let onUpgrade: () -> Void
+    let onLater: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(request.trigger.title)
+                .font(.appFont(for: .Bold, size: 22))
+                .foregroundStyle(Color.appTextDarkGray)
+            Text(request.trigger.message)
+                .font(.appFont(for: .Regular, size: 14))
+                .foregroundStyle(Color.appTextDarkGray)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("• 계정 연동 후 자동 백업")
+                Text("• 기기 변경 시 기록 복원")
+                Text("• 로그인 완료 후 현재 화면으로 복귀")
+            }
+            .font(.appFont(for: .Regular, size: 13))
+            .foregroundStyle(Color.appTextDarkGray)
+            HStack(spacing: 10) {
+                Button("나중에") {
+                    onLater()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.appYellowPale)
+                .foregroundStyle(Color.appTextDarkGray)
+                .cornerRadius(10)
+
+                Button("로그인하고 계속") {
+                    onUpgrade()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.appGreen)
+                .foregroundStyle(Color.white)
+                .cornerRadius(10)
+            }
+        }
+        .padding(20)
+        .background(Color.white)
     }
 }

--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct RootView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @EnvironmentObject var myAlert: CustomAlertViewModel
+    @EnvironmentObject var authFlow: AuthFlowCoordinator
     @StateObject var loading: LoadingViewModel = LoadingViewModel()
     @State private var selectedTab = 2
     @State private var tabbarHidden = false
@@ -74,6 +75,14 @@ struct RootView: View {
                     LoadingView()
                 }
             })
+            .sheet(item: $authFlow.pendingUpgradeRequest) { request in
+                MemberUpgradeSheetView(
+                    request: request,
+                    onUpgrade: { authFlow.proceedToSignIn() },
+                    onLater: { authFlow.dismissUpgradeRequest() }
+                )
+                .presentationDetents([.medium])
+            }
 
     }
 }

--- a/dogArea/Views/ImageGeneratorView/TextToImageView.swift
+++ b/dogArea/Views/ImageGeneratorView/TextToImageView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import Foundation
 import Observation
 struct TextToImageView: View {
+    @EnvironmentObject var authFlow: AuthFlowCoordinator
     @Bindable var vm = ImageGenerateViewModel()
     var body: some View {
         VStack {
@@ -25,6 +26,9 @@ struct TextToImageView: View {
                     .textFieldStyle(.roundedBorder)
                     .disabled(vm.fetchPhase == .loading)
                 Button(action: {
+                    guard authFlow.requireMember(trigger: .imageGenerator) else {
+                        return
+                    }
                     Task { await vm.generateImage() }
                 }, label: {
                     Text("만들기")

--- a/dogArea/Views/MapView/MapSubViews/StartButtonView.swift
+++ b/dogArea/Views/MapView/MapSubViews/StartButtonView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct StartButtonView: View {
     @ObservedObject var viewModel: MapViewModel
     @ObservedObject var myAlert: CustomAlertViewModel
+    @EnvironmentObject var authFlow: AuthFlowCoordinator
     @Binding var isModalPresented: Bool
     @Binding var endWalkingViewPresented: Bool
     @State var isMeter: Bool = true
@@ -30,6 +31,9 @@ struct StartButtonView: View {
                 .frame(width: 64, height: 64)
                 .onTapGesture {
                     if !viewModel.isWalking {
+                        guard authFlow.requireMember(trigger: .walkStart) else {
+                            return
+                        }
                         viewModel.reloadSelectedPetContext()
                         guard viewModel.hasSelectedPet else {
                             myAlert.callAlert(

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import _MapKit_SwiftUI
 struct MapView : View{
     @EnvironmentObject var loading: LoadingViewModel
+    @EnvironmentObject var authFlow: AuthFlowCoordinator
     @ObservedObject var myAlert: CustomAlertViewModel = .init()
     @ObservedObject var viewModel: MapViewModel = .init()
     @State private var isModalPresented = false
@@ -52,6 +53,9 @@ struct MapView : View{
                 }
                 if viewModel.hasSyncOutboxStatus {
                     syncOutboxBanner
+                }
+                if authFlow.isGuestMode && !viewModel.isWalking && !viewModel.polygonList.isEmpty {
+                    guestBackupBanner
                 }
                 Spacer()
                 
@@ -244,6 +248,28 @@ struct MapView : View{
             .background(Color.white.opacity(0.9))
             .cornerRadius(8)
             .padding(.top, 2)
+    }
+
+    var guestBackupBanner: some View {
+        HStack(spacing: 8) {
+            Text("게스트 기록은 이 기기에만 저장돼요.")
+                .font(.appFont(for: .Light, size: 11))
+                .foregroundStyle(Color.appTextDarkGray)
+            Spacer()
+            Button("로그인하고 백업") {
+                _ = authFlow.requireMember(trigger: .walkBackup)
+            }
+            .font(.appFont(for: .SemiBold, size: 11))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(Color.appYellow)
+            .cornerRadius(8)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.white.opacity(0.9))
+        .cornerRadius(8)
+        .padding(.top, 2)
     }
 
     var addPointBtn: some View {

--- a/dogArea/Views/SigningView/PetProfileSettingView.swift
+++ b/dogArea/Views/SigningView/PetProfileSettingView.swift
@@ -11,9 +11,16 @@ struct PetProfileSettingView: View {
     @Environment(\.colorScheme) var scheme
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var viewModel: SigningViewModel
-    @State var rootViewAppear: Bool = false
     @Binding var path: NavigationPath
     @State var imageSelect: Bool = false
+    @State private var didCompleteSignup: Bool = false
+    let onSignupCompleted: () -> Void
+
+    init(path: Binding<NavigationPath>, onSignupCompleted: @escaping () -> Void = {}) {
+        self._path = path
+        self.onSignupCompleted = onSignupCompleted
+    }
+
     var body: some View {
         VStack {
             TitleTextView(title: "강아지 사진",type: .MediumTitle, subTitle: "강아지 사진을 추가해주세요!")
@@ -45,9 +52,6 @@ struct PetProfileSettingView: View {
             Spacer()
             Button(action: {
                 viewModel.setValue()
-                if viewModel.loading == .success {
-                    rootViewAppear.toggle()
-                }
             }, label: {
                 Text("회원 가입하기")
             })
@@ -62,9 +66,12 @@ struct PetProfileSettingView: View {
                 LoadingView()
             }
         })
-        .fullScreenCover(isPresented: .constant(viewModel.loading == .success), content: {
-            RootView()
-        })
+        .onChange(of: viewModel.loading) { state in
+            guard didCompleteSignup == false else { return }
+            if state == .success {
+                didCompleteSignup = true
+                onSignupCompleted()
+            }
+        }
     }
 }
-

--- a/dogArea/Views/SigningView/ProfileSettingsView.swift
+++ b/dogArea/Views/SigningView/ProfileSettingsView.swift
@@ -12,6 +12,18 @@ struct ProfileSettingsView: View {
     @Binding var path: NavigationPath
     @StateObject var viewModel: SigningViewModel
     @State var imageSelect: Bool = false
+    let onSignupCompleted: () -> Void
+
+    init(
+        path: Binding<NavigationPath>,
+        viewModel: SigningViewModel,
+        onSignupCompleted: @escaping () -> Void = {}
+    ) {
+        self._path = path
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.onSignupCompleted = onSignupCompleted
+    }
+
     var body: some View {
         VStack {
             TitleTextView(title: "프로필 사진",type: .MediumTitle, subTitle: "프로필 사진을 추가해주세요!")
@@ -43,7 +55,7 @@ struct ProfileSettingsView: View {
             }
             Spacer()
             NavigationLink(destination: {
-                PetProfileSettingView(path: $path).environmentObject(viewModel)}
+                PetProfileSettingView(path: $path, onSignupCompleted: onSignupCompleted).environmentObject(viewModel)}
                            , label: {Text("다음 단계로")})
             .disabled(viewModel.userName.isEmpty)
             .padding()

--- a/dogArea/Views/SigningView/SignInView.swift
+++ b/dogArea/Views/SigningView/SignInView.swift
@@ -13,81 +13,113 @@ struct SignInView: View {
     @Environment(\.colorScheme) var scheme
     @State var userId: AppleUserInfo? = nil
     @State var path = NavigationPath()
+    let allowDismiss: Bool
+    let onAuthenticated: () -> Void
+    let onDismiss: () -> Void
+
+    init(
+        allowDismiss: Bool = false,
+        onAuthenticated: @escaping () -> Void = {},
+        onDismiss: @escaping () -> Void = {}
+    ) {
+        self.allowDismiss = allowDismiss
+        self.onAuthenticated = onAuthenticated
+        self.onDismiss = onDismiss
+    }
+
     var body: some View {
         NavigationStack(path: $path) {
             VStack {
                 TitleTextView(title: "로그인/회원가입", subTitle: "계정 정보가 필요해요!")
                 Spacer()
-                AppleSigninButton(userId: $userId)
+                AppleSigninButton(userId: $userId, onAuthenticated: onAuthenticated)
             }
             .navigationDestination(item: $userId, destination: { info in
-                ProfileSettingsView(path: $path,viewModel: .init(info: info))
+                ProfileSettingsView(
+                    path: $path,
+                    viewModel: .init(info: info),
+                    onSignupCompleted: onAuthenticated
+                )
             })
             .frame(maxHeight: .infinity)
             .background(Color.appColor(type: .appYellowPale, scheme: scheme))
+            .toolbar {
+                if allowDismiss {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("나중에") {
+                            onDismiss()
+                        }
+                    }
+                }
+            }
         }
     }
 }
 struct AppleSigninButton : View{
     @Binding var userId: AppleUserInfo?
-    @State var isLogined: Bool = false
+    let onAuthenticated: () -> Void
+    @State private var isAuthenticating: Bool = false
+
     var body: some View{
-        SignInWithAppleButton(
-            onRequest: { request in
-                request.requestedScopes = [.fullName, .email]
-            },
-            onCompletion: { result in
-//                #if DEBUG
-//                UserdefaultSetting().removeAll()
-//                #endif
-                switch result {
-                case .success(let authResults):
-//                    print("Apple Login Successful")
-                    switch authResults.credential{
-                    case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                        // 계정 정보 가져오기
-                        let userInfo = UserdefaultSetting().getValue()
-                        let UserIdentifier = appleIDCredential.user
-                        let fullName = appleIDCredential.fullName
-                        let name =  (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
-                        if userInfo?.name == UserIdentifier {
-                            guard userInfo != nil else { return }
-                            isLogined.toggle()
-                            // 첫 가입 아님(이미 가입함)
-                        } else {
-                            guard let identityTokenData = appleIDCredential.identityToken,
-                                  let identityToken = String(data: identityTokenData, encoding: .utf8) else {
-                                print("identity token missing")
-                                return
-                            }
-                            if appleIDCredential.authorizationCode == nil {
-                                print("authorization code missing")
-                            }
-                            let credential = OAuthProvider.credential(withProviderID: "apple.com",
-                                                                      idToken: identityToken,
-                                                                      rawNonce: nil)
-                            Auth.auth().signIn(with: credential){ _, error in
-                                guard error == nil else {
-                                    print(error?.localizedDescription)
+        VStack(spacing: 8) {
+            SignInWithAppleButton(
+                onRequest: { request in
+                    request.requestedScopes = [.fullName, .email]
+                },
+                onCompletion: { result in
+                    switch result {
+                    case .success(let authResults):
+                        isAuthenticating = true
+                        switch authResults.credential{
+                        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+                            let userInfo = UserdefaultSetting().getValue()
+                            let userIdentifier = appleIDCredential.user
+                            let fullName = appleIDCredential.fullName
+                            let name =  (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
+                            if userInfo?.id == userIdentifier {
+                                isAuthenticating = false
+                                onAuthenticated()
+                            } else {
+                                guard let identityTokenData = appleIDCredential.identityToken,
+                                      let identityToken = String(data: identityTokenData, encoding: .utf8) else {
+                                    isAuthenticating = false
+                                    print("identity token missing")
                                     return
                                 }
-                                userId = .init(createdAt: Date().timeIntervalSince1970, id: appleIDCredential.user, name: name)
+                                if appleIDCredential.authorizationCode == nil {
+                                    print("authorization code missing")
+                                }
+                                let credential = OAuthProvider.credential(withProviderID: "apple.com",
+                                                                          idToken: identityToken,
+                                                                          rawNonce: nil)
+                                Auth.auth().signIn(with: credential){ _, error in
+                                    isAuthenticating = false
+                                    guard error == nil else {
+                                        print(error?.localizedDescription ?? "apple sign in failed")
+                                        return
+                                    }
+                                    userId = .init(createdAt: Date().timeIntervalSince1970, id: appleIDCredential.user, name: name)
+                                }
                             }
+                            
+                        default:
+                            isAuthenticating = false
+                            break
                         }
-
-                    default:
-                        break
+                    case .failure(let error):
+                        isAuthenticating = false
+                        print(error.localizedDescription)
                     }
-                case .failure(let error):
-                    print(error.localizedDescription)
                 }
+            )
+            .frame(width : UIScreen.main.bounds.width * 0.9, height:50)
+            .cornerRadius(5)
+
+            if isAuthenticating {
+                ProgressView("로그인 처리 중...")
+                    .font(.appFont(for: .Regular, size: 12))
             }
-        )
-        .frame(width : UIScreen.main.bounds.width * 0.9, height:50)
-        .cornerRadius(5)
-        .fullScreenCover(isPresented: $isLogined, content: {
-            RootView()
-        })
+        }
 
     }
 }

--- a/dogArea/Views/WalkListView/WalkListView.swift
+++ b/dogArea/Views/WalkListView/WalkListView.swift
@@ -11,11 +11,17 @@ struct WalkListView: View {
     @StateObject var tabStatus = TabAppear.shared
     @ObservedObject private var viewModel = WalkListViewModel()
     @State private var scrollPosition: CGFloat = 0
+    @EnvironmentObject var authFlow: AuthFlowCoordinator
     @Environment(\.colorScheme) var scheme
     var body: some View {
         NavigationStack {
             ScrollView {
                 LazyVStack(pinnedViews: [.sectionHeaders]) {
+                    if authFlow.isGuestMode {
+                        guestUpgradeCard
+                            .padding(.horizontal, 16)
+                            .padding(.top, 10)
+                    }
                     Section(content: {
                         VStack {
                             ForEach(viewModel.walkingDatas.thisWeekList.reversed(), id:\.self) { walk in
@@ -47,7 +53,7 @@ struct WalkListView: View {
                                     .cornerRadius(15)
                                     .overlay(
                                         RoundedRectangle(cornerRadius: 15)
-                                        /Users/gimtaehun/멋사/dogArea/dogArea/Views/WalkListView/WalkListSubView                   .stroke(Color.appTextDarkGray, lineWidth: 0.3)
+                                            .stroke(Color.appTextDarkGray, lineWidth: 0.3)
                                     )
                                     .padding(.horizontal, 15)
 
@@ -74,6 +80,34 @@ struct WalkListView: View {
             }.navigationTitle("산책 목록")
                 .font(.appFont(for: .ExtraBold, size: 36))
         }
+    }
+
+    var guestUpgradeCard: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("게스트 모드")
+                    .font(.appFont(for: .SemiBold, size: 13))
+                Text("로그인하면 산책 기록을 백업하고 다른 기기와 동기화할 수 있어요.")
+                    .font(.appFont(for: .Light, size: 11))
+                    .foregroundStyle(Color.appTextDarkGray)
+            }
+            Spacer()
+            Button("로그인") {
+                _ = authFlow.requireMember(trigger: .walkHistory)
+            }
+            .font(.appFont(for: .SemiBold, size: 12))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(Color.appYellow)
+            .cornerRadius(8)
+        }
+        .padding(10)
+        .background(Color.white)
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.appTextDarkGray, lineWidth: 0.25)
+        )
     }
 }
 

--- a/dogArea/dogAreaApp.swift
+++ b/dogArea/dogAreaApp.swift
@@ -25,6 +25,7 @@ struct dogAreaApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     @State var splash = true
+    @StateObject private var authFlow = AuthFlowCoordinator()
     let persistenceController = PersistenceController.shared
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
@@ -52,14 +53,59 @@ struct dogAreaApp: App {
             } else {
                 RootView()
                     .environmentObject(CustomAlertViewModel())
-                    .fullScreenCover(isPresented: .constant(
-                        UserdefaultSetting().getValue()?.id == nil
-//                        true
-                    ), content: {
-                        SignInView()
+                    .environmentObject(authFlow)
+                    .onAppear {
+                        authFlow.refresh()
+                    }
+                    .sheet(isPresented: $authFlow.shouldShowEntryChoice) {
+                        GuestEntryChoiceSheet(
+                            onContinueAsGuest: { authFlow.continueAsGuest() },
+                            onSignIn: { authFlow.chooseSignInFromEntry() }
+                        )
+                        .presentationDetents([.medium])
+                        .interactiveDismissDisabled(true)
+                    }
+                    .fullScreenCover(isPresented: $authFlow.shouldShowSignIn, content: {
+                        SignInView(
+                            allowDismiss: true,
+                            onAuthenticated: { authFlow.completeSignIn() },
+                            onDismiss: { authFlow.dismissSignIn() }
+                        )
                     })
             }
         }
         .modelContainer(sharedModelContainer)
+    }
+}
+
+private struct GuestEntryChoiceSheet: View {
+    let onContinueAsGuest: () -> Void
+    let onSignIn: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("DogArea 시작 방법 선택")
+                .font(.appFont(for: .Bold, size: 24))
+            Text("지금은 바로 시작하고, 필요할 때 로그인해서 기록을 동기화할 수 있어요.")
+                .font(.appFont(for: .Regular, size: 14))
+                .foregroundStyle(Color.appTextDarkGray)
+            Button("바로 시작") {
+                onContinueAsGuest()
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(Color.appYellowPale)
+            .foregroundStyle(Color.appTextDarkGray)
+            .cornerRadius(12)
+            Button("로그인하고 동기화") {
+                onSignIn()
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(Color.appGreen)
+            .foregroundStyle(Color.white)
+            .cornerRadius(12)
+        }
+        .padding(20)
     }
 }

--- a/scripts/guest_upgrade_ux_unit_check.swift
+++ b/scripts/guest_upgrade_ux_unit_check.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct Check {
+    static var failed = false
+
+    static func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            print("[PASS] \(message)")
+        } else {
+            failed = true
+            print("[FAIL] \(message)")
+        }
+    }
+}
+
+func read(_ path: String) -> String {
+    (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+}
+
+let app = read("dogArea/dogAreaApp.swift")
+let root = read("dogArea/Views/GlobalViews/BaseView/RootView.swift")
+let signIn = read("dogArea/Views/SigningView/SignInView.swift")
+let mapStart = read("dogArea/Views/MapView/MapSubViews/StartButtonView.swift")
+let image = read("dogArea/Views/ImageGeneratorView/TextToImageView.swift")
+let walkList = read("dogArea/Views/WalkListView/WalkListView.swift")
+let source = read("dogArea/Source/UserdefaultSetting.swift")
+
+Check.assertTrue(app.contains("GuestEntryChoiceSheet"), "app should expose first-run split sheet")
+Check.assertTrue(app.contains("shouldShowSignIn"), "app should control sign-in cover via coordinator")
+Check.assertTrue(root.contains("pendingUpgradeRequest"), "root should host shared upgrade bottom sheet")
+Check.assertTrue(source.contains("final class AuthFlowCoordinator"), "auth flow coordinator must exist")
+Check.assertTrue(source.contains("MemberUpgradeSheetView"), "shared upgrade sheet view must exist")
+Check.assertTrue(signIn.contains("allowDismiss"), "sign-in should support later/cancel path")
+Check.assertTrue(signIn.contains("onAuthenticated"), "sign-in should use callback completion")
+Check.assertTrue(mapStart.contains("requireMember(trigger: .walkStart)"), "walk start should be member-gated")
+Check.assertTrue(image.contains("requireMember(trigger: .imageGenerator)"), "image generation should be member-gated")
+Check.assertTrue(walkList.contains("requireMember(trigger: .walkHistory)"), "walk list should provide login-to-sync path")
+
+if Check.failed {
+    exit(1)
+}
+
+print("All guest upgrade UX checks passed.")


### PR DESCRIPTION
## Summary
- 첫 실행 진입 분기("바로 시작" / "로그인하고 동기화") 추가
- 회원 전용 액션 공통 잠금 바텀시트(`MemberUpgradeSheetView`) 도입
- 로그인 성공 시 `RootView` 재생성 대신 콜백 복귀로 컨텍스트 유지
- 적용 지점: 산책 시작, 이미지 생성, 산책 목록 동기화 CTA, 지도 백업 배너
- 문서/유닛체크 추가: `docs/guest-upgrade-ux-v1.md`, `scripts/guest_upgrade_ux_unit_check.swift`

## Test
- `swift scripts/guest_upgrade_ux_unit_check.swift`
- `swift scripts/walk_start_stop_ux_unit_check.swift`
- `swift scripts/release_regression_checklist_unit_check.swift`

## Notes
- 전체 `xcodebuild`는 작업 머신 디스크 여유 부족(100~500MB 구간)으로 안정 실행이 불가해 스크립트 기반 검증으로 대체했습니다.

Closes #77
