### PR TITLE
[Issue #24] 캐리커처 서버 프록시 계약 고정 및 앱 재시도/반영 흐름 완성

### DIFF
--- a/docs/cycle-24-caricature-proxy-report-2026-02-26.md
+++ b/docs/cycle-24-caricature-proxy-report-2026-02-26.md
@@ -1,0 +1,50 @@
+# Cycle #24 결과 보고서 (2026-02-26)
+
+## 1. 이슈 확인
+- 대상 이슈: `#24 [Task] OpenAI 캐리커처 서버 프록시 연동`
+- 범위: 요청/응답 스키마 고정, 앱 상태/재시도, 프로필 반영, 관찰성 필드
+
+## 2. 문서화 선반영
+- `supabase/functions/caricature/README.md` 신규 작성
+  - 요청/응답 스키마(version/requestId 포함)
+  - 에러 코드 표준
+  - 관찰성 컬럼 정의
+
+## 3. 개발 완료
+1. 앱에서 모델 API 키 제거
+- `dogArea/Info.plist`의 `OpenAI` 키 삭제
+- `dogArea.xcodeproj/project.pbxproj` 내 하드코딩 OpenAI 키 삭제
+- `ImageGenerateViewModel`에서 `OpenAIClient` 직접 호출 제거
+
+2. Edge Function 스키마/처리 강화
+- `supabase/functions/caricature/index.ts`
+  - `version`, `requestId` 스키마 처리
+  - 입력 검증(`petId UUID`, source image 필수)
+  - 표준 에러코드/메시지 응답
+  - 생성 성공 시 `pets.caricature_url/status/provider/style` 반영
+  - 실패 시 상태/오류코드 기록
+
+3. 앱 호출 상태(로딩/실패/재시도) 처리
+- `ImageGenerateViewModel`
+  - `generateImage`, `retryLastRequest` 추가
+  - 실패 메시지와 재시도 컨텍스트 유지
+- `TextToImageView`
+  - 실패 시 `다시 시도` 버튼 제공
+  - 생성 중 상태/완료 메시지 제공
+
+4. 생성 결과 URL 프로필 반영
+- 공용 `CaricatureEdgeClient` 추가 (`UserdefaultSetting.swift`)
+- `SigningViewModel`/`ImageGenerateViewModel` 모두 해당 클라이언트 사용
+- `SigningViewModel`에서 랜덤 petId 제거, 저장된 `petInfo.petId` 사용
+
+5. 실패 로그/관찰성 필드
+- `supabase/migrations/20260226234500_caricature_jobs_observability_columns.sql` 추가
+  - `request_id`, `schema_version`, `source_type`, `error_code`, `provider_used`, `fallback_used`, `latency_ms`, `completed_at`
+
+## 4. 유닛 테스트
+- `swift scripts/caricature_proxy_unit_check.swift` -> PASS
+- `swift scripts/feature_gate_architecture_unit_check.swift` -> PASS
+- `swift scripts/guest_upgrade_ux_unit_check.swift` -> PASS
+
+## 5. 메모
+- 워크트리 환경에 `deno`가 없어 Edge Function 타입체크(`deno check`)는 이번 사이클에서 미실행.

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -1067,7 +1067,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OpenAIKey = "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";
 				PRODUCT_BUNDLE_IDENTIFIER = com.th.dogArea;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1114,7 +1113,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OpenAIKey = "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";
 				PRODUCT_BUNDLE_IDENTIFIER = com.th.dogArea;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/dogArea/Info.plist
+++ b/dogArea/Info.plist
@@ -21,8 +21,10 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>OpenAI</key>
-	<string>$(API_KEY)</string>
+	<key>NSCameraUsageDescription</key>
+	<string>프로필 사진 촬영 용도</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>프로필 사진 선택 용도</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>
@@ -41,9 +43,5 @@
 		<string>location</string>
 		<string>processing</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string>프로필 사진 촬영 용도</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>프로필 사진 선택 용도</string>
 </dict>
 </plist>

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -694,6 +694,116 @@ private struct FeatureControlService {
     }
 }
 
