### PR TITLE
[P0] Rival privacy hard guard (k-anon + night delay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - Watch 액션 신뢰성 명세 v1: `docs/watch-connectivity-reliability-v1.md`
 - 캐리커처 비동기 파이프라인 명세 v1: `docs/caricature-async-pipeline-v1.md`
 - 근처 사용자 익명 핫스팟 명세 v1: `docs/nearby-anonymous-hotspot-v1.md`
+- 라이벌 프라이버시 하드 가드 v1: `docs/rival-privacy-hard-guard-v1.md`
 - Feature Flag/롤아웃 모니터링 명세 v1: `docs/feature-flag-rollout-monitoring-v1.md`
 - ViewModel 현대화 리팩토링 명세 v1: `docs/viewmodel-modernization-v1.md`
 - CoreData 반환 계약 정리 v1: `docs/coredata-return-contract-v1.md`

--- a/docs/cycle-150-rival-privacy-hard-guard-report-2026-02-27.md
+++ b/docs/cycle-150-rival-privacy-hard-guard-report-2026-02-27.md
@@ -1,0 +1,36 @@
+# Cycle 150 Report — Rival Privacy Hard Guard (2026-02-27)
+
+## 1. 대상
+- Issue: `#150 [P0][Task] 라이벌 프라이버시 하드 가드(k-anon + 야간 지연)`
+- Branch: `codex/cycle-150-rival-privacy`
+
+## 2. 구현 요약
+- Supabase에 프라이버시 가드 정책 테이블(`privacy_guard_policies`)을 추가하고 기본 정책(`k=20`, 주간 30분/야간 60분, 퍼센타일 fallback)을 고정
+- `rpc_get_nearby_hotspots`를 지연 반영 + k-anon + 민감 구역 마스킹 규칙으로 재구현
+- 표본 미달 셀은 `count=0`으로 비공개 처리하고 `percentile_only` 모드 intensity만 반환
+- 민감 구역 정의 테이블(`privacy_sensitive_geo_masks`)과 자동 마스킹 판별 함수 추가
+- `privacy_guard_audit_logs` + `view_privacy_guard_alerts_24h`로 요청 단위 점검 로그/경보 경로 추가
+- Edge Function(`nearby-presence`)에서 suppression 메타데이터를 파싱해 audit log를 적재하도록 확장
+
+## 3. 변경 파일
+- `supabase/migrations/20260227192000_rival_privacy_hard_guard.sql`
+- `supabase/functions/nearby-presence/index.ts`
+- `dogArea/Views/MapView/MapViewModel.swift`
+- `docs/nearby-anonymous-hotspot-v1.md`
+- `docs/rival-privacy-hard-guard-v1.md`
+- `docs/release-regression-checklist-v1.md`
+- `README.md`
+- `scripts/nearby_hotspot_unit_check.swift`
+- `scripts/rival_privacy_hard_guard_unit_check.swift`
+- `scripts/release_regression_checklist_unit_check.swift`
+- `scripts/ios_pr_check.sh`
+
+## 4. 유닛 체크
+- `swift scripts/nearby_hotspot_unit_check.swift` -> PASS
+- `swift scripts/rival_privacy_hard_guard_unit_check.swift` -> PASS
+- `swift scripts/release_regression_checklist_unit_check.swift` -> PASS
+- `swift scripts/project_stability_unit_check.swift` -> PASS
+
+## 5. 리스크/후속
+- 라이벌 전용 리더보드/매칭 백엔드(Stage 2, #131)가 아직 미구현이라 현재 가드는 nearby 경로에 선적용 상태.
+- 운영 단계에서 `privacy_sensitive_geo_masks` seed와 `view_privacy_guard_alerts_24h` 경보 임계치 조정이 추가로 필요.

--- a/docs/nearby-anonymous-hotspot-v1.md
+++ b/docs/nearby-anonymous-hotspot-v1.md
@@ -5,11 +5,15 @@
 
 연결 이슈:
 - 구현: #45
+- 프라이버시 하드 가드: #150
 
 ## 2. 프라이버시 규칙
 - 기본값: `location_sharing_enabled = false`
 - 명시적 동의 사용자만 presence 송신
 - 지도에는 닉네임/개별 좌표를 노출하지 않고 geohash7 집계 강도만 노출
+- 최소 표본(`k>=20`) 미달 셀은 정확 count를 숨기고 상위 퍼센타일 intensity만 노출
+- 반영 지연: 주간 30분, 야간 60분(`Asia/Seoul`, 기본값)
+- 민감 구역(`privacy_sensitive_geo_masks`)은 집계 결과에서 자동 마스킹
 
 ## 3. 데이터 계약
 
@@ -27,9 +31,11 @@
 - `updated_at timestamptz`
 
 ## 4. 집계 계약
-- TTL: `last_seen_at >= now() - interval '10 minutes'`
+- 지연 윈도우: `last_seen_at ∈ [now - (delay + 10m), now - delay]`
 - 조회 단위: geohash7
 - 반환: `geohash7`, `count`, `intensity`, `center_lat`, `center_lng`
+  - `count`: 표본 미달/민감 셀은 `0`으로 비공개 처리
+  - `intensity`: 표본 미달 셀은 percentile 기반(`privacy_mode=percentile_only`)
 - 반경 필터: 기본 1km
 
 ## 5. 주기
@@ -44,5 +50,8 @@
 ## 7. 검증 체크리스트
 - [ ] 비동의 사용자 송신 0건
 - [ ] 연결 상태에서 30초 주기 upsert 동작
-- [ ] TTL 10분 지난 presence 집계 제외
+- [ ] 주간 30분/야간 60분 지연 반영 후 핫스팟 노출
+- [ ] 표본 미달 셀 count 비공개 + percentile 노출 동작
+- [ ] 민감 구역 셀 자동 마스킹 동작
 - [ ] 지도 갱신 주기 10초 이내 반영
+- [ ] `privacy_guard_audit_logs`에 요청별 점검 로그/경보 적재

--- a/docs/release-regression-checklist-v1.md
+++ b/docs/release-regression-checklist-v1.md
@@ -64,6 +64,9 @@
 - [ ] 악천후 단계에서 실외 미션이 실내 대체 미션으로 자동 치환됨
 - [ ] 실내 미션 최소 행동량 미달 시 완료 확정이 거절됨
 - [ ] 실내 미션이 연속 일자에 동일 템플릿으로 반복 노출되지 않음
+- [ ] nearby 핫스팟에서 표본 미달 셀은 count가 노출되지 않고(percentile-only) 강도만 표시됨
+- [ ] nearby 핫스팟에서 야간(22~06) 지연 60분 정책이 반영됨
+- [ ] 민감 구역 마스킹 대상 셀이 지도 오버레이에 노출되지 않음
 
 ### 4.3 목록/상세
 - [ ] 산책 목록 로딩 정상
@@ -89,6 +92,7 @@
 - [ ] DDL/RLS/함수 변경사항 문서와 일치
 - [ ] `profiles.profile_message`, `pets.breed/age_years/gender` 컬럼 및 제약 확인
 - [ ] `area_reference_catalogs` + `area_references.catalog_id/display_order/is_featured` 구조 확인
+- [ ] `privacy_guard_policies/privacy_sensitive_geo_masks/privacy_guard_audit_logs` 구조 및 `rpc_get_nearby_hotspots` 확장 컬럼 확인
 
 ## 6. 배포 파이프라인 검증 시나리오
 ### 6.1 Workflow 정의/활성 상태

--- a/docs/rival-privacy-hard-guard-v1.md
+++ b/docs/rival-privacy-hard-guard-v1.md
@@ -1,0 +1,55 @@
+# Rival Privacy Hard Guard v1
+
+## 1. 목적
+라이벌/근처 익명 노출 경로에서 재식별 위험을 줄이기 위해 서버 강제형 프라이버시 가드를 적용한다.
+
+연결 이슈:
+- 구현: #150
+- 선행 정책: #130
+
+## 2. 정책 요약
+- 최소 표본 임계값: `k >= 20`
+- 표본 미달 셀: 정확 count 비노출(`count = 0`), 상위 퍼센타일 intensity만 노출
+- 반영 지연: 주간 30분, 야간 60분 (`policy_timezone` 기준)
+- 민감 구역: `privacy_sensitive_geo_masks`에 매칭되는 셀 자동 마스킹
+- 판정 주체: 서버(`rpc_get_nearby_hotspots`)가 최종 결정, 앱은 표현만 수행
+
+## 3. 스키마
+### 3.1 `privacy_guard_policies`
+- `policy_key text pk`
+- `min_sample_size int`
+- `percentile_fallback double precision`
+- `daytime_delay_minutes int`
+- `nighttime_delay_minutes int`
+- `active_window_minutes int`
+- `night_start_hour int`, `night_end_hour int`
+- `policy_timezone text`
+- `sensitive_mask_enabled boolean`
+- `updated_at timestamptz`
+
+### 3.2 `privacy_sensitive_geo_masks`
+- 민감 구역 경계 박스 기반 마스킹 룰 테이블
+- `min_lat/max_lat/min_lng/max_lng` 범위 매칭
+
+### 3.3 `privacy_guard_audit_logs`
+- 요청 단위 프라이버시 점검 로그/경보
+- `suppressed_hotspots`, `masked_hotspots`, `k_anon_hotspots`
+- `alert_level(info|warn|critical)`
+
+## 4. RPC 계약
+`rpc_get_nearby_hotspots(center_lat, center_lng, radius_km, now_ts)`
+
+반환 컬럼:
+- 기본: `geohash7`, `count`, `intensity`, `center_lat`, `center_lng`
+- 확장: `sample_count`, `privacy_mode`, `suppression_reason`, `delay_minutes`, `required_min_sample`
+
+## 5. 운영 가이드
+- 경보 모니터링 뷰: `view_privacy_guard_alerts_24h`
+- 초기 운영은 기본 정책(`nearby_hotspot`) 1개로 시작
+- 민감 구역은 운영자가 `privacy_sensitive_geo_masks`에 추가/비활성화
+
+## 6. 검증 포인트
+- 표본 경계값(19/20)에서 노출 모드 전환 정확성
+- 야간 시간대(22~06) 지연 60분 적용
+- 민감 구역 셀 미노출 확인
+- `privacy_guard_audit_logs` 경보 적재 확인

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -1238,10 +1238,12 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, CoreD
     }
 
     private func fetchNearbyHotspots(center: CLLocationCoordinate2D) {
+        let userId = currentPresenceUserId()
         Task { [weak self] in
             guard let self else { return }
             do {
                 let hotspots = try await nearbyService.getHotspots(
+                    userId: userId,
                     centerLatitude: center.latitude,
                     centerLongitude: center.longitude,
                     radiusKm: 1.0
@@ -1886,16 +1888,21 @@ private struct NearbyPresenceService {
     }
 
     func getHotspots(
+        userId: String?,
         centerLatitude: Double,
         centerLongitude: Double,
         radiusKm: Double
     ) async throws -> [NearbyHotspotDTO] {
-        let data = try await post(payload: [
+        var payload: [String: Any] = [
             "action": "get_hotspots",
             "centerLat": centerLatitude,
             "centerLng": centerLongitude,
             "radiusKm": radiusKm
-        ])
+        ]
+        if let userId, userId.isEmpty == false {
+            payload["userId"] = userId
+        }
+        let data = try await post(payload: payload)
         let decoded = try JSONDecoder().decode(HotspotEnvelope.self, from: data)
         return decoded.hotspots.map {
             NearbyHotspotDTO(

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -28,6 +28,7 @@ swift scripts/swift_stability_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift
 swift scripts/supabase_ops_hardening_unit_check.swift
+swift scripts/rival_privacy_hard_guard_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 
 if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then

--- a/scripts/nearby_hotspot_unit_check.swift
+++ b/scripts/nearby_hotspot_unit_check.swift
@@ -5,35 +5,133 @@ struct PresenceRecord {
     let lastSeenAt: TimeInterval
 }
 
-final class NearbyScheduler {
-    var locationSharingEnabled = false
-    var nearbyHotspotEnabled = true
-    var isWalking = false
-    private(set) var sentCount = 0
-    private(set) var fetchedCount = 0
-    private var lastSentAt: TimeInterval = 0
-    private var lastFetchedAt: TimeInterval = 0
-
-    func tick(now: TimeInterval) {
-        if locationSharingEnabled && isWalking && now - lastSentAt >= 30 {
-            lastSentAt = now
-            sentCount += 1
-        }
-        if nearbyHotspotEnabled && now - lastFetchedAt >= 10 {
-            lastFetchedAt = now
-            fetchedCount += 1
-        }
-    }
+struct NearbyPrivacyPolicy {
+    var minSampleSize: Int = 20
+    var percentileFallback: Double = 0.8
+    var daytimeDelayMinutes: Int = 30
+    var nighttimeDelayMinutes: Int = 60
+    var activeWindowMinutes: Int = 10
+    var nightStartHour: Int = 22
+    var nightEndHour: Int = 6
 }
 
-func aggregateAlive(records: [PresenceRecord], now: TimeInterval) -> [String: Int] {
+struct HotspotResult {
+    let geohash7: String
+    let countPublic: Int
+    let sampleCount: Int
+    let intensity: Double
+    let privacyMode: String
+    let suppressionReason: String?
+}
+
+func effectiveDelayMinutes(hour: Int, policy: NearbyPrivacyPolicy) -> Int {
+    let isNight: Bool
+    if policy.nightStartHour == policy.nightEndHour {
+        isNight = false
+    } else if policy.nightStartHour < policy.nightEndHour {
+        isNight = hour >= policy.nightStartHour && hour < policy.nightEndHour
+    } else {
+        isNight = hour >= policy.nightStartHour || hour < policy.nightEndHour
+    }
+    return isNight ? policy.nighttimeDelayMinutes : policy.daytimeDelayMinutes
+}
+
+func percentileRank(index: Int, total: Int) -> Double {
+    guard total > 1 else { return 1.0 }
+    return Double(index) / Double(total - 1)
+}
+
+func aggregateHotspots(
+    records: [PresenceRecord],
+    now: TimeInterval,
+    hour: Int,
+    sensitiveGeohashes: Set<String>,
+    policy: NearbyPrivacyPolicy = .init()
+) -> [HotspotResult] {
+    let delay = effectiveDelayMinutes(hour: hour, policy: policy)
+    let windowStart = now - Double(delay + policy.activeWindowMinutes) * 60.0
+    let windowEnd = now - Double(delay) * 60.0
+
     var grouped: [String: Int] = [:]
     for record in records {
-        if now - record.lastSeenAt <= 600 {
+        if record.lastSeenAt >= windowStart && record.lastSeenAt <= windowEnd {
             grouped[record.geohash7, default: 0] += 1
         }
     }
-    return grouped
+
+    let ranked = grouped
+        .map { (geohash: $0.key, sampleCount: $0.value) }
+        .sorted {
+            if $0.sampleCount == $1.sampleCount {
+                return $0.geohash < $1.geohash
+            }
+            return $0.sampleCount < $1.sampleCount
+        }
+
+    struct Candidate {
+        let geohash: String
+        let sampleCount: Int
+        let percentile: Double
+        let suppressionReason: String?
+    }
+
+    let candidates: [Candidate] = ranked.enumerated().compactMap { index, item in
+        let percentile = percentileRank(index: index, total: ranked.count)
+        let reason: String?
+        if sensitiveGeohashes.contains(item.geohash) {
+            reason = "sensitive_mask"
+        } else if item.sampleCount < policy.minSampleSize {
+            reason = "k_anon"
+        } else {
+            reason = nil
+        }
+
+        if reason == "sensitive_mask" {
+            return nil
+        }
+        if reason == "k_anon" && percentile < policy.percentileFallback {
+            return nil
+        }
+        return Candidate(
+            geohash: item.geohash,
+            sampleCount: item.sampleCount,
+            percentile: percentile,
+            suppressionReason: reason
+        )
+    }
+
+    let maxVisibleCount = candidates
+        .filter { $0.suppressionReason == nil }
+        .map(\.sampleCount)
+        .max() ?? 0
+
+    let sortedByIntensity = candidates
+        .map { candidate -> HotspotResult in
+            let intensity: Double
+            if candidate.suppressionReason == "k_anon" {
+                intensity = max(0.05, min(1.0, candidate.percentile))
+            } else if maxVisibleCount > 0 {
+                intensity = min(1.0, max(0.0, Double(candidate.sampleCount) / Double(maxVisibleCount)))
+            } else {
+                intensity = 0.0
+            }
+            return HotspotResult(
+                geohash7: candidate.geohash,
+                countPublic: candidate.suppressionReason == nil ? candidate.sampleCount : 0,
+                sampleCount: candidate.sampleCount,
+                intensity: intensity,
+                privacyMode: candidate.suppressionReason == "k_anon" ? "percentile_only" : "full",
+                suppressionReason: candidate.suppressionReason
+            )
+        }
+        .sorted {
+            if $0.intensity == $1.intensity {
+                return $0.geohash7 < $1.geohash7
+            }
+            return $0.intensity > $1.intensity
+        }
+
+    return sortedByIntensity
 }
 
 @inline(__always)
@@ -44,31 +142,41 @@ func assertTrue(_ condition: Bool, _ message: String) {
     }
 }
 
-let scheduler = NearbyScheduler()
-scheduler.tick(now: 10)
-assertTrue(scheduler.sentCount == 0, "opt-out user must not send presence")
-assertTrue(scheduler.fetchedCount == 1, "hotspot fetch runs every 10s baseline")
-
-scheduler.locationSharingEnabled = true
-scheduler.isWalking = true
-scheduler.tick(now: 20)
-assertTrue(scheduler.sentCount == 0, "30s interval not reached")
-scheduler.tick(now: 31)
-assertTrue(scheduler.sentCount == 1, "presence should send at 30s interval")
-scheduler.tick(now: 59)
-assertTrue(scheduler.sentCount == 1, "presence must not oversend before next interval")
-scheduler.tick(now: 61)
-assertTrue(scheduler.sentCount == 2, "presence sends again after another 30s")
-
 let now = 1_770_000_000.0
-let grouped = aggregateAlive(records: [
-    .init(geohash7: "wydm3yr", lastSeenAt: now - 100),
-    .init(geohash7: "wydm3yr", lastSeenAt: now - 500),
-    .init(geohash7: "wydm3yx", lastSeenAt: now - 700),
-    .init(geohash7: "wydm3yx", lastSeenAt: now - 601),
-], now: now)
+let policy = NearbyPrivacyPolicy()
 
-assertTrue(grouped["wydm3yr"] == 2, "alive records should be counted")
-assertTrue(grouped["wydm3yx"] == nil, "ttl-expired records must be excluded")
+assertTrue(effectiveDelayMinutes(hour: 11, policy: policy) == 30, "daytime delay should be 30 minutes")
+assertTrue(effectiveDelayMinutes(hour: 23, policy: policy) == 60, "nighttime delay should be 60 minutes")
+assertTrue(effectiveDelayMinutes(hour: 3, policy: policy) == 60, "overnight delay should be 60 minutes")
+
+let dayWindowRecords = [
+    PresenceRecord(geohash7: "day-a", lastSeenAt: now - 35 * 60),
+    PresenceRecord(geohash7: "day-a", lastSeenAt: now - 31 * 60),
+    PresenceRecord(geohash7: "day-a", lastSeenAt: now - 25 * 60), // too recent for delayed window
+]
+let dayResult = aggregateHotspots(records: dayWindowRecords, now: now, hour: 11, sensitiveGeohashes: [])
+assertTrue(dayResult.first?.sampleCount == 2, "day delayed window should include only 30~40 minute records")
+
+let nightWindowRecords = [
+    PresenceRecord(geohash7: "night-a", lastSeenAt: now - 65 * 60),
+    PresenceRecord(geohash7: "night-a", lastSeenAt: now - 59 * 60), // too recent for night delayed window
+]
+let nightResult = aggregateHotspots(records: nightWindowRecords, now: now, hour: 23, sensitiveGeohashes: [])
+assertTrue(nightResult.first?.sampleCount == 1, "night delayed window should include only 60~70 minute records")
+
+var sparseRecords: [PresenceRecord] = []
+for _ in 0..<5 { sparseRecords.append(.init(geohash7: "cell-low", lastSeenAt: now - 33 * 60)) }
+for _ in 0..<10 { sparseRecords.append(.init(geohash7: "cell-mid", lastSeenAt: now - 33 * 60)) }
+for _ in 0..<15 { sparseRecords.append(.init(geohash7: "cell-high", lastSeenAt: now - 33 * 60)) }
+
+let sparseResult = aggregateHotspots(records: sparseRecords, now: now, hour: 11, sensitiveGeohashes: [])
+assertTrue(sparseResult.count == 1, "k-anon fallback should keep only top-percentile sparse cell")
+assertTrue(sparseResult[0].geohash7 == "cell-high", "highest sparse percentile cell should remain")
+assertTrue(sparseResult[0].countPublic == 0, "sparse cell should hide exact count")
+assertTrue(sparseResult[0].privacyMode == "percentile_only", "sparse cell should be percentile-only mode")
+assertTrue(sparseResult[0].suppressionReason == "k_anon", "sparse cell should be marked as k-anon suppressed")
+
+let maskedResult = aggregateHotspots(records: sparseRecords, now: now, hour: 11, sensitiveGeohashes: ["cell-high"])
+assertTrue(maskedResult.isEmpty, "sensitive mask should remove matching hotspot from output")
 
 print("PASS: nearby hotspot unit checks")

--- a/scripts/release_regression_checklist_unit_check.swift
+++ b/scripts/release_regression_checklist_unit_check.swift
@@ -26,6 +26,9 @@ assertTrue(checklist.contains("## 7. 결과 기록 템플릿"), "checklist must 
 assertTrue(checklist.contains("## 8. 배포 전/후 핵심 지표 비교"), "checklist must include pre/post metric comparison section")
 assertTrue(checklist.contains("## 9. 예외 시나리오 게이트 (P0/P1)"), "checklist must include exception gate section")
 assertTrue(checklist.contains("P0 FAIL >= 1"), "checklist must include P0 auto blocking rule")
+assertTrue(checklist.contains("표본 미달 셀은 count가 노출되지 않고(percentile-only)"), "checklist should include privacy k-anon scenario")
+assertTrue(checklist.contains("야간(22~06) 지연 60분 정책"), "checklist should include nighttime delay scenario")
+assertTrue(checklist.contains("privacy_guard_policies/privacy_sensitive_geo_masks/privacy_guard_audit_logs"), "checklist should include privacy guard migration verification")
 
 assertTrue(report.contains("## 1. 빌드 체크 결과"), "report must include build results")
 assertTrue(report.contains("## 2. 핵심 시나리오 점검 결과"), "report must include scenario results")

--- a/scripts/rival_privacy_hard_guard_unit_check.swift
+++ b/scripts/rival_privacy_hard_guard_unit_check.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let migration = load("supabase/migrations/20260227192000_rival_privacy_hard_guard.sql")
+let nearbyFunction = load("supabase/functions/nearby-presence/index.ts")
+let doc = load("docs/rival-privacy-hard-guard-v1.md")
+let nearbyDoc = load("docs/nearby-anonymous-hotspot-v1.md")
+let readme = load("README.md")
+
+assertTrue(migration.contains("create table if not exists public.privacy_guard_policies"), "migration should create privacy_guard_policies")
+assertTrue(migration.contains("create table if not exists public.privacy_sensitive_geo_masks"), "migration should create privacy_sensitive_geo_masks")
+assertTrue(migration.contains("create table if not exists public.privacy_guard_audit_logs"), "migration should create privacy_guard_audit_logs")
+assertTrue(migration.contains("create or replace function public.rpc_get_nearby_hotspots"), "migration should replace hotspot rpc with privacy guard")
+assertTrue(migration.contains("suppression_reason text"), "migration rpc should expose suppression reason")
+assertTrue(migration.contains("daytime_delay_minutes"), "migration should include daytime delay policy")
+assertTrue(migration.contains("nighttime_delay_minutes"), "migration should include nighttime delay policy")
+assertTrue(migration.contains("percentile_fallback"), "migration should include percentile fallback policy")
+assertTrue(migration.contains("view_privacy_guard_alerts_24h"), "migration should expose privacy alert monitoring view")
+
+assertTrue(nearbyFunction.contains("privacy_guard_audit_logs"), "nearby edge function should write privacy audit logs")
+assertTrue(nearbyFunction.contains("suppression_reason"), "nearby edge function should parse suppression metadata")
+assertTrue(nearbyFunction.contains("alert_level"), "nearby edge function should compute alert level")
+
+assertTrue(doc.contains("k >= 20"), "privacy guard doc should define minimum sample")
+assertTrue(doc.contains("주간 30분"), "privacy guard doc should define daytime delay")
+assertTrue(doc.contains("야간 60분"), "privacy guard doc should define nighttime delay")
+assertTrue(doc.contains("privacy_guard_audit_logs"), "privacy guard doc should include audit log table")
+
+assertTrue(nearbyDoc.contains("표본 미달"), "nearby doc should include sparse sample guard wording")
+assertTrue(nearbyDoc.contains("k>=20"), "nearby doc should include k-anon threshold")
+assertTrue(readme.contains("docs/rival-privacy-hard-guard-v1.md"), "README should reference privacy hard guard doc")
+
+print("PASS: rival privacy hard guard unit checks")

--- a/supabase/functions/nearby-presence/index.ts
+++ b/supabase/functions/nearby-presence/index.ts
@@ -13,6 +13,19 @@ type RequestDTO = {
   radiusKm?: number;
 };
 
+type ResponseHotspotDTO = {
+  geohash7: string;
+  count: number;
+  intensity: number;
+  center_lat: number;
+  center_lng: number;
+  sample_count?: number;
+  privacy_mode?: string;
+  suppression_reason?: string | null;
+  delay_minutes?: number;
+  required_min_sample?: number;
+};
+
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
     status,
@@ -20,6 +33,13 @@ const json = (body: unknown, status = 200) =>
   });
 
 const roundCoord = (value: number) => Math.round(value * 10_000) / 10_000;
+
+const asUUIDOrNull = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+  return uuidPattern.test(normalized) ? normalized : null;
+};
 
 const geohashEncode = (lat: number, lng: number, precision = 7): string => {
   const base32 = "0123456789bcdefghjkmnpqrstuvwxyz";
@@ -81,11 +101,12 @@ Deno.serve(async (req) => {
   if (!body.action) return json({ error: "ACTION_REQUIRED" }, 400);
 
   if (body.action === "set_visibility") {
-    if (!body.userId || typeof body.enabled !== "boolean") {
+    const userId = asUUIDOrNull(body.userId);
+    if (!userId || typeof body.enabled !== "boolean") {
       return json({ error: "INVALID_PAYLOAD" }, 400);
     }
     const { error } = await client.from("user_visibility_settings").upsert({
-      user_id: body.userId,
+      user_id: userId,
       location_sharing_enabled: body.enabled,
       updated_at: new Date().toISOString(),
     });
@@ -94,14 +115,15 @@ Deno.serve(async (req) => {
   }
 
   if (body.action === "upsert_presence") {
-    if (!body.userId || typeof body.lat !== "number" || typeof body.lng !== "number") {
+    const userId = asUUIDOrNull(body.userId);
+    if (!userId || typeof body.lat !== "number" || typeof body.lng !== "number") {
       return json({ error: "INVALID_PAYLOAD" }, 400);
     }
 
     const { data: visibility, error: visibilityError } = await client
       .from("user_visibility_settings")
       .select("location_sharing_enabled")
-      .eq("user_id", body.userId)
+      .eq("user_id", userId)
       .maybeSingle();
 
     if (visibilityError) return json({ error: visibilityError.message }, 500);
@@ -114,7 +136,7 @@ Deno.serve(async (req) => {
     const geohash7 = geohashEncode(latRounded, lngRounded, 7);
 
     const { error } = await client.from("nearby_presence").upsert({
-      user_id: body.userId,
+      user_id: userId,
       geohash7,
       lat_rounded: latRounded,
       lng_rounded: lngRounded,
@@ -129,6 +151,7 @@ Deno.serve(async (req) => {
     if (typeof body.centerLat !== "number" || typeof body.centerLng !== "number") {
       return json({ error: "INVALID_PAYLOAD" }, 400);
     }
+
     const radiusKm = typeof body.radiusKm === "number" ? body.radiusKm : 1.0;
     const { data, error } = await client.rpc("rpc_get_nearby_hotspots", {
       center_lat: body.centerLat,
@@ -137,7 +160,43 @@ Deno.serve(async (req) => {
       now_ts: new Date().toISOString(),
     });
     if (error) return json({ error: error.message }, 500);
-    return json({ hotspots: data ?? [] });
+
+    const hotspots = (data ?? []) as ResponseHotspotDTO[];
+    const suppressedHotspots = hotspots.filter((row) => row.suppression_reason != null);
+    const maskedHotspots = suppressedHotspots.filter((row) => row.suppression_reason === "sensitive_mask");
+    const kAnonHotspots = suppressedHotspots.filter((row) => row.suppression_reason === "k_anon");
+    const delayMinutes = hotspots.find((row) => typeof row.delay_minutes === "number")?.delay_minutes ?? 0;
+    const alertLevel = suppressedHotspots.length == 0
+      ? "info"
+      : suppressedHotspots.length >= hotspots.length && hotspots.length > 0
+      ? "critical"
+      : "warn";
+
+    const requestUserId = asUUIDOrNull(body.userId);
+    const { error: auditError } = await client.from("privacy_guard_audit_logs").insert({
+      policy_key: "nearby_hotspot",
+      request_action: "get_hotspots",
+      request_user_id: requestUserId,
+      center_lat: body.centerLat,
+      center_lng: body.centerLng,
+      radius_km: radiusKm,
+      total_hotspots: hotspots.length,
+      suppressed_hotspots: suppressedHotspots.length,
+      masked_hotspots: maskedHotspots.length,
+      k_anon_hotspots: kAnonHotspots.length,
+      delay_minutes: delayMinutes,
+      alert_level: alertLevel,
+      payload: {
+        required_min_sample: hotspots.find((row) => typeof row.required_min_sample === "number")?.required_min_sample ?? null,
+        returned_modes: Array.from(new Set(hotspots.map((row) => row.privacy_mode).filter(Boolean))),
+      },
+    });
+
+    if (auditError) {
+      console.error("privacy audit insert failed", auditError.message);
+    }
+
+    return json({ hotspots });
   }
 
   return json({ error: "UNSUPPORTED_ACTION" }, 400);

--- a/supabase/migrations/20260227192000_rival_privacy_hard_guard.sql
+++ b/supabase/migrations/20260227192000_rival_privacy_hard_guard.sql
@@ -1,0 +1,332 @@
+-- #150 rival privacy hard guard (k-anon + nighttime delay)
+
+create extension if not exists pgcrypto;
+
+create or replace function public.touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create table if not exists public.privacy_guard_policies (
+  policy_key text primary key,
+  min_sample_size integer not null default 20 check (min_sample_size >= 2 and min_sample_size <= 500),
+  percentile_fallback double precision not null default 0.8 check (percentile_fallback >= 0 and percentile_fallback <= 1),
+  daytime_delay_minutes integer not null default 30 check (daytime_delay_minutes >= 0 and daytime_delay_minutes <= 240),
+  nighttime_delay_minutes integer not null default 60 check (nighttime_delay_minutes >= 0 and nighttime_delay_minutes <= 240),
+  active_window_minutes integer not null default 10 check (active_window_minutes >= 1 and active_window_minutes <= 120),
+  night_start_hour integer not null default 22 check (night_start_hour >= 0 and night_start_hour <= 23),
+  night_end_hour integer not null default 6 check (night_end_hour >= 0 and night_end_hour <= 23),
+  policy_timezone text not null default 'Asia/Seoul',
+  sensitive_mask_enabled boolean not null default true,
+  updated_at timestamptz not null default now()
+);
+
+insert into public.privacy_guard_policies (
+  policy_key,
+  min_sample_size,
+  percentile_fallback,
+  daytime_delay_minutes,
+  nighttime_delay_minutes,
+  active_window_minutes,
+  night_start_hour,
+  night_end_hour,
+  policy_timezone,
+  sensitive_mask_enabled
+)
+values (
+  'nearby_hotspot',
+  20,
+  0.80,
+  30,
+  60,
+  10,
+  22,
+  6,
+  'Asia/Seoul',
+  true
+)
+on conflict (policy_key) do nothing;
+
+create table if not exists public.privacy_sensitive_geo_masks (
+  id uuid primary key default gen_random_uuid(),
+  label text not null,
+  min_lat double precision not null,
+  max_lat double precision not null,
+  min_lng double precision not null,
+  max_lng double precision not null,
+  enabled boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint privacy_sensitive_geo_masks_lat_bounds check (min_lat <= max_lat),
+  constraint privacy_sensitive_geo_masks_lng_bounds check (min_lng <= max_lng)
+);
+
+create table if not exists public.privacy_guard_audit_logs (
+  id bigint generated always as identity primary key,
+  policy_key text not null,
+  request_action text not null,
+  request_user_id uuid,
+  center_lat double precision,
+  center_lng double precision,
+  radius_km double precision,
+  total_hotspots integer not null default 0,
+  suppressed_hotspots integer not null default 0,
+  masked_hotspots integer not null default 0,
+  k_anon_hotspots integer not null default 0,
+  delay_minutes integer not null default 0,
+  alert_level text not null default 'info' check (alert_level in ('info', 'warn', 'critical')),
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_privacy_guard_logs_created_at
+  on public.privacy_guard_audit_logs(created_at desc);
+create index if not exists idx_privacy_guard_logs_alert_level_created_at
+  on public.privacy_guard_audit_logs(alert_level, created_at desc);
+
+alter table public.privacy_guard_policies enable row level security;
+alter table public.privacy_sensitive_geo_masks enable row level security;
+alter table public.privacy_guard_audit_logs enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'privacy_guard_policies'
+      and policyname = 'privacy_guard_policies_select_all'
+  ) then
+    create policy privacy_guard_policies_select_all
+      on public.privacy_guard_policies
+      for select
+      to anon, authenticated
+      using (true);
+  end if;
+end $$;
+
+drop trigger if exists trg_privacy_guard_policies_updated_at on public.privacy_guard_policies;
+create trigger trg_privacy_guard_policies_updated_at
+before update on public.privacy_guard_policies
+for each row execute function public.touch_updated_at();
+
+drop trigger if exists trg_privacy_sensitive_geo_masks_updated_at on public.privacy_sensitive_geo_masks;
+create trigger trg_privacy_sensitive_geo_masks_updated_at
+before update on public.privacy_sensitive_geo_masks
+for each row execute function public.touch_updated_at();
+
+create or replace function public.is_coordinate_in_sensitive_mask(
+  target_lat double precision,
+  target_lng double precision
+)
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.privacy_sensitive_geo_masks m
+    where m.enabled = true
+      and target_lat between m.min_lat and m.max_lat
+      and target_lng between m.min_lng and m.max_lng
+  );
+$$;
+
+drop function if exists public.rpc_get_nearby_hotspots(double precision, double precision, double precision, timestamptz);
+
+create or replace function public.rpc_get_nearby_hotspots(
+  center_lat double precision,
+  center_lng double precision,
+  radius_km double precision default 1.0,
+  now_ts timestamptz default now()
+)
+returns table (
+  geohash7 text,
+  count int,
+  intensity double precision,
+  center_lat double precision,
+  center_lng double precision,
+  sample_count int,
+  privacy_mode text,
+  suppression_reason text,
+  delay_minutes int,
+  required_min_sample int
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  policy_row public.privacy_guard_policies%rowtype;
+  local_now timestamp;
+  local_hour integer;
+  is_night boolean;
+  effective_delay integer;
+  active_window integer;
+  fallback_percentile double precision;
+  min_samples integer;
+  mask_enabled boolean;
+  clamped_radius double precision;
+  query_center_lat double precision;
+  query_center_lng double precision;
+begin
+  select *
+  into policy_row
+  from public.privacy_guard_policies
+  where policy_key = 'nearby_hotspot'
+  limit 1;
+
+  if not found then
+    min_samples := 20;
+    fallback_percentile := 0.80;
+    effective_delay := 30;
+    active_window := 10;
+    mask_enabled := true;
+    local_now := now_ts at time zone 'Asia/Seoul';
+    local_hour := extract(hour from local_now)::integer;
+    is_night := local_hour >= 22 or local_hour < 6;
+    if is_night then
+      effective_delay := 60;
+    end if;
+  else
+    min_samples := greatest(2, coalesce(policy_row.min_sample_size, 20));
+    fallback_percentile := least(1.0, greatest(0.0, coalesce(policy_row.percentile_fallback, 0.80)));
+    active_window := greatest(1, coalesce(policy_row.active_window_minutes, 10));
+    mask_enabled := coalesce(policy_row.sensitive_mask_enabled, true);
+
+    local_now := now_ts at time zone coalesce(nullif(policy_row.policy_timezone, ''), 'Asia/Seoul');
+    local_hour := extract(hour from local_now)::integer;
+
+    if policy_row.night_start_hour = policy_row.night_end_hour then
+      is_night := false;
+    elsif policy_row.night_start_hour < policy_row.night_end_hour then
+      is_night := local_hour >= policy_row.night_start_hour
+        and local_hour < policy_row.night_end_hour;
+    else
+      is_night := local_hour >= policy_row.night_start_hour
+        or local_hour < policy_row.night_end_hour;
+    end if;
+
+    effective_delay := case
+      when is_night then coalesce(policy_row.nighttime_delay_minutes, 60)
+      else coalesce(policy_row.daytime_delay_minutes, 30)
+    end;
+  end if;
+
+  clamped_radius := least(5.0, greatest(0.1, coalesce(radius_km, 1.0)));
+  query_center_lat := center_lat;
+  query_center_lng := center_lng;
+
+  return query
+  with delayed as (
+    select p.*
+    from public.nearby_presence p
+    where p.last_seen_at <= now_ts - make_interval(mins => effective_delay)
+      and p.last_seen_at >= now_ts - make_interval(mins => (effective_delay + active_window))
+  ),
+  grouped as (
+    select
+      p.geohash7,
+      count(*)::int as sample_count,
+      avg(p.lat_rounded)::double precision as center_lat,
+      avg(p.lng_rounded)::double precision as center_lng
+    from delayed p
+    where
+      sqrt(
+        power((p.lat_rounded - query_center_lat), 2) +
+        power((p.lng_rounded - query_center_lng) * cos(radians(query_center_lat)), 2)
+      ) * 111.32 <= clamped_radius
+    group by p.geohash7
+  ),
+  ranked as (
+    select
+      g.*,
+      percent_rank() over (order by g.sample_count asc, g.geohash7 asc) as percentile_rank,
+      case
+        when mask_enabled then public.is_coordinate_in_sensitive_mask(g.center_lat, g.center_lng)
+        else false
+      end as is_sensitive
+    from grouped g
+  ),
+  guarded as (
+    select
+      r.*,
+      (r.sample_count < min_samples) as is_k_anon_suppressed,
+      case
+        when r.is_sensitive then 'sensitive_mask'
+        when r.sample_count < min_samples then 'k_anon'
+        else null
+      end as suppression_reason
+    from ranked r
+  ),
+  filtered as (
+    select
+      g.*,
+      case
+        when g.suppression_reason = 'sensitive_mask' then false
+        when g.suppression_reason = 'k_anon' then g.percentile_rank >= fallback_percentile
+        else true
+      end as include_row
+    from guarded g
+  ),
+  included as (
+    select *
+    from filtered
+    where include_row
+  ),
+  scored as (
+    select
+      i.*,
+      max(
+        case
+          when i.suppression_reason is null then i.sample_count
+          else null
+        end
+      ) over () as max_visible_count
+    from included i
+  )
+  select
+    s.geohash7,
+    case
+      when s.suppression_reason is null then s.sample_count
+      else 0
+    end as count,
+    case
+      when s.suppression_reason = 'k_anon' then greatest(0.05, least(1.0, s.percentile_rank))
+      when coalesce(s.max_visible_count, 0) = 0 then 0
+      else least(1.0, greatest(0.0, s.sample_count::double precision / s.max_visible_count::double precision))
+    end as intensity,
+    s.center_lat,
+    s.center_lng,
+    s.sample_count,
+    case
+      when s.suppression_reason = 'k_anon' then 'percentile_only'
+      else 'full'
+    end as privacy_mode,
+    s.suppression_reason,
+    effective_delay as delay_minutes,
+    min_samples as required_min_sample
+  from scored s
+  order by intensity desc, s.geohash7 asc;
+end;
+$$;
+
+create or replace view public.view_privacy_guard_alerts_24h as
+select
+  date_trunc('hour', created_at) as hour_bucket,
+  policy_key,
+  count(*) filter (where alert_level = 'warn')::bigint as warn_count,
+  count(*) filter (where alert_level = 'critical')::bigint as critical_count,
+  count(*)::bigint as total_count
+from public.privacy_guard_audit_logs
+where created_at >= now() - interval '24 hours'
+group by date_trunc('hour', created_at), policy_key
+order by hour_bucket desc;
+
+grant select on public.privacy_guard_policies to anon, authenticated;
+grant execute on function public.rpc_get_nearby_hotspots(double precision, double precision, double precision, timestamptz) to anon, authenticated;
+grant select on public.view_privacy_guard_alerts_24h to authenticated;


### PR DESCRIPTION
## Summary
- add Supabase privacy guard policy/mask/audit schema and replace `rpc_get_nearby_hotspots` with k-anon + delayed exposure logic
- enforce daytime(30m)/nighttime(60m) delayed window and percentile-only fallback for sparse cells
- add sensitive-area auto-mask rule path and privacy alert/audit logging in `nearby-presence` edge function
- update nearby docs, release checklist, cycle report, and add dedicated unit checks

## Test
- `swift scripts/nearby_hotspot_unit_check.swift`
- `swift scripts/rival_privacy_hard_guard_unit_check.swift`
- `swift scripts/release_regression_checklist_unit_check.swift`
- `swift scripts/project_stability_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #150
