### PR TITLE
feat: 게스트 데이터 회원 승격 이관 플로우 구현 (#76)

### DIFF
--- a/docs/guest-data-upgrade-v1.md
+++ b/docs/guest-data-upgrade-v1.md
@@ -1,0 +1,40 @@
+# Guest Data Upgrade Flow v1 (Issue #76)
+
+## 목표
+- 로그인 직후 로컬 게스트 산책 데이터를 회원 계정으로 안전하게 승격한다.
+- 동일 데이터 재실행 시 중복 적재/중복 반영 없이 멱등적으로 수렴한다.
+- 실패 시 데이터 손실 없이 재시도 가능 상태를 유지한다.
+
+## 구현 요약
+1. 감지
+- 로그인 완료 시 `GuestDataUpgradeService.pendingPrompt(for:)`로 로컬 스냅샷을 계산한다.
+- 스냅샷(`sessionCount`, `pointCount`, `area`, `duration`, `signature`)이 있고,
+  사용자별 완료 signature와 다르면 가져오기 시트를 띄운다.
+
+2. 이관
+- 각 로컬 폴리곤(session)을 `SyncOutboxStore.enqueueWalkStages`로
+  `session -> points -> meta` 3단계 큐에 적재한다.
+- `idempotencyKey = walk-{sessionId}-{stage}` 를 재사용한다.
+- 큐 flush를 즉시 1회 실행하고 결과를 리포트로 저장한다.
+
+3. 재시도
+- 영구실패 항목은 `requeuePermanentFailures`로 재큐잉 가능.
+- 로그인 후 이전 리포트에 미처리 항목이 있으면 시트가 재시도 모드로 노출된다.
+
+4. 결과 피드백
+- `RootView` 상단 배너: 진행중/완료/재시도 상태 표시
+- `HomeView` 카드: 최근 이관 리포트(세션/포인트/면적) 표시
+
+## 멱등성 규칙
+- 로컬 큐 적재는 동일 `idempotencyKey`가 이미 있으면 상태와 무관하게 재적재하지 않는다.
+- 서버 측 중복 충돌(409)은 성공으로 간주해 누적값 왜곡을 방지한다.
+
+## 저장 키
+- 리포트: `guest.data.upgrade.report.v1.<stableUserKey>`
+- 완료 signature: `guest.data.upgrade.signature.v1.<stableUserKey>`
+
+## QA 체크
+- [ ] 게스트 산책 데이터 보유 상태에서 로그인 시 가져오기 시트 노출
+- [ ] 가져오기 실행 후 리포트/배너/홈 카드 갱신
+- [ ] 동일 데이터 재실행 시 outbox 중복 적재 없음
+- [ ] 실패 후 재시도로 상태 회복 가능

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -8,6 +8,7 @@
 import Foundation
 import CryptoKit
 import SwiftUI
+import CoreData
 class UserdefaultSetting {
     enum keyValue: String {
         case userId = "userId"
@@ -686,7 +687,7 @@ final class SyncOutboxStore {
         var mutableItems = items
         stagePayloads.forEach { stage, payload in
             let idempotencyKey = "\(baseKey)-\(stage.rawValue)"
-            let exists = mutableItems.contains(where: { $0.idempotencyKey == idempotencyKey && $0.status != .completed })
+            let exists = mutableItems.contains(where: { $0.idempotencyKey == idempotencyKey })
             guard exists == false else { return }
             mutableItems.append(
                 SyncOutboxItem(
@@ -765,6 +766,24 @@ final class SyncOutboxStore {
             }
         }
         return summary()
+    }
+
+    func requeuePermanentFailures(walkSessionIds: Set<String>? = nil) {
+        lock.lock()
+        let now = Date().timeIntervalSince1970
+        for index in items.indices {
+            guard items[index].status == .permanentFailed else { continue }
+            if let walkSessionIds, walkSessionIds.contains(items[index].walkSessionId) == false {
+                continue
+            }
+            items[index].status = .retrying
+            items[index].retryCount = 0
+            items[index].nextRetryAt = now
+            items[index].lastErrorCode = nil
+            items[index].updatedAt = now
+        }
+        persistLocked()
+        lock.unlock()
     }
 
     private static func retryDelay(retryCount: Int) -> TimeInterval {
@@ -920,14 +939,178 @@ struct MemberUpgradeRequest: Identifiable {
     let trigger: MemberUpgradeTrigger
 }
 
+struct GuestDataUpgradeSnapshot: Equatable {
+    let sessionCount: Int
+    let pointCount: Int
+    let totalAreaM2: Double
+    let totalDurationSec: Double
+    let sessionIds: [String]
+    let signature: String
+}
+
+struct GuestDataUpgradeReport: Codable, Equatable, Identifiable {
+    var id: String { userId + ":" + signature }
+    let userId: String
+    let signature: String
+    let sessionCount: Int
+    let pointCount: Int
+    let totalAreaM2: Double
+    let totalDurationSec: Double
+    let pendingCount: Int
+    let permanentFailureCount: Int
+    let lastErrorCode: String?
+    let executedAt: TimeInterval
+
+    var hasOutstandingWork: Bool {
+        pendingCount > 0 || permanentFailureCount > 0
+    }
+}
+
+struct GuestDataUpgradePrompt: Identifiable {
+    let id = UUID()
+    let snapshot: GuestDataUpgradeSnapshot
+    let shouldEmphasizeRetry: Bool
+}
+
+final class GuestDataUpgradeService: CoreDataProtocol {
+    static let shared = GuestDataUpgradeService()
+
+    private let syncOutbox = SyncOutboxStore.shared
+    private let syncTransport = SupabaseSyncOutboxTransport()
+    private let reportStoragePrefix = "guest.data.upgrade.report.v1."
+    private let acknowledgedSignaturePrefix = "guest.data.upgrade.signature.v1."
+
+    private init() {}
+
+    func pendingPrompt(for userId: String) -> GuestDataUpgradePrompt? {
+        guard let snapshot = localSnapshot(), snapshot.sessionCount > 0 else { return nil }
+        let report = latestReport(for: userId)
+        let acknowledgedSignature = UserDefaults.standard.string(forKey: signatureKey(for: userId))
+        if acknowledgedSignature == snapshot.signature, report?.hasOutstandingWork == false {
+            return nil
+        }
+        return GuestDataUpgradePrompt(
+            snapshot: snapshot,
+            shouldEmphasizeRetry: report?.hasOutstandingWork == true
+        )
+    }
+
+    func latestReport(for userId: String) -> GuestDataUpgradeReport? {
+        guard let data = UserDefaults.standard.data(forKey: reportKey(for: userId)),
+              let decoded = try? JSONDecoder().decode(GuestDataUpgradeReport.self, from: data) else {
+            return nil
+        }
+        return decoded
+    }
+
+    func runUpgrade(for userId: String, forceRetry: Bool = false) async -> GuestDataUpgradeReport? {
+        guard let snapshot = localSnapshot(), snapshot.sessionCount > 0 else { return nil }
+
+        if forceRetry {
+            syncOutbox.requeuePermanentFailures(walkSessionIds: Set(snapshot.sessionIds))
+        }
+
+        for polygon in fetchPolygons() {
+            syncOutbox.enqueueWalkStages(
+                walkSessionId: polygon.id,
+                userId: userId,
+                pointCount: polygon.locations.count,
+                durationSec: polygon.walkingTime,
+                areaM2: polygon.walkingArea,
+                hasImage: polygon.binaryImage != nil,
+                createdAt: polygon.createdAt
+            )
+        }
+
+        let summary = await syncOutbox.flush(using: syncTransport, now: Date())
+        let report = GuestDataUpgradeReport(
+            userId: userId,
+            signature: snapshot.signature,
+            sessionCount: snapshot.sessionCount,
+            pointCount: snapshot.pointCount,
+            totalAreaM2: snapshot.totalAreaM2,
+            totalDurationSec: snapshot.totalDurationSec,
+            pendingCount: summary.pendingCount,
+            permanentFailureCount: summary.permanentFailureCount,
+            lastErrorCode: summary.lastErrorCode?.rawValue,
+            executedAt: Date().timeIntervalSince1970
+        )
+
+        persist(report: report, for: userId)
+        if report.hasOutstandingWork == false {
+            UserDefaults.standard.set(snapshot.signature, forKey: signatureKey(for: userId))
+        }
+        return report
+    }
+
+    private func localSnapshot() -> GuestDataUpgradeSnapshot? {
+        let polygons = fetchPolygons()
+        guard polygons.isEmpty == false else { return nil }
+
+        let sessionIds = polygons.map { $0.id.uuidString.lowercased() }.sorted()
+        let pointCount = polygons.reduce(0) { $0 + $1.locations.count }
+        let totalArea = polygons.reduce(0.0) { $0 + $1.walkingArea }
+        let totalDuration = polygons.reduce(0.0) { $0 + $1.walkingTime }
+        let signature = signatureForSnapshot(
+            sessionIds: sessionIds,
+            pointCount: pointCount,
+            totalAreaM2: totalArea,
+            totalDurationSec: totalDuration
+        )
+        return GuestDataUpgradeSnapshot(
+            sessionCount: sessionIds.count,
+            pointCount: pointCount,
+            totalAreaM2: totalArea,
+            totalDurationSec: totalDuration,
+            sessionIds: sessionIds,
+            signature: signature
+        )
+    }
+
+    private func persist(report: GuestDataUpgradeReport, for userId: String) {
+        guard let data = try? JSONEncoder().encode(report) else { return }
+        UserDefaults.standard.set(data, forKey: reportKey(for: userId))
+    }
+
+    private func reportKey(for userId: String) -> String {
+        reportStoragePrefix + stableKey(from: userId)
+    }
+
+    private func signatureKey(for userId: String) -> String {
+        acknowledgedSignaturePrefix + stableKey(from: userId)
+    }
+
+    private func signatureForSnapshot(
+        sessionIds: [String],
+        pointCount: Int,
+        totalAreaM2: Double,
+        totalDurationSec: Double
+    ) -> String {
+        let payload = sessionIds.joined(separator: "|")
+        + "|p:\(pointCount)"
+        + "|a:\(totalAreaM2)"
+        + "|t:\(totalDurationSec)"
+        return stableKey(from: payload)
+    }
+
+    private func stableKey(from raw: String) -> String {
+        let digest = SHA256.hash(data: Data(raw.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
 @MainActor
 final class AuthFlowCoordinator: ObservableObject {
     @Published var shouldShowEntryChoice: Bool = false
     @Published var shouldShowSignIn: Bool = false
     @Published var pendingUpgradeRequest: MemberUpgradeRequest? = nil
+    @Published var pendingGuestDataUpgradePrompt: GuestDataUpgradePrompt? = nil
+    @Published var guestDataUpgradeInProgress: Bool = false
+    @Published var guestDataUpgradeResult: GuestDataUpgradeReport? = nil
 
     private let guestModeKey = "auth.guest_mode.v1"
     private let entryChoiceCompletedKey = "auth.entry_choice_completed.v1"
+    private let guestDataUpgradeService = GuestDataUpgradeService.shared
     private var onAuthenticated: (() -> Void)?
 
     var isLoggedIn: Bool {
@@ -948,6 +1131,9 @@ final class AuthFlowCoordinator: ObservableObject {
             pendingUpgradeRequest = nil
             return
         }
+        pendingGuestDataUpgradePrompt = nil
+        guestDataUpgradeInProgress = false
+        guestDataUpgradeResult = nil
         let didChooseEntryPath = UserDefaults.standard.bool(forKey: entryChoiceCompletedKey)
         shouldShowEntryChoice = !didChooseEntryPath
     }
@@ -993,12 +1179,46 @@ final class AuthFlowCoordinator: ObservableObject {
         onAuthenticated = nil
     }
 
+    func dismissGuestDataUpgradePrompt() {
+        pendingGuestDataUpgradePrompt = nil
+    }
+
+    func clearGuestDataUpgradeResult() {
+        guestDataUpgradeResult = nil
+    }
+
+    func startGuestDataUpgrade(forceRetry: Bool = false) {
+        guard let userId = UserdefaultSetting.shared.getValue()?.id, userId.isEmpty == false else {
+            return
+        }
+        pendingGuestDataUpgradePrompt = nil
+        guestDataUpgradeInProgress = true
+        Task {
+            let report = await guestDataUpgradeService.runUpgrade(for: userId, forceRetry: forceRetry)
+            await MainActor.run {
+                self.guestDataUpgradeInProgress = false
+                self.guestDataUpgradeResult = report
+            }
+        }
+    }
+
+    func latestGuestDataUpgradeReport() -> GuestDataUpgradeReport? {
+        guard let userId = UserdefaultSetting.shared.getValue()?.id, userId.isEmpty == false else {
+            return nil
+        }
+        return guestDataUpgradeService.latestReport(for: userId)
+    }
+
     func completeSignIn() {
         UserDefaults.standard.set(false, forKey: guestModeKey)
         UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
         shouldShowSignIn = false
         shouldShowEntryChoice = false
         pendingUpgradeRequest = nil
+        if let userId = UserdefaultSetting.shared.getValue()?.id, userId.isEmpty == false {
+            pendingGuestDataUpgradePrompt = guestDataUpgradeService.pendingPrompt(for: userId)
+            guestDataUpgradeResult = guestDataUpgradeService.latestReport(for: userId)
+        }
         let completion = onAuthenticated
         onAuthenticated = nil
         completion?()
@@ -1037,6 +1257,52 @@ struct MemberUpgradeSheetView: View {
 
                 Button("로그인하고 계속") {
                     onUpgrade()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.appGreen)
+                .foregroundStyle(Color.white)
+                .cornerRadius(10)
+            }
+        }
+        .padding(20)
+        .background(Color.white)
+    }
+}
+
+struct GuestDataUpgradePromptSheetView: View {
+    let prompt: GuestDataUpgradePrompt
+    let onImport: () -> Void
+    let onLater: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(prompt.shouldEmphasizeRetry ? "산책 데이터 이관 재시도" : "게스트 산책 데이터 가져오기")
+                .font(.appFont(for: .Bold, size: 22))
+                .foregroundStyle(Color.appTextDarkGray)
+            Text("로그인 전에 기록한 산책 데이터를 계정으로 이관합니다. 중복 없이 안전하게 처리돼요.")
+                .font(.appFont(for: .Regular, size: 14))
+                .foregroundStyle(Color.appTextDarkGray)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("세션 \(prompt.snapshot.sessionCount)건")
+                Text("포인트 \(prompt.snapshot.pointCount)건")
+                Text("누적 면적 \(prompt.snapshot.totalAreaM2.calculatedAreaString)")
+                Text("누적 시간 \(prompt.snapshot.totalDurationSec.walkingTimeInterval)")
+            }
+            .font(.appFont(for: .Regular, size: 13))
+            .foregroundStyle(Color.appTextDarkGray)
+            HStack(spacing: 10) {
+                Button("나중에") {
+                    onLater()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.appYellowPale)
+                .foregroundStyle(Color.appTextDarkGray)
+                .cornerRadius(10)
+
+                Button(prompt.shouldEmphasizeRetry ? "다시 가져오기" : "가져오기") {
+                    onImport()
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)

--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -75,6 +75,28 @@ struct RootView: View {
                     LoadingView()
                 }
             })
+            .overlay(alignment: .top) {
+                if authFlow.guestDataUpgradeInProgress {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                        Text("게스트 데이터를 계정으로 이관 중...")
+                            .font(.appFont(for: .Regular, size: 12))
+                            .foregroundStyle(Color.appTextDarkGray)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color.white.opacity(0.95))
+                    .cornerRadius(10)
+                    .padding(.top, 12)
+                } else if let report = authFlow.guestDataUpgradeResult {
+                    GuestDataUpgradeResultBanner(
+                        report: report,
+                        onRetry: { authFlow.startGuestDataUpgrade(forceRetry: true) },
+                        onDismiss: { authFlow.clearGuestDataUpgradeResult() }
+                    )
+                    .padding(.top, 12)
+                }
+            }
             .sheet(item: $authFlow.pendingUpgradeRequest) { request in
                 MemberUpgradeSheetView(
                     request: request,
@@ -83,7 +105,58 @@ struct RootView: View {
                 )
                 .presentationDetents([.medium])
             }
+            .sheet(item: $authFlow.pendingGuestDataUpgradePrompt) { prompt in
+                GuestDataUpgradePromptSheetView(
+                    prompt: prompt,
+                    onImport: { authFlow.startGuestDataUpgrade(forceRetry: prompt.shouldEmphasizeRetry) },
+                    onLater: { authFlow.dismissGuestDataUpgradePrompt() }
+                )
+                .presentationDetents([.medium])
+            }
 
+    }
+}
+
+private struct GuestDataUpgradeResultBanner: View {
+    let report: GuestDataUpgradeReport
+    let onRetry: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(report.hasOutstandingWork ? "데이터 이관 진행 중" : "데이터 이관 완료")
+                .font(.appFont(for: .SemiBold, size: 13))
+            Text(
+                "세션 \(report.sessionCount)건 · 포인트 \(report.pointCount)건 · \(report.totalAreaM2.calculatedAreaString)"
+            )
+            .font(.appFont(for: .Light, size: 11))
+            .foregroundStyle(Color.appTextDarkGray)
+            HStack(spacing: 10) {
+                if report.hasOutstandingWork {
+                    Button("재시도") {
+                        onRetry()
+                    }
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.appYellow)
+                    .cornerRadius(8)
+                }
+                Button("닫기") {
+                    onDismiss()
+                }
+                .font(.appFont(for: .SemiBold, size: 11))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color.appYellowPale)
+                .cornerRadius(8)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color.white.opacity(0.95))
+        .cornerRadius(12)
+        .padding(.horizontal, 12)
     }
 }
 

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -22,6 +22,11 @@ struct HomeView: View {
                     }.padding()
                     Spacer()
                 }
+                if let report = viewModel.guestDataUpgradeReport {
+                    guestDataUpgradeCard(report: report)
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 8)
+                }
                 if viewModel.pets.isEmpty == false {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: 8) {
@@ -182,6 +187,27 @@ struct HomeView: View {
             viewModel.reloadUserInfo()
             viewModel.fetchData()
         }.padding(.top,20)
+    }
+
+    @ViewBuilder
+    private func guestDataUpgradeCard(report: GuestDataUpgradeReport) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(report.hasOutstandingWork ? "데이터 이관 재시도 필요" : "게스트 데이터 이관 완료")
+                .font(.appFont(for: .SemiBold, size: 13))
+            Text(
+                "세션 \(report.sessionCount)건 · 포인트 \(report.pointCount)건 · 면적 \(report.totalAreaM2.calculatedAreaString)"
+            )
+            .font(.appFont(for: .Light, size: 11))
+            .foregroundStyle(Color.appTextDarkGray)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(Color.white)
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(report.hasOutstandingWork ? Color.appRed : Color.appGreen, lineWidth: 0.4)
+        )
     }
 }
 

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -17,6 +17,7 @@ final class HomeViewModel: ObservableObject, CoreDataProtocol {
     @Published var userInfo: UserInfo? = nil
     @Published var selectedPetId: String = ""
     @Published var selectedPet: PetInfo? = nil
+    @Published var guestDataUpgradeReport: GuestDataUpgradeReport? = nil
 
     var pets: [PetInfo] {
         userInfo?.pet ?? []
@@ -39,6 +40,7 @@ final class HomeViewModel: ObservableObject, CoreDataProtocol {
         myArea = .init("\(selectedPetNameWithYi)의 영역", totalArea)
         updateCurrentMeter()
         myAreaList = fetchArea()
+        refreshGuestDataUpgradeReport()
     }
 
     func reloadUserInfo() {
@@ -52,6 +54,14 @@ final class HomeViewModel: ObservableObject, CoreDataProtocol {
         UserdefaultSetting.shared.setSelectedPetId(petId)
         reloadUserInfo()
         myArea = .init("\(selectedPetNameWithYi)의 영역", totalArea)
+    }
+
+    func refreshGuestDataUpgradeReport() {
+        guard let userId = userInfo?.id, userId.isEmpty == false else {
+            guestDataUpgradeReport = nil
+            return
+        }
+        guestDataUpgradeReport = GuestDataUpgradeService.shared.latestReport(for: userId)
     }
 
     func refreshAreaList () {

--- a/scripts/guest_data_upgrade_unit_check.swift
+++ b/scripts/guest_data_upgrade_unit_check.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct Check {
+    static var failed = false
+
+    static func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            print("[PASS] \(message)")
+        } else {
+            failed = true
+            print("[FAIL] \(message)")
+        }
+    }
+}
+
+func read(_ path: String) -> String {
+    (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+}
+
+let source = read("dogArea/Source/UserdefaultSetting.swift")
+let root = read("dogArea/Views/GlobalViews/BaseView/RootView.swift")
+let home = read("dogArea/Views/HomeView/HomeView.swift")
+let homeVM = read("dogArea/Views/HomeView/HomeViewModel.swift")
+
+Check.assertTrue(source.contains("struct GuestDataUpgradeSnapshot"), "snapshot model must exist")
+Check.assertTrue(source.contains("struct GuestDataUpgradeReport"), "upgrade report model must exist")
+Check.assertTrue(source.contains("final class GuestDataUpgradeService"), "upgrade service must exist")
+Check.assertTrue(source.contains("func pendingPrompt(for userId:"), "service should expose prompt detection")
+Check.assertTrue(source.contains("func runUpgrade(for userId:"), "service should expose upgrade execution")
+Check.assertTrue(source.contains("requeuePermanentFailures"), "outbox should support manual retry requeue")
+Check.assertTrue(source.contains("contains(where: { $0.idempotencyKey == idempotencyKey })"), "outbox enqueue must block duplicate idempotency keys")
+Check.assertTrue(source.contains("pendingGuestDataUpgradePrompt"), "auth coordinator must track upgrade prompt state")
+Check.assertTrue(source.contains("startGuestDataUpgrade(forceRetry:"), "auth coordinator must trigger background migration")
+Check.assertTrue(root.contains("GuestDataUpgradePromptSheetView"), "root should present guest data import sheet")
+Check.assertTrue(root.contains("GuestDataUpgradeResultBanner"), "root should expose upgrade result feedback banner")
+Check.assertTrue(home.contains("guestDataUpgradeCard"), "home view should display migration report card")
+Check.assertTrue(homeVM.contains("guestDataUpgradeReport"), "home view model should load latest migration report")
+
+if Check.failed {
+    exit(1)
+}
+
+print("All guest data upgrade checks passed.")


### PR DESCRIPTION
## Summary
- 로그인 직후 로컬 게스트 산책 데이터 감지 + 가져오기 시트(`GuestDataUpgradePromptSheetView`) 추가
- `GuestDataUpgradeService` 도입: 세션/포인트/면적/시간 스냅샷 계산, outbox 이관 실행, 결과 리포트 저장
- `SyncOutboxStore` 멱등 보강: 동일 `idempotencyKey` 중복 적재 차단(상태 무관)
- 영구 실패 재시도 지원: `requeuePermanentFailures` 추가
- 결과 피드백 UI 추가
  - `RootView` 상단 진행/완료/재시도 배너
  - `HomeView` 최근 이관 리포트 카드
- 문서/검증 스크립트 추가
  - `docs/guest-data-upgrade-v1.md`
  - `scripts/guest_data_upgrade_unit_check.swift`

## Tests
- `swift scripts/guest_data_upgrade_unit_check.swift`
- `swift scripts/walk_sync_consistency_outbox_unit_check.swift`
- `swift scripts/guest_upgrade_ux_unit_check.swift`
- `swift scripts/release_regression_checklist_unit_check.swift`

## Notes
- 본 사이클은 이슈 #76의 앱측 흐름(감지/확인/이관/재시도/결과피드백)에 집중했습니다.
- 원격 QA는 기존과 동일하게 런타임 Supabase 환경변수/네트워크 상태에 따라 결과가 달라질 수 있습니다.

Closes #76