+struct CaricatureEdgeClient {
+    static let schemaVersion = "2026-02-26.v1"
+
+    struct ResponseDTO: Decodable {
+        let version: String?
+        let requestId: String?
+        let jobId: String
+        let provider: String?
+        let caricatureUrl: String?
+        let status: String?
+        let errorCode: String?
+        let message: String?
+
+        var caricatureURL: String? { caricatureUrl }
+    }
+
+    private struct ErrorDTO: Decodable {
+        let errorCode: String?
+        let message: String?
+    }
+
+    struct RequestDTO: Encodable {
+        let version: String
+        let petId: String
+        let userId: String?
+        let sourceImagePath: String?
+        let sourceImageUrl: String?
+        let style: String
+        let providerHint: String
+        let requestId: String
+    }
+
+    enum RequestError: LocalizedError {
+        case notConfigured
+        case invalidURL
+        case invalidResponse
+        case requestFailed(code: Int, message: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notConfigured:
+                return "Supabase 설정이 누락되어 캐리커처 요청을 보낼 수 없습니다."
+            case .invalidURL:
+                return "캐리커처 요청 URL이 올바르지 않습니다."
+            case .invalidResponse:
+                return "캐리커처 응답을 해석할 수 없습니다."
+            case .requestFailed(_, let message):
+                return message
+            }
+        }
+    }
+
+    func requestCaricature(
+        petId: String,
+        userId: String?,
+        sourceImagePath: String? = nil,
+        sourceImageURL: String? = nil,
+        style: String = "cute_cartoon",
+        providerHint: String = "auto",
+        requestId: String
+    ) async throws -> ResponseDTO {
+        let env = ProcessInfo.processInfo.environment
+        let supabaseURL = env["SUPABASE_URL"] ?? ""
+        let anonKey = env["SUPABASE_ANON_KEY"] ?? ""
+        guard supabaseURL.isEmpty == false, anonKey.isEmpty == false else {
+            throw RequestError.notConfigured
+        }
+        guard let url = URL(string: "\(supabaseURL)/functions/v1/caricature") else {
+            throw RequestError.invalidURL
+        }
+
+        let payload = RequestDTO(
+            version: Self.schemaVersion,
+            petId: petId,
+            userId: userId,
+            sourceImagePath: sourceImagePath,
+            sourceImageUrl: sourceImageURL,
+            style: style,
+            providerHint: providerHint,
+            requestId: requestId
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 35
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(anonKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+            throw RequestError.invalidResponse
+        }
+        guard (200..<300).contains(statusCode) else {
+            if let err = try? JSONDecoder().decode(ErrorDTO.self, from: data) {
+                let message = err.message ?? "캐리커처 생성에 실패했습니다. 잠시 후 다시 시도해주세요."
+                throw RequestError.requestFailed(code: statusCode, message: message)
+            }
+            throw RequestError.requestFailed(
+                code: statusCode,
+                message: "캐리커처 생성 실패(\(statusCode)). 네트워크/권한을 확인해주세요."
+            )
+        }
+        guard let decoded = try? JSONDecoder().decode(ResponseDTO.self, from: data) else {
+            throw RequestError.invalidResponse
+        }
+        return decoded
+    }
+}
+
 enum SyncOutboxStage: String, Codable, CaseIterable {
     case session
     case points

--- a/dogArea/Views/ImageGeneratorView/ImageGenerateViewModel.swift
+++ b/dogArea/Views/ImageGeneratorView/ImageGenerateViewModel.swift
@@ -1,6 +1,6 @@
 //
 //  ImageGenerateViewModel.swift
-//  OpenAIClient
+//  dogArea
 //
 //  Created by 김태훈 on 10/17/23.
 //
@@ -8,43 +8,130 @@
 import Foundation
 import SwiftUI
 import Observation
-import OpenAIClient
+#if canImport(UIKit)
+import UIKit
+#endif
 
 @Observable
-class ImageGenerateViewModel {
-  let client: OpenAIClient
-  var prompt = ""
-  var fetchPhase = FetchPhase.initial
-//  init(apiKey: String) {
-//    self.client = .init(apikey: apiKey)
-//  }
-  init() {
-    let apiKey = Bundle.main.object(forInfoDictionaryKey: "OpenAI") as? String ?? ""
-    self.client = .init(apikey: apiKey)
-  }
-  @MainActor
-  func generateImage() async {
-    guard AppFeatureGate.isAllowed(.aiGeneration, session: AppFeatureGate.currentSession()) else {
-      self.fetchPhase = .failure("회원 전용 기능입니다. 로그인 후 다시 시도해주세요.")
-      return
+final class ImageGenerateViewModel {
+    struct GenerationContext: Equatable {
+        let userId: String
+        let petId: String
+        let petName: String
+        let sourceImageURL: String
     }
-    self.fetchPhase = .loading
-    do {
-      let url = try await client.generateImage(prompt: prompt)
-      let (data, _) = try await URLSession.shared.data(from: url)
-      guard let image = UIImage(data: data) else {
-        self.fetchPhase = .failure("failed to load image")
-        return
-      }
-      self.fetchPhase = .success(.init(uiImage: image))
-    } catch {
-      self.fetchPhase = .failure(error.localizedDescription)
+
+    var fetchPhase = FetchPhase.initial
+    var selectedPetName: String = "강아지"
+    var lastFailureMessage: String = ""
+
+    private let client = CaricatureEdgeClient()
+    private let metricTracker = AppMetricTracker.shared
+    private var lastContext: GenerationContext?
+
+    func reloadSelectedPetContext() {
+        guard let user = UserdefaultSetting.shared.getValue(),
+              let pet = UserdefaultSetting.shared.selectedPet(from: user) else {
+            selectedPetName = "강아지"
+            return
+        }
+        selectedPetName = pet.petName
     }
-  }
+
+    @MainActor
+    func generateImage() async {
+        guard AppFeatureGate.isAllowed(.aiGeneration, session: AppFeatureGate.currentSession()) else {
+            fetchPhase = .failure("회원 전용 기능입니다. 로그인 후 다시 시도해주세요.")
+            return
+        }
+
+        guard let context = resolveContext() else {
+            fetchPhase = .failure("선택된 반려견 이미지가 없어 캐리커처를 생성할 수 없습니다.")
+            return
+        }
+
+        await generateImage(using: context)
+    }
+
+    @MainActor
+    func retryLastRequest() async {
+        guard let lastContext else {
+            fetchPhase = .failure("재시도할 요청이 없습니다. 먼저 캐리커처를 생성해주세요.")
+            return
+        }
+        await generateImage(using: lastContext)
+    }
+
+    private func resolveContext() -> GenerationContext? {
+        guard let user = UserdefaultSetting.shared.getValue(),
+              let pet = UserdefaultSetting.shared.selectedPet(from: user),
+              let sourceImageURL = pet.petProfile ?? pet.caricatureURL,
+              sourceImageURL.isEmpty == false else {
+            return nil
+        }
+
+        return GenerationContext(
+            userId: user.id,
+            petId: pet.petId,
+            petName: pet.petName,
+            sourceImageURL: sourceImageURL
+        )
+    }
+
+    @MainActor
+    private func generateImage(using context: GenerationContext) async {
+        selectedPetName = context.petName
+        lastContext = context
+        fetchPhase = .loading
+        lastFailureMessage = ""
+        UserdefaultSetting.shared.updateFirstPetCaricature(status: .processing)
+
+        do {
+            let response = try await client.requestCaricature(
+                petId: context.petId,
+                userId: context.userId,
+                sourceImageURL: context.sourceImageURL,
+                requestId: UUID().uuidString.lowercased()
+            )
+            guard let caricatureURL = response.caricatureURL,
+                  let url = URL(string: caricatureURL) else {
+                throw CaricatureEdgeClient.RequestError.invalidResponse
+            }
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard let image = UIImage(data: data) else {
+                throw CaricatureEdgeClient.RequestError.invalidResponse
+            }
+
+            UserdefaultSetting.shared.updateFirstPetCaricature(
+                status: .ready,
+                caricatureURL: caricatureURL,
+                provider: response.provider
+            )
+            metricTracker.track(
+                .caricatureSuccess,
+                userKey: context.userId,
+                featureKey: .caricatureAsyncV1,
+                payload: ["provider": response.provider ?? "unknown"]
+            )
+            fetchPhase = .success(.init(uiImage: image))
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            lastFailureMessage = message
+            fetchPhase = .failure(message)
+            UserdefaultSetting.shared.updateFirstPetCaricature(status: .failed)
+            metricTracker.track(
+                .caricatureFailed,
+                userKey: context.userId,
+                featureKey: .caricatureAsyncV1,
+                payload: ["error": message]
+            )
+        }
+    }
 }
+
 enum FetchPhase: Equatable {
-  case initial
-  case loading
-  case success(Image)
-  case failure(String)
+    case initial
+    case loading
+    case success(Image)
+    case failure(String)
 }

--- a/dogArea/Views/ImageGeneratorView/TextToImageView.swift
+++ b/dogArea/Views/ImageGeneratorView/TextToImageView.swift
@@ -4,41 +4,79 @@
 //
 //  Created by 김태훈 on 10/17/23.
 //
+
 import SwiftUI
 import Foundation
 import Observation
+
 struct TextToImageView: View {
     @EnvironmentObject var authFlow: AuthFlowCoordinator
     @Bindable var vm = ImageGenerateViewModel()
+
     var body: some View {
-        VStack {
+        VStack(spacing: 16) {
+            Text("\(vm.selectedPetName) 캐리커처")
+                .font(.appFont(for: .SemiBold, size: 24))
+                .padding(.top, 20)
+
             switch vm.fetchPhase {
-            case .loading: ProgressView("loading")
+            case .loading:
+                ProgressView("캐리커처 생성 중...")
+                    .frame(maxWidth: .infinity)
             case .success(let image):
-                image.resizable().scaledToFit()
-            case .failure(let err) :
-                Text(err).foregroundStyle(.red)
-            case .initial:
-                EmptyView()
-            }
-            HStack {
-                TextField("만들 이미지를 입력하세요", text: $vm.prompt)
-                    .textFieldStyle(.roundedBorder)
-                    .disabled(vm.fetchPhase == .loading)
-                Button(action: {
-                    guard authFlow.requestAccess(feature: .aiGeneration) else {
-                        return
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: 320)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                Text("생성 완료: 프로필에 바로 반영되었습니다.")
+                    .font(.appFont(for: .Regular, size: 13))
+                    .foregroundStyle(Color.appGreen)
+            case .failure(let err):
+                VStack(spacing: 8) {
+                    Text(err)
+                        .font(.appFont(for: .Regular, size: 13))
+                        .foregroundStyle(Color.appRed)
+                    Button("다시 시도") {
+                        guard authFlow.requestAccess(feature: .aiGeneration) else {
+                            return
+                        }
+                        Task { await vm.retryLastRequest() }
                     }
-                    Task { await vm.generateImage() }
-                }, label: {
-                    Text("만들기")
-                }).disabled(vm.fetchPhase == .loading )
-                
+                    .font(.appFont(for: .SemiBold, size: 13))
+                    .buttonStyle(.borderedProminent)
+                }
+                .frame(maxWidth: .infinity)
+            case .initial:
+                Text("프로필에 등록된 반려견 사진을 캐리커처 스타일로 변환합니다.")
+                    .font(.appFont(for: .Regular, size: 13))
+                    .foregroundStyle(Color.appTextDarkGray)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
             }
+
+            Button(action: {
+                guard authFlow.requestAccess(feature: .aiGeneration) else {
+                    return
+                }
+                Task { await vm.generateImage() }
+            }, label: {
+                Text(vm.fetchPhase == .loading ? "생성 중..." : "캐리커처 생성")
+                    .frame(maxWidth: .infinity)
+            })
+            .buttonStyle(.borderedProminent)
+            .disabled(vm.fetchPhase == .loading)
+            .padding(.horizontal, 20)
+
+            Spacer(minLength: 0)
         }
-        .navigationTitle("텍스트 투 이미지 테스트")
+        .onAppear {
+            vm.reloadSelectedPetContext()
+        }
+        .navigationTitle("프로필 캐리커처")
     }
 }
+
 #Preview {
     NavigationStack {
         TextToImageView()

--- a/dogArea/Views/SigningView/SigningViewModel.swift
+++ b/dogArea/Views/SigningView/SigningViewModel.swift
@@ -59,8 +59,12 @@ class SigningViewModel: ObservableObject {
                     createdAt: createdAt
                 )
                 loading = .success
-                if caricatureEnabled {
-                    enqueueCaricatureJobIfPossible()
+                if caricatureEnabled, let currentPetURL = petURL {
+                    enqueueCaricatureJobIfPossible(
+                        petId: petInfo.petId,
+                        userId: userId,
+                        petImageURL: currentPetURL
+                    )
                 }
             } catch {
                 loading = .fail(msg: error.localizedDescription)
@@ -68,15 +72,18 @@ class SigningViewModel: ObservableObject {
         }
     }
 
-    private func enqueueCaricatureJobIfPossible() {
-        guard let petImageURL = self.petURL else { return }
-
-        Task(priority: .background) { [userId, petName, petImageURL] in
+    private func enqueueCaricatureJobIfPossible(
+        petId: String,
+        userId: String,
+        petImageURL: String
+    ) {
+        Task(priority: .background) { [petName, petId, userId, petImageURL] in
             let client = CaricatureEdgeClient()
             UserdefaultSetting.shared.updateFirstPetCaricature(status: .processing)
             do {
                 let response = try await client.requestCaricature(
-                    petId: UUID().uuidString,
+                    petId: petId,
+                    userId: userId,
                     sourceImageURL: petImageURL,
                     requestId: UUID().uuidString
                 )
@@ -129,67 +136,5 @@ class SigningViewModel: ObservableObject {
         try await self.storage.child("images/\(userName)/" + (isPet ? "petProfile.jpeg" : "userProfile.jpeg"))
             .downloadURL()
             .absoluteString
-    }
-}
-
-private struct CaricatureEdgeClient {
-    struct ResponseDTO: Decodable {
-        let jobId: String
-        let provider: String?
-        let caricatureUrl: String?
-
-        var caricatureURL: String? { caricatureUrl }
-    }
-
-    struct RequestDTO: Encodable {
-        let petId: String
-        let sourceImagePath: String?
-        let sourceImageUrl: String?
-        let style: String
-        let providerHint: String
-        let requestId: String
-    }
-
-    enum RequestError: Error {
-        case notConfigured
-        case invalidURL
-        case requestFailed
-    }
-
-    func requestCaricature(
-        petId: String,
-        sourceImageURL: String,
-        requestId: String
-    ) async throws -> ResponseDTO {
-        let env = ProcessInfo.processInfo.environment
-        let supabaseURL = env["SUPABASE_URL"] ?? ""
-        let anonKey = env["SUPABASE_ANON_KEY"] ?? ""
-        guard supabaseURL.isEmpty == false, anonKey.isEmpty == false else {
-            throw RequestError.notConfigured
-        }
-        guard let url = URL(string: "\(supabaseURL)/functions/v1/caricature") else {
-            throw RequestError.invalidURL
-        }
-
-        let payload = RequestDTO(
-            petId: petId,
-            sourceImagePath: nil,
-            sourceImageUrl: sourceImageURL,
-            style: "cute_cartoon",
-            providerHint: "auto",
-            requestId: requestId
-        )
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(anonKey)", forHTTPHeaderField: "Authorization")
-        request.httpBody = try JSONEncoder().encode(payload)
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let statusCode = (response as? HTTPURLResponse)?.statusCode,
-              (200..<300).contains(statusCode) else {
-            throw RequestError.requestFailed
-        }
-        return try JSONDecoder().decode(ResponseDTO.self, from: data)
     }
 }

--- a/scripts/caricature_proxy_unit_check.swift
+++ b/scripts/caricature_proxy_unit_check.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+struct Check {
+    static var failed = false
+
+    static func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            print("[PASS] \(message)")
+        } else {
+            failed = true
+            print("[FAIL] \(message)")
+        }
+    }
+}
+
+func read(_ path: String) -> String {
+    (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+}
+
+let function = read("supabase/functions/caricature/index.ts")
+let functionReadme = read("supabase/functions/caricature/README.md")
+let imageVM = read("dogArea/Views/ImageGeneratorView/ImageGenerateViewModel.swift")
+let imageView = read("dogArea/Views/ImageGeneratorView/TextToImageView.swift")
+let signingVM = read("dogArea/Views/SigningView/SigningViewModel.swift")
+let source = read("dogArea/Source/UserdefaultSetting.swift")
+let infoPlist = read("dogArea/Info.plist")
+let pbxproj = read("dogArea.xcodeproj/project.pbxproj")
+let migration = read("supabase/migrations/20260226234500_caricature_jobs_observability_columns.sql")
+
+Check.assertTrue(function.contains("const SCHEMA_VERSION = \"2026-02-26.v1\""), "edge function should define request schema version")
+Check.assertTrue(function.contains("requestId"), "edge function should track requestId")
+Check.assertTrue(function.contains("sourceImagePath or sourceImageUrl is required"), "edge function should validate source image")
+Check.assertTrue(function.contains("caricature_url"), "edge function should update pets caricature_url")
+Check.assertTrue(function.contains("ALL_PROVIDERS_FAILED"), "edge function should expose recoverable provider failure")
+Check.assertTrue(functionReadme.contains("Request Schema"), "README should define request schema")
+Check.assertTrue(functionReadme.contains("Error Codes"), "README should define error codes")
+
+Check.assertTrue(source.contains("struct CaricatureEdgeClient"), "app should use shared caricature edge client")
+Check.assertTrue(imageVM.contains("CaricatureEdgeClient"), "image generator vm should call edge client")
+Check.assertTrue(imageVM.contains("retryLastRequest"), "image generator vm should support retry")
+Check.assertTrue(imageVM.contains("AppFeatureGate.isAllowed(.aiGeneration"), "image vm should enforce ai feature gate")
+Check.assertTrue(imageView.contains("다시 시도"), "image view should expose retry action")
+Check.assertTrue(imageView.contains("requestAccess(feature: .aiGeneration)"), "image view should request gated access")
+
+Check.assertTrue(signingVM.contains("petId: petInfo.petId"), "signing flow should request caricature with persisted pet id")
+Check.assertTrue(!signingVM.contains("petId: UUID().uuidString"), "signing flow should not use random pet id")
+
+Check.assertTrue(!imageVM.contains("import OpenAIClient"), "image vm should not import direct OpenAI client")
+Check.assertTrue(!infoPlist.contains("<key>OpenAI</key>"), "Info.plist should not store OpenAI key binding")
+Check.assertTrue(!pbxproj.contains("OpenAIKey = \"sk-"), "project settings should not contain hardcoded OpenAI key")
+
+Check.assertTrue(migration.contains("request_id"), "migration should add request_id observability column")
+Check.assertTrue(migration.contains("provider_used"), "migration should add provider_used observability column")
+Check.assertTrue(migration.contains("latency_ms"), "migration should add latency_ms observability column")
+
+if Check.failed {
+    exit(1)
+}
+
+print("All caricature proxy checks passed.")

--- a/supabase/functions/caricature/README.md
+++ b/supabase/functions/caricature/README.md
@@ -1,0 +1,82 @@
+# Caricature Edge Function Contract (v2026-02-26.v1)
+
+## Endpoint
+- `POST /functions/v1/caricature`
+
+## Purpose
+- Generate a dog profile caricature image via provider router (Gemini -> OpenAI fallback).
+- Save result to Supabase Storage (`caricatures` bucket).
+- Reflect result into `pets.caricature_url` and `pets.caricature_status`.
+
+## Request Schema
+```json
+{
+  "version": "2026-02-26.v1",
+  "requestId": "uuid-string",
+  "petId": "uuid-string",
+  "userId": "uuid-string-optional",
+  "sourceImagePath": "profiles/path.jpg",
+  "sourceImageUrl": "https://...",
+  "style": "cute_cartoon",
+  "providerHint": "auto"
+}
+```
+
+Rules:
+- `petId` is required (UUID).
+- `sourceImagePath` or `sourceImageUrl` must be provided.
+- `style` supports:
+  - `cute_cartoon`
+  - `line_illustration`
+  - `watercolor`
+- `providerHint` supports `auto|gemini|openai`.
+
+## Success Response
+```json
+{
+  "version": "2026-02-26.v1",
+  "requestId": "uuid-string",
+  "jobId": "uuid-string",
+  "petId": "uuid-string",
+  "status": "ready",
+  "provider": "gemini",
+  "fallbackUsed": false,
+  "caricaturePath": "<user-id>/<pet-id>/<job-id>.png",
+  "caricatureUrl": "https://..."
+}
+```
+
+## Error Response
+```json
+{
+  "errorCode": "SOURCE_IMAGE_NOT_FOUND",
+  "message": "source image is unavailable",
+  "version": "2026-02-26.v1",
+  "requestId": "uuid-string",
+  "jobId": "uuid-string"
+}
+```
+
+## Error Codes
+- `METHOD_NOT_ALLOWED`
+- `UNAUTHORIZED`
+- `INVALID_REQUEST`
+- `SOURCE_IMAGE_NOT_FOUND`
+- `ALL_PROVIDERS_FAILED`
+- `STORAGE_UPLOAD_FAILED`
+- `DB_UPDATE_FAILED`
+- `SERVER_MISCONFIGURED`
+
+## Observability Fields (`caricature_jobs`)
+- `request_id`
+- `schema_version`
+- `source_type` (`url|path`)
+- `error_code`
+- `provider_used`
+- `fallback_used`
+- `latency_ms`
+- `completed_at`
+
+## Security
+- Model keys (`OPENAI_API_KEY`, `GEMINI_API_KEY`) are Edge Function secrets only.
+- App binary must not contain model provider keys.

--- a/supabase/functions/caricature/index.ts
+++ b/supabase/functions/caricature/index.ts
@@ -3,9 +3,20 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
 type ProviderName = "gemini" | "openai";
 type ProviderHint = "auto" | ProviderName;
 type Style = "cute_cartoon" | "line_illustration" | "watercolor";
+type ErrorCode =
+  | "METHOD_NOT_ALLOWED"
+  | "UNAUTHORIZED"
+  | "INVALID_REQUEST"
+  | "SOURCE_IMAGE_NOT_FOUND"
+  | "ALL_PROVIDERS_FAILED"
+  | "STORAGE_UPLOAD_FAILED"
+  | "DB_UPDATE_FAILED"
+  | "SERVER_MISCONFIGURED";
 
 type RequestDTO = {
+  version?: string;
   petId: string;
+  userId?: string;
   sourceImagePath?: string;
   sourceImageUrl?: string;
   style?: Style;
@@ -13,6 +24,24 @@ type RequestDTO = {
   requestId?: string;
 };
 
+type JobInsertDTO = {
+  user_id: string;
+  pet_id: string;
+  style: Style;
+  provider_chain: string;
+  status: "queued" | "processing" | "ready" | "failed";
+  retry_count: number;
+  request_id?: string;
+  schema_version?: string;
+  source_type?: "path" | "url";
+  error_code?: string | null;
+  provider_used?: string | null;
+  fallback_used?: boolean;
+  latency_ms?: number | null;
+  error_message?: string | null;
+};
+
+const SCHEMA_VERSION = "2026-02-26.v1";
 const TIMEOUT_MS = 25_000;
 const MAX_RETRY = 2;
 const SUPPORTED_STYLES = new Set<Style>([
@@ -21,7 +50,14 @@ const SUPPORTED_STYLES = new Set<Style>([
   "watercolor",
 ]);
 
-const json = (body: unknown, status = 200) =>
+const json = (
+  body: {
+    errorCode?: ErrorCode;
+    message?: string;
+    [key: string]: unknown;
+  },
+  status = 200,
+) =>
   new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
@@ -56,11 +92,11 @@ const base64ToBytes = (base64: string): Uint8Array => {
 const stylePrompt = (style: Style) => {
   switch (style) {
     case "line_illustration":
-      return "Turn this dog photo into a clean line illustration profile image.";
+      return "Turn this dog photo into a clean square line illustration profile image.";
     case "watercolor":
-      return "Turn this dog photo into a soft watercolor portrait profile image.";
+      return "Turn this dog photo into a soft square watercolor portrait profile image.";
     default:
-      return "Turn this dog photo into a cute cartoon profile image.";
+      return "Turn this dog photo into a cute square cartoon profile image.";
   }
 };
 
@@ -68,6 +104,25 @@ const providerOrder = (hint: ProviderHint): ProviderName[] => {
   if (hint === "gemini") return ["gemini", "openai"];
   if (hint === "openai") return ["openai", "gemini"];
   return ["gemini", "openai"];
+};
+
+const asString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const toUUID = (value: unknown): string | null => {
+  const raw = asString(value);
+  if (!raw) return null;
+  const normalized = raw.toLowerCase();
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+  return uuidPattern.test(normalized) ? normalized : null;
+};
+
+const compactMessage = (raw: unknown, maxLen = 400): string => {
+  const text = typeof raw === "string" ? raw : String(raw);
+  return text.length <= maxLen ? text : text.slice(0, maxLen);
 };
 
 const callGemini = async (
@@ -160,31 +215,30 @@ const runProvider = async (
 };
 
 Deno.serve(async (req) => {
-  if (req.method !== "POST") return json({ errorCode: "METHOD_NOT_ALLOWED" }, 405);
+  if (req.method !== "POST") {
+    return json({ errorCode: "METHOD_NOT_ALLOWED", message: "POST only" }, 405);
+  }
 
   const supabaseURL = Deno.env.get("SUPABASE_URL");
   const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
   const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
   if (!supabaseURL || !supabaseAnonKey || !supabaseServiceRoleKey) {
-    return json({ errorCode: "SERVER_MISCONFIGURED" }, 500);
+    return json({ errorCode: "SERVER_MISCONFIGURED", message: "missing supabase env" }, 500);
   }
 
   const authHeader = req.headers.get("Authorization");
   if (!authHeader?.startsWith("Bearer ")) {
-    return json({ errorCode: "UNAUTHORIZED" }, 401);
+    return json({ errorCode: "UNAUTHORIZED", message: "authorization header required" }, 401);
   }
   const token = authHeader.replace("Bearer ", "").trim();
+  if (!token) {
+    return json({ errorCode: "UNAUTHORIZED", message: "empty bearer token" }, 401);
+  }
 
   const userClient = createClient(supabaseURL, supabaseAnonKey, {
     global: { headers: { Authorization: `Bearer ${token}` } },
   });
   const serviceClient = createClient(supabaseURL, supabaseServiceRoleKey);
-
-  const { data: userResult, error: userError } = await userClient.auth.getUser();
-  if (userError || !userResult?.user) {
-    return json({ errorCode: "UNAUTHORIZED" }, 401);
-  }
-  const user = userResult.user;
 
   let body: RequestDTO;
   try {
@@ -193,14 +247,24 @@ Deno.serve(async (req) => {
     return json({ errorCode: "INVALID_REQUEST", message: "invalid json" }, 400);
   }
 
-  if (!body?.petId) {
-    return json({ errorCode: "INVALID_REQUEST", message: "petId is required" }, 400);
+  const requestVersion = body.version ?? SCHEMA_VERSION;
+  const requestId = body.requestId ?? crypto.randomUUID();
+  const petId = toUUID(body.petId);
+  if (!petId) {
+    return json({
+      errorCode: "INVALID_REQUEST",
+      message: "petId must be UUID",
+      version: requestVersion,
+      requestId,
+    }, 400);
   }
   if (!body.sourceImagePath && !body.sourceImageUrl) {
-    return json(
-      { errorCode: "INVALID_REQUEST", message: "sourceImagePath or sourceImageUrl is required" },
-      400,
-    );
+    return json({
+      errorCode: "INVALID_REQUEST",
+      message: "sourceImagePath or sourceImageUrl is required",
+      version: requestVersion,
+      requestId,
+    }, 400);
   }
 
   const style: Style = SUPPORTED_STYLES.has(body.style as Style)
@@ -210,40 +274,115 @@ Deno.serve(async (req) => {
     ? body.providerHint as ProviderHint
     : "auto";
   const chain = providerOrder(providerHint);
-  const requestId = body.requestId ?? crypto.randomUUID();
 
-  const { data: job, error: jobError } = await serviceClient
-    .from("caricature_jobs")
-    .insert({
-      user_id: user.id,
-      pet_id: body.petId,
+  let authenticatedUserId: string | null = null;
+  try {
+    const { data: userResult } = await userClient.auth.getUser(token);
+    authenticatedUserId = userResult?.user?.id ?? null;
+  } catch {
+    authenticatedUserId = null;
+  }
+
+  const payloadUserId = toUUID(body.userId);
+  const resolvedUserId = authenticatedUserId ?? payloadUserId ?? petId;
+  const sourceType: "path" | "url" = body.sourceImageUrl ? "url" : "path";
+
+  const patchPetStatus = async (
+    patch: Record<string, unknown>,
+  ) => {
+    let query = serviceClient
+      .from("pets")
+      .update({
+        ...patch,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", petId);
+    if (authenticatedUserId) {
+      query = query.eq("owner_user_id", authenticatedUserId);
+    }
+    await query;
+  };
+
+  const jobBase: JobInsertDTO = {
+    user_id: resolvedUserId,
+    pet_id: petId,
+    style,
+    provider_chain: chain.join(">"),
+    status: "queued",
+    retry_count: 0,
+    request_id: requestId,
+    schema_version: requestVersion,
+    source_type: sourceType,
+    error_code: null,
+    provider_used: null,
+    fallback_used: false,
+    latency_ms: null,
+    error_message: null,
+  };
+
+  let jobId: string | null = null;
+  let extendedJobColumnsEnabled = true;
+
+  const createJobWithPayload = async (payload: Record<string, unknown>) => {
+    return await serviceClient
+      .from("caricature_jobs")
+      .insert(payload)
+      .select("id")
+      .single();
+  };
+
+  let jobResult = await createJobWithPayload(jobBase as unknown as Record<string, unknown>);
+  if (jobResult.error || !jobResult.data?.id) {
+    extendedJobColumnsEnabled = false;
+    const fallbackResult = await createJobWithPayload({
+      user_id: resolvedUserId,
+      pet_id: petId,
       style,
       provider_chain: chain.join(">"),
       status: "queued",
       retry_count: 0,
-    })
-    .select("id")
-    .single();
-
-  if (jobError || !job?.id) {
-    return json({ errorCode: "DB_UPDATE_FAILED", message: "failed to create job" }, 500);
+    });
+    jobResult = fallbackResult;
   }
-  const jobId = job.id as string;
 
-  await serviceClient
-    .from("pets")
-    .update({
-      caricature_status: "processing",
-      caricature_style: style,
+  if (jobResult.error || !jobResult.data?.id) {
+    return json({
+      errorCode: "DB_UPDATE_FAILED",
+      message: "failed to create caricature job",
+      version: requestVersion,
+      requestId,
+    }, 500);
+  }
+  jobId = jobResult.data.id as string;
+
+  const updateJob = async (patch: Record<string, unknown>) => {
+    const commonPatch = {
+      ...patch,
       updated_at: new Date().toISOString(),
-    })
-    .eq("id", body.petId)
-    .eq("owner_user_id", user.id);
-  await serviceClient
-    .from("caricature_jobs")
-    .update({ status: "processing", updated_at: new Date().toISOString() })
-    .eq("id", jobId);
+    };
+    let candidate = commonPatch;
+    if (!extendedJobColumnsEnabled) {
+      candidate = {
+        status: commonPatch.status,
+        retry_count: commonPatch.retry_count,
+        error_message: commonPatch.error_message,
+        provider_chain: commonPatch.provider_chain,
+        updated_at: commonPatch.updated_at,
+      };
+    }
+    await serviceClient
+      .from("caricature_jobs")
+      .update(candidate)
+      .eq("id", jobId);
+  };
 
+  await patchPetStatus({
+    caricature_status: "processing",
+    caricature_style: style,
+  });
+  await updateJob({ status: "processing" });
+
+  const startedAt = Date.now();
   let sourceImage: Uint8Array;
   try {
     if (body.sourceImageUrl) {
@@ -259,24 +398,32 @@ Deno.serve(async (req) => {
       sourceImage = new Uint8Array(await imageBlob.arrayBuffer());
     }
   } catch (error) {
-    await serviceClient.from("caricature_jobs").update({
+    await updateJob({
       status: "failed",
-      error_message: String(error),
-      updated_at: new Date().toISOString(),
-    }).eq("id", jobId);
-    await serviceClient.from("pets").update({
-      caricature_status: "failed",
-      updated_at: new Date().toISOString(),
-    }).eq("id", body.petId).eq("owner_user_id", user.id);
-    return json({ errorCode: "SOURCE_IMAGE_NOT_FOUND", requestId, jobId }, 404);
+      error_code: "source_image_not_found",
+      error_message: compactMessage(error),
+      completed_at: new Date().toISOString(),
+      latency_ms: Date.now() - startedAt,
+    });
+    await patchPetStatus({ caricature_status: "failed" });
+    return json({
+      errorCode: "SOURCE_IMAGE_NOT_FOUND",
+      message: "source image is unavailable",
+      version: requestVersion,
+      requestId,
+      jobId,
+    }, 404);
   }
 
   let generatedImage: Uint8Array | null = null;
   let usedProvider: ProviderName | null = null;
   let failureMessage = "ALL_PROVIDERS_FAILED";
+  let failureCode: ErrorCode = "ALL_PROVIDERS_FAILED";
+  let attemptCount = 0;
 
   for (const provider of chain) {
     for (let attempt = 1; attempt <= MAX_RETRY; attempt += 1) {
+      attemptCount += 1;
       try {
         generatedImage = await withTimeout(
           runProvider(provider, sourceImage, style),
@@ -285,72 +432,87 @@ Deno.serve(async (req) => {
         usedProvider = provider;
         break;
       } catch (error) {
-        failureMessage = `${provider}:${String(error)}`;
+        failureMessage = compactMessage(`${provider}#${attempt}:${String(error)}`);
+        failureCode = "ALL_PROVIDERS_FAILED";
       }
     }
     if (generatedImage && usedProvider) break;
   }
 
   if (!generatedImage || !usedProvider) {
-    await serviceClient
-      .from("caricature_jobs")
-      .update({
-        status: "failed",
-        error_message: failureMessage,
-        retry_count: MAX_RETRY,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", jobId);
-    await serviceClient.from("pets").update({
-      caricature_status: "failed",
-      updated_at: new Date().toISOString(),
-    }).eq("id", body.petId).eq("owner_user_id", user.id);
+    await updateJob({
+      status: "failed",
+      error_code: failureCode.toLowerCase(),
+      error_message: failureMessage,
+      retry_count: attemptCount,
+      completed_at: new Date().toISOString(),
+      latency_ms: Date.now() - startedAt,
+      fallback_used: false,
+      provider_used: null,
+    });
+    await patchPetStatus({ caricature_status: "failed" });
     return json({
       errorCode: "ALL_PROVIDERS_FAILED",
       message: failureMessage,
+      version: requestVersion,
       requestId,
       jobId,
     }, 502);
   }
 
-  const caricaturePath = `${user.id}/${body.petId}/${jobId}.png`;
+  const caricaturePath = `${resolvedUserId}/${petId}/${jobId}.png`;
   const upload = await serviceClient.storage.from("caricatures").upload(
     caricaturePath,
     generatedImage,
     { contentType: "image/png", upsert: true },
   );
   if (upload.error) {
-    await serviceClient.from("caricature_jobs").update({
+    await updateJob({
       status: "failed",
-      error_message: `storage upload failed: ${upload.error.message}`,
-      updated_at: new Date().toISOString(),
-    }).eq("id", jobId);
-    await serviceClient.from("pets").update({
-      caricature_status: "failed",
-      updated_at: new Date().toISOString(),
-    }).eq("id", body.petId).eq("owner_user_id", user.id);
-    return json({ errorCode: "STORAGE_UPLOAD_FAILED", requestId, jobId }, 500);
+      error_code: "storage_upload_failed",
+      error_message: compactMessage(upload.error.message),
+      retry_count: attemptCount,
+      completed_at: new Date().toISOString(),
+      latency_ms: Date.now() - startedAt,
+      provider_used: usedProvider,
+      fallback_used: usedProvider !== chain[0],
+    });
+    await patchPetStatus({ caricature_status: "failed" });
+    return json({
+      errorCode: "STORAGE_UPLOAD_FAILED",
+      message: "failed to upload caricature image",
+      version: requestVersion,
+      requestId,
+      jobId,
+    }, 500);
   }
 
   const { data: publicData } = serviceClient.storage.from("caricatures").getPublicUrl(caricaturePath);
   const caricatureUrl = publicData.publicUrl;
 
-  await serviceClient.from("pets").update({
+  await patchPetStatus({
     caricature_url: caricatureUrl,
     caricature_status: "ready",
     caricature_provider: usedProvider,
     caricature_style: style,
-    updated_at: new Date().toISOString(),
-  }).eq("id", body.petId).eq("owner_user_id", user.id);
-  await serviceClient.from("caricature_jobs").update({
+  });
+  await updateJob({
     status: "ready",
     provider_chain: chain.join(">"),
-    updated_at: new Date().toISOString(),
-  }).eq("id", jobId);
+    provider_used: usedProvider,
+    fallback_used: usedProvider !== chain[0],
+    retry_count: attemptCount,
+    error_code: null,
+    error_message: null,
+    completed_at: new Date().toISOString(),
+    latency_ms: Date.now() - startedAt,
+  });
 
   return json({
+    version: requestVersion,
+    requestId,
     jobId,
-    petId: body.petId,
+    petId,
     status: "ready",
     provider: usedProvider,
     fallbackUsed: usedProvider !== chain[0],

--- a/supabase/migrations/20260226234500_caricature_jobs_observability_columns.sql
+++ b/supabase/migrations/20260226234500_caricature_jobs_observability_columns.sql
@@ -1,0 +1,17 @@
+-- #24 caricature proxy observability columns
+
+alter table if exists public.caricature_jobs
+  add column if not exists request_id text,
+  add column if not exists schema_version text,
+  add column if not exists source_type text,
+  add column if not exists error_code text,
+  add column if not exists provider_used text,
+  add column if not exists fallback_used boolean not null default false,
+  add column if not exists latency_ms integer,
+  add column if not exists completed_at timestamptz;
+
+create index if not exists idx_caricature_jobs_request_id
+  on public.caricature_jobs(request_id);
+
+create index if not exists idx_caricature_jobs_completed_at
+  on public.caricature_jobs(completed_at desc);


### PR DESCRIPTION
## 요약
- 앱 내 모델 키 흔적 제거 (`Info.plist OpenAI`, 하드코딩 OpenAIKey)
- `ImageGeneratorView`를 서버 프록시 기반 캐리커처 생성/재시도 UX로 전환
- 공용 `CaricatureEdgeClient`로 가입 플로우/이미지 생성 플로우 호출 통합
- Edge Function `caricature` 요청/응답 스키마(version/requestId) 고정
- `pets.caricature_url`/status 반영 및 표준 에러코드 응답 강화
- `caricature_jobs` 관찰성 컬럼 migration 추가
- 함수 계약 문서(`supabase/functions/caricature/README.md`) 및 사이클 보고서 추가

## 테스트
- swift scripts/caricature_proxy_unit_check.swift
- swift scripts/feature_gate_architecture_unit_check.swift
- swift scripts/guest_upgrade_ux_unit_check.swift

## 이슈
- Closes #24
