### PR TITLE
[Issue #25] watchOS 원격 버튼형 제어 계약/ACK/재연결 신뢰성 완성

### DIFF
--- a/docs/cycle-25-watch-remote-report-2026-02-26.md
+++ b/docs/cycle-25-watch-remote-report-2026-02-26.md
@@ -1,0 +1,37 @@
+# Cycle #25 결과 보고서 (2026-02-26)
+
+## 1. 이슈 확인
+- 대상 이슈: `#25 [Task] watchOS 원격 버튼형 산책 제어 완성`
+- 목표: `startWalk/addPoint/endWalk` 계약 고정 + dedupe + 상태 피드백 + 재연결 동작 정리
+
+## 2. 개발 완료
+1. WCSession 메시지 계약 고정
+- 계약 버전: `watch.remote.v1`
+- Watch -> iPhone 액션 envelope: `version/type/action/action_id/sent_at/payload`
+- iPhone -> Watch ACK envelope: `type=watch_ack`, `status`, `action_id`
+- iPhone 파서는 구형(flat) payload와 신규(payload nested) 계약 모두 수용
+
+2. 중복 수신 방지(dedupe)
+- iPhone에서 `action_id` 기반 dedupe 유지
+- duplicate 수신 시 ACK `status=duplicate` 응답
+
+3. iPhone -> Watch 상태 피드백 보강
+- context에 `version`, `type=watch_state`, `watch_status`, `last_action_id_applied` 추가
+- Watch UI에 queue count/ACK/action id/last sync 시각 노출
+
+4. 오프라인/재연결 동작 정의 구현
+- Watch 즉시 전송: `sendMessage` + ACK 처리
+- 즉시 실패 시 로컬 큐 적재
+- 재연결 시 큐를 `transferUserInfo`로 등록하여 재전송
+
+## 3. 문서화
+- `docs/watch-connectivity-reliability-v1.md`를 #25 기준 계약으로 갱신
+- 신규 유닛체크: `scripts/watch_remote_contract_unit_check.swift`
+
+## 4. 유닛 테스트
+- `swift scripts/watch_remote_contract_unit_check.swift` -> PASS
+- `swift scripts/watch_reliability_unit_check.swift` -> PASS
+- `swift scripts/walk_runtime_guardrails_unit_check.swift` -> PASS
+
+## 5. 메모
+- 실기기(iPhone+Watch) 연동 확인은 별도 QA 단계에서 수행 필요.

--- a/docs/watch-connectivity-reliability-v1.md
+++ b/docs/watch-connectivity-reliability-v1.md
@@ -1,61 +1,79 @@
-# Watch Connectivity Reliability v1
+# Watch Connectivity Reliability v1 (Issue #25)
 
 ## 1. 목적
-watchOS 액션 전달에서 중복 적용과 유실을 줄이기 위한 신뢰성 규약을 고정한다.
+watchOS 원격 액션(`startWalk/addPoint/endWalk`)을 iPhone 상태머신에 멱등/복구 가능하게 반영한다.
 
 연결 이슈:
-- 구현: #43
+- 구현: #25
 
-## 2. 액션 계약
-iPhone <- Watch payload:
+## 2. 액션 계약 (Watch -> iPhone)
+버전 고정: `watch.remote.v1`
 
 ```json
 {
-  "action": "startWalk | addPoint | endWalk",
+  "version": "watch.remote.v1",
+  "type": "watch_action",
+  "action": "startWalk",
   "action_id": "uuid",
-  "sent_at": 1770000000.0
+  "sent_at": 1770000000.0,
+  "payload": {
+    "action": "startWalk",
+    "action_id": "uuid",
+    "sent_at": 1770000000.0
+  }
 }
 ```
 
-필드 규칙:
-- `action`: watch 사용자 의도
-- `action_id`: 멱등키(중복 제거 기준)
-- `sent_at`: watch 발생 시각(epoch seconds)
+규칙:
+- `action_id`는 멱등키(중복 수신 제거 기준)
+- `payload`가 표준 계약이며, 상위 필드는 레거시 호환용으로도 유지
+- `type != watch_action` 인 메시지는 무시
 
-## 3. 수신 측(iPhone) 처리
-- `action_id`를 최근 N개(기본 500) 캐시
-- 이미 처리된 `action_id`는 무시
-- 액션 적용:
-  - `startWalk`: 산책이 꺼져 있으면 시작
-  - `addPoint`: 산책 중일 때만 포인트 추가
-  - `endWalk`: 산책 중일 때만 종료
-
-## 4. 송신 측(Watch) 처리
-- 즉시 전송 경로:
-  - `session.isReachable == true`이면 `sendMessage` 시도
-- 비연결/실패 경로:
-  - 로컬 큐(UserDefaults)에 저장
-  - 세션 활성화 후 `transferUserInfo`로 재전송
-- 큐는 전송 등록 후 비움(전송 보장은 `transferUserInfo`가 담당)
-
-## 5. 컨텍스트 동기화
-iPhone -> Watch application context:
+## 3. ACK 계약 (iPhone -> Watch reply)
 
 ```json
 {
+  "version": "watch.remote.v1",
+  "type": "watch_ack",
+  "status": "accepted | duplicate | ignored",
+  "action": "startWalk",
+  "action_id": "uuid",
+  "last_sync_at": 1770000001.0
+}
+```
+
+## 4. iPhone 수신 처리
+- 최근 `action_id` 500개 캐시 후 dedupe
+- 액션 적용 기준
+  - `startWalk`: 미산책 상태에서만 시작
+  - `addPoint`: 산책 중 + 위치가 있을 때만 추가
+  - `endWalk`: 산책 중일 때만 종료
+  - `syncState`: 상태 재동기화
+- 적용 결과는 `syncWatchContext(force: true)`로 즉시 피드백
+
+## 5. 상태 컨텍스트 계약 (iPhone -> Watch)
+
+```json
+{
+  "version": "watch.remote.v1",
+  "type": "watch_state",
   "isWalking": true,
   "time": 123.0,
   "area": 45.6,
-  "last_sync_at": 1770000000.0
+  "last_sync_at": 1770000002.0,
+  "watch_status": "워치 동기화 12:34:56",
+  "last_action_id_applied": "uuid"
 }
 ```
 
-목적:
-- Watch UI 상태 표시(연동 상태/시간/면적)
-- 로컬 액션 시점 판단 보조
+## 6. 오프라인/재연결 동작
+- Watch 즉시 전송: `sendMessage` + ACK 처리
+- 즉시 전송 실패 시: 로컬 큐(UserDefaults)에 적재
+- 재연결 시: 큐를 `transferUserInfo`로 등록하여 순차 재전송
+- 큐 등록 후 로컬 큐는 비워 `중복 등록`을 방지
 
-## 6. 검증 시나리오
-- [ ] 동일 `action_id`를 2회 보내도 1회만 적용
-- [ ] watch 오프라인에서 액션 누적 후 연결 복구 시 반영
-- [ ] 산책 중이 아닐 때 `addPoint`가 무시됨
-- [ ] `startWalk -> addPoint -> endWalk` 순서가 iPhone에 반영
+## 7. 검증 시나리오
+- [ ] 워치에서 `startWalk -> addPoint x3 -> endWalk` 순서 반영
+- [ ] 동일 `action_id` 재수신 시 duplicate ACK + 1회 적용
+- [ ] 오프라인 액션 누적 후 재연결 시 큐 반영
+- [ ] 컨텍스트(`time/area/last_action_id_applied`)가 Watch UI와 일치

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -127,6 +127,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     private var processedWatchActionOrder: [String] = []
     private let maxProcessedWatchActions = 500
     private var lastWatchContextSyncAt: Date = .distantPast
+    private var lastAppliedWatchActionId: String = ""
     private let processedWatchActionStorageKey = "watch.processedActionIds"
     private let activeWalkSessionStorageKey = "walk.activeSession.v1"
     private let heatmapEnabledKey = "heatmap.enabled"
@@ -170,6 +171,19 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         case addPoint
         case endWalk
         case syncState
+    }
+
+    private struct WatchActionEnvelope {
+        let version: String
+        let action: WatchIncomingAction
+        let actionId: String
+        let sentAt: TimeInterval?
+    }
+
+    private enum WatchContract {
+        static let version = "watch.remote.v1"
+        static let actionType = "watch_action"
+        static let ackType = "watch_ack"
     }
 
     private enum PointAppendSource {
@@ -1322,10 +1336,14 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         }
 
         let context: [String: Any] = [
+            "version": WatchContract.version,
+            "type": "watch_state",
             "isWalking": self.isWalking,
             "time": self.time,
             "area": self.polygon.walkingArea,
-            "last_sync_at": now.timeIntervalSince1970
+            "last_sync_at": now.timeIntervalSince1970,
+            "watch_status": self.watchSyncStatusText,
+            "last_action_id_applied": self.lastAppliedWatchActionId
         ]
 
         do {
@@ -1364,80 +1382,118 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
         return true
     }
 
