### PR TITLE
[Cycle #121] 명소 넓이 데이터 확장 1차: area_references 카탈로그/시드 고도화

### DIFF
--- a/docs/cycle-121-area-reference-catalog-report-2026-02-26.md
+++ b/docs/cycle-121-area-reference-catalog-report-2026-02-26.md
@@ -1,0 +1,41 @@
+# Cycle 121 Report — Area Reference Catalog & Seed Upgrade v1 (2026-02-26)
+
+## 1. Scope
+- Target issue: #121
+- Goal: `area_references`를 카탈로그 기반 운영 구조로 확장하고 비교군 시드를 확대
+
+## 2. Documentation First
+- Updated `docs/supabase-schema-v1.md`
+  - `area_reference_catalogs` 엔티티 추가
+  - `area_references.catalog_id/display_order/is_featured` 반영
+- Updated `docs/supabase-migration.md`
+  - 카탈로그/시드 정합성 검증 SQL(5.6) 추가
+- Updated `docs/release-regression-checklist-v1.md`
+  - 카탈로그 구조 회귀 체크 항목 추가
+
+## 3. Implementation
+1. Migration
+- Added `supabase/migrations/20260227013000_area_references_catalog_seed_upgrade.sql`
+  - `area_reference_catalogs` 테이블 추가
+  - `area_references`에 `catalog_id`, `display_order`, `is_featured` 컬럼 추가
+  - 중복 `reference_name` 정리 + unique index + catalog FK 추가
+  - RLS/정책/인덱스/updated_at trigger 확장
+  - 국내 지자체/해외 도시공원/국립공원 시드 upsert(카탈로그 기반)
+
+2. Unit check
+- Added `scripts/area_reference_catalog_seed_unit_check.swift`
+
+## 4. Unit Tests
+- `swift scripts/area_reference_catalog_seed_unit_check.swift` -> PASS
+- `swift scripts/release_regression_checklist_unit_check.swift` -> PASS
+- `swift scripts/supabase_ops_hardening_unit_check.swift` -> PASS
+- `swift scripts/project_stability_unit_check.swift` -> PASS
+- `swift scripts/swift_stability_unit_check.swift` -> PASS
+
+## 5. Outcome
+- 비교군 데이터가 카탈로그/정렬/featured 기반으로 운영 가능한 구조가 됨
+- 시드 업서트 기반으로 중복 없이 데이터 확장이 가능해짐
+
+## 6. Supabase QA Status
+- `npx --yes supabase migration list --local` -> BLOCKED (local DB 미실행)
+- `npx --yes supabase migration list --linked` -> BLOCKED (`supabase link` 미설정 워크트리)

--- a/docs/release-regression-checklist-v1.md
+++ b/docs/release-regression-checklist-v1.md
@@ -79,6 +79,7 @@
 - [ ] 신규 migration 파일 존재 확인
 - [ ] DDL/RLS/함수 변경사항 문서와 일치
 - [ ] `profiles.profile_message`, `pets.breed/age_years/gender` 컬럼 및 제약 확인
+- [ ] `area_reference_catalogs` + `area_references.catalog_id/display_order/is_featured` 구조 확인
 
 ## 6. 배포 파이프라인 검증 시나리오
 ### 6.1 Workflow 정의/활성 상태

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -142,9 +142,31 @@ order by pet.created_at asc;
 - `age_years`는 `null` 또는 `0..30`
 - 로컬 UserDefaults 저장값과 조회 결과가 동일
 
+### 5.6 비교군 카탈로그/시드 정합성 확인 (#121)
+```sql
+select
+  c.code as catalog_code,
+  c.name as catalog_name,
+  count(r.id) as reference_count,
+  sum(case when r.is_featured then 1 else 0 end) as featured_count,
+  min(r.display_order) as min_display_order,
+  max(r.display_order) as max_display_order
+from public.area_reference_catalogs c
+left join public.area_references r on r.catalog_id = c.id and r.is_active = true
+where c.is_active = true
+group by c.code, c.name
+order by c.sort_order asc, c.code asc;
+```
+
+기대값:
+- 활성 카탈로그별 `reference_count`가 0보다 큼
+- `featured_count`가 최소 1개 이상(큐레이션 카탈로그 기준)
+- `display_order`가 음수 없이 정렬 가능 범위로 유지
+
 ## 6. 운영 체크리스트
 - [ ] `migration list --local` / `migration list --linked` 결과 저장
 - [ ] User A/B 교차 접근 차단 SQL 결과 저장
 - [ ] Storage 버킷 정책/경로 규칙 검증
 - [ ] 핵심 통계 SQL 결과를 릴리스 문서에 첨부
 - [ ] User/Pet 확장 필드 정합성 SQL 결과 첨부
+- [ ] 비교군 카탈로그/시드 정합성 SQL 결과 첨부

--- a/docs/supabase-schema-v1.md
+++ b/docs/supabase-schema-v1.md
@@ -30,6 +30,7 @@ erDiagram
   WALK_SESSIONS ||--o{ WALK_SESSION_PETS : "n:m bridge"
   PETS ||--o{ WALK_SESSION_PETS : "n:m bridge"
   AUTH_USERS ||--o{ AREA_MILESTONES : "achieves"
+  AREA_REFERENCE_CATALOGS ||--o{ AREA_REFERENCES : "groups"
   PETS ||--o{ AREA_MILESTONES : "optional"
   PETS ||--o{ CARICATURE_JOBS : "queued jobs"
   AUTH_USERS ||--|| USER_VISIBILITY_SETTINGS : "privacy"
@@ -101,14 +102,28 @@ erDiagram
     timestamptz created_at
   }
 
+  AREA_REFERENCE_CATALOGS {
+    uuid id PK
+    text code
+    text name
+    text description
+    int sort_order
+    boolean is_active
+    timestamptz created_at
+    timestamptz updated_at
+  }
+
   AREA_REFERENCES {
     uuid id PK
+    uuid catalog_id FK
     text reference_name
     float area_m2
     text category
     text country_code
     text source_label
     text source_url
+    int display_order
+    boolean is_featured
     boolean is_active
     jsonb metadata
     timestamptz created_at
@@ -163,7 +178,10 @@ erDiagram
   - `caricature_status` 허용값: `queued`, `processing`, `ready`, `failed`
 
 ### 4.3 비교군
+- `area_reference_catalogs`: 비교군 카탈로그(큐레이션/정렬/활성 관리)
 - `area_references`: 지자체/명소 넓이 비교 데이터
+  - `catalog_id` 기반 그룹화
+  - `display_order`, `is_featured` 기반 홈/상세 노출 순서 제어
 - `area_milestones`: 사용자(또는 반려견) 달성 이력
 
 ### 4.4 캐리커처 비동기
@@ -190,6 +208,9 @@ erDiagram
   - `select/insert/update/delete`: 소유자만
 - `area_references`
   - `select`: 전체 공개
+  - `insert/update/delete`: `service_role`
+- `area_reference_catalogs`
+  - `select`: 전체 공개(활성 카탈로그)
   - `insert/update/delete`: `service_role`
 - `caricature_jobs`
   - `select`: 소유자
@@ -219,7 +240,7 @@ erDiagram
 ## 7. 마이그레이션 순서
 1. 확장/기본 함수 생성(`set_updated_at`)
 2. 핵심 테이블 생성(`profiles`, `pets`, `walk_sessions`, `walk_points`, `area_milestones`, `walk_session_pets`)
-3. 비교군 테이블 생성(`area_references`) 및 seed
+3. 비교군 테이블 생성(`area_reference_catalogs`, `area_references`) 및 seed
 4. 캐리커처/근처 기능 테이블 생성(`caricature_jobs`, `user_visibility_settings`, `nearby_presence`)
 5. 인덱스 생성
 6. RLS enable + 정책 적용

--- a/scripts/area_reference_catalog_seed_unit_check.swift
+++ b/scripts/area_reference_catalog_seed_unit_check.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let migration = load("supabase/migrations/20260227013000_area_references_catalog_seed_upgrade.sql")
+let schemaDoc = load("docs/supabase-schema-v1.md")
+let migrationDoc = load("docs/supabase-migration.md")
+
+assertTrue(
+    migration.contains("create table if not exists public.area_reference_catalogs"),
+    "migration should create area_reference_catalogs table"
+)
+assertTrue(
+    migration.contains("add column if not exists catalog_id uuid"),
+    "migration should extend area_references with catalog_id"
+)
+assertTrue(
+    migration.contains("add column if not exists display_order integer"),
+    "migration should extend area_references with display_order"
+)
+assertTrue(
+    migration.contains("add column if not exists is_featured boolean"),
+    "migration should extend area_references with is_featured"
+)
+assertTrue(
+    migration.contains("area_references_catalog_id_fkey"),
+    "migration should enforce catalog foreign key"
+)
+assertTrue(
+    migration.contains("idx_area_references_reference_name_unique"),
+    "migration should enforce unique reference_name index for deterministic upsert"
+)
+assertTrue(
+    migration.contains("on conflict (reference_name)"),
+    "migration should upsert area reference seeds by reference_name"
+)
+assertTrue(
+    migration.contains("seed_version"),
+    "migration should stamp metadata seed_version"
+)
+
+assertTrue(
+    schemaDoc.contains("AREA_REFERENCE_CATALOGS"),
+    "schema doc should include area reference catalogs entity"
+)
+assertTrue(
+    schemaDoc.contains("display_order"),
+    "schema doc should document display_order"
+)
+assertTrue(
+    schemaDoc.contains("is_featured"),
+    "schema doc should document is_featured"
+)
+assertTrue(
+    migrationDoc.contains("5.6 비교군 카탈로그/시드 정합성 확인"),
+    "migration ops doc should include area reference catalog validation SQL"
+)
+
+print("PASS: area reference catalog seed unit checks")

--- a/supabase/migrations/20260227013000_area_references_catalog_seed_upgrade.sql
+++ b/supabase/migrations/20260227013000_area_references_catalog_seed_upgrade.sql
@@ -1,0 +1,244 @@
+-- #121 area_references catalog management + seed expansion
+
+create table if not exists public.area_reference_catalogs (
+  id uuid primary key default gen_random_uuid(),
+  code text not null,
+  name text not null,
+  description text,
+  sort_order integer not null default 100,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.area_reference_catalogs
+  add column if not exists code text,
+  add column if not exists name text,
+  add column if not exists description text,
+  add column if not exists sort_order integer not null default 100,
+  add column if not exists is_active boolean not null default true,
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now();
+
+with ranked as (
+  select ctid,
+         row_number() over (
+           partition by lower(reference_name)
+           order by updated_at desc nulls last, created_at desc nulls last, id
+         ) as rn
+  from public.area_references
+)
+delete from public.area_references ar
+using ranked r
+where ar.ctid = r.ctid
+  and r.rn > 1;
+
+create unique index if not exists idx_area_references_reference_name_unique
+  on public.area_references(reference_name);
+
+create unique index if not exists idx_area_reference_catalogs_code_unique
+  on public.area_reference_catalogs(code);
+
+create index if not exists idx_area_reference_catalogs_active_sort
+  on public.area_reference_catalogs(is_active, sort_order asc);
+
+alter table public.area_references
+  add column if not exists catalog_id uuid,
+  add column if not exists display_order integer not null default 1000,
+  add column if not exists is_featured boolean not null default false;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'area_references_display_order_nonnegative_check'
+  ) then
+    alter table public.area_references
+      add constraint area_references_display_order_nonnegative_check
+      check (display_order >= 0);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'area_reference_catalogs_sort_order_nonnegative_check'
+  ) then
+    alter table public.area_reference_catalogs
+      add constraint area_reference_catalogs_sort_order_nonnegative_check
+      check (sort_order >= 0);
+  end if;
+end $$;
+
+insert into public.area_reference_catalogs (code, name, description, sort_order, is_active)
+values
+  ('kr_local_government', '국내 지자체', '국내 시군구/광역 지자체 비교군', 10, true),
+  ('global_urban_parks', '해외 도시 공원', '글로벌 주요 도시 공원 비교군', 20, true),
+  ('national_parks', '국립공원/보호구역', '국내외 대규모 자연공원 비교군', 30, true)
+on conflict (code) do update
+set
+  name = excluded.name,
+  description = excluded.description,
+  sort_order = excluded.sort_order,
+  is_active = excluded.is_active,
+  updated_at = now();
+
+with default_catalog as (
+  select id
+  from public.area_reference_catalogs
+  where code = 'kr_local_government'
+  limit 1
+)
+update public.area_references ar
+set
+  catalog_id = dc.id,
+  display_order = coalesce(ar.display_order, 1000),
+  is_featured = coalesce(ar.is_featured, false)
+from default_catalog dc
+where ar.catalog_id is null;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'area_references_catalog_id_fkey'
+  ) then
+    alter table public.area_references
+      add constraint area_references_catalog_id_fkey
+      foreign key (catalog_id) references public.area_reference_catalogs(id) on delete restrict;
+  end if;
+end $$;
+
+alter table public.area_references
+  alter column catalog_id set not null;
+
+create index if not exists idx_area_references_catalog_featured_order
+  on public.area_references(catalog_id, is_featured desc, display_order asc, area_m2 desc);
+
+create index if not exists idx_area_references_country_category
+  on public.area_references(country_code, category, area_m2 desc);
+
+drop trigger if exists trg_area_reference_catalogs_updated_at on public.area_reference_catalogs;
+create trigger trg_area_reference_catalogs_updated_at
+before update on public.area_reference_catalogs
+for each row execute function public.touch_updated_at();
+
+alter table public.area_reference_catalogs enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'area_reference_catalogs' and policyname = 'area_reference_catalogs_select_all'
+  ) then
+    create policy area_reference_catalogs_select_all on public.area_reference_catalogs
+      for select to anon, authenticated
+      using (is_active = true or auth.role() = 'service_role');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'area_reference_catalogs' and policyname = 'area_reference_catalogs_service_role_write'
+  ) then
+    create policy area_reference_catalogs_service_role_write on public.area_reference_catalogs
+      for all
+      using (auth.role() = 'service_role')
+      with check (auth.role() = 'service_role');
+  end if;
+end $$;
+
+grant select on public.area_reference_catalogs to anon, authenticated;
+grant all on public.area_reference_catalogs to service_role;
+
+with catalogs as (
+  select code, id
+  from public.area_reference_catalogs
+),
+seed(catalog_code, reference_name, area_m2, category, country_code, source_label, source_url, source_note, is_featured, display_order) as (
+  values
+    ('kr_local_government', '강원특별자치도 홍천군', 1820580000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', true, 10),
+    ('kr_local_government', '강원특별자치도 인제군', 1646190000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', true, 20),
+    ('kr_local_government', '경상북도 안동시', 1522210000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', true, 30),
+    ('kr_local_government', '강원특별자치도 평창군', 1464190000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', true, 40),
+    ('kr_local_government', '경상북도 경주시', 1324950000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 50),
+    ('kr_local_government', '경상북도 상주시', 1254680000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 60),
+    ('kr_local_government', '강원특별자치도 정선군', 1219880000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 70),
+    ('kr_local_government', '경상북도 봉화군', 1202280000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 80),
+    ('kr_local_government', '강원특별자치도 삼척시', 1187830000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 90),
+    ('kr_local_government', '경상북도 의성군', 1174630000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 100),
+    ('kr_local_government', '경상북도 포항시', 1130780000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 110),
+    ('kr_local_government', '강원특별자치도 영월군', 1127330000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 120),
+    ('kr_local_government', '강원특별자치도 춘천시', 1116410000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 130),
+    ('kr_local_government', '전라남도 해남군', 1043840000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 140),
+    ('kr_local_government', '강원특별자치도 강릉시', 1040680000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '면적 단위 km² -> m² 변환 시드', false, 150),
+    ('kr_local_government', '서울특별시', 605210000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '광역 지자체 비교군', true, 300),
+    ('kr_local_government', '세종특별자치시', 464920000::double precision, 'municipality', 'KR', 'KOSIS', 'https://kosis.kr', '광역 지자체 비교군', false, 310),
+
+    ('global_urban_parks', 'Central Park (NYC)', 3410000::double precision, 'urban_park', 'US', 'NYC Open Data', 'https://data.cityofnewyork.us', '도시 공원 비교군', true, 10),
+    ('global_urban_parks', 'Golden Gate Park', 4120000::double precision, 'urban_park', 'US', 'San Francisco Data', 'https://data.sfgov.org', '도시 공원 비교군', true, 20),
+    ('global_urban_parks', 'Griffith Park', 17400000::double precision, 'urban_park', 'US', 'LA Open Data', 'https://data.lacity.org', '도시 공원 비교군', true, 30),
+    ('global_urban_parks', 'Hyde Park (London)', 1420000::double precision, 'urban_park', 'GB', 'Royal Parks', 'https://www.royalparks.org.uk', '도시 공원 비교군', false, 40),
+    ('global_urban_parks', 'Ueno Park', 538000::double precision, 'urban_park', 'JP', 'Tokyo Park Data', 'https://www.tokyo-park.or.jp', '도시 공원 비교군', false, 50),
+    ('global_urban_parks', 'Yoyogi Park', 540000::double precision, 'urban_park', 'JP', 'Tokyo Park Data', 'https://www.tokyo-park.or.jp', '도시 공원 비교군', false, 60),
+    ('global_urban_parks', 'Nara Park', 5020000::double precision, 'urban_park', 'JP', 'Nara City', 'https://www.city.nara.lg.jp', '도시 공원 비교군', false, 70),
+    ('global_urban_parks', 'Tiergarten (Berlin)', 2100000::double precision, 'urban_park', 'DE', 'Berlin Open Data', 'https://daten.berlin.de', '도시 공원 비교군', false, 80),
+    ('global_urban_parks', 'Stanley Park', 4050000::double precision, 'urban_park', 'CA', 'City of Vancouver', 'https://opendata.vancouver.ca', '도시 공원 비교군', false, 90),
+    ('global_urban_parks', 'Chapultepec Park', 6860000::double precision, 'urban_park', 'MX', 'CDMX Data', 'https://datos.cdmx.gob.mx', '도시 공원 비교군', false, 100),
+    ('global_urban_parks', 'Lumpini Park', 576000::double precision, 'urban_park', 'TH', 'Bangkok Metropolitan', 'https://www.bangkok.go.th', '도시 공원 비교군', false, 110),
+    ('global_urban_parks', 'Ibirapuera Park', 1580000::double precision, 'urban_park', 'BR', 'Sao Paulo Data', 'https://www.prefeitura.sp.gov.br', '도시 공원 비교군', false, 120),
+    ('global_urban_parks', 'Parque del Retiro', 1250000::double precision, 'urban_park', 'ES', 'Madrid City', 'https://www.madrid.es', '도시 공원 비교군', false, 130),
+    ('global_urban_parks', 'Phoenix Park (Dublin)', 7070000::double precision, 'urban_park', 'IE', 'OPW Ireland', 'https://www.opw.ie', '도시 공원 비교군', false, 140),
+    ('global_urban_parks', 'Bois de Boulogne', 8460000::double precision, 'urban_park', 'FR', 'Paris Open Data', 'https://opendata.paris.fr', '도시 공원 비교군', false, 150),
+
+    ('national_parks', '설악산국립공원', 398000000::double precision, 'national_park', 'KR', '국립공원공단', 'https://www.knps.or.kr', '국내 국립공원 비교군', true, 10),
+    ('national_parks', '지리산국립공원', 471758000::double precision, 'national_park', 'KR', '국립공원공단', 'https://www.knps.or.kr', '국내 국립공원 비교군', true, 20),
+    ('national_parks', '한라산국립공원', 153300000::double precision, 'national_park', 'KR', '국립공원공단', 'https://www.knps.or.kr', '국내 국립공원 비교군', false, 30),
+    ('national_parks', '북한산국립공원', 79900000::double precision, 'national_park', 'KR', '국립공원공단', 'https://www.knps.or.kr', '국내 국립공원 비교군', false, 40),
+    ('national_parks', 'Yosemite National Park', 3027000000::double precision, 'national_park', 'US', 'US National Park Service', 'https://www.nps.gov', '해외 국립공원 비교군', true, 100),
+    ('national_parks', 'Yellowstone National Park', 8983000000::double precision, 'national_park', 'US', 'US National Park Service', 'https://www.nps.gov', '해외 국립공원 비교군', true, 110),
+    ('national_parks', 'Everglades National Park', 6105000000::double precision, 'national_park', 'US', 'US National Park Service', 'https://www.nps.gov', '해외 국립공원 비교군', false, 120),
+    ('national_parks', 'Great Smoky Mountains', 2114000000::double precision, 'national_park', 'US', 'US National Park Service', 'https://www.nps.gov', '해외 국립공원 비교군', false, 130),
+    ('national_parks', 'Grand Canyon National Park', 4927000000::double precision, 'national_park', 'US', 'US National Park Service', 'https://www.nps.gov', '해외 국립공원 비교군', false, 140),
+    ('national_parks', 'Banff National Park', 6641000000::double precision, 'national_park', 'CA', 'Parks Canada', 'https://parks.canada.ca', '해외 국립공원 비교군', false, 150)
+)
+insert into public.area_references (
+  catalog_id,
+  reference_name,
+  area_m2,
+  category,
+  country_code,
+  source_label,
+  source_url,
+  is_active,
+  metadata,
+  display_order,
+  is_featured
+)
+select
+  c.id,
+  s.reference_name,
+  s.area_m2,
+  s.category,
+  s.country_code,
+  s.source_label,
+  s.source_url,
+  true,
+  jsonb_build_object(
+    'source_note', s.source_note,
+    'seed_version', '2026_q1_v2'
+  ),
+  s.display_order,
+  s.is_featured
+from seed s
+join catalogs c on c.code = s.catalog_code
+on conflict (reference_name)
+do update set
+  catalog_id = excluded.catalog_id,
+  area_m2 = excluded.area_m2,
+  category = excluded.category,
+  country_code = excluded.country_code,
+  source_label = excluded.source_label,
+  source_url = excluded.source_url,
+  is_active = excluded.is_active,
+  metadata = excluded.metadata,
+  display_order = excluded.display_order,
+  is_featured = excluded.is_featured,
+  updated_at = now();


### PR DESCRIPTION
## Summary
- `area_reference_catalogs` 테이블을 추가하고 `area_references`를 `catalog_id/display_order/is_featured` 기반 운영 구조로 확장했습니다.
- `reference_name` 중복 정리 + unique index + catalog FK를 추가해 시드 업서트 정합성을 고정했습니다.
- 국내 지자체/해외 도시공원/국립공원 비교군 시드를 카탈로그 기반으로 대량 upsert하도록 migration을 추가했습니다.
- 스키마/마이그레이션/회귀 체크 문서를 동기화하고 신규 단위체크를 추가했습니다.

## Tests
- `swift scripts/area_reference_catalog_seed_unit_check.swift`
- `swift scripts/release_regression_checklist_unit_check.swift`
- `swift scripts/supabase_ops_hardening_unit_check.swift`
- `swift scripts/project_stability_unit_check.swift`
- `swift scripts/swift_stability_unit_check.swift`

## Supabase QA
- `npx --yes supabase migration list --local` -> BLOCKED (local DB not running)
- `npx --yes supabase migration list --linked` -> BLOCKED (`supabase link` not configured in this worktree)

Closes #121
