### PR TITLE
refactor: 비회원/회원 FeatureGate 아키텍처 통합 (#75)

### DIFF
--- a/docs/feature-gate-architecture-v1.md
+++ b/docs/feature-gate-architecture-v1.md
@@ -1,0 +1,48 @@
+# FeatureGate Architecture v1 (Issue #75)
+
+## 목적
+- 세션 상태를 `guest` / `member` 2상태로 고정한다.
+- 기능 접근 판정을 단일 매트릭스(`AppFeatureGate`)로 통합한다.
+- 권한 미충족을 에러 대신 업그레이드 제안 UX로 처리한다.
+
+## 세션 모델
+- `AppSessionState.guest`
+- `AppSessionState.member(userId)`
+
+현재 세션은 `UserdefaultSetting.shared.getValue()?.id` 기반으로 산출한다.
+
+## 기능 정책 매트릭스
+- `walkRead` -> guest 허용
+- `walkWrite` -> guest 허용
+- `cloudSync` -> member 전용 (`walkHistory` 트리거)
+- `aiGeneration` -> member 전용 (`imageGenerator` 트리거)
+- `nearbySocial` -> member 전용 (`walkHistory` 트리거)
+
+## 적용 방식
+1. UI 계층
+- 뷰에서 직접 `if userId != nil`로 분기하지 않고
+  `AuthFlowCoordinator.requestAccess(feature:)` 사용
+- 차단 시 자동으로 공통 업그레이드 시트(`MemberUpgradeSheetView`) 노출
+
+2. API 계층
+- `SupabaseSyncOutboxTransport.send`에서 `cloudSync` 권한 가드 적용
+- 권한 미충족 상태에서는 네트워크 요청을 보내지 않고 즉시 반환
+
+3. 핵심 UX 보장
+- 게스트도 산책 시작/종료/목록 조회는 그대로 사용 가능
+- 회원 전용 기능만 업그레이드 유도
+
+## 반영 파일
+- `dogArea/Source/UserdefaultSetting.swift`
+- `dogArea/Views/MapView/MapSubViews/StartButtonView.swift`
+- `dogArea/Views/ImageGeneratorView/TextToImageView.swift`
+- `dogArea/Views/ImageGeneratorView/ImageGenerateViewModel.swift`
+- `dogArea/Views/WalkListView/WalkListView.swift`
+- `dogArea/Views/MapView/MapView.swift`
+- `dogArea/Views/MapView/MapViewModel.swift`
+
+## QA 체크
+- [ ] 게스트로 산책 시작/종료/목록 조회 정상 동작
+- [ ] 게스트 상태 이미지 생성 시 업그레이드 시트/차단 메시지 일관 동작
+- [ ] 게스트 상태 cloud sync API 호출 미발생
+- [ ] 로그인 후 재시작 없이 member 전용 기능 즉시 사용 가능

--- a/docs/guest-upgrade-ux-v1.md
+++ b/docs/guest-upgrade-ux-v1.md
@@ -19,7 +19,7 @@
 - 콜백 기반(`onAuthenticated`)으로 현재 컨텍스트 복귀
 
 4. 적용 지점
-- 산책 시작 버튼(`walk_start`)
+- 산책 시작 버튼은 게스트 허용(FeatureGate `walkWrite`)으로 전환
 - 텍스트-이미지 생성(`image_generator`)
 - 산책 목록 동기화 유도(`walk_history`)
 - 지도 상 백업 유도 배너(`walk_backup`)

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -836,6 +836,9 @@ final class SyncOutboxStore {
 
 struct SupabaseSyncOutboxTransport: SyncOutboxTransporting {
     func send(item: SyncOutboxItem) async -> SyncOutboxSendResult {
+        guard AppFeatureGate.isAllowed(.cloudSync, session: AppFeatureGate.currentSession()) else {
+            return .retryable(.unauthorized)
+        }
         let env = ProcessInfo.processInfo.environment
         guard let rawURL = env["SUPABASE_URL"], rawURL.isEmpty == false else {
             return .retryable(.notConfigured)
@@ -898,6 +901,70 @@ struct SupabaseSyncOutboxTransport: SyncOutboxTransporting {
         } catch {
             return .retryable(.unknown)
         }
+    }
+}
+
+enum AppSessionState: Equatable {
+    case guest
+    case member(userId: String)
+
+    var isMember: Bool {
+        if case .member = self { return true }
+        return false
+    }
+}
+
+enum FeatureCapability: String, CaseIterable {
+    case walkRead = "walk_read"
+    case walkWrite = "walk_write"
+    case cloudSync = "cloud_sync"
+    case aiGeneration = "ai_generation"
+    case nearbySocial = "nearby_social"
+}
+
+enum FeatureGateDecision: Equatable {
+    case allowed
+    case requiresMember(MemberUpgradeTrigger)
+}
+
+enum AppFeatureGate {
+    private enum AccessPolicy {
+        case guestAllowed
+        case memberOnly(trigger: MemberUpgradeTrigger)
+    }
+
+    private static let matrix: [FeatureCapability: AccessPolicy] = [
+        .walkRead: .guestAllowed,
+        .walkWrite: .guestAllowed,
+        .cloudSync: .memberOnly(trigger: .walkHistory),
+        .aiGeneration: .memberOnly(trigger: .imageGenerator),
+        .nearbySocial: .memberOnly(trigger: .walkHistory),
+    ]
+
+    static func currentSession() -> AppSessionState {
+        guard let id = UserdefaultSetting.shared.getValue()?.id, id.isEmpty == false else {
+            return .guest
+        }
+        return .member(userId: id)
+    }
+
+    static func decision(for capability: FeatureCapability, session: AppSessionState) -> FeatureGateDecision {
+        guard let policy = matrix[capability] else {
+            return .allowed
+        }
+        switch policy {
+        case .guestAllowed:
+            return .allowed
+        case .memberOnly(let trigger):
+            return session.isMember ? .allowed : .requiresMember(trigger)
+        }
+    }
+
+    static func isAllowed(_ capability: FeatureCapability, session: AppSessionState = currentSession()) -> Bool {
+        if case .allowed = decision(for: capability, session: session) {
+            return true
+        }
+        return false
     }
 }
 
@@ -1113,9 +1180,12 @@ final class AuthFlowCoordinator: ObservableObject {
     private let guestDataUpgradeService = GuestDataUpgradeService.shared
     private var onAuthenticated: (() -> Void)?
 
+    var sessionState: AppSessionState {
+        AppFeatureGate.currentSession()
+    }
+
     var isLoggedIn: Bool {
-        guard let id = UserdefaultSetting.shared.getValue()?.id else { return false }
-        return id.isEmpty == false
+        sessionState.isMember
     }
 
     var isGuestMode: Bool {
@@ -1148,6 +1218,22 @@ final class AuthFlowCoordinator: ObservableObject {
         UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
         shouldShowEntryChoice = false
         shouldShowSignIn = true
+    }
+
+    func canAccess(_ feature: FeatureCapability) -> Bool {
+        AppFeatureGate.isAllowed(feature, session: sessionState)
+    }
+
+    @discardableResult
+    func requestAccess(feature: FeatureCapability, onAllowed: (() -> Void)? = nil) -> Bool {
+        let decision = AppFeatureGate.decision(for: feature, session: sessionState)
+        switch decision {
+        case .allowed:
+            onAllowed?()
+            return true
+        case .requiresMember(let trigger):
+            return requireMember(trigger: trigger, onAuthenticated: onAllowed)
+        }
     }
 
     @discardableResult

--- a/dogArea/Views/ImageGeneratorView/ImageGenerateViewModel.swift
+++ b/dogArea/Views/ImageGeneratorView/ImageGenerateViewModel.swift
@@ -24,6 +24,10 @@ class ImageGenerateViewModel {
   }
   @MainActor
   func generateImage() async {
+    guard AppFeatureGate.isAllowed(.aiGeneration, session: AppFeatureGate.currentSession()) else {
+      self.fetchPhase = .failure("회원 전용 기능입니다. 로그인 후 다시 시도해주세요.")
+      return
+    }
     self.fetchPhase = .loading
     do {
       let url = try await client.generateImage(prompt: prompt)

--- a/dogArea/Views/ImageGeneratorView/TextToImageView.swift
+++ b/dogArea/Views/ImageGeneratorView/TextToImageView.swift
@@ -26,7 +26,7 @@ struct TextToImageView: View {
                     .textFieldStyle(.roundedBorder)
                     .disabled(vm.fetchPhase == .loading)
                 Button(action: {
-                    guard authFlow.requireMember(trigger: .imageGenerator) else {
+                    guard authFlow.requestAccess(feature: .aiGeneration) else {
                         return
                     }
                     Task { await vm.generateImage() }

--- a/dogArea/Views/MapView/MapSubViews/StartButtonView.swift
+++ b/dogArea/Views/MapView/MapSubViews/StartButtonView.swift
@@ -31,7 +31,7 @@ struct StartButtonView: View {
                 .frame(width: 64, height: 64)
                 .onTapGesture {
                     if !viewModel.isWalking {
-                        guard authFlow.requireMember(trigger: .walkStart) else {
+                        guard authFlow.requestAccess(feature: .walkWrite) else {
                             return
                         }
                         viewModel.reloadSelectedPetContext()

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -54,7 +54,7 @@ struct MapView : View{
                 if viewModel.hasSyncOutboxStatus {
                     syncOutboxBanner
                 }
-                if authFlow.isGuestMode && !viewModel.isWalking && !viewModel.polygonList.isEmpty {
+                if !authFlow.canAccess(.cloudSync) && !viewModel.isWalking && !viewModel.polygonList.isEmpty {
                     guestBackupBanner
                 }
                 Spacer()
@@ -257,7 +257,7 @@ struct MapView : View{
                 .foregroundStyle(Color.appTextDarkGray)
             Spacer()
             Button("로그인하고 백업") {
-                _ = authFlow.requireMember(trigger: .walkBackup)
+                _ = authFlow.requestAccess(feature: .cloudSync)
             }
             .font(.appFont(for: .SemiBold, size: 11))
             .padding(.horizontal, 8)

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -386,6 +386,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     }
 
     private func enqueueSyncOutbox(for polygon: Polygon, hasImage: Bool) {
+        guard isCloudSyncAvailableForSession else { return }
         syncOutbox.enqueueWalkStages(
             walkSessionId: polygon.id,
             userId: currentMetricUserId(),
@@ -882,8 +883,16 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         featureFlags.isEnabled(.heatmapV1)
     }
 
+    var isCloudSyncAvailableForSession: Bool {
+        AppFeatureGate.isAllowed(.cloudSync)
+    }
+
+    var isNearbySocialAvailableForSession: Bool {
+        AppFeatureGate.isAllowed(.nearbySocial)
+    }
+
     var isNearbyHotspotFeatureAvailable: Bool {
-        featureFlags.isEnabled(.nearbyHotspotV1)
+        featureFlags.isEnabled(.nearbyHotspotV1) && isNearbySocialAvailableForSession
     }
 
     func heatmapColor(for score: Double) -> Color {
@@ -1060,13 +1069,14 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     private func applyFeatureFlags() {
         let heatmapAllowed = featureFlags.isEnabled(.heatmapV1)
         let nearbyAllowed = featureFlags.isEnabled(.nearbyHotspotV1)
+        let nearbyAllowedForSession = nearbyAllowed && isNearbySocialAvailableForSession
         let heatmapPreference = UserDefaults.standard.object(forKey: heatmapEnabledKey) as? Bool ?? true
         let nearbyPreference = UserDefaults.standard.object(forKey: nearbyHotspotEnabledKey) as? Bool ?? true
         let sharingPreference = UserDefaults.standard.bool(forKey: locationSharingKey)
 
         self.heatmapEnabled = heatmapAllowed ? heatmapPreference : false
-        self.nearbyHotspotEnabled = nearbyAllowed ? nearbyPreference : false
-        self.locationSharingEnabled = nearbyAllowed ? sharingPreference : false
+        self.nearbyHotspotEnabled = nearbyAllowedForSession ? nearbyPreference : false
+        self.locationSharingEnabled = nearbyAllowedForSession ? sharingPreference : false
 
         if heatmapAllowed {
             self.refreshHeatmap()
@@ -1074,7 +1084,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
             self.heatmapCells = []
         }
 
-        if nearbyAllowed == false {
+        if nearbyAllowedForSession == false {
             self.nearbyHotspots = []
             UserDefaults.standard.set(false, forKey: locationSharingKey)
             self.syncVisibilitySettingIfNeeded()

--- a/dogArea/Views/WalkListView/WalkListView.swift
+++ b/dogArea/Views/WalkListView/WalkListView.swift
@@ -93,7 +93,7 @@ struct WalkListView: View {
             }
             Spacer()
             Button("로그인") {
-                _ = authFlow.requireMember(trigger: .walkHistory)
+                _ = authFlow.requestAccess(feature: .cloudSync)
             }
             .font(.appFont(for: .SemiBold, size: 12))
             .padding(.horizontal, 12)

--- a/scripts/feature_gate_architecture_unit_check.swift
+++ b/scripts/feature_gate_architecture_unit_check.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct Check {
+    static var failed = false
+
+    static func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            print("[PASS] \(message)")
+        } else {
+            failed = true
+            print("[FAIL] \(message)")
+        }
+    }
+}
+
+func read(_ path: String) -> String {
+    (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+}
+
+let source = read("dogArea/Source/UserdefaultSetting.swift")
+let mapStart = read("dogArea/Views/MapView/MapSubViews/StartButtonView.swift")
+let imageView = read("dogArea/Views/ImageGeneratorView/TextToImageView.swift")
+let imageVM = read("dogArea/Views/ImageGeneratorView/ImageGenerateViewModel.swift")
+let walkList = read("dogArea/Views/WalkListView/WalkListView.swift")
+let mapView = read("dogArea/Views/MapView/MapView.swift")
+let mapVM = read("dogArea/Views/MapView/MapViewModel.swift")
+
+Check.assertTrue(source.contains("enum AppSessionState"), "session should be modeled as guest/member")
+Check.assertTrue(source.contains("enum FeatureCapability"), "feature capability matrix should exist")
+Check.assertTrue(source.contains("enum AppFeatureGate"), "feature gate module should exist")
+Check.assertTrue(source.contains("func requestAccess(feature:"), "auth coordinator should expose centralized request method")
+Check.assertTrue(mapStart.contains("requestAccess(feature: .walkWrite)"), "walk start should be gated through centralized matrix")
+Check.assertTrue(imageView.contains("requestAccess(feature: .aiGeneration)"), "image view should use centralized ai gate")
+Check.assertTrue(walkList.contains("requestAccess(feature: .cloudSync)"), "walk list sync CTA should use centralized gate")
+Check.assertTrue(mapView.contains("canAccess(.cloudSync)"), "map backup banner should depend on central gate")
+Check.assertTrue(source.contains("AppFeatureGate.isAllowed(.cloudSync"), "sync transport should be guarded before network")
+Check.assertTrue(imageVM.contains("AppFeatureGate.isAllowed(.aiGeneration"), "image API layer should guard member-only calls")
+Check.assertTrue(mapVM.contains("isCloudSyncAvailableForSession"), "map view model should check session-aware cloud sync availability")
+Check.assertTrue(mapVM.contains("isNearbySocialAvailableForSession"), "map view model should check session-aware nearby availability")
+
+if Check.failed {
+    exit(1)
+}
+
+print("All feature gate architecture checks passed.")

--- a/scripts/guest_upgrade_ux_unit_check.swift
+++ b/scripts/guest_upgrade_ux_unit_check.swift
@@ -32,9 +32,12 @@ Check.assertTrue(source.contains("final class AuthFlowCoordinator"), "auth flow 
 Check.assertTrue(source.contains("MemberUpgradeSheetView"), "shared upgrade sheet view must exist")
 Check.assertTrue(signIn.contains("allowDismiss"), "sign-in should support later/cancel path")
 Check.assertTrue(signIn.contains("onAuthenticated"), "sign-in should use callback completion")
-Check.assertTrue(mapStart.contains("requireMember(trigger: .walkStart)"), "walk start should be member-gated")
-Check.assertTrue(image.contains("requireMember(trigger: .imageGenerator)"), "image generation should be member-gated")
-Check.assertTrue(walkList.contains("requireMember(trigger: .walkHistory)"), "walk list should provide login-to-sync path")
+Check.assertTrue(source.contains("enum FeatureCapability"), "feature capability matrix should be defined")
+Check.assertTrue(source.contains("enum AppFeatureGate"), "central feature gate module should exist")
+Check.assertTrue(source.contains("func requestAccess(feature:"), "auth flow should expose centralized feature access request")
+Check.assertTrue(mapStart.contains("requestAccess(feature: .walkWrite)"), "walk start should use centralized gate")
+Check.assertTrue(image.contains("requestAccess(feature: .aiGeneration)"), "image generation should use centralized gate")
+Check.assertTrue(walkList.contains("requestAccess(feature: .cloudSync)"), "walk list should use centralized gate for sync CTA")
 
 if Check.failed {
     exit(1)


### PR DESCRIPTION
## Summary
- 세션 상태를 `guest/member`로 고정한 중앙 FeatureGate 모듈(`AppFeatureGate`) 추가
- 기능 정책 매트릭스 도입
  - guest 허용: `walkRead`, `walkWrite`
  - member 전용: `cloudSync`, `aiGeneration`, `nearbySocial`
- 화면 분산 접근 판정을 `AuthFlowCoordinator.requestAccess(feature:)`로 통합
  - `StartButtonView`, `TextToImageView`, `WalkListView`, `MapView` 반영
- 회원 전용 API 호출 가드 추가
  - `SupabaseSyncOutboxTransport.send`에서 `cloudSync` 권한 체크
  - `ImageGenerateViewModel.generateImage`에서 `aiGeneration` 권한 체크
- `MapViewModel`에 세션 기반 가용성(`isCloudSyncAvailableForSession`, `isNearbySocialAvailableForSession`) 적용
- 문서/검증 스크립트 추가
  - `docs/feature-gate-architecture-v1.md`
  - `scripts/feature_gate_architecture_unit_check.swift`

## Tests
- `swift scripts/feature_gate_architecture_unit_check.swift`
- `swift scripts/guest_upgrade_ux_unit_check.swift`
- `swift scripts/guest_data_upgrade_unit_check.swift`
- `swift scripts/walk_sync_consistency_outbox_unit_check.swift`
- `swift scripts/release_regression_checklist_unit_check.swift`

## Notes
- #75 의사결정에 맞춰 게스트 핵심 경험(산책 시작/종료/목록)을 허용하고,
  회원 전용 기능만 업그레이드 UX로 게이트 처리했습니다.

Closes #75