-    private func handleWatchPayload(_ payload: [String: Any]) {
-        guard let action = parseWatchAction(from: payload) else { return }
-        let actionName = action.rawValue
+    @discardableResult
+    private func handleWatchPayload(_ payload: [String: Any]) -> [String: Any]? {
+        guard let envelope = parseWatchEnvelope(from: payload) else { return nil }
+        let actionName = envelope.action.rawValue
+        let sentAtLabel: String = {
+            guard let sentAt = envelope.sentAt else { return "" }
+            return " sent:\(Int(sentAt))"
+        }()
         latestWatchActionText = "워치 \(actionName) 수신 \(Self.statusTimeString(from: Date()))"
         metricTracker.track(
             .watchActionReceived,
             userKey: currentMetricUserId(),
-            payload: ["action": actionName]
+            payload: [
+                "action": actionName,
+                "version": envelope.version + sentAtLabel
+            ]
         )
-        let actionId: String = {
-            if let id = payload["action_id"] as? String, id.isEmpty == false {
-                return id
-            }
-            if let sentAt = payload["sent_at"] as? TimeInterval {
-                return "\(actionName):\(Int(sentAt * 1000.0))"
-            }
-            return UUID().uuidString
-        }()
-        if shouldProcessWatchAction(actionId: actionId) == false {
+        if shouldProcessWatchAction(actionId: envelope.actionId) == false {
             metricTracker.track(
                 .watchActionDuplicate,
                 userKey: currentMetricUserId(),
-                payload: ["action": actionName]
+                payload: [
+                    "action": actionName,
+                    "actionId": envelope.actionId
+                ]
             )
-            return
+            return [
+                "version": WatchContract.version,
+                "type": WatchContract.ackType,
+                "status": "duplicate",
+                "action": actionName,
+                "action_id": envelope.actionId,
+                "last_sync_at": Date().timeIntervalSince1970
+            ]
         }
         metricTracker.track(
             .watchActionProcessed,
             userKey: currentMetricUserId(),
-            payload: ["action": actionName]
+            payload: [
+                "action": actionName,
+                "actionId": envelope.actionId
+            ]
         )
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.applyWatchAction(action)
+            self.applyWatchAction(envelope)
         }
+        return [
+            "version": WatchContract.version,
+            "type": WatchContract.ackType,
+            "status": "accepted",
+            "action": actionName,
+            "action_id": envelope.actionId,
+            "last_sync_at": Date().timeIntervalSince1970
+        ]
     }
 
-    private func parseWatchAction(from payload: [String: Any]) -> WatchIncomingAction? {
-        guard let rawAction = payload["action"] as? String else { return nil }
-        return WatchIncomingAction(rawValue: rawAction)
+    private func parseWatchEnvelope(from payload: [String: Any]) -> WatchActionEnvelope? {
+        let version = (payload["version"] as? String) ?? "watch.legacy.v0"
+        if let type = payload["type"] as? String,
+           type.isEmpty == false,
+           type != WatchContract.actionType {
+            return nil
+        }
+        let nestedPayload = payload["payload"] as? [String: Any]
+        let actionPayload = nestedPayload ?? payload
+
+        guard let rawAction = (actionPayload["action"] as? String) ?? (payload["action"] as? String),
+              let action = WatchIncomingAction(rawValue: rawAction) else {
+            return nil
+        }
+        let actionId: String = {
+            if let id = (actionPayload["action_id"] as? String) ?? (payload["action_id"] as? String),
+               id.isEmpty == false {
+                return id
+            }
+            if let sentAt = (actionPayload["sent_at"] as? TimeInterval) ?? (payload["sent_at"] as? TimeInterval) {
+                return "\(rawAction):\(Int(sentAt * 1000.0))"
+            }
+            return UUID().uuidString.lowercased()
+        }()
+        let sentAt = (actionPayload["sent_at"] as? TimeInterval) ?? (payload["sent_at"] as? TimeInterval)
+        return WatchActionEnvelope(version: version, action: action, actionId: actionId, sentAt: sentAt)
     }
 
-    private func applyWatchAction(_ action: WatchIncomingAction) {
+    private func applyWatchAction(_ envelope: WatchActionEnvelope) {
+        let action = envelope.action
         switch action {
         case .startWalk:
             if self.isWalking == false {
                 self.startWalkNow()
                 self.latestWatchActionText = "워치 시작 반영 \(Self.statusTimeString(from: Date()))"
                 self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action.rawValue])
-            } else {
-                self.syncWatchContext(force: true)
             }
         case .addPoint:
             if self.isWalking {
                 if let location = self.location {
                     self.appendWalkPoint(from: location, recordedAt: Date(), source: .watch)
-                    self.syncWatchContext(force: true)
                     self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action.rawValue])
                 }
-            } else {
-                self.syncWatchContext(force: true)
             }
         case .endWalk:
             if self.isWalking {
                 self.endWalk()
                 self.latestWatchActionText = "워치 종료 반영 \(Self.statusTimeString(from: Date()))"
                 self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action.rawValue])
