### PR TITLE
[Issue #105] Firebase workflow YAML 파싱 실패 복구

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -62,16 +62,17 @@ jobs:
           set -euo pipefail
           [[ -f OpenAIConfiguration.xcconfig ]] || printf 'OPENAI_API_KEY=\n' > OpenAIConfiguration.xcconfig
           mkdir -p supabase
-          [[ -f supabase/supabaseConfig.xcconfig ]] || cat > supabase/supabaseConfig.xcconfig <<'CONFIG'
-          SUPABASE_URL=
-          SUPABASE_ANON_KEY=
-          SUPABASE_SERVICE_ROLE_KEY=
-          PROJECT_REF=
-          STORAGE_BUCKETS=
-          AUTH_REDIRECT_URL=
-          DB_CONN_STRING=
-          EXISTING_SCHEMA=
-CONFIG
+          if [[ ! -f supabase/supabaseConfig.xcconfig ]]; then
+            printf '%s\n' \
+              'SUPABASE_URL=' \
+              'SUPABASE_ANON_KEY=' \
+              'SUPABASE_SERVICE_ROLE_KEY=' \
+              'PROJECT_REF=' \
+              'STORAGE_BUCKETS=' \
+              'AUTH_REDIRECT_URL=' \
+              'DB_CONN_STRING=' \
+              'EXISTING_SCHEMA=' > supabase/supabaseConfig.xcconfig
+          fi
 
       - name: Prepare signing assets
         id: signing_assets

--- a/docs/cycle-105-firebase-workflow-yaml-fix-report-2026-02-26.md
+++ b/docs/cycle-105-firebase-workflow-yaml-fix-report-2026-02-26.md
@@ -1,0 +1,31 @@
+# Cycle 105 Report — Firebase Workflow YAML Parse Recovery (2026-02-26)
+
+## 1. Scope
+- Issue: #105
+- Goal: Recover `.github/workflows/firebase-app-distribution.yml` from YAML parse failure causing `0s` failed runs and `workflow_dispatch` 422 errors.
+
+## 2. Root Cause
+- In step `Ensure CI config placeholders`, a heredoc terminator (`CONFIG`) lost indentation inside the YAML `run: |` block.
+- This broke workflow parsing before job execution.
+
+## 3. Changes
+1. Workflow fix
+- Replaced heredoc placeholder generation with `printf`-based file generation in:
+  - `.github/workflows/firebase-app-distribution.yml`
+
+2. Regression guard
+- Added unit assertion to ensure problematic heredoc pattern is absent:
+  - `scripts/firebase_distribution_workflow_unit_check.swift`
+
+3. Runbook update
+- Added “YAML stability guard” section explaining why `printf` is required:
+  - `docs/github-actions-firebase-distribution.md`
+
+## 4. Verification
+- `swift scripts/firebase_distribution_workflow_unit_check.swift`
+- `swift scripts/release_regression_checklist_unit_check.swift`
+- `swift scripts/swift_stability_unit_check.swift`
+
+## 5. Expected Outcome
+- Push-triggered Firebase workflow starts actual jobs (not immediate parse failure).
+- `gh workflow run firebase-app-distribution.yml --ref main` no longer returns 422.

--- a/docs/github-actions-firebase-distribution.md
+++ b/docs/github-actions-firebase-distribution.md
@@ -80,3 +80,7 @@ gh workflow run firebase-app-distribution.yml --ref main
 - [ ] workflow_dispatch 1회 실행
 - [ ] artifact 생성 확인
 - [ ] tester 그룹 배포 확인
+
+## 10. YAML 안정성 가드
+- `Ensure CI config placeholders` 단계는 heredoc 대신 `printf`로 `supabaseConfig.xcconfig`를 생성한다.
+- 이유: 들여쓰기 실수로 workflow 전체 YAML 파싱이 깨지는 회귀를 방지하기 위함.

--- a/scripts/firebase_distribution_workflow_unit_check.swift
+++ b/scripts/firebase_distribution_workflow_unit_check.swift
@@ -30,6 +30,7 @@ Check.assertTrue(workflow.contains("xcodebuild \\"), "workflow should archive wi
 Check.assertTrue(workflow.contains("-exportArchive"), "workflow should export IPA")
 Check.assertTrue(workflow.contains("firebase appdistribution:distribute"), "workflow should upload to Firebase App Distribution")
 Check.assertTrue(workflow.contains("Failure classification guide"), "workflow should contain failure classification step")
+Check.assertTrue(!workflow.contains("<<'CONFIG'"), "workflow should avoid heredoc placeholders that can break YAML indentation")
 
 Check.assertTrue(doc.contains("GitHub Actions Firebase Distribution Runbook"), "runbook doc should exist")
 Check.assertTrue(doc.contains("시크릿/변수"), "runbook should describe required secrets")


### PR DESCRIPTION
## 요약
Issue #105 대응: Firebase distribution workflow YAML 파싱 실패를 복구해 push/manual dispatch가 정상 인식되도록 수정했습니다.

## 변경사항
- `.github/workflows/firebase-app-distribution.yml`
  - `Ensure CI config placeholders` 단계의 heredoc 제거
  - `printf` 기반 파일 생성으로 YAML 블록 안정화
- `scripts/firebase_distribution_workflow_unit_check.swift`
  - heredoc 회귀 방지 assertion 추가
- `docs/github-actions-firebase-distribution.md`
  - YAML 안정성 가드 섹션 추가
- `docs/cycle-105-firebase-workflow-yaml-fix-report-2026-02-26.md`
  - 이슈/원인/검증 기록 추가

## 테스트
- `swift scripts/firebase_distribution_workflow_unit_check.swift`
- `swift scripts/release_regression_checklist_unit_check.swift`
- `swift scripts/swift_stability_unit_check.swift`
