### PR TITLE
[CI Hotfix] Firebase Distribution workflow_dispatch 호환성 수정

### DIFF
--- a/.github/workflows/firebase-distribution.yml
+++ b/.github/workflows/firebase-distribution.yml
@@ -10,7 +10,6 @@ on:
         description: "Firebase release notes (optional)"
         required: false
         default: ""
-        type: string
 
 concurrency:
   group: firebase-distribution-${{ github.ref }}


### PR DESCRIPTION
## 요약
- `firebase-distribution.yml`의 `workflow_dispatch` 입력 스키마에서 `type` 필드를 제거해 API dispatch 호환성 확보

## 테스트
- swift scripts/firebase_distribution_workflow_unit_check.swift

## 참고
- #36 후속 안정화 수정