-            } else {
-                self.syncWatchContext(force: true)
             }
         case .syncState:
             self.latestWatchActionText = "워치 상태 재동기화 \(Self.statusTimeString(from: Date()))"
-            self.syncWatchContext(force: true)
         }
+        self.lastAppliedWatchActionId = envelope.actionId
+        self.syncWatchContext(force: true)
     }
 
 }
@@ -1659,6 +1715,20 @@ extension MapViewModel {
 
     func sessionReachabilityDidChange(_ session: WCSession) {
         self.syncWatchContext(force: true)
+    }
+
+    func session(
+        _ session: WCSession,
+        didReceiveMessage message: [String : Any],
+        replyHandler: @escaping ([String : Any]) -> Void
+    ) {
+        let ack = self.handleWatchPayload(message) ?? [
+            "version": WatchContract.version,
+            "type": WatchContract.ackType,
+            "status": "ignored",
+            "last_sync_at": Date().timeIntervalSince1970
+        ]
+        replyHandler(ack)
     }
 
     func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {

--- a/dogAreaWatch Watch App/ContentView.swift
+++ b/dogAreaWatch Watch App/ContentView.swift
@@ -17,8 +17,16 @@ struct ContentView: View {
         return String(format: "%02d:%02d", min, sec)
     }
 
+    private var lastSyncText: String {
+        guard viewModel.lastSyncAt > 0 else { return "-" }
+        let date = Date(timeIntervalSince1970: viewModel.lastSyncAt)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
+    }
+
     var body: some View {
-        VStack {
+        VStack(spacing: 8) {
             Text(viewModel.isWalking ? "산책 중" : "대기 중")
             Text("시간 \(durationText)")
                 .font(.footnote)
@@ -27,6 +35,15 @@ struct ContentView: View {
             Text(viewModel.isReachable ? "연결됨" : "오프라인 큐")
                 .font(.caption2)
                 .foregroundStyle(viewModel.isReachable ? .green : .orange)
+            Text("큐 \(viewModel.pendingActionCount)건")
+                .font(.caption2)
+                .foregroundStyle(viewModel.pendingActionCount > 0 ? .orange : .secondary)
+            Text("ACK \(viewModel.lastAckActionId.isEmpty ? "-" : String(viewModel.lastAckActionId.prefix(8)))")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("동기화 \(lastSyncText)")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
 
             if viewModel.isWalking {
                 Button("영역 표시하기") {

--- a/dogAreaWatch Watch App/ContentsViewModel.swift
+++ b/dogAreaWatch Watch App/ContentsViewModel.swift
@@ -9,15 +9,25 @@ import Foundation
 import WatchConnectivity
 
 struct WatchActionDTO: Codable, Equatable {
+    let version: String
+    let type: String
     let action: String
     let actionId: String
     let sentAt: TimeInterval
 
-    var payload: [String: Any] {
-        [
+    var envelope: [String: Any] {
+        let payload: [String: Any] = [
             "action": action,
             "action_id": actionId,
             "sent_at": sentAt
+        ]
+        return [
+            "version": version,
+            "type": type,
+            "action": action,
+            "action_id": actionId,
+            "sent_at": sentAt,
+            "payload": payload
         ]
     }
 }
@@ -35,8 +45,15 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
     @Published var walkingArea: Double = 0
     @Published var isReachable = false
     @Published var lastSyncAt: TimeInterval = 0
+    @Published var pendingActionCount: Int = 0
+    @Published var lastAckStatus: String = "대기"
+    @Published var lastAckActionId: String = ""
+    @Published var contractVersion: String = "watch.remote.v1"
 
     private let actionQueueStorageKey = "watch.pendingActions.v1"
+    private let watchContractVersion = "watch.remote.v1"
+    private let watchActionMessageType = "watch_action"
+    private let watchAckMessageType = "watch_ack"
     private var pendingActions: [WatchActionDTO] = []
     private let session = WCSession.default
 
@@ -54,16 +71,15 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
 
     func sendAction(_ action: WatchActionType) {
         let dto = WatchActionDTO(
+            version: watchContractVersion,
+            type: watchActionMessageType,
             action: action.rawValue,
-            actionId: UUID().uuidString,
+            actionId: UUID().uuidString.lowercased(),
             sentAt: Date().timeIntervalSince1970
         )
 
         if session.activationState == .activated, session.isReachable {
-            session.sendMessage(dto.payload, replyHandler: nil) { [weak self] _ in
-                self?.enqueue(dto)
-                self?.flushPendingActions()
-            }
+            sendImmediately(dto)
             return
         }
 
@@ -71,18 +87,35 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
         flushPendingActions()
     }
 
+    private func sendImmediately(_ action: WatchActionDTO) {
+        session.sendMessage(action.envelope, replyHandler: { [weak self] reply in
+            self?.handleAck(reply, fallbackActionId: action.actionId)
+        }, errorHandler: { [weak self] _ in
+            self?.enqueue(action)
+            self?.flushPendingActions()
+            DispatchQueue.main.async {
+                self?.lastAckStatus = "즉시 전송 실패, 큐로 보관"
+                self?.lastAckActionId = action.actionId
+            }
+        })
+    }
+
     private func enqueue(_ action: WatchActionDTO) {
+        guard pendingActions.contains(where: { $0.actionId == action.actionId }) == false else { return }
         pendingActions.append(action)
         persistPendingActions()
+        pendingActionCount = pendingActions.count
     }
 
     private func loadPendingActions() {
         guard let data = UserDefaults.standard.data(forKey: actionQueueStorageKey),
               let decoded = try? JSONDecoder().decode([WatchActionDTO].self, from: data) else {
             pendingActions = []
+            pendingActionCount = 0
             return
         }
         pendingActions = decoded
+        pendingActionCount = decoded.count
     }
 
     private func persistPendingActions() {
@@ -93,21 +126,48 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
     private func flushPendingActions() {
         guard session.activationState == .activated,
               session.isReachable,
-              pendingActions.isEmpty == false else { return }
+              pendingActions.isEmpty == false else {
+            pendingActionCount = pendingActions.count
+            return
+        }
 
-        // Flush queued actions when the connection is restored.
-        pendingActions.forEach { session.transferUserInfo($0.payload) }
+        let queued = pendingActions
+        queued.forEach { session.transferUserInfo($0.envelope) }
         pendingActions.removeAll()
         persistPendingActions()
+        pendingActionCount = 0
+        lastAckStatus = "큐 전송 등록 \(queued.count)건"
     }
 
     private func applyContext(_ context: [String: Any]) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            self.contractVersion = context["version"] as? String ?? self.contractVersion
             self.isWalking = context["isWalking"] as? Bool ?? false
             self.walkingTime = context["time"] as? TimeInterval ?? 0
             self.walkingArea = context["area"] as? Double ?? 0
             self.lastSyncAt = context["last_sync_at"] as? TimeInterval ?? 0
+            if let appliedActionId = context["last_action_id_applied"] as? String, appliedActionId.isEmpty == false {
+                self.lastAckActionId = appliedActionId
+            }
+            if let status = context["watch_status"] as? String, status.isEmpty == false {
+                self.lastAckStatus = status
+            }
+        }
+    }
+
+    private func handleAck(_ reply: [String: Any], fallbackActionId: String) {
+        let replyType = reply["type"] as? String
+        if let replyType, replyType.isEmpty == false, replyType != watchAckMessageType {
+            return
+        }
+        let status = (reply["status"] as? String) ?? "accepted"
+        let actionId = (reply["action_id"] as? String) ?? fallbackActionId
+        let syncedAt = (reply["last_sync_at"] as? TimeInterval) ?? Date().timeIntervalSince1970
+        DispatchQueue.main.async { [weak self] in
+            self?.lastAckStatus = "ACK \(status)"
+            self?.lastAckActionId = actionId
+            self?.lastSyncAt = syncedAt
         }
     }
 

--- a/scripts/watch_remote_contract_unit_check.swift
+++ b/scripts/watch_remote_contract_unit_check.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct Check {
+    static var failed = false
+
+    static func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            print("[PASS] \(message)")
+        } else {
+            failed = true
+            print("[FAIL] \(message)")
+        }
+    }
+}
+
+func read(_ path: String) -> String {
+    (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+}
+
+let mapViewModel = read("dogArea/Views/MapView/MapViewModel.swift")
+let watchVM = read("dogAreaWatch Watch App/ContentsViewModel.swift")
+let watchView = read("dogAreaWatch Watch App/ContentView.swift")
+let docs = read("docs/watch-connectivity-reliability-v1.md")
+
+Check.assertTrue(mapViewModel.contains("static let version = \"watch.remote.v1\""), "iphone side should define watch contract version")
+Check.assertTrue(mapViewModel.contains("WatchActionEnvelope"), "iphone side should parse watch envelope")
+Check.assertTrue(mapViewModel.contains("payload\"] as? [String: Any]"), "iphone parser should support nested payload contract")
+Check.assertTrue(mapViewModel.contains("didReceiveMessage message: [String : Any],"), "iphone delegate should support reply handler message path")
+Check.assertTrue(mapViewModel.contains("type\": WatchContract.ackType"), "iphone should return watch ack type")
+Check.assertTrue(mapViewModel.contains("last_action_id_applied"), "iphone should send last applied action id in context")
+
+Check.assertTrue(watchVM.contains("watch.remote.v1"), "watch side should pin contract version")
+Check.assertTrue(watchVM.contains("\"type\": type"), "watch side should include type in envelope")
+Check.assertTrue(watchVM.contains("session.sendMessage(action.envelope"), "watch should send immediate message with envelope")
+Check.assertTrue(watchVM.contains("session.transferUserInfo($0.envelope)"), "watch should queue and resend via transferUserInfo")
+Check.assertTrue(watchVM.contains("lastAckStatus"), "watch view model should expose ack status")
+Check.assertTrue(watchVM.contains("pendingActionCount"), "watch view model should expose pending queue size")
+
+Check.assertTrue(watchView.contains("큐 \\(viewModel.pendingActionCount)건"), "watch UI should render pending queue count")
+Check.assertTrue(watchView.contains("ACK"), "watch UI should show ack state")
+
+Check.assertTrue(docs.contains("watch.remote.v1"), "docs should describe contract version")
+Check.assertTrue(docs.contains("watch_ack"), "docs should describe ack contract")
+Check.assertTrue(docs.contains("transferUserInfo"), "docs should define reconnect queue behavior")
+
+if Check.failed {
+    exit(1)
+}
+
+print("All watch remote contract checks passed.")


### PR DESCRIPTION
## 요약
- Watch 원격 액션 계약을 `watch.remote.v1`로 고정(version/type/payload)
- iPhone 수신 파서를 신규/구형 payload 모두 처리하도록 확장
- iPhone -> Watch ACK(`watch_ack`) 응답 경로 추가
- dedupe duplicate 시 ACK `status=duplicate` 반환
- iPhone 상태 컨텍스트에 `last_action_id_applied`, `watch_status` 등 피드백 필드 추가
- Watch 오프라인 큐 + 재연결 `transferUserInfo` 재전송 흐름 보강
- Watch UI에 queue/ACK/sync 상태 노출
- 신뢰성 문서 갱신 + watch 계약 유닛체크 추가

## 테스트
- swift scripts/watch_remote_contract_unit_check.swift
- swift scripts/watch_reliability_unit_check.swift
- swift scripts/walk_runtime_guardrails_unit_check.swift

## 이슈
- Closes #25
