### PR TITLE
[P0] Season anti-farming rules (repeat suppression + novelty bonus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - 캐리커처 비동기 파이프라인 명세 v1: `docs/caricature-async-pipeline-v1.md`
 - 근처 사용자 익명 핫스팟 명세 v1: `docs/nearby-anonymous-hotspot-v1.md`
 - 라이벌 프라이버시 하드 가드 v1: `docs/rival-privacy-hard-guard-v1.md`
+- 시즌 안티 농사 규칙 v1: `docs/season-anti-farming-v1.md`
 - Feature Flag/롤아웃 모니터링 명세 v1: `docs/feature-flag-rollout-monitoring-v1.md`
 - ViewModel 현대화 리팩토링 명세 v1: `docs/viewmodel-modernization-v1.md`
 - CoreData 반환 계약 정리 v1: `docs/coredata-return-contract-v1.md`

--- a/docs/cycle-146-season-anti-farming-report-2026-02-27.md
+++ b/docs/cycle-146-season-anti-farming-report-2026-02-27.md
@@ -1,0 +1,38 @@
+# Cycle 146 Report — Season Anti-Farming Rules (2026-02-27)
+
+## 1. 대상
+- Issue: `#146 [P0][Task] 시즌 안티 농사 규칙(동일 타일 반복 점수 억제)`
+- Branch: `codex/cycle-146-season-anti-farming`
+
+## 2. 구현 요약
+- Supabase에 시즌 점수 정책 테이블(`season_scoring_policies`)을 추가하고 운영 파라미터 서버화
+- `rpc_score_walk_session_anti_farming` 구현:
+  - 동일 타일 30분 내 반복 0점 처리
+  - 신규 경로 비율(`novelty_ratio`) 기반 보너스 부여
+  - 반복/저이동/저신규 조합에서 `score_blocked=true` 차단
+- 포인트 단위 점수 원장(`season_tile_score_events`)과 감사 로그(`season_score_audit_logs`) 추가
+- `sync-walk` points stage에서 시즌 점수 요약(`season_score_summary`)을 응답으로 반환
+- 운영 문서/릴리즈 체크리스트/검증 스크립트 갱신
+
+## 3. 변경 파일
+- `supabase/migrations/20260227195500_season_anti_farming_rules.sql`
+- `supabase/functions/sync-walk/index.ts`
+- `docs/season-anti-farming-v1.md`
+- `docs/supabase-schema-v1.md`
+- `docs/supabase-migration.md`
+- `docs/release-regression-checklist-v1.md`
+- `docs/cycle-146-season-anti-farming-report-2026-02-27.md`
+- `README.md`
+- `scripts/season_anti_farming_unit_check.swift`
+- `scripts/release_regression_checklist_unit_check.swift`
+- `scripts/ios_pr_check.sh`
+
+## 4. 유닛 체크
+- `swift scripts/season_anti_farming_unit_check.swift` -> PASS
+- `swift scripts/release_regression_checklist_unit_check.swift` -> PASS
+- `swift scripts/project_stability_unit_check.swift` -> PASS
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh` -> PASS
+
+## 5. 리스크/후속
+- 현재 앱 UI는 `season_score_summary.explain.ui_reason` 노출 전이라, 서버 응답 기반 설명 UI 연결은 시즌/퀘스트 UI 단계에서 후속 구현 필요.
+- 타일 정밀도(`tile_decimal_precision`)는 기본 3으로 설정되어 운영 중 오탐/미탐 비율을 보고 조정해야 함.

--- a/docs/release-regression-checklist-v1.md
+++ b/docs/release-regression-checklist-v1.md
@@ -67,6 +67,9 @@
 - [ ] nearby 핫스팟에서 표본 미달 셀은 count가 노출되지 않고(percentile-only) 강도만 표시됨
 - [ ] nearby 핫스팟에서 야간(22~06) 지연 60분 정책이 반영됨
 - [ ] 민감 구역 마스킹 대상 셀이 지도 오버레이에 노출되지 않음
+- [ ] 시즌 점수에서 동일 타일 30분 내 반복 이벤트가 0점 처리됨
+- [ ] 시즌 점수에서 신규 경로 비율이 높을수록 보너스가 증가함
+- [ ] 반복 파밍 의심 패턴에서 `score_blocked=true` + 감사 로그가 기록됨
 
 ### 4.3 목록/상세
 - [ ] 산책 목록 로딩 정상
@@ -93,6 +96,7 @@
 - [ ] `profiles.profile_message`, `pets.breed/age_years/gender` 컬럼 및 제약 확인
 - [ ] `area_reference_catalogs` + `area_references.catalog_id/display_order/is_featured` 구조 확인
 - [ ] `privacy_guard_policies/privacy_sensitive_geo_masks/privacy_guard_audit_logs` 구조 및 `rpc_get_nearby_hotspots` 확장 컬럼 확인
+- [ ] `season_scoring_policies/season_tile_score_events/season_score_audit_logs` 구조 및 `rpc_score_walk_session_anti_farming` 실행 확인
 
 ## 6. 배포 파이프라인 검증 시나리오
 ### 6.1 Workflow 정의/활성 상태

--- a/docs/season-anti-farming-v1.md
+++ b/docs/season-anti-farming-v1.md
@@ -1,0 +1,77 @@
+# Season Anti-Farming Rule v1
+
+## 1. 목적
+시즌 점수에서 동일 타일 반복 파밍을 억제하고, 실제 이동/신규 경로 중심의 기여를 우대한다.
+
+연결 이슈:
+- 구현: #146
+- 상위 Epic: #123
+
+## 2. 핵심 규칙
+- 동일 타일 반복 억제:
+  - 동일 타일(`tile_decimal_precision`) 재입력이 `30분` 이내면 해당 이벤트 점수 `0점`
+- 신규 경로 보너스:
+  - 세션 `novelty_ratio = unique_tiles / total_points`
+  - 보너스 = `base_tile_score * new_route_bonus_weight * novelty_ratio`
+  - 최초 타일 기여(`is_first_tile_hit=true`)에만 부여
+- 비정상 반복 차단:
+  - `repeat_suppressed_count >= suspicious_repeat_threshold`
+  - `novelty_ratio <= suspicious_max_novelty_ratio`
+  - `session_distance_m <= suspicious_low_movement_meters`
+  - 모두 충족 시 `score_blocked=true` (정책 활성 시 총점 0)
+
+## 3. 서버 파라미터
+테이블: `season_scoring_policies`
+- `repeat_cooldown_minutes`
+- `tile_decimal_precision`
+- `base_tile_score`
+- `new_route_bonus_weight`
+- `suspicious_repeat_threshold`
+- `suspicious_max_novelty_ratio`
+- `suspicious_low_movement_meters`
+- `suspicious_block_enabled`
+
+## 4. 이벤트/감사 로그
+- 이벤트 원장: `season_tile_score_events`
+  - per-point 점수 계산 결과(`base_score`, `novelty_bonus`, `final_score`, `suppression_reason`)
+- 감사 로그: `season_score_audit_logs`
+  - severity: `info|warn|block`
+  - 차단 여부(`blocked`) + 판정 근거 payload 저장
+- 운영 뷰: `view_season_score_audit_24h`
+
+## 5. RPC 계약
+함수: `rpc_score_walk_session_anti_farming(target_walk_session_id, now_ts)`
+
+반환 필드:
+- `total_points`, `unique_tiles`, `novelty_ratio`
+- `repeat_suppressed_count`, `suspicious_repeat_count`
+- `base_score`, `new_route_bonus`, `total_score`
+- `score_blocked`
+- `explain`(UI 표시용 이유/정책 스냅샷)
+
+## 6. UX 연결 계약
+`sync-walk` points stage 응답에 `season_score_summary`를 포함한다.
+
+예시:
+```json
+{
+  "ok": true,
+  "stage": "points",
+  "walk_session_id": "...",
+  "point_count": 120,
+  "season_score_summary": {
+    "total_score": 42.8,
+    "score_blocked": false,
+    "repeat_suppressed_count": 14,
+    "explain": {
+      "ui_reason": "동일 타일 반복 입력(30분 이내)은 점수에서 제외되었습니다."
+    }
+  }
+}
+```
+
+## 7. 검증 체크리스트
+- [ ] 동일 타일 10회 반복에서 30분 내 반복 이벤트 점수가 0으로 계산
+- [ ] 신규 경로 비율이 높은 세션이 더 높은 보너스를 획득
+- [ ] 비정상 반복 패턴에서 `score_blocked=true` + 감사 로그 적재
+- [ ] 정상 산책(충분 이동/신규경로)에서 과도 차감 없이 점수 반영

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -163,6 +163,35 @@ order by c.sort_order asc, c.code asc;
 - `featured_count`가 최소 1개 이상(큐레이션 카탈로그 기준)
 - `display_order`가 음수 없이 정렬 가능 범위로 유지
 
+### 5.7 시즌 안티 농사 점수 검증 (#146)
+```sql
+select *
+from public.rpc_score_walk_session_anti_farming(
+  ':walk_session_uuid'::uuid,
+  now()
+);
+```
+
+기대값:
+- 동일 타일 반복 입력이 많은 세션은 `repeat_suppressed_count`가 증가
+- `score_blocked=true`일 때 `total_score=0`
+- `explain.ui_reason`에 차단/감쇠 사유가 포함
+
+감사 로그 확인:
+```sql
+select
+  severity,
+  blocked,
+  repeat_suppressed_count,
+  novelty_ratio,
+  session_distance_m,
+  created_at
+from public.season_score_audit_logs
+where walk_session_id = ':walk_session_uuid'::uuid
+order by created_at desc
+limit 20;
+```
+
 ## 6. 운영 체크리스트
 - [ ] `migration list --local` / `migration list --linked` 결과 저장
 - [ ] User A/B 교차 접근 차단 SQL 결과 저장
@@ -170,3 +199,4 @@ order by c.sort_order asc, c.code asc;
 - [ ] 핵심 통계 SQL 결과를 릴리스 문서에 첨부
 - [ ] User/Pet 확장 필드 정합성 SQL 결과 첨부
 - [ ] 비교군 카탈로그/시드 정합성 SQL 결과 첨부
+- [ ] 시즌 안티 농사 RPC/감사 로그 검증 결과 첨부

--- a/docs/supabase-schema-v1.md
+++ b/docs/supabase-schema-v1.md
@@ -15,6 +15,7 @@
 - 사용자/다견/산책/좌표/명소비교 구조
 - 캐리커처 비동기 파이프라인용 데이터 구조
 - 근처 사용자 익명 핫스팟용 데이터 구조
+- 시즌 안티 농사 점수 규칙용 데이터 구조
 - RLS 정책 원칙
 - Storage 경로 규칙
 - 마이그레이션/롤백 절차
@@ -197,6 +198,16 @@ erDiagram
   - 사용자 1행 upsert 패턴
   - TTL 10분 기준으로 집계 시 제외
 
+### 4.6 시즌 안티 농사 점수
+- `season_scoring_policies`
+  - 동일 타일 반복 억제/신규 경로 보너스/차단 임계값을 서버 파라미터로 관리
+- `season_tile_score_events`
+  - 포인트 단위 점수 원장(`base_score`, `novelty_bonus`, `suppression_reason`)
+- `season_score_audit_logs`
+  - 반복 파밍 의심/차단 판정 근거 로그
+- `rpc_score_walk_session_anti_farming`
+  - 세션 점수 계산 결과 + UX 설명(`explain.ui_reason`) 반환
+
 ## 5. RLS 정책 원칙
 - 사용자 데이터는 `auth.uid()` 소유 범위로만 접근
 - `area_references`는 읽기 공개(`anon`, `authenticated`)
@@ -220,6 +231,11 @@ erDiagram
 - `nearby_presence`
   - 소유자 upsert
   - 익명 조회는 RPC/View 통해 집계 결과만 반환
+- `season_scoring_policies`
+  - `select`: 공개(읽기)
+- `season_tile_score_events`, `season_score_audit_logs`
+  - `select`: 소유자
+  - write: 서비스 경로(RPC/service role)
 
 ## 6. Storage 규칙
 버킷:

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -29,6 +29,7 @@ swift scripts/release_regression_checklist_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift
 swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift
+swift scripts/season_anti_farming_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 
 if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then

--- a/scripts/release_regression_checklist_unit_check.swift
+++ b/scripts/release_regression_checklist_unit_check.swift
@@ -29,6 +29,9 @@ assertTrue(checklist.contains("P0 FAIL >= 1"), "checklist must include P0 auto b
 assertTrue(checklist.contains("표본 미달 셀은 count가 노출되지 않고(percentile-only)"), "checklist should include privacy k-anon scenario")
 assertTrue(checklist.contains("야간(22~06) 지연 60분 정책"), "checklist should include nighttime delay scenario")
 assertTrue(checklist.contains("privacy_guard_policies/privacy_sensitive_geo_masks/privacy_guard_audit_logs"), "checklist should include privacy guard migration verification")
+assertTrue(checklist.contains("동일 타일 30분 내 반복 이벤트가 0점 처리"), "checklist should include season anti-farming repeat suppression scenario")
+assertTrue(checklist.contains("score_blocked=true"), "checklist should include season anti-farming blocking scenario")
+assertTrue(checklist.contains("season_scoring_policies/season_tile_score_events/season_score_audit_logs"), "checklist should include season anti-farming migration verification")
 
 assertTrue(report.contains("## 1. 빌드 체크 결과"), "report must include build results")
 assertTrue(report.contains("## 2. 핵심 시나리오 점검 결과"), "report must include scenario results")

--- a/scripts/season_anti_farming_unit_check.swift
+++ b/scripts/season_anti_farming_unit_check.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+struct SeasonPolicy {
+    let repeatCooldownMinutes: Int
+    let baseTileScore: Double
+    let newRouteBonusWeight: Double
+    let suspiciousRepeatThreshold: Int
+    let suspiciousMaxNoveltyRatio: Double
+    let suspiciousLowMovementMeters: Double
+    let suspiciousBlockEnabled: Bool
+
+    static let v1 = SeasonPolicy(
+        repeatCooldownMinutes: 30,
+        baseTileScore: 1.0,
+        newRouteBonusWeight: 0.7,
+        suspiciousRepeatThreshold: 10,
+        suspiciousMaxNoveltyRatio: 0.35,
+        suspiciousLowMovementMeters: 120,
+        suspiciousBlockEnabled: true
+    )
+}
+
+struct PointEvent {
+    let tile: String
+    let minute: Int
+    let distanceFromPrev: Double
+}
+
+struct ScoreSummary {
+    let totalPoints: Int
+    let uniqueTiles: Int
+    let noveltyRatio: Double
+    let repeatSuppressedCount: Int
+    let totalScore: Double
+    let blocked: Bool
+}
+
+func scoreSession(_ events: [PointEvent], policy: SeasonPolicy = .v1) -> ScoreSummary {
+    guard events.isEmpty == false else {
+        return ScoreSummary(totalPoints: 0, uniqueTiles: 0, noveltyRatio: 0, repeatSuppressedCount: 0, totalScore: 0, blocked: false)
+    }
+
+    let totalPoints = events.count
+    let uniqueTiles = Set(events.map(\.tile)).count
+    let noveltyRatio = Double(uniqueTiles) / Double(totalPoints)
+
+    var lastSeenByTile: [String: Int] = [:]
+    var firstHitByTile: Set<String> = []
+    var repeatSuppressedCount = 0
+    var totalDistance = 0.0
+    var rawScore = 0.0
+
+    for event in events {
+        totalDistance += event.distanceFromPrev
+
+        let lastSeenMinute = lastSeenByTile[event.tile]
+        let isRepeatWithinCooldown: Bool
+        if let lastSeenMinute {
+            isRepeatWithinCooldown = (event.minute - lastSeenMinute) <= policy.repeatCooldownMinutes
+        } else {
+            isRepeatWithinCooldown = false
+        }
+
+        let isFirstHit = firstHitByTile.contains(event.tile) == false
+        if isFirstHit {
+            firstHitByTile.insert(event.tile)
+        }
+
+        let base = isRepeatWithinCooldown ? 0.0 : policy.baseTileScore
+        let bonus = (isFirstHit && isRepeatWithinCooldown == false)
+            ? policy.baseTileScore * policy.newRouteBonusWeight * noveltyRatio
+            : 0.0
+
+        rawScore += base + bonus
+        if isRepeatWithinCooldown {
+            repeatSuppressedCount += 1
+        }
+
+        lastSeenByTile[event.tile] = event.minute
+    }
+
+    let blocked = policy.suspiciousBlockEnabled
+        && repeatSuppressedCount >= policy.suspiciousRepeatThreshold
+        && noveltyRatio <= policy.suspiciousMaxNoveltyRatio
+        && totalDistance <= policy.suspiciousLowMovementMeters
+
+    return ScoreSummary(
+        totalPoints: totalPoints,
+        uniqueTiles: uniqueTiles,
+        noveltyRatio: noveltyRatio,
+        repeatSuppressedCount: repeatSuppressedCount,
+        totalScore: blocked ? 0.0 : rawScore,
+        blocked: blocked
+    )
+}
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let migration = load("supabase/migrations/20260227195500_season_anti_farming_rules.sql")
+let syncWalkFunction = load("supabase/functions/sync-walk/index.ts")
+let doc = load("docs/season-anti-farming-v1.md")
+let schemaDoc = load("docs/supabase-schema-v1.md")
+let migrationDoc = load("docs/supabase-migration.md")
+let readme = load("README.md")
+
+assertTrue(migration.contains("create table if not exists public.season_scoring_policies"), "migration should create season_scoring_policies")
+assertTrue(migration.contains("create table if not exists public.season_tile_score_events"), "migration should create season_tile_score_events")
+assertTrue(migration.contains("create table if not exists public.season_score_audit_logs"), "migration should create season_score_audit_logs")
+assertTrue(migration.contains("create or replace function public.rpc_score_walk_session_anti_farming"), "migration should define season scoring rpc")
+assertTrue(migration.contains("repeat_within_30m"), "migration should include repeat suppression reason")
+assertTrue(migration.contains("new_route_bonus_weight"), "migration should include novelty bonus parameter")
+
+assertTrue(syncWalkFunction.contains("rpc_score_walk_session_anti_farming"), "sync-walk function should call season scoring rpc")
+assertTrue(syncWalkFunction.contains("season_score_summary"), "sync-walk response should include season score summary")
+
+assertTrue(doc.contains("동일 타일"), "season anti-farming doc should describe repeat suppression")
+assertTrue(doc.contains("신규 경로"), "season anti-farming doc should describe novelty bonus")
+assertTrue(doc.contains("score_blocked"), "season anti-farming doc should describe blocking state")
+assertTrue(schemaDoc.contains("시즌 안티 농사 점수"), "schema doc should include season anti-farming section")
+assertTrue(migrationDoc.contains("rpc_score_walk_session_anti_farming"), "migration ops doc should include season rpc verification")
+assertTrue(readme.contains("docs/season-anti-farming-v1.md"), "README should reference season anti-farming doc")
+
+let repeatedTileEvents = [
+    PointEvent(tile: "A", minute: 0, distanceFromPrev: 0),
+    PointEvent(tile: "A", minute: 2, distanceFromPrev: 1),
+    PointEvent(tile: "A", minute: 5, distanceFromPrev: 1),
+    PointEvent(tile: "A", minute: 8, distanceFromPrev: 1),
+    PointEvent(tile: "A", minute: 11, distanceFromPrev: 1),
+    PointEvent(tile: "A", minute: 14, distanceFromPrev: 1),
+    PointEvent(tile: "A", minute: 17, distanceFromPrev: 1),
+    PointEvent(tile: "A", minute: 20, distanceFromPrev: 1),
+    PointEvent(tile: "A", minute: 23, distanceFromPrev: 1),
+    PointEvent(tile: "A", minute: 26, distanceFromPrev: 1),
+    PointEvent(tile: "A", minute: 29, distanceFromPrev: 1)
+]
+
+let repeatedSummary = scoreSession(repeatedTileEvents)
+assertTrue(repeatedSummary.repeatSuppressedCount == 10, "repeated tile entries within 30 minutes should be suppressed")
+assertTrue(repeatedSummary.blocked, "high repeat + low novelty + low movement should trigger block")
+assertTrue(repeatedSummary.totalScore == 0, "blocked session should have zero score")
+
+let noveltyHighEvents = [
+    PointEvent(tile: "A", minute: 0, distanceFromPrev: 30),
+    PointEvent(tile: "B", minute: 5, distanceFromPrev: 40),
+    PointEvent(tile: "C", minute: 10, distanceFromPrev: 35),
+    PointEvent(tile: "D", minute: 15, distanceFromPrev: 32),
+    PointEvent(tile: "E", minute: 20, distanceFromPrev: 28),
+    PointEvent(tile: "F", minute: 25, distanceFromPrev: 36)
+]
+
+let noveltyHighSummary = scoreSession(noveltyHighEvents)
+assertTrue(noveltyHighSummary.noveltyRatio > 0.9, "new route-heavy session should have high novelty ratio")
+assertTrue(noveltyHighSummary.repeatSuppressedCount == 0, "new route-heavy session should not be suppressed")
+assertTrue(noveltyHighSummary.blocked == false, "new route-heavy session should not be blocked")
+assertTrue(noveltyHighSummary.totalScore > 6.0, "new route-heavy session should receive base + novelty bonus")
+
+print("PASS: season anti-farming unit checks")

--- a/supabase/functions/sync-walk/index.ts
+++ b/supabase/functions/sync-walk/index.ts
@@ -12,6 +12,20 @@ type RequestDTO = {
   session_ids?: string[];
 };
 
+type SeasonScoreSummaryDTO = {
+  walk_session_id: string;
+  total_points: number;
+  unique_tiles: number;
+  novelty_ratio: number;
+  repeat_suppressed_count: number;
+  suspicious_repeat_count: number;
+  base_score: number;
+  new_route_bonus: number;
+  total_score: number;
+  score_blocked: boolean;
+  explain?: Record<string, unknown>;
+};
+
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
     status,
@@ -227,7 +241,28 @@ Deno.serve(async (req) => {
       if (pointsError) return json({ error: pointsError.message }, 500);
     }
 
-    return json({ ok: true, stage, walk_session_id: walkSessionId, point_count: rows.length });
+    let seasonScoreSummary: SeasonScoreSummaryDTO | null = null;
+    const { data: seasonScoreRows, error: seasonScoreError } = await userClient.rpc(
+      "rpc_score_walk_session_anti_farming",
+      {
+        target_walk_session_id: walkSessionId,
+        now_ts: new Date().toISOString(),
+      },
+    );
+
+    if (seasonScoreError) {
+      console.warn("season scoring rpc failed", seasonScoreError.message);
+    } else if (Array.isArray(seasonScoreRows) && seasonScoreRows.length > 0) {
+      seasonScoreSummary = seasonScoreRows[0] as SeasonScoreSummaryDTO;
+    }
+
+    return json({
+      ok: true,
+      stage,
+      walk_session_id: walkSessionId,
+      point_count: rows.length,
+      season_score_summary: seasonScoreSummary,
+    });
   }
 
   if (stage === "meta") {

--- a/supabase/migrations/20260227195500_season_anti_farming_rules.sql
+++ b/supabase/migrations/20260227195500_season_anti_farming_rules.sql
@@ -1,0 +1,493 @@
+-- #146 season anti-farming rules (same tile repeat suppression + novelty bonus)
+
+create extension if not exists pgcrypto;
+
+create or replace function public.touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create table if not exists public.season_scoring_policies (
+  policy_key text primary key,
+  repeat_cooldown_minutes integer not null default 30 check (repeat_cooldown_minutes between 1 and 180),
+  tile_decimal_precision integer not null default 3 check (tile_decimal_precision between 2 and 5),
+  base_tile_score double precision not null default 1.0 check (base_tile_score >= 0),
+  new_route_bonus_weight double precision not null default 0.7 check (new_route_bonus_weight >= 0 and new_route_bonus_weight <= 3),
+  suspicious_repeat_threshold integer not null default 10 check (suspicious_repeat_threshold between 3 and 100),
+  suspicious_max_novelty_ratio double precision not null default 0.35 check (suspicious_max_novelty_ratio >= 0 and suspicious_max_novelty_ratio <= 1),
+  suspicious_low_movement_meters double precision not null default 120 check (suspicious_low_movement_meters >= 0),
+  suspicious_block_enabled boolean not null default true,
+  updated_at timestamptz not null default now()
+);
+
+insert into public.season_scoring_policies (
+  policy_key,
+  repeat_cooldown_minutes,
+  tile_decimal_precision,
+  base_tile_score,
+  new_route_bonus_weight,
+  suspicious_repeat_threshold,
+  suspicious_max_novelty_ratio,
+  suspicious_low_movement_meters,
+  suspicious_block_enabled
+)
+values (
+  'season_tile_anti_farming_v1',
+  30,
+  3,
+  1.0,
+  0.7,
+  10,
+  0.35,
+  120,
+  true
+)
+on conflict (policy_key) do nothing;
+
+create table if not exists public.season_tile_score_events (
+  id bigint generated always as identity primary key,
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  walk_session_id uuid not null references public.walk_sessions(id) on delete cascade,
+  seq_no integer not null,
+  geotile text not null,
+  recorded_at timestamptz not null,
+  is_first_tile_hit boolean not null,
+  is_repeat_within_cooldown boolean not null,
+  distance_from_prev_m double precision not null default 0,
+  novelty_ratio double precision not null default 0,
+  base_score double precision not null default 0,
+  novelty_bonus double precision not null default 0,
+  final_score double precision not null default 0,
+  suppression_reason text,
+  created_at timestamptz not null default now(),
+  constraint season_tile_score_events_session_seq_unique unique (walk_session_id, seq_no)
+);
+
+create index if not exists idx_season_tile_score_events_session
+  on public.season_tile_score_events(walk_session_id, seq_no);
+create index if not exists idx_season_tile_score_events_owner_created
+  on public.season_tile_score_events(owner_user_id, created_at desc);
+
+create table if not exists public.season_score_audit_logs (
+  id bigint generated always as identity primary key,
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  walk_session_id uuid not null references public.walk_sessions(id) on delete cascade,
+  policy_key text not null,
+  severity text not null check (severity in ('info', 'warn', 'block')),
+  blocked boolean not null default false,
+  repeat_suppressed_count integer not null default 0,
+  novelty_ratio double precision not null default 0,
+  session_distance_m double precision not null default 0,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_season_score_audit_owner_created
+  on public.season_score_audit_logs(owner_user_id, created_at desc);
+create index if not exists idx_season_score_audit_severity_created
+  on public.season_score_audit_logs(severity, created_at desc);
+
+alter table public.season_scoring_policies enable row level security;
+alter table public.season_tile_score_events enable row level security;
+alter table public.season_score_audit_logs enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'season_scoring_policies'
+      and policyname = 'season_scoring_policies_select_all'
+  ) then
+    create policy season_scoring_policies_select_all
+      on public.season_scoring_policies
+      for select
+      to anon, authenticated
+      using (true);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'season_tile_score_events'
+      and policyname = 'season_tile_score_events_owner_select'
+  ) then
+    create policy season_tile_score_events_owner_select
+      on public.season_tile_score_events
+      for select
+      to authenticated
+      using (owner_user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'season_tile_score_events'
+      and policyname = 'season_tile_score_events_service_write'
+  ) then
+    create policy season_tile_score_events_service_write
+      on public.season_tile_score_events
+      for all
+      using (auth.role() = 'service_role')
+      with check (auth.role() = 'service_role');
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'season_score_audit_logs'
+      and policyname = 'season_score_audit_logs_owner_select'
+  ) then
+    create policy season_score_audit_logs_owner_select
+      on public.season_score_audit_logs
+      for select
+      to authenticated
+      using (owner_user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'season_score_audit_logs'
+      and policyname = 'season_score_audit_logs_service_write'
+  ) then
+    create policy season_score_audit_logs_service_write
+      on public.season_score_audit_logs
+      for all
+      using (auth.role() = 'service_role')
+      with check (auth.role() = 'service_role');
+  end if;
+end $$;
+
+drop trigger if exists trg_season_scoring_policies_updated_at on public.season_scoring_policies;
+create trigger trg_season_scoring_policies_updated_at
+before update on public.season_scoring_policies
+for each row execute function public.touch_updated_at();
+
+create or replace function public.season_tile_key_from_coord(
+  lat double precision,
+  lng double precision,
+  precision_digits integer default 3
+)
+returns text
+language sql
+immutable
+as $$
+  select concat(
+    round(lat::numeric, least(5, greatest(2, precision_digits)))::text,
+    ',',
+    round(lng::numeric, least(5, greatest(2, precision_digits)))::text
+  );
+$$;
+
+create or replace function public.rpc_score_walk_session_anti_farming(
+  target_walk_session_id uuid,
+  now_ts timestamptz default now()
+)
+returns table (
+  walk_session_id uuid,
+  total_points int,
+  unique_tiles int,
+  novelty_ratio double precision,
+  repeat_suppressed_count int,
+  suspicious_repeat_count int,
+  base_score double precision,
+  new_route_bonus double precision,
+  total_score double precision,
+  score_blocked boolean,
+  explain jsonb
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  policy_row public.season_scoring_policies%rowtype;
+  session_owner uuid;
+  requester_uid uuid;
+  requester_role text;
+  v_total_points int := 0;
+  v_unique_tiles int := 0;
+  v_novelty_ratio double precision := 0;
+  v_repeat_suppressed int := 0;
+  v_suspicious_repeat int := 0;
+  v_base_score double precision := 0;
+  v_bonus_score double precision := 0;
+  v_raw_total_score double precision := 0;
+  v_total_distance_m double precision := 0;
+  v_score_blocked boolean := false;
+  v_total_score double precision := 0;
+  v_severity text := 'info';
+begin
+  if target_walk_session_id is null then
+    return;
+  end if;
+
+  select owner_user_id into session_owner
+  from public.walk_sessions
+  where id = target_walk_session_id
+  limit 1;
+
+  if session_owner is null then
+    return;
+  end if;
+
+  requester_uid := auth.uid();
+  requester_role := auth.role();
+
+  if requester_role <> 'service_role' then
+    if requester_uid is null or requester_uid <> session_owner then
+      raise exception 'permission denied for walk session %', target_walk_session_id;
+    end if;
+  end if;
+
+  select *
+  into policy_row
+  from public.season_scoring_policies
+  where policy_key = 'season_tile_anti_farming_v1'
+  limit 1;
+
+  if not found then
+    policy_row.policy_key := 'season_tile_anti_farming_v1';
+    policy_row.repeat_cooldown_minutes := 30;
+    policy_row.tile_decimal_precision := 3;
+    policy_row.base_tile_score := 1.0;
+    policy_row.new_route_bonus_weight := 0.7;
+    policy_row.suspicious_repeat_threshold := 10;
+    policy_row.suspicious_max_novelty_ratio := 0.35;
+    policy_row.suspicious_low_movement_meters := 120;
+    policy_row.suspicious_block_enabled := true;
+  end if;
+
+  delete from public.season_tile_score_events
+  where walk_session_id = target_walk_session_id;
+
+  with points as (
+    select
+      wp.seq_no,
+      wp.lat,
+      wp.lng,
+      wp.recorded_at,
+      public.season_tile_key_from_coord(wp.lat, wp.lng, policy_row.tile_decimal_precision) as geotile,
+      lag(wp.recorded_at) over (
+        partition by public.season_tile_key_from_coord(wp.lat, wp.lng, policy_row.tile_decimal_precision)
+        order by wp.recorded_at, wp.seq_no
+      ) as prev_same_tile_at,
+      lag(wp.lat) over (order by wp.recorded_at, wp.seq_no) as prev_lat,
+      lag(wp.lng) over (order by wp.recorded_at, wp.seq_no) as prev_lng,
+      row_number() over (
+        partition by public.season_tile_key_from_coord(wp.lat, wp.lng, policy_row.tile_decimal_precision)
+        order by wp.recorded_at, wp.seq_no
+      ) = 1 as is_first_tile_hit
+    from public.walk_points wp
+    where wp.walk_session_id = target_walk_session_id
+  ),
+  normalized as (
+    select
+      p.*,
+      (
+        p.prev_same_tile_at is not null
+        and p.recorded_at <= p.prev_same_tile_at + make_interval(mins => policy_row.repeat_cooldown_minutes)
+      ) as is_repeat_within_cooldown,
+      case
+        when p.prev_lat is null or p.prev_lng is null then 0::double precision
+        else sqrt(
+          power((p.lat - p.prev_lat), 2) +
+          power((p.lng - p.prev_lng) * cos(radians(p.lat)), 2)
+        ) * 111320.0
+      end as distance_from_prev_m
+    from points p
+  ),
+  session_stats as (
+    select
+      count(*)::int as total_points,
+      count(distinct geotile)::int as unique_tiles,
+      case
+        when count(*) = 0 then 0::double precision
+        else count(distinct geotile)::double precision / count(*)::double precision
+      end as novelty_ratio
+    from normalized
+  ),
+  scored as (
+    select
+      n.seq_no,
+      n.geotile,
+      n.recorded_at,
+      n.is_first_tile_hit,
+      n.is_repeat_within_cooldown,
+      n.distance_from_prev_m,
+      ss.novelty_ratio,
+      case
+        when n.is_repeat_within_cooldown then 0::double precision
+        else policy_row.base_tile_score
+      end as base_score,
+      case
+        when n.is_first_tile_hit and n.is_repeat_within_cooldown = false
+          then policy_row.base_tile_score * policy_row.new_route_bonus_weight * ss.novelty_ratio
+        else 0::double precision
+      end as novelty_bonus,
+      case
+        when n.is_repeat_within_cooldown then 'repeat_within_30m'
+        else null
+      end as suppression_reason
+    from normalized n
+    cross join session_stats ss
+  )
+  insert into public.season_tile_score_events (
+    owner_user_id,
+    walk_session_id,
+    seq_no,
+    geotile,
+    recorded_at,
+    is_first_tile_hit,
+    is_repeat_within_cooldown,
+    distance_from_prev_m,
+    novelty_ratio,
+    base_score,
+    novelty_bonus,
+    final_score,
+    suppression_reason,
+    created_at
+  )
+  select
+    session_owner,
+    target_walk_session_id,
+    s.seq_no,
+    s.geotile,
+    s.recorded_at,
+    s.is_first_tile_hit,
+    s.is_repeat_within_cooldown,
+    s.distance_from_prev_m,
+    s.novelty_ratio,
+    s.base_score,
+    s.novelty_bonus,
+    (s.base_score + s.novelty_bonus) as final_score,
+    s.suppression_reason,
+    now_ts
+  from scored s
+  order by s.seq_no;
+
+  select
+    count(*)::int,
+    count(distinct geotile)::int,
+    coalesce(max(novelty_ratio), 0::double precision),
+    count(*) filter (where is_repeat_within_cooldown)::int,
+    count(*) filter (where suppression_reason = 'repeat_within_30m')::int,
+    coalesce(sum(base_score), 0::double precision),
+    coalesce(sum(novelty_bonus), 0::double precision),
+    coalesce(sum(final_score), 0::double precision),
+    coalesce(sum(distance_from_prev_m), 0::double precision)
+  into
+    v_total_points,
+    v_unique_tiles,
+    v_novelty_ratio,
+    v_repeat_suppressed,
+    v_suspicious_repeat,
+    v_base_score,
+    v_bonus_score,
+    v_raw_total_score,
+    v_total_distance_m
+  from public.season_tile_score_events
+  where walk_session_id = target_walk_session_id;
+
+  v_score_blocked :=
+    policy_row.suspicious_block_enabled
+    and v_repeat_suppressed >= policy_row.suspicious_repeat_threshold
+    and v_novelty_ratio <= policy_row.suspicious_max_novelty_ratio
+    and v_total_distance_m <= policy_row.suspicious_low_movement_meters;
+
+  v_total_score := case when v_score_blocked then 0 else v_raw_total_score end;
+
+  if v_score_blocked then
+    v_severity := 'block';
+  elsif v_repeat_suppressed > 0 then
+    v_severity := 'warn';
+  else
+    v_severity := 'info';
+  end if;
+
+  if v_repeat_suppressed > 0 then
+    insert into public.season_score_audit_logs (
+      owner_user_id,
+      walk_session_id,
+      policy_key,
+      severity,
+      blocked,
+      repeat_suppressed_count,
+      novelty_ratio,
+      session_distance_m,
+      payload,
+      created_at
+    )
+    values (
+      session_owner,
+      target_walk_session_id,
+      policy_row.policy_key,
+      v_severity,
+      v_score_blocked,
+      v_repeat_suppressed,
+      v_novelty_ratio,
+      v_total_distance_m,
+      jsonb_build_object(
+        'cooldown_minutes', policy_row.repeat_cooldown_minutes,
+        'repeat_threshold', policy_row.suspicious_repeat_threshold,
+        'novelty_limit', policy_row.suspicious_max_novelty_ratio,
+        'distance_limit_m', policy_row.suspicious_low_movement_meters,
+        'score_before_block', v_raw_total_score,
+        'scored_at', now_ts
+      ),
+      now_ts
+    );
+  end if;
+
+  return query
+  select
+    target_walk_session_id as walk_session_id,
+    v_total_points,
+    v_unique_tiles,
+    v_novelty_ratio,
+    v_repeat_suppressed,
+    v_suspicious_repeat,
+    v_base_score,
+    v_bonus_score,
+    v_total_score,
+    v_score_blocked,
+    jsonb_build_object(
+      'policy_key', policy_row.policy_key,
+      'repeat_cooldown_minutes', policy_row.repeat_cooldown_minutes,
+      'repeat_suppressed_count', v_repeat_suppressed,
+      'novelty_ratio', v_novelty_ratio,
+      'score_blocked', v_score_blocked,
+      'ui_reason', case
+        when v_score_blocked then '반복 패턴이 감지되어 이번 세션 시즌 점수가 차단되었습니다.'
+        when v_repeat_suppressed > 0 then '동일 타일 반복 입력(30분 이내)은 점수에서 제외되었습니다.'
+        else '신규 경로 중심 점수 규칙이 적용되었습니다.'
+      end,
+      'distance_m', v_total_distance_m,
+      'scored_at', now_ts
+    ) as explain;
+end;
+$$;
+
+create or replace view public.view_season_score_audit_24h as
+select
+  date_trunc('hour', created_at) as hour_bucket,
+  severity,
+  count(*)::bigint as event_count,
+  sum(case when blocked then 1 else 0 end)::bigint as blocked_count
+from public.season_score_audit_logs
+where created_at >= now() - interval '24 hours'
+group by date_trunc('hour', created_at), severity
+order by hour_bucket desc, severity asc;
+
+grant select on public.season_scoring_policies to anon, authenticated;
+grant select on public.season_tile_score_events to authenticated;
+grant select on public.season_score_audit_logs to authenticated;
+grant execute on function public.rpc_score_walk_session_anti_farming(uuid, timestamptz) to authenticated, service_role;
+grant select on public.view_season_score_audit_24h to authenticated;


### PR DESCRIPTION
## Summary
- add `season_scoring_policies`, `season_tile_score_events`, `season_score_audit_logs` schema and `rpc_score_walk_session_anti_farming` rule engine
- implement same-tile repeat suppression (30m -> 0 points), novelty bonus, and suspicious repeat blocking rule with audit logging
- wire `sync-walk` points stage to call scoring rpc and return `season_score_summary` for UX explanation path
- update schema/ops docs, release checklist, and cycle report for season anti-farming rollout
- add regression/unit checks for migration/function/doc contracts and scoring behavior

## Test
- `swift scripts/season_anti_farming_unit_check.swift`
- `swift scripts/release_regression_checklist_unit_check.swift`
- `swift scripts/project_stability_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #146
