### PR TITLE
[Task] #22 Supabase 스키마/RLS/Storage 운영 고도화

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - CoreData 반환 계약 정리 v1: `docs/coredata-return-contract-v1.md`
 - Swift 안정화(강제 언래핑/타이머 수명) v1: `docs/swift-stability-hardening-v1.md`
 - 프로젝트 설정/의존성 안정화 v1: `docs/project-settings-dependency-stability-v1.md`
+- Supabase 마이그레이션/운영 검증 v1: `docs/supabase-migration.md`
 - 릴리즈 회귀 체크리스트 v1: `docs/release-regression-checklist-v1.md`
 - 릴리즈 회귀 실행 리포트(2026-02-26): `docs/release-regression-report-2026-02-26.md`
 - 다중 반려견 산책 N:M 2차 설계 v2: `docs/multi-pet-session-nm-v2.md`

--- a/docs/cycle-22-supabase-ops-report-2026-02-26.md
+++ b/docs/cycle-22-supabase-ops-report-2026-02-26.md
@@ -1,0 +1,49 @@
+# Cycle #22 결과 보고서 (2026-02-26)
+
+## 1. 이슈 확인
+- 대상 이슈: `#22 [Task] Supabase 스키마/RLS/Storage 운영 고도화`
+- 범위:
+  - 핵심 테이블 제약/인덱스 보강
+  - owner 기반 RLS 정책 고정
+  - Storage(`profiles/caricatures/walk-maps`) 정책 고정
+  - 운영 검증 SQL 문서화
+
+## 2. 개발/문서 반영
+- `supabase/migrations/20260226230000_supabase_schema_ops_hardening.sql` 추가
+  - 핵심 테이블 생성/보강:
+    - `profiles`, `pets`, `walk_sessions`, `walk_points`, `area_milestones`, `walk_session_pets`, `area_references`
+  - 제약/인덱스 보강:
+    - `walk_points(walk_session_id, seq_no)` unique
+    - owner/시계열 조회 인덱스 추가
+  - RLS 정책 보강:
+    - owner 기반 접근(`auth.uid()`) 정책
+    - `walk_points`, `walk_session_pets`는 `walk_sessions` 소유자 조인 검증
+  - Storage 버킷/정책 보강:
+    - `profiles`, `caricatures`, `walk-maps` 버킷 비공개 보장
+    - 객체 경로 첫 세그먼트=`auth.uid()` 기반 정책 추가
+  - 운영 통계 view:
+    - `public.view_owner_walk_stats`
+- `docs/supabase-migration.md` 추가
+  - local/linked migration 동기화 절차
+  - A/B 교차 접근 차단 SQL
+  - Storage 정책 검증 기준
+  - 핵심 통계 검증 SQL 세트
+- `scripts/supabase_ops_hardening_unit_check.swift` 추가
+  - migration/문서 계약 검증
+- `scripts/ios_pr_check.sh` 갱신
+  - Supabase ops 유닛 체크를 공통 PR 체크에 포함
+- `README.md`, `docs/supabase-schema-v1.md`에 운영 문서 링크 반영
+
+## 3. 유닛 테스트
+- `swift scripts/supabase_ops_hardening_unit_check.swift` -> `PASS`
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh` -> `PASS`
+
+## 4. Supabase 상태 검증 실행 결과
+- `npx --yes supabase migration list --local` -> `BLOCKED`
+  - 로컬 Postgres 미기동(`127.0.0.1:54322 connect refused`)
+- `npx --yes supabase migration list --linked` -> `BLOCKED`
+  - 프로젝트 ref 미링크(`supabase link` 필요)
+
+## 5. 비고
+- 이번 사이클은 운영 스키마/정책/검증 SQL 기준을 코드로 고정하는 데 초점을 맞췄다.
+- local/linked 상태 동기화 확인은 Supabase 실행 환경(로컬 DB 기동 + linked ref) 준비 후 즉시 재실행 가능하다.

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -1,0 +1,129 @@
+# Supabase Migration & Ops Verification v1
+
+## 1. 목적
+`profiles/pets/walk_sessions/walk_points/area_milestones/walk_session_pets`와 Storage 정책을 운영 기준으로 검증하기 위한 실행 절차/SQL 세트를 고정한다.
+
+연결 이슈:
+- #22 `[Task] Supabase 스키마/RLS/Storage 운영 고도화`
+
+## 2. Migration 상태 동기화
+
+### 2.1 로컬 상태
+```bash
+npx --yes supabase migration list --local
+```
+
+### 2.2 원격(linked) 상태
+```bash
+npx --yes supabase migration list --linked
+```
+
+### 2.3 일치 조건
+- 로컬 최신 migration 파일이 원격에 동일 순서로 적용되어야 한다.
+- 신규 migration 추가 시 `db push --linked` 이후 다시 `migration list --linked`로 확인한다.
+
+```bash
+npx --yes supabase db push --linked --dry-run
+npx --yes supabase db push --linked
+npx --yes supabase migration list --linked
+```
+
+## 3. RLS 교차 계정 차단 검증 SQL
+
+사전 준비:
+- 테스트 유저 UUID
+  - `:user_a_uuid`
+  - `:user_b_uuid`
+- 테스트용 세션 UUID: `:walk_session_uuid`
+
+### 3.1 User A 컨텍스트
+```sql
+set local role authenticated;
+set local "request.jwt.claim.sub" = ':user_a_uuid';
+
+select id, owner_user_id
+from public.walk_sessions
+where owner_user_id = auth.uid()
+limit 5;
+```
+기대값: User A 데이터만 조회된다.
+
+### 3.2 User B로 A 데이터 접근 시도
+```sql
+set local role authenticated;
+set local "request.jwt.claim.sub" = ':user_b_uuid';
+
+select id, owner_user_id
+from public.walk_sessions
+where id = ':walk_session_uuid'::uuid;
+```
+기대값: 결과 0건(또는 정책 위반).
+
+### 3.3 User B가 A 세션에 포인트 쓰기 시도
+```sql
+set local role authenticated;
+set local "request.jwt.claim.sub" = ':user_b_uuid';
+
+insert into public.walk_points (walk_session_id, seq_no, lat, lng, recorded_at)
+values (':walk_session_uuid'::uuid, 9999, 37.5, 127.0, now());
+```
+기대값: `walk_points_owner_all` 정책으로 차단된다.
+
+## 4. Storage 정책 검증
+
+버킷:
+- `profiles`
+- `caricatures`
+- `walk-maps`
+
+검증 규칙:
+- 객체 경로 첫 세그먼트가 `auth.uid()`와 일치해야 접근 가능
+- 교차 계정 접근은 차단
+
+예시(개념):
+- 허용: `profiles/{auth.uid()}/userProfile.jpg`
+- 차단: `profiles/{other_user_id}/userProfile.jpg`
+
+## 5. 운영 검증 SQL (핵심 통계)
+
+### 5.1 오너별 세션/포인트/누적면적
+```sql
+select owner_user_id, session_count, point_count, total_area_m2
+from public.view_owner_walk_stats
+order by total_area_m2 desc;
+```
+
+### 5.2 산책 세션 대비 포인트 누락 확인
+```sql
+select
+  ws.id as walk_session_id,
+  ws.owner_user_id,
+  count(wp.id) as point_count
+from public.walk_sessions ws
+left join public.walk_points wp on wp.walk_session_id = ws.id
+group by ws.id, ws.owner_user_id
+having count(wp.id) = 0;
+```
+
+### 5.3 좌표 시퀀스 중복 확인
+```sql
+select walk_session_id, seq_no, count(*)
+from public.walk_points
+group by walk_session_id, seq_no
+having count(*) > 1;
+```
+
+### 5.4 N:M 브릿지 누락 확인
+```sql
+select count(*) as missing_bridge_count
+from public.walk_sessions ws
+left join public.walk_session_pets wsp on wsp.walk_session_id = ws.id
+where ws.pet_id is not null
+  and wsp.walk_session_id is null;
+```
+
+## 6. 운영 체크리스트
+- [ ] `migration list --local` / `migration list --linked` 결과 저장
+- [ ] User A/B 교차 접근 차단 SQL 결과 저장
+- [ ] Storage 버킷 정책/경로 규칙 검증
+- [ ] 핵심 통계 SQL 결과를 릴리스 문서에 첨부

--- a/docs/supabase-schema-v1.md
+++ b/docs/supabase-schema-v1.md
@@ -250,3 +250,6 @@ erDiagram
 - CoreData -> Supabase 이중쓰기/백필: #23
 - 다견 1차 UX: #26
 - 다중 반려견 N:M 2차: #27
+
+운영 실행 문서:
+- `docs/supabase-migration.md`

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -27,6 +27,7 @@ echo "[dogArea] running document/unit checks"
 swift scripts/swift_stability_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift
+swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 
 if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then

--- a/scripts/supabase_ops_hardening_unit_check.swift
+++ b/scripts/supabase_ops_hardening_unit_check.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let migration = load("supabase/migrations/20260226230000_supabase_schema_ops_hardening.sql")
+let opsDoc = load("docs/supabase-migration.md")
+let readme = load("README.md")
+
+assertTrue(migration.contains("create table if not exists public.profiles"), "migration should define profiles table")
+assertTrue(migration.contains("create table if not exists public.pets"), "migration should define pets table")
+assertTrue(migration.contains("create table if not exists public.walk_sessions"), "migration should define walk_sessions table")
+assertTrue(migration.contains("create table if not exists public.walk_points"), "migration should define walk_points table")
+assertTrue(migration.contains("create table if not exists public.area_milestones"), "migration should define area_milestones table")
+assertTrue(migration.contains("create table if not exists public.walk_session_pets"), "migration should define walk_session_pets table")
+assertTrue(migration.contains("create policy walk_points_owner_all"), "migration should include owner policy for walk_points")
+assertTrue(migration.contains("create policy walk_session_pets_owner_all"), "migration should include owner policy for walk_session_pets")
+assertTrue(migration.contains("create policy storage_profiles_insert_own"), "migration should include storage profile policy")
+assertTrue(migration.contains("create policy storage_caricatures_insert_own"), "migration should include storage caricatures policy")
+assertTrue(migration.contains("create policy storage_walk_maps_insert_own"), "migration should include storage walk maps policy")
+assertTrue(migration.contains("create or replace view public.view_owner_walk_stats"), "migration should expose owner stats view")
+
+assertTrue(opsDoc.contains("## 2. Migration 상태 동기화"), "ops doc should include migration sync section")
+assertTrue(opsDoc.contains("npx --yes supabase migration list --linked"), "ops doc should include linked migration command")
+assertTrue(opsDoc.contains("## 3. RLS 교차 계정 차단 검증 SQL"), "ops doc should include cross-account RLS checks")
+assertTrue(opsDoc.contains("## 4. Storage 정책 검증"), "ops doc should include storage policy checks")
+assertTrue(opsDoc.contains("## 5. 운영 검증 SQL (핵심 통계)"), "ops doc should include operational SQL")
+assertTrue(opsDoc.contains("view_owner_walk_stats"), "ops doc should reference owner stats view")
+
+assertTrue(readme.contains("docs/supabase-migration.md"), "README should include supabase migration ops doc link")
+
+print("PASS: supabase ops hardening unit checks")

--- a/supabase/migrations/20260226230000_supabase_schema_ops_hardening.sql
+++ b/supabase/migrations/20260226230000_supabase_schema_ops_hardening.sql
@@ -1,0 +1,697 @@
+-- #22 Supabase schema/RLS/storage operational hardening
+
+create extension if not exists pgcrypto;
+
+create or replace function public.touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- 1) Core tables (create-if-missing + shape hardening)
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  display_name text not null default '',
+  profile_image_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.profiles
+  add column if not exists display_name text not null default '',
+  add column if not exists profile_image_url text,
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now();
+
+create table if not exists public.pets (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  photo_url text,
+  caricature_url text,
+  caricature_status text not null default 'queued',
+  caricature_provider text,
+  caricature_style text,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.pets
+  add column if not exists owner_user_id uuid,
+  add column if not exists name text,
+  add column if not exists photo_url text,
+  add column if not exists caricature_url text,
+  add column if not exists caricature_status text not null default 'queued',
+  add column if not exists caricature_provider text,
+  add column if not exists caricature_style text,
+  add column if not exists is_active boolean not null default true,
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now();
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'pets_owner_user_id_fkey'
+  ) then
+    alter table public.pets
+      add constraint pets_owner_user_id_fkey
+      foreign key (owner_user_id) references auth.users(id) on delete cascade;
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'pets_name_nonempty_check'
+  ) then
+    alter table public.pets
+      add constraint pets_name_nonempty_check
+      check (length(btrim(name)) > 0);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'pets_caricature_status_check'
+  ) then
+    alter table public.pets
+      add constraint pets_caricature_status_check
+      check (caricature_status in ('queued', 'processing', 'ready', 'failed'));
+  end if;
+end $$;
+
+create table if not exists public.walk_sessions (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  pet_id uuid references public.pets(id) on delete set null,
+  started_at timestamptz not null default now(),
+  ended_at timestamptz,
+  duration_sec integer not null default 0,
+  area_m2 double precision not null default 0,
+  map_image_url text,
+  source_device text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.walk_sessions
+  add column if not exists owner_user_id uuid,
+  add column if not exists pet_id uuid,
+  add column if not exists started_at timestamptz not null default now(),
+  add column if not exists ended_at timestamptz,
+  add column if not exists duration_sec integer not null default 0,
+  add column if not exists area_m2 double precision not null default 0,
+  add column if not exists map_image_url text,
+  add column if not exists source_device text,
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now();
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'walk_sessions_owner_user_id_fkey'
+  ) then
+    alter table public.walk_sessions
+      add constraint walk_sessions_owner_user_id_fkey
+      foreign key (owner_user_id) references auth.users(id) on delete cascade;
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'walk_sessions_pet_id_fkey'
+  ) then
+    alter table public.walk_sessions
+      add constraint walk_sessions_pet_id_fkey
+      foreign key (pet_id) references public.pets(id) on delete set null;
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'walk_sessions_duration_nonnegative_check'
+  ) then
+    alter table public.walk_sessions
+      add constraint walk_sessions_duration_nonnegative_check
+      check (duration_sec >= 0);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'walk_sessions_area_nonnegative_check'
+  ) then
+    alter table public.walk_sessions
+      add constraint walk_sessions_area_nonnegative_check
+      check (area_m2 >= 0);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'walk_sessions_ended_after_started_check'
+  ) then
+    alter table public.walk_sessions
+      add constraint walk_sessions_ended_after_started_check
+      check (ended_at is null or ended_at >= started_at);
+  end if;
+end $$;
+
+create table if not exists public.walk_points (
+  id bigint generated always as identity primary key,
+  walk_session_id uuid not null references public.walk_sessions(id) on delete cascade,
+  seq_no integer not null,
+  lat double precision not null,
+  lng double precision not null,
+  recorded_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+alter table public.walk_points
+  add column if not exists walk_session_id uuid,
+  add column if not exists seq_no integer,
+  add column if not exists lat double precision,
+  add column if not exists lng double precision,
+  add column if not exists recorded_at timestamptz not null default now(),
+  add column if not exists created_at timestamptz not null default now();
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'walk_points_walk_session_id_fkey'
+  ) then
+    alter table public.walk_points
+      add constraint walk_points_walk_session_id_fkey
+      foreign key (walk_session_id) references public.walk_sessions(id) on delete cascade;
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'walk_points_walk_session_id_seq_no_key'
+  ) then
+    alter table public.walk_points
+      add constraint walk_points_walk_session_id_seq_no_key
+      unique (walk_session_id, seq_no);
+  end if;
+end $$;
+
+create table if not exists public.area_milestones (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  pet_id uuid references public.pets(id) on delete set null,
+  area_name text not null,
+  area_m2 double precision not null,
+  achieved_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+alter table public.area_milestones
+  add column if not exists owner_user_id uuid,
+  add column if not exists pet_id uuid,
+  add column if not exists area_name text,
+  add column if not exists area_m2 double precision,
+  add column if not exists achieved_at timestamptz not null default now(),
+  add column if not exists created_at timestamptz not null default now();
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'area_milestones_owner_user_id_fkey'
+  ) then
+    alter table public.area_milestones
+      add constraint area_milestones_owner_user_id_fkey
+      foreign key (owner_user_id) references auth.users(id) on delete cascade;
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'area_milestones_pet_id_fkey'
+  ) then
+    alter table public.area_milestones
+      add constraint area_milestones_pet_id_fkey
+      foreign key (pet_id) references public.pets(id) on delete set null;
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'area_milestones_area_nonnegative_check'
+  ) then
+    alter table public.area_milestones
+      add constraint area_milestones_area_nonnegative_check
+      check (area_m2 >= 0);
+  end if;
+end $$;
+
+create table if not exists public.walk_session_pets (
+  walk_session_id uuid not null references public.walk_sessions(id) on delete cascade,
+  pet_id uuid not null references public.pets(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (walk_session_id, pet_id)
+);
+
+alter table public.walk_session_pets
+  add column if not exists created_at timestamptz not null default now();
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'walk_session_pets_walk_session_id_fkey'
+  ) then
+    alter table public.walk_session_pets
+      add constraint walk_session_pets_walk_session_id_fkey
+      foreign key (walk_session_id) references public.walk_sessions(id) on delete cascade;
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'walk_session_pets_pet_id_fkey'
+  ) then
+    alter table public.walk_session_pets
+      add constraint walk_session_pets_pet_id_fkey
+      foreign key (pet_id) references public.pets(id) on delete cascade;
+  end if;
+end $$;
+
+create table if not exists public.area_references (
+  id uuid primary key default gen_random_uuid(),
+  reference_name text not null,
+  area_m2 double precision not null,
+  category text not null,
+  country_code text,
+  source_label text,
+  source_url text,
+  is_active boolean not null default true,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.area_references
+  add column if not exists reference_name text,
+  add column if not exists area_m2 double precision,
+  add column if not exists category text,
+  add column if not exists country_code text,
+  add column if not exists source_label text,
+  add column if not exists source_url text,
+  add column if not exists is_active boolean not null default true,
+  add column if not exists metadata jsonb not null default '{}'::jsonb,
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now();
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'area_references_area_positive_check'
+  ) then
+    alter table public.area_references
+      add constraint area_references_area_positive_check
+      check (area_m2 > 0);
+  end if;
+end $$;
+
+-- 2) Index hardening
+create index if not exists idx_profiles_updated_at
+  on public.profiles(updated_at desc);
+
+create index if not exists idx_pets_owner_active_created
+  on public.pets(owner_user_id, is_active, created_at desc);
+
+create index if not exists idx_walk_sessions_owner_started
+  on public.walk_sessions(owner_user_id, started_at desc);
+
+create index if not exists idx_walk_sessions_pet_started
+  on public.walk_sessions(pet_id, started_at desc);
+
+create index if not exists idx_walk_points_session_seq
+  on public.walk_points(walk_session_id, seq_no);
+
+create index if not exists idx_walk_points_session_recorded
+  on public.walk_points(walk_session_id, recorded_at asc);
+
+create index if not exists idx_area_milestones_owner_achieved
+  on public.area_milestones(owner_user_id, achieved_at desc);
+
+create index if not exists idx_walk_session_pets_pet_session
+  on public.walk_session_pets(pet_id, walk_session_id);
+
+create index if not exists idx_area_references_active_category
+  on public.area_references(is_active, category, area_m2 desc);
+
+-- 3) updated_at triggers
+drop trigger if exists trg_profiles_updated_at on public.profiles;
+create trigger trg_profiles_updated_at
+before update on public.profiles
+for each row execute function public.touch_updated_at();
+
+drop trigger if exists trg_pets_updated_at on public.pets;
+create trigger trg_pets_updated_at
+before update on public.pets
+for each row execute function public.touch_updated_at();
+
+drop trigger if exists trg_walk_sessions_updated_at on public.walk_sessions;
+create trigger trg_walk_sessions_updated_at
+before update on public.walk_sessions
+for each row execute function public.touch_updated_at();
+
+drop trigger if exists trg_area_references_updated_at on public.area_references;
+create trigger trg_area_references_updated_at
+before update on public.area_references
+for each row execute function public.touch_updated_at();
+
+-- 4) RLS and owner policies
+alter table public.profiles enable row level security;
+alter table public.pets enable row level security;
+alter table public.walk_sessions enable row level security;
+alter table public.walk_points enable row level security;
+alter table public.area_milestones enable row level security;
+alter table public.walk_session_pets enable row level security;
+alter table public.area_references enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'profiles' and policyname = 'profiles_select_own'
+  ) then
+    create policy profiles_select_own on public.profiles
+      for select using (id = auth.uid());
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'profiles' and policyname = 'profiles_insert_own'
+  ) then
+    create policy profiles_insert_own on public.profiles
+      for insert with check (id = auth.uid());
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'profiles' and policyname = 'profiles_update_own'
+  ) then
+    create policy profiles_update_own on public.profiles
+      for update using (id = auth.uid()) with check (id = auth.uid());
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'profiles' and policyname = 'profiles_delete_own'
+  ) then
+    create policy profiles_delete_own on public.profiles
+      for delete using (id = auth.uid());
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'pets' and policyname = 'pets_owner_all'
+  ) then
+    create policy pets_owner_all on public.pets
+      for all using (owner_user_id = auth.uid())
+      with check (owner_user_id = auth.uid());
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'walk_sessions' and policyname = 'walk_sessions_owner_all'
+  ) then
+    create policy walk_sessions_owner_all on public.walk_sessions
+      for all using (owner_user_id = auth.uid())
+      with check (owner_user_id = auth.uid());
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'walk_points' and policyname = 'walk_points_owner_all'
+  ) then
+    create policy walk_points_owner_all on public.walk_points
+      for all
+      using (
+        exists (
+          select 1
+          from public.walk_sessions ws
+          where ws.id = walk_points.walk_session_id
+            and ws.owner_user_id = auth.uid()
+        )
+      )
+      with check (
+        exists (
+          select 1
+          from public.walk_sessions ws
+          where ws.id = walk_points.walk_session_id
+            and ws.owner_user_id = auth.uid()
+        )
+      );
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'area_milestones' and policyname = 'area_milestones_owner_all'
+  ) then
+    create policy area_milestones_owner_all on public.area_milestones
+      for all using (owner_user_id = auth.uid())
+      with check (owner_user_id = auth.uid());
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'walk_session_pets' and policyname = 'walk_session_pets_owner_all'
+  ) then
+    create policy walk_session_pets_owner_all on public.walk_session_pets
+      for all
+      using (
+        exists (
+          select 1
+          from public.walk_sessions ws
+          where ws.id = walk_session_pets.walk_session_id
+            and ws.owner_user_id = auth.uid()
+        )
+      )
+      with check (
+        exists (
+          select 1
+          from public.walk_sessions ws
+          where ws.id = walk_session_pets.walk_session_id
+            and ws.owner_user_id = auth.uid()
+        )
+      );
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'area_references' and policyname = 'area_references_select_all'
+  ) then
+    create policy area_references_select_all on public.area_references
+      for select to anon, authenticated
+      using (is_active = true or auth.role() = 'service_role');
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'area_references' and policyname = 'area_references_service_role_write'
+  ) then
+    create policy area_references_service_role_write on public.area_references
+      for all
+      using (auth.role() = 'service_role')
+      with check (auth.role() = 'service_role');
+  end if;
+end $$;
+
+-- 5) Storage buckets + object policies
+do $$
+begin
+  if to_regclass('storage.buckets') is null or to_regclass('storage.objects') is null then
+    return;
+  end if;
+
+  insert into storage.buckets (id, name, public)
+  values
+    ('profiles', 'profiles', false),
+    ('caricatures', 'caricatures', false),
+    ('walk-maps', 'walk-maps', false)
+  on conflict (id) do nothing;
+
+  update storage.buckets
+  set public = false
+  where id in ('profiles', 'caricatures', 'walk-maps');
+
+  execute 'alter table storage.objects enable row level security';
+end $$;
+
+do $$
+begin
+  if to_regclass('storage.objects') is null then
+    return;
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_profiles_select_own'
+  ) then
+    create policy storage_profiles_select_own on storage.objects
+      for select
+      using (bucket_id = 'profiles' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_profiles_insert_own'
+  ) then
+    create policy storage_profiles_insert_own on storage.objects
+      for insert
+      with check (bucket_id = 'profiles' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_profiles_update_own'
+  ) then
+    create policy storage_profiles_update_own on storage.objects
+      for update
+      using (bucket_id = 'profiles' and split_part(name, '/', 1) = auth.uid()::text)
+      with check (bucket_id = 'profiles' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_profiles_delete_own'
+  ) then
+    create policy storage_profiles_delete_own on storage.objects
+      for delete
+      using (bucket_id = 'profiles' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_caricatures_select_own'
+  ) then
+    create policy storage_caricatures_select_own on storage.objects
+      for select
+      using (bucket_id = 'caricatures' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_caricatures_insert_own'
+  ) then
+    create policy storage_caricatures_insert_own on storage.objects
+      for insert
+      with check (bucket_id = 'caricatures' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_caricatures_update_own'
+  ) then
+    create policy storage_caricatures_update_own on storage.objects
+      for update
+      using (bucket_id = 'caricatures' and split_part(name, '/', 1) = auth.uid()::text)
+      with check (bucket_id = 'caricatures' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_caricatures_delete_own'
+  ) then
+    create policy storage_caricatures_delete_own on storage.objects
+      for delete
+      using (bucket_id = 'caricatures' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_walk_maps_select_own'
+  ) then
+    create policy storage_walk_maps_select_own on storage.objects
+      for select
+      using (bucket_id = 'walk-maps' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_walk_maps_insert_own'
+  ) then
+    create policy storage_walk_maps_insert_own on storage.objects
+      for insert
+      with check (bucket_id = 'walk-maps' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_walk_maps_update_own'
+  ) then
+    create policy storage_walk_maps_update_own on storage.objects
+      for update
+      using (bucket_id = 'walk-maps' and split_part(name, '/', 1) = auth.uid()::text)
+      with check (bucket_id = 'walk-maps' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'storage_walk_maps_delete_own'
+  ) then
+    create policy storage_walk_maps_delete_own on storage.objects
+      for delete
+      using (bucket_id = 'walk-maps' and split_part(name, '/', 1) = auth.uid()::text);
+  end if;
+end $$;
+
+-- 6) Operational verification view (stats)
+create or replace view public.view_owner_walk_stats as
+with session_stats as (
+  select
+    owner_user_id,
+    count(*)::bigint as session_count,
+    coalesce(sum(area_m2), 0)::double precision as total_area_m2
+  from public.walk_sessions
+  group by owner_user_id
+),
+point_stats as (
+  select
+    ws.owner_user_id,
+    count(wp.id)::bigint as point_count
+  from public.walk_points wp
+  join public.walk_sessions ws on ws.id = wp.walk_session_id
+  group by ws.owner_user_id
+)
+select
+  coalesce(s.owner_user_id, p.owner_user_id) as owner_user_id,
+  coalesce(s.session_count, 0)::bigint as session_count,
+  coalesce(p.point_count, 0)::bigint as point_count,
+  coalesce(s.total_area_m2, 0)::double precision as total_area_m2
+from session_stats s
+full outer join point_stats p on p.owner_user_id = s.owner_user_id;
+
+grant select on public.view_owner_walk_stats to authenticated, service_role;


### PR DESCRIPTION
## Summary
- Supabase 운영 하드닝 migration 추가
  - 핵심 테이블/제약/인덱스 보강
  - owner 기반 RLS 정책 보강
  - storage bucket/object 정책 보강
  - 운영 통계 view(`view_owner_walk_stats`) 추가
- 운영 실행 문서 추가(`docs/supabase-migration.md`)
- Supabase ops 계약 유닛 체크 추가(`scripts/supabase_ops_hardening_unit_check.swift`)
- 공통 PR 체크 스크립트에 supabase ops 검증 포함
- cycle 결과 문서화

## Test
- swift scripts/supabase_ops_hardening_unit_check.swift
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh
- npx --yes supabase migration list --local (blocked: local db not running)
- npx --yes supabase migration list --linked (blocked: project ref not linked)

## Notes
- local/linked migration 상태 비교는 Supabase 실행 환경(local db + linked ref) 준비 후 바로 재실행 가능.

Closes #22
