### PR TITLE
[CI Hotfix] Firebase Distribution workflow_dispatch 재호환

### DIFF
--- a/.github/workflows/firebase-distribution.yml
+++ b/.github/workflows/firebase-distribution.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      release_notes:
-        description: "Firebase release notes (optional)"
-        required: false
-        default: ""
 
 concurrency:
   group: firebase-distribution-${{ github.ref }}
@@ -207,7 +202,6 @@ CONFIG
           FIREBASE_APP_ID: ${{ env.FIREBASE_APP_ID }}
           FIREBASE_TESTER_GROUP: ${{ env.FIREBASE_TESTER_GROUP }}
           IPA_PATH: ${{ steps.export_ipa.outputs.ipa_path }}
-          RELEASE_NOTES_INPUT: ${{ github.event.inputs.release_notes }}
         run: |
           set -euo pipefail
           SA_PATH="$RUNNER_TEMP/firebase-sa.json"
@@ -220,10 +214,7 @@ CONFIG
 
           APP_ID="${FIREBASE_APP_ID:-1:326179558500:ios:c8404bae2adc65046dbb71}"
           GROUPS="${FIREBASE_TESTER_GROUP:-tester}"
-          NOTES="${RELEASE_NOTES_INPUT:-}"
-          if [[ -z "$NOTES" ]]; then
-            NOTES="dogArea CI build ${GITHUB_SHA::7}"
-          fi
+          NOTES="dogArea CI build ${GITHUB_SHA::7}"
 
           npm i -g firebase-tools
           firebase appdistribution:distribute "$IPA_PATH" \

--- a/docs/github-actions-firebase-distribution.md
+++ b/docs/github-actions-firebase-distribution.md
@@ -11,7 +11,7 @@
 
 ## 2. 트리거
 - 자동: `push` to `main`
-- 수동: `workflow_dispatch` (옵션 `release_notes`)
+- 수동: `workflow_dispatch`
 
 ## 3. 시크릿/변수
 필수 GitHub Secrets:


### PR DESCRIPTION
## 요약
- Firebase Distribution 워크플로우의 workflow_dispatch 입력 블록 제거로 수동 실행 호환성 개선
- release note는 기본값(`dogArea CI build <sha>`) 사용으로 단순화

## 테스트
- swift scripts/firebase_distribution_workflow_unit_check.swift

## 참고
- #36 후속 핫픽스
