### PR TITLE
[Issue #36] Firebase App Distribution 서명/배포 체인 확정

### DIFF
--- a/.github/workflows/firebase-distribution.yml
+++ b/.github/workflows/firebase-distribution.yml
@@ -1,0 +1,268 @@
+name: Firebase Distribution
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: "Firebase release notes (optional)"
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: firebase-distribution-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  distribute-ios:
+    runs-on: macos-14
+    timeout-minutes: 90
+    env:
+      FIREBASE_APP_ID: ${{ vars.FIREBASE_APP_ID }}
+      FIREBASE_TESTER_GROUP: ${{ vars.FIREBASE_TESTER_GROUP }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Xcode Version
+        run: xcodebuild -version
+
+      - name: Validate required secrets
+        id: validate
+        env:
+          IOS_DIST_CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
+          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+          FIREBASE_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          WATCH_PROVISIONING_PROFILE_BASE64: ${{ secrets.WATCH_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "${IOS_DIST_CERT_P12_BASE64}" ]] && missing+=("IOS_DIST_CERT_P12_BASE64(signing)")
+          [[ -z "${IOS_DIST_CERT_PASSWORD}" ]] && missing+=("IOS_DIST_CERT_PASSWORD(signing)")
+          [[ -z "${IOS_PROVISIONING_PROFILE_BASE64}" ]] && missing+=("IOS_PROVISIONING_PROFILE_BASE64(signing)")
+          if [[ -z "${FIREBASE_SERVICE_ACCOUNT_JSON_BASE64}" && -z "${FIREBASE_SERVICE_ACCOUNT_JSON}" ]]; then
+            missing+=("FIREBASE_SERVICE_ACCOUNT_JSON_BASE64|FIREBASE_SERVICE_ACCOUNT_JSON(permission)")
+          fi
+
+          watchState="not_set"
+          if [[ -n "${WATCH_PROVISIONING_PROFILE_BASE64}" ]]; then
+            watchState="provided"
+          fi
+          echo "watch_profile_state=${watchState}" >> "$GITHUB_OUTPUT"
+
+          if (( ${#missing[@]} > 0 )); then
+            printf '%s\n' "${missing[@]}" > .failure_missing_secrets.txt
+            echo "::error title=CI_SECRET_MISSING::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Ensure CI config placeholders
+        id: config_placeholders
+        run: |
+          set -euo pipefail
+          [[ -f OpenAIConfiguration.xcconfig ]] || printf 'OPENAI_API_KEY=\n' > OpenAIConfiguration.xcconfig
+          mkdir -p supabase
+          [[ -f supabase/supabaseConfig.xcconfig ]] || cat > supabase/supabaseConfig.xcconfig <<'CONFIG'
+          SUPABASE_URL=
+          SUPABASE_ANON_KEY=
+          SUPABASE_SERVICE_ROLE_KEY=
+          PROJECT_REF=
+          STORAGE_BUCKETS=
+          AUTH_REDIRECT_URL=
+          DB_CONN_STRING=
+          EXISTING_SCHEMA=
+CONFIG
+
+      - name: Prepare signing assets
+        id: signing_assets
+        env:
+          IOS_DIST_CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
+          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+          WATCH_PROVISIONING_PROFILE_BASE64: ${{ secrets.WATCH_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/dogarea-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          CERT_PATH="$RUNNER_TEMP/dist.p12"
+          IOS_PROFILE_PATH="$RUNNER_TEMP/ios.mobileprovision"
+          WATCH_PROFILE_PATH="$RUNNER_TEMP/watch.mobileprovision"
+
+          echo "$IOS_DIST_CERT_P12_BASE64" | base64 --decode > "$CERT_PATH"
+          echo "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$IOS_PROFILE_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$IOS_DIST_CERT_PASSWORD" -A -t cert -f pkcs12
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILE_DIR"
+          cp "$IOS_PROFILE_PATH" "$PROFILE_DIR/$(uuidgen).mobileprovision"
+
+          security cms -D -i "$IOS_PROFILE_PATH" > "$RUNNER_TEMP/ios_profile.plist"
+          IOS_PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print :Name' "$RUNNER_TEMP/ios_profile.plist")
+          TEAM_ID=$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$RUNNER_TEMP/ios_profile.plist")
+
+          WATCH_PROFILE_NAME=""
+          if [[ -n "${WATCH_PROVISIONING_PROFILE_BASE64}" ]]; then
+            echo "$WATCH_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$WATCH_PROFILE_PATH"
+            cp "$WATCH_PROFILE_PATH" "$PROFILE_DIR/$(uuidgen).mobileprovision"
+            security cms -D -i "$WATCH_PROFILE_PATH" > "$RUNNER_TEMP/watch_profile.plist"
+            WATCH_PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print :Name' "$RUNNER_TEMP/watch_profile.plist")
+          fi
+
+          EXPORT_PLIST="$RUNNER_TEMP/ExportOptions.plist"
+          {
+            echo '<?xml version="1.0" encoding="UTF-8"?>'
+            echo '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+            echo '<plist version="1.0">'
+            echo '<dict>'
+            echo '  <key>method</key><string>ad-hoc</string>'
+            echo '  <key>signingStyle</key><string>manual</string>'
+            echo "  <key>teamID</key><string>${TEAM_ID}</string>"
+            echo '  <key>provisioningProfiles</key>'
+            echo '  <dict>'
+            echo "    <key>com.th.dogArea</key><string>${IOS_PROFILE_NAME}</string>"
+            if [[ -n "$WATCH_PROFILE_NAME" ]]; then
+              echo "    <key>com.th.dogArea.watchkitapp</key><string>${WATCH_PROFILE_NAME}</string>"
+            fi
+            echo '  </dict>'
+            echo '  <key>compileBitcode</key><false/>'
+            echo '  <key>stripSwiftSymbols</key><true/>'
+            echo '</dict>'
+            echo '</plist>'
+          } > "$EXPORT_PLIST"
+
+          echo "team_id=${TEAM_ID}" >> "$GITHUB_OUTPUT"
+          echo "export_plist=${EXPORT_PLIST}" >> "$GITHUB_OUTPUT"
+          echo "watch_profile_name=${WATCH_PROFILE_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Archive iOS app
+        id: archive
+        env:
+          TEAM_ID: ${{ steps.signing_assets.outputs.team_id }}
+          WATCH_PROFILE_NAME: ${{ steps.signing_assets.outputs.watch_profile_name }}
+          WATCH_PROFILE_STATE: ${{ steps.validate.outputs.watch_profile_state }}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          set -o pipefail
+          xcodebuild \
+            -skipPackagePluginValidation \
+            -project dogArea.xcodeproj \
+            -scheme dogArea \
+            -configuration Release \
+            -archivePath build/dogArea.xcarchive \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="$TEAM_ID" \
+            clean archive | tee build/archive.log
+
+          if [[ "${WATCH_PROFILE_STATE}" != "provided" && "${WATCH_PROFILE_NAME}" == "" ]]; then
+            if rg -n "watchkitapp|watchOS|No profiles for" build/archive.log >/dev/null 2>&1; then
+              echo "::error title=SIGNING_WATCH_PROFILE_MISSING::watchOS signing hints detected; set WATCH_PROVISIONING_PROFILE_BASE64"
+            fi
+          fi
+
+      - name: Export IPA
+        id: export_ipa
+        run: |
+          set -euo pipefail
+          mkdir -p build/export
+          set -o pipefail
+          xcodebuild \
+            -exportArchive \
+            -archivePath build/dogArea.xcarchive \
+            -exportPath build/export \
+            -exportOptionsPlist "${{ steps.signing_assets.outputs.export_plist }}" | tee build/export.log
+
+          IPA_PATH="$(find build/export -maxdepth 1 -name '*.ipa' | head -n 1)"
+          if [[ -z "$IPA_PATH" ]]; then
+            echo "::error title=BUILD_NO_IPA::IPA not found in build/export"
+            exit 1
+          fi
+          echo "ipa_path=$IPA_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dogArea-ipa-${{ github.run_number }}
+          path: ${{ steps.export_ipa.outputs.ipa_path }}
+          if-no-files-found: error
+
+      - name: Distribute to Firebase App Distribution
+        id: firebase_distribution
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          FIREBASE_APP_ID: ${{ env.FIREBASE_APP_ID }}
+          FIREBASE_TESTER_GROUP: ${{ env.FIREBASE_TESTER_GROUP }}
+          IPA_PATH: ${{ steps.export_ipa.outputs.ipa_path }}
+          RELEASE_NOTES_INPUT: ${{ github.event.inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          SA_PATH="$RUNNER_TEMP/firebase-sa.json"
+          if [[ -n "${FIREBASE_SERVICE_ACCOUNT_JSON_BASE64}" ]]; then
+            echo "$FIREBASE_SERVICE_ACCOUNT_JSON_BASE64" | base64 --decode > "$SA_PATH"
+          else
+            printf '%s\n' "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$SA_PATH"
+          fi
+          export GOOGLE_APPLICATION_CREDENTIALS="$SA_PATH"
+
+          APP_ID="${FIREBASE_APP_ID:-1:326179558500:ios:c8404bae2adc65046dbb71}"
+          GROUPS="${FIREBASE_TESTER_GROUP:-tester}"
+          NOTES="${RELEASE_NOTES_INPUT:-}"
+          if [[ -z "$NOTES" ]]; then
+            NOTES="dogArea CI build ${GITHUB_SHA::7}"
+          fi
+
+          npm i -g firebase-tools
+          firebase appdistribution:distribute "$IPA_PATH" \
+            --app "$APP_ID" \
+            --groups "$GROUPS" \
+            --release-notes "$NOTES"
+
+      - name: Failure classification guide
+        if: failure()
+        run: |
+          set -euo pipefail
+          echo "## Failure Classification" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ steps.validate.outcome }}" == "failure" ]]; then
+            echo "- 분류: 서명/권한 시크릿 누락" >> "$GITHUB_STEP_SUMMARY"
+            if [[ -f .failure_missing_secrets.txt ]]; then
+              echo "- 누락 시크릿:" >> "$GITHUB_STEP_SUMMARY"
+              while read -r line; do
+                echo "  - ${line}" >> "$GITHUB_STEP_SUMMARY"
+              done < .failure_missing_secrets.txt
+            fi
+            exit 0
+          fi
+
+          if [[ "${{ steps.archive.outcome }}" == "failure" || "${{ steps.export_ipa.outcome }}" == "failure" ]]; then
+            echo "- 분류: 빌드/서명 단계 실패" >> "$GITHUB_STEP_SUMMARY"
+            if [[ -f build/archive.log ]] && rg -n "No profiles for|CodeSign|Provisioning" build/archive.log >/dev/null 2>&1; then
+              echo "- 상세: 서명 실패 로그 감지 (archive.log)" >> "$GITHUB_STEP_SUMMARY"
+            fi
+            if [[ -f build/archive.log ]] && rg -n "watchkitapp|watchOS" build/archive.log >/dev/null 2>&1; then
+              echo "- 상세: watch 서명 실패 가능성 (WATCH_PROVISIONING_PROFILE_BASE64 확인)" >> "$GITHUB_STEP_SUMMARY"
+            fi
+            exit 0
+          fi
+
+          if [[ "${{ steps.firebase_distribution.outcome }}" == "failure" ]]; then
+            echo "- 분류: Firebase 권한/배포 실패" >> "$GITHUB_STEP_SUMMARY"
+            echo "- 확인: FIREBASE_SERVICE_ACCOUNT_JSON_BASE64, FIREBASE_APP_ID, tester 그룹 권한" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "- 분류 불명: 실행 로그를 확인하세요." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/cycle-36-firebase-distribution-report-2026-02-26.md
+++ b/docs/cycle-36-firebase-distribution-report-2026-02-26.md
@@ -1,0 +1,41 @@
+# Cycle #36 결과 보고서 (2026-02-26)
+
+## 1. 이슈 확인
+- 대상 이슈: `#36 [Task] Firebase App Distribution 서명/배포 체인 확정`
+- 상태: 워크플로우/런북/실패분류 체인 구현 완료
+
+## 2. 개발 완료
+1. Firebase Distribution 워크플로우 신규 추가
+- 파일: `.github/workflows/firebase-distribution.yml`
+- 트리거: `main` push + `workflow_dispatch`
+- 산출물: IPA artifact 업로드 + Firebase tester 배포
+
+2. 서명 체인 및 watch 분기
+- iOS cert/profile 시크릿 검증
+- watch profile(`WATCH_PROVISIONING_PROFILE_BASE64`) 선택 적용
+- watch signing 힌트 로그 감지 시 Step Summary에 원인 분류
+
+3. 실패 로그 분류 가이드
+- 워크플로우 실패 시 마지막 단계에서 분류:
+  - 시크릿 누락
+  - 빌드/서명 실패
+  - Firebase 권한/배포 실패
+- Step Summary에 즉시 원인 표기
+
+4. 운영 문서화
+- 파일: `docs/github-actions-firebase-distribution.md`
+- 포함 내용:
+  - 시크릿/변수 목록
+  - Apple/Firebase material 준비 방법
+  - watch profile 분기
+  - workflow_dispatch 리허설 절차
+
+## 3. 유닛 테스트
+- `swift scripts/firebase_distribution_workflow_unit_check.swift` -> PASS
+- `swift scripts/release_regression_checklist_unit_check.swift` -> PASS
+- `swift scripts/swift_stability_unit_check.swift` -> PASS
+
+## 4. 메모
+- 브랜치 상태에서는 `gh workflow run firebase-distribution.yml --ref <branch>`가
+  default branch 기준 제한으로 실행되지 않음(404).
+- 리허설 1회는 `main` 머지 후 workflow_dispatch로 수행.

--- a/docs/github-actions-firebase-distribution.md
+++ b/docs/github-actions-firebase-distribution.md
@@ -1,0 +1,82 @@
+# GitHub Actions Firebase Distribution Runbook (Issue #36)
+
+## 1. 목표
+- `main` 머지 또는 수동 실행(`workflow_dispatch`) 시
+  - iOS archive/export(IPA)
+  - Firebase App Distribution `tester` 그룹 배포
+  를 자동 수행한다.
+
+워크플로우 파일:
+- `.github/workflows/firebase-distribution.yml`
+
+## 2. 트리거
+- 자동: `push` to `main`
+- 수동: `workflow_dispatch` (옵션 `release_notes`)
+
+## 3. 시크릿/변수
+필수 GitHub Secrets:
+- `IOS_DIST_CERT_P12_BASE64`
+- `IOS_DIST_CERT_PASSWORD`
+- `IOS_PROVISIONING_PROFILE_BASE64`
+- `FIREBASE_SERVICE_ACCOUNT_JSON_BASE64` 또는 `FIREBASE_SERVICE_ACCOUNT_JSON`
+
+선택 GitHub Secret:
+- `WATCH_PROVISIONING_PROFILE_BASE64`
+  - watch 서명 실패 시 설정 권장
+
+선택 GitHub Variables:
+- `FIREBASE_APP_ID` (없으면 기본값 사용)
+- `FIREBASE_TESTER_GROUP` (없으면 `tester`)
+
+## 4. Apple signing material 준비
+1. 배포 인증서(.p12) 생성 후 Base64 인코딩
+```bash
+base64 -i dist-cert.p12 | pbcopy
+```
+2. iOS provisioning profile(.mobileprovision) Base64 인코딩
+```bash
+base64 -i ios.mobileprovision | pbcopy
+```
+3. watch profile이 있으면 동일 방식으로 `WATCH_PROVISIONING_PROFILE_BASE64` 등록
+
+## 5. Firebase service account 준비
+1. Firebase 프로젝트 서비스 계정 JSON 발급
+2. 아래 둘 중 하나로 등록
+  - Base64 인코딩 후 `FIREBASE_SERVICE_ACCOUNT_JSON_BASE64`
+  - 원문 JSON 그대로 `FIREBASE_SERVICE_ACCOUNT_JSON`
+```bash
+base64 -i firebase-service-account.json | pbcopy
+```
+
+## 6. watch profile 분기
+- watch profile secret이 비어 있어도 워크플로우는 실행됨
+- archive 로그에 watch 서명 오류가 감지되면
+  - Step Summary에 `watch 서명 실패 가능성`으로 분류됨
+  - `WATCH_PROVISIONING_PROFILE_BASE64` 설정 후 재실행
+
+## 7. 실패 분류 기준
+워크플로우 마지막 `Failure classification guide` 단계에서 분류:
+- 시크릿 누락: `서명/권한 시크릿 누락`
+- archive/export 실패: `빌드/서명 단계 실패`
+- Firebase 배포 실패: `Firebase 권한/배포 실패`
+
+## 8. 리허설 실행
+수동 실행 1회:
+1. GitHub Actions -> `Firebase Distribution`
+2. `Run workflow` 클릭
+3. `main` 기준 실행
+4. 결과 확인
+- artifact: `dogArea-ipa-*`
+- Firebase 배포 대상 그룹: `tester`
+
+CLI 실행 예시:
+```bash
+gh workflow run firebase-distribution.yml --ref main
+```
+
+## 9. 운영 체크리스트
+- [ ] 시크릿 4종 등록 완료
+- [ ] (선택) watch profile 시크릿 등록
+- [ ] workflow_dispatch 1회 실행
+- [ ] artifact 생성 확인
+- [ ] tester 그룹 배포 확인

--- a/scripts/firebase_distribution_workflow_unit_check.swift
+++ b/scripts/firebase_distribution_workflow_unit_check.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct Check {
+    static var failed = false
+
+    static func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            print("[PASS] \(message)")
+        } else {
+            failed = true
+            print("[FAIL] \(message)")
+        }
+    }
+}
+
+func read(_ path: String) -> String {
+    (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+}
+
+let workflow = read(".github/workflows/firebase-distribution.yml")
+let doc = read("docs/github-actions-firebase-distribution.md")
+
+Check.assertTrue(workflow.contains("name: Firebase Distribution"), "workflow should exist with expected name")
+Check.assertTrue(workflow.contains("push:"), "workflow should trigger on main push")
+Check.assertTrue(workflow.contains("workflow_dispatch:"), "workflow should support manual dispatch")
+Check.assertTrue(workflow.contains("IOS_DIST_CERT_P12_BASE64"), "workflow should validate iOS cert secret")
+Check.assertTrue(workflow.contains("IOS_PROVISIONING_PROFILE_BASE64"), "workflow should validate iOS profile secret")
+Check.assertTrue(workflow.contains("WATCH_PROVISIONING_PROFILE_BASE64"), "workflow should include optional watch profile branch")
+Check.assertTrue(workflow.contains("xcodebuild \\"), "workflow should archive with xcodebuild")
+Check.assertTrue(workflow.contains("-exportArchive"), "workflow should export IPA")
+Check.assertTrue(workflow.contains("firebase appdistribution:distribute"), "workflow should upload to Firebase App Distribution")
+Check.assertTrue(workflow.contains("Failure classification guide"), "workflow should contain failure classification step")
+
+Check.assertTrue(doc.contains("GitHub Actions Firebase Distribution Runbook"), "runbook doc should exist")
+Check.assertTrue(doc.contains("시크릿/변수"), "runbook should describe required secrets")
+Check.assertTrue(doc.contains("watch profile 분기"), "runbook should document watch profile fallback")
+Check.assertTrue(doc.contains("실패 분류 기준"), "runbook should document failure classification")
+Check.assertTrue(doc.contains("리허설 실행"), "runbook should document workflow_dispatch rehearsal")
+
+if Check.failed {
+    exit(1)
+}
+
+print("All firebase distribution workflow checks passed.")


### PR DESCRIPTION
## 요약
- Firebase App Distribution 전용 워크플로우 신규 추가
  - main push + workflow_dispatch 트리거
  - signed archive/export(IPA) + artifact 업로드 + tester 그룹 배포
- 시크릿 검증/서명 체인 구성
  - iOS cert/profile 필수
  - watch profile optional 분기
  - Firebase service account(base64/plain) 호환
- 실패 분류 가이드 단계 추가
  - 시크릿 누락 / 빌드·서명 실패 / Firebase 권한 실패
- 운영 런북 문서화
  - 시크릿 등록 방법
  - watch profile 분기
  - 리허설 실행 절차
- 워크플로우 유닛 체크 스크립트 추가

## 테스트
- swift scripts/firebase_distribution_workflow_unit_check.swift
- swift scripts/release_regression_checklist_unit_check.swift
- swift scripts/swift_stability_unit_check.swift

## 이슈
- Closes #36
