### PR TITLE
[P1] Perceived weather feedback loop (same-day reevaluation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - 근처 사용자 익명 핫스팟 명세 v1: `docs/nearby-anonymous-hotspot-v1.md`
 - 라이벌 프라이버시 하드 가드 v1: `docs/rival-privacy-hard-guard-v1.md`
 - 시즌 안티 농사 규칙 v1: `docs/season-anti-farming-v1.md`
+- 체감 날씨 피드백 루프 v1: `docs/weather-feedback-loop-v1.md`
 - Feature Flag/롤아웃 모니터링 명세 v1: `docs/feature-flag-rollout-monitoring-v1.md`
 - ViewModel 현대화 리팩토링 명세 v1: `docs/viewmodel-modernization-v1.md`
 - CoreData 반환 계약 정리 v1: `docs/coredata-return-contract-v1.md`

--- a/docs/cycle-151-weather-feedback-loop-report-2026-02-27.md
+++ b/docs/cycle-151-weather-feedback-loop-report-2026-02-27.md
@@ -1,0 +1,45 @@
+# Cycle 151 Report — Weather Feedback Loop (2026-02-27)
+
+## 1. 대상
+- Issue: `#151 [P1][Task] 날씨 오판 보정(체감 날씨 피드백 루프)`
+- Branch: `codex/cycle-151-weather-feedback`
+
+## 2. 구현 요약
+- 홈 실내 대체 미션 카드에 `체감 날씨 다름` 1탭 액션과 주간 잔여 반영 횟수 UI 추가
+- 체감 피드백 로직 구현:
+  - 당일 판정만 재평가
+  - 주간 2회 제한
+  - `severe->bad`, `bad->caution`, `caution` 유지(완전 해제 금지)
+- 피드백 반영 결과를 홈 카드/상태 메시지로 즉시 노출
+- 메트릭 이벤트 추가:
+  - `weather_feedback_submitted`
+  - `weather_feedback_rate_limited`
+  - `weather_risk_reevaluated`
+- Supabase KPI 뷰 `view_weather_feedback_kpis_7d` 추가로 오탐/정탐/제한 비율 관측 경로 제공
+
+## 3. 변경 파일
+- `dogArea/Views/HomeView/HomeViewModel.swift`
+- `dogArea/Views/HomeView/HomeView.swift`
+- `dogArea/Source/UserdefaultSetting.swift`
+- `supabase/migrations/20260227203000_weather_feedback_kpis.sql`
+- `docs/weather-feedback-loop-v1.md`
+- `docs/indoor-weather-mission-v1.md`
+- `docs/release-regression-checklist-v1.md`
+- `docs/supabase-schema-v1.md`
+- `docs/supabase-migration.md`
+- `docs/cycle-151-weather-feedback-loop-report-2026-02-27.md`
+- `README.md`
+- `scripts/weather_feedback_loop_unit_check.swift`
+- `scripts/release_regression_checklist_unit_check.swift`
+- `scripts/ios_pr_check.sh`
+
+## 4. 유닛 체크
+- `swift scripts/weather_feedback_loop_unit_check.swift` -> PASS
+- `swift scripts/indoor_weather_mission_unit_check.swift` -> PASS
+- `swift scripts/release_regression_checklist_unit_check.swift` -> PASS
+- `swift scripts/project_stability_unit_check.swift` -> PASS
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh` -> PASS
+
+## 5. 리스크/후속
+- 현재는 클라이언트 저장 기반 주간 제한이므로, 서버 정책 동기화가 필요하면 후속으로 제한 로직을 서버 검증 경로로 이관해야 함.
+- Weather provider 실연동 단계(#133~#135)에서 피드백 가중치와 위험도 재평가 매핑을 서버 정책화하는 작업이 필요.

--- a/docs/indoor-weather-mission-v1.md
+++ b/docs/indoor-weather-mission-v1.md
@@ -39,3 +39,9 @@
 - `indoor_mission_action_logged`
 - `indoor_mission_completed`
 - `indoor_mission_completion_rejected`
+
+## 7. 체감 날씨 피드백 루프 연계 (#151)
+- 홈 카드에서 `체감 날씨 다름` 1탭 액션 제공
+- 반영 범위는 당일 위험도에 한정, 주간 2회 제한 적용
+- 피드백으로 위험도를 완전 해제(`clear`)하지 않음
+- 상세 명세: `docs/weather-feedback-loop-v1.md`

--- a/docs/release-regression-checklist-v1.md
+++ b/docs/release-regression-checklist-v1.md
@@ -64,6 +64,9 @@
 - [ ] 악천후 단계에서 실외 미션이 실내 대체 미션으로 자동 치환됨
 - [ ] 실내 미션 최소 행동량 미달 시 완료 확정이 거절됨
 - [ ] 실내 미션이 연속 일자에 동일 템플릿으로 반복 노출되지 않음
+- [ ] `체감 날씨 다름` 1탭 입력 시 당일 위험도 재평가 결과가 즉시 노출됨
+- [ ] 체감 피드백 주간 3회 입력 시 3회차가 제한 처리되고 잔여 횟수가 정확히 표시됨
+- [ ] 체감 피드백만으로 위험도 `clear` 완전 해제가 발생하지 않음
 - [ ] nearby 핫스팟에서 표본 미달 셀은 count가 노출되지 않고(percentile-only) 강도만 표시됨
 - [ ] nearby 핫스팟에서 야간(22~06) 지연 60분 정책이 반영됨
 - [ ] 민감 구역 마스킹 대상 셀이 지도 오버레이에 노출되지 않음
@@ -97,6 +100,7 @@
 - [ ] `area_reference_catalogs` + `area_references.catalog_id/display_order/is_featured` 구조 확인
 - [ ] `privacy_guard_policies/privacy_sensitive_geo_masks/privacy_guard_audit_logs` 구조 및 `rpc_get_nearby_hotspots` 확장 컬럼 확인
 - [ ] `season_scoring_policies/season_tile_score_events/season_score_audit_logs` 구조 및 `rpc_score_walk_session_anti_farming` 실행 확인
+- [ ] `view_weather_feedback_kpis_7d` 뷰 조회 및 지표 컬럼(`submitted/rate_limited/changed_ratio`) 확인
 
 ## 6. 배포 파이프라인 검증 시나리오
 ### 6.1 Workflow 정의/활성 상태

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -192,6 +192,26 @@ order by created_at desc
 limit 20;
 ```
 
+### 5.8 체감 날씨 피드백 KPI 검증 (#151)
+```sql
+select
+  day_bucket,
+  submitted_count,
+  rate_limited_count,
+  changed_count,
+  unchanged_count,
+  changed_ratio,
+  rate_limited_ratio
+from public.view_weather_feedback_kpis_7d
+order by day_bucket desc
+limit 7;
+```
+
+기대값:
+- 피드백 이벤트가 발생한 일자에 `submitted_count`/`rate_limited_count`가 반영
+- 위험도 재평가 이벤트에서 `changed_ratio`가 0~1 범위로 계산
+- 제한 발생 시 `rate_limited_ratio`가 증가
+
 ## 6. 운영 체크리스트
 - [ ] `migration list --local` / `migration list --linked` 결과 저장
 - [ ] User A/B 교차 접근 차단 SQL 결과 저장
@@ -200,3 +220,4 @@ limit 20;
 - [ ] User/Pet 확장 필드 정합성 SQL 결과 첨부
 - [ ] 비교군 카탈로그/시드 정합성 SQL 결과 첨부
 - [ ] 시즌 안티 농사 RPC/감사 로그 검증 결과 첨부
+- [ ] 체감 날씨 피드백 KPI 뷰 검증 결과 첨부

--- a/docs/supabase-schema-v1.md
+++ b/docs/supabase-schema-v1.md
@@ -16,6 +16,7 @@
 - 캐리커처 비동기 파이프라인용 데이터 구조
 - 근처 사용자 익명 핫스팟용 데이터 구조
 - 시즌 안티 농사 점수 규칙용 데이터 구조
+- 체감 날씨 피드백 KPI 뷰
 - RLS 정책 원칙
 - Storage 경로 규칙
 - 마이그레이션/롤백 절차
@@ -208,6 +209,11 @@ erDiagram
 - `rpc_score_walk_session_anti_farming`
   - 세션 점수 계산 결과 + UX 설명(`explain.ui_reason`) 반환
 
+### 4.7 체감 날씨 피드백 KPI
+- `view_weather_feedback_kpis_7d`
+  - `weather_feedback_submitted/rate_limited/weather_risk_reevaluated` 기반 일자별 지표 집계
+  - `changed_ratio`, `rate_limited_ratio`로 오탐/정탐/남용 상태 관측
+
 ## 5. RLS 정책 원칙
 - 사용자 데이터는 `auth.uid()` 소유 범위로만 접근
 - `area_references`는 읽기 공개(`anon`, `authenticated`)
@@ -236,6 +242,8 @@ erDiagram
 - `season_tile_score_events`, `season_score_audit_logs`
   - `select`: 소유자
   - write: 서비스 경로(RPC/service role)
+- `view_weather_feedback_kpis_7d`
+  - `select`: 공개(운영 관측용)
 
 ## 6. Storage 규칙
 버킷:

--- a/docs/weather-feedback-loop-v1.md
+++ b/docs/weather-feedback-loop-v1.md
@@ -1,0 +1,41 @@
+# Weather Feedback Loop v1 (Issue #151)
+
+## 1. 목표
+- 날씨 API 판정과 체감 불일치 시 사용자가 1탭으로 당일 판정을 보정할 수 있게 한다.
+- 남용을 막기 위해 주간 반영 횟수를 제한한다.
+
+## 2. UX 계약
+- CTA: `체감 날씨 다름` 버튼(홈 실내 대체 미션 카드 내)
+- 즉시 결과 표시:
+  - 판정 조정 시: `원래 위험도 -> 조정 위험도`
+  - 미조정 시: 안전 기준으로 유지 안내
+- 잔여 횟수 표시: `주간 남은 반영 N/2`
+
+## 3. 반영 규칙
+- 반영 범위: `당일` 판정에만 적용
+- 주간 제한: `2회`
+- 위험도 조정:
+  - `severe -> bad`
+  - `bad -> caution`
+  - `caution -> caution` (완전 해제 금지)
+- 피드백만으로 `clear`로 완전 해제하지 않음
+
+## 4. 저장 키(클라이언트)
+- `weather.feedback.timestamps.v1`: 주간 제한 계산용 timestamp 배열
+- `weather.feedback.dailyAdjustment.v1`: 일자별 위험도 보정 step
+
+## 5. 관측 지표
+- `weather_feedback_submitted`
+- `weather_feedback_rate_limited`
+- `weather_risk_reevaluated`
+
+대시보드 뷰:
+- `public.view_weather_feedback_kpis_7d`
+  - `submitted_count`, `rate_limited_count`, `changed_count`, `unchanged_count`
+  - `changed_ratio`, `rate_limited_ratio`
+
+## 6. 검증 체크리스트
+- [ ] 피드백 1회 입력 시 당일 위험도 재평가 반영
+- [ ] 주간 3회 입력 시 3회차가 rate-limit 처리
+- [ ] 피드백으로 위험도가 `clear`로 완전 해제되지 않음
+- [ ] `view_weather_feedback_kpis_7d`에서 일자별 지표 조회 가능

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -553,6 +553,9 @@ enum AppMetricEvent: String {
     case indoorMissionActionLogged = "indoor_mission_action_logged"
     case indoorMissionCompleted = "indoor_mission_completed"
     case indoorMissionCompletionRejected = "indoor_mission_completion_rejected"
+    case weatherFeedbackSubmitted = "weather_feedback_submitted"
+    case weatherFeedbackRateLimited = "weather_feedback_rate_limited"
+    case weatherRiskReevaluated = "weather_risk_reevaluated"
 }
 
 final class FeatureFlagStore {

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -148,6 +148,11 @@ struct HomeView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.8) {
                 viewModel.clearIndoorMissionStatusMessage()
             }
+        }.onChange(of: viewModel.weatherFeedbackResultMessage) { newValue in
+            guard newValue != nil else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.2) {
+                viewModel.clearWeatherFeedbackResultMessage()
+            }
         }.padding(.top,20)
     }
 
@@ -328,6 +333,30 @@ struct HomeView: View {
             Text("악천후 단계에 맞춰 실외 미션 일부를 실내 미션으로 치환했어요.")
                 .font(.appFont(for: .Light, size: 12))
                 .foregroundStyle(Color.appTextDarkGray)
+            HStack(spacing: 8) {
+                Button("체감 날씨 다름") {
+                    viewModel.submitWeatherMismatchFeedback()
+                }
+                .disabled(viewModel.canSubmitWeatherMismatchFeedback == false)
+                .font(.appFont(for: .SemiBold, size: 11))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .background(viewModel.canSubmitWeatherMismatchFeedback ? Color.appYellow : Color.appTextLightGray)
+                .cornerRadius(8)
+
+                Text("주간 남은 반영 \(viewModel.weatherFeedbackRemainingCount)/\(viewModel.weatherFeedbackWeeklyLimit)")
+                    .font(.appFont(for: .Light, size: 11))
+                    .foregroundStyle(Color.appTextDarkGray)
+            }
+            if let feedbackMessage = viewModel.weatherFeedbackResultMessage {
+                Text(feedbackMessage)
+                    .font(.appFont(for: .Light, size: 11))
+                    .foregroundStyle(Color.appTextDarkGray)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(Color.appYellowPale)
+                    .cornerRadius(8)
+            }
 
             ForEach(board.missions) { mission in
                 indoorMissionRow(mission: mission)

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -25,6 +25,8 @@ final class HomeViewModel: ObservableObject, CoreDataProtocol {
     @Published private(set) var aggregationTimeZoneIdentifier: String = TimeZone.current.identifier
     @Published var indoorMissionBoard: IndoorMissionBoard = .empty
     @Published var indoorMissionStatusMessage: String? = nil
+    @Published var weatherFeedbackRemainingCount: Int = 2
+    @Published var weatherFeedbackResultMessage: String? = nil
 
     private var allPolygons: [Polygon] = []
     private var cancellables: Set<AnyCancellable> = []
@@ -42,6 +44,14 @@ final class HomeViewModel: ObservableObject, CoreDataProtocol {
 
     var nextGoalArea: AreaMeter? {
         nearlistMore()
+    }
+
+    var weatherFeedbackWeeklyLimit: Int {
+        indoorMissionStore.weeklyFeedbackLimit
+    }
+
+    var canSubmitWeatherMismatchFeedback: Bool {
+        indoorMissionBoard.riskLevel != .clear && weatherFeedbackRemainingCount > 0
     }
 
     var remainingAreaToGoal: Double {
@@ -89,6 +99,10 @@ final class HomeViewModel: ObservableObject, CoreDataProtocol {
 
     func clearIndoorMissionStatusMessage() {
         indoorMissionStatusMessage = nil
+    }
+
+    func clearWeatherFeedbackResultMessage() {
+        weatherFeedbackResultMessage = nil
     }
 
     private func bindSelectedPetSync() {
@@ -235,6 +249,7 @@ final class HomeViewModel: ObservableObject, CoreDataProtocol {
 
     func refreshIndoorMissions(now: Date = Date()) {
         indoorMissionBoard = indoorMissionStore.buildBoard(now: now)
+        weatherFeedbackRemainingCount = indoorMissionStore.weatherFeedbackRemainingCount(now: now)
         guard indoorMissionBoard.isIndoorReplacementActive else { return }
         let exposureKey = "\(indoorMissionBoard.dayKey)|\(indoorMissionBoard.riskLevel.rawValue)"
         guard exposureKey != lastIndoorMissionExposureTrackKey else { return }
@@ -296,6 +311,48 @@ final class HomeViewModel: ObservableObject, CoreDataProtocol {
         case .alreadyCompleted:
             indoorMissionStatusMessage = "이미 완료한 미션입니다."
         }
+    }
+
+    func submitWeatherMismatchFeedback(now: Date = Date()) {
+        let outcome = indoorMissionStore.submitWeatherMismatchFeedback(now: now)
+        weatherFeedbackRemainingCount = outcome.remainingWeeklyQuota
+
+        if outcome.accepted {
+            let hasRiskChanged = outcome.originalRisk != outcome.adjustedRisk
+            weatherFeedbackResultMessage = hasRiskChanged
+                ? "체감 피드백 반영: \(outcome.originalRisk.displayTitle) → \(outcome.adjustedRisk.displayTitle)"
+                : "피드백을 반영했지만 안전 기준상 오늘 판정은 \(outcome.adjustedRisk.displayTitle)로 유지돼요."
+            metricTracker.track(
+                .weatherFeedbackSubmitted,
+                userKey: userInfo?.id,
+                payload: [
+                    "fromRisk": outcome.originalRisk.rawValue,
+                    "toRisk": outcome.adjustedRisk.rawValue,
+                    "remainingQuota": "\(outcome.remainingWeeklyQuota)"
+                ]
+            )
+            metricTracker.track(
+                .weatherRiskReevaluated,
+                userKey: userInfo?.id,
+                payload: [
+                    "fromRisk": outcome.originalRisk.rawValue,
+                    "toRisk": outcome.adjustedRisk.rawValue,
+                    "changed": hasRiskChanged ? "true" : "false"
+                ]
+            )
+        } else {
+            weatherFeedbackResultMessage = outcome.message
+            metricTracker.track(
+                .weatherFeedbackRateLimited,
+                userKey: userInfo?.id,
+                payload: [
+                    "remainingQuota": "\(outcome.remainingWeeklyQuota)"
+                ]
+            )
+        }
+
+        indoorMissionStatusMessage = weatherFeedbackResultMessage
+        refreshIndoorMissions(now: now)
     }
 
     private func currentCalendar() -> Calendar {
@@ -532,6 +589,14 @@ struct IndoorMissionBoard: Equatable {
     }
 }
 
+struct WeatherFeedbackOutcome: Equatable {
+    let accepted: Bool
+    let message: String
+    let originalRisk: IndoorWeatherRiskLevel
+    let adjustedRisk: IndoorWeatherRiskLevel
+    let remainingWeeklyQuota: Int
+}
+
 private enum IndoorMissionCompletionResult {
     case completed
     case insufficientAction(actionCount: Int, required: Int)
@@ -544,7 +609,11 @@ private final class IndoorMissionStore {
         static let actionCounts = "indoor.mission.actionCounts.v1"
         static let completionFlags = "indoor.mission.completed.v1"
         static let exposureHistory = "indoor.mission.exposureHistory.v1"
+        static let weatherFeedbackTimestamps = "weather.feedback.timestamps.v1"
+        static let weatherFeedbackDailyAdjustment = "weather.feedback.dailyAdjustment.v1"
     }
+
+    let weeklyFeedbackLimit = 2
 
     private let calendar: Calendar = {
         var value = Calendar.autoupdatingCurrent
@@ -601,7 +670,7 @@ private final class IndoorMissionStore {
     ]
 
     func buildBoard(now: Date) -> IndoorMissionBoard {
-        let riskLevel = resolveRiskLevel()
+        let riskLevel = resolveRiskLevel(now: now)
         let dayKey = dayStamp(for: now)
         guard riskLevel.replacementMissionCount > 0 else {
             return .init(riskLevel: riskLevel, dayKey: dayKey, missions: [])
@@ -660,6 +729,55 @@ private final class IndoorMissionStore {
         )
     }
 
+    func weatherFeedbackRemainingCount(now: Date = Date()) -> Int {
+        max(0, weeklyFeedbackLimit - feedbackCountInCurrentWeek(now: now))
+    }
+
+    func submitWeatherMismatchFeedback(now: Date = Date()) -> WeatherFeedbackOutcome {
+        let originalRisk = resolveRiskLevel(now: now)
+        let remainingBefore = weatherFeedbackRemainingCount(now: now)
+        guard remainingBefore > 0 else {
+            return .init(
+                accepted: false,
+                message: "체감 피드백은 주간 \(weeklyFeedbackLimit)회까지 반영할 수 있어요.",
+                originalRisk: originalRisk,
+                adjustedRisk: originalRisk,
+                remainingWeeklyQuota: 0
+            )
+        }
+
+        appendFeedbackTimestamp(now: now)
+        let dayKey = dayStamp(for: now)
+
+        let adjustedRisk: IndoorWeatherRiskLevel
+        if originalRisk == .severe {
+            adjustedRisk = .bad
+        } else if originalRisk == .bad {
+            adjustedRisk = .caution
+        } else {
+            adjustedRisk = originalRisk
+        }
+
+        let adjustmentStep = adjustmentStep(from: originalRisk, to: adjustedRisk)
+        persistDailyAdjustment(dayKey: dayKey, step: adjustmentStep)
+
+        let remainingAfter = weatherFeedbackRemainingCount(now: now)
+        let message: String
+        if originalRisk != adjustedRisk {
+            message = "체감 피드백이 반영되어 오늘 판정을 \(adjustedRisk.displayTitle)로 재평가했어요."
+        } else {
+            message = "피드백은 반영했지만 안전 기준상 오늘 판정은 \(adjustedRisk.displayTitle)로 유지돼요."
+        }
+
+        return .init(
+            accepted: true,
+            message: message,
+            originalRisk: originalRisk,
+            adjustedRisk: adjustedRisk,
+            remainingWeeklyQuota: remainingAfter
+        )
+    }
+
     private func makeCardModel(
         template: IndoorMissionTemplate,
         riskLevel: IndoorWeatherRiskLevel,
@@ -693,7 +811,7 @@ private final class IndoorMissionStore {
         templates.first(where: { $0.id == missionId })
     }
 
-    private func resolveRiskLevel() -> IndoorWeatherRiskLevel {
+    private func resolveBaseRiskLevel() -> IndoorWeatherRiskLevel {
         if let env = ProcessInfo.processInfo.environment["WEATHER_RISK_LEVEL"],
            let level = IndoorWeatherRiskLevel(rawValue: env.lowercased()) {
             return level
@@ -703,6 +821,13 @@ private final class IndoorMissionStore {
             return level
         }
         return .caution
+    }
+
+    private func resolveRiskLevel(now: Date = Date()) -> IndoorWeatherRiskLevel {
+        let baseRisk = resolveBaseRiskLevel()
+        let dayKey = dayStamp(for: now)
+        let adjustment = dailyAdjustmentMap()[dayKey] ?? 0
+        return adjustedRisk(from: baseRisk, step: adjustment)
     }
 
     private func selectedTemplatesForToday(
@@ -786,6 +911,63 @@ private final class IndoorMissionStore {
 
     private func resolvedRiskLevelFromBoard() -> IndoorWeatherRiskLevel {
         resolveRiskLevel()
+    }
+
+    private func adjustedRisk(from risk: IndoorWeatherRiskLevel, step: Int) -> IndoorWeatherRiskLevel {
+        guard step != 0 else { return risk }
+        let allCases = IndoorWeatherRiskLevel.allCases
+        guard let currentIndex = allCases.firstIndex(of: risk) else { return risk }
+        let targetIndex = min(max(0, currentIndex + step), allCases.count - 1)
+        let targetRisk = allCases[targetIndex]
+        if risk != .clear && targetRisk == .clear {
+            return .caution
+        }
+        return targetRisk
+    }
+
+    private func adjustmentStep(from originalRisk: IndoorWeatherRiskLevel, to adjustedRisk: IndoorWeatherRiskLevel) -> Int {
+        guard let originalIndex = IndoorWeatherRiskLevel.allCases.firstIndex(of: originalRisk),
+              let adjustedIndex = IndoorWeatherRiskLevel.allCases.firstIndex(of: adjustedRisk) else {
+            return 0
+        }
+        return adjustedIndex - originalIndex
+    }
+
+    private func feedbackCountInCurrentWeek(now: Date) -> Int {
+        guard let interval = calendar.dateInterval(of: .weekOfYear, for: now) else { return 0 }
+        let events = feedbackTimestamps().filter { timestamp in
+            let date = Date(timeIntervalSince1970: timestamp)
+            return interval.contains(date)
+        }
+        return events.count
+    }
+
+    private func feedbackTimestamps() -> [TimeInterval] {
+        let raw = UserDefaults.standard.array(forKey: DefaultsKey.weatherFeedbackTimestamps) as? [Double] ?? []
+        return raw.sorted()
+    }
+
+    private func appendFeedbackTimestamp(now: Date) {
+        let expiration = now.addingTimeInterval(-60 * 24 * 3600).timeIntervalSince1970
+        var values = feedbackTimestamps().filter { $0 >= expiration }
+        values.append(now.timeIntervalSince1970)
+        UserDefaults.standard.set(values, forKey: DefaultsKey.weatherFeedbackTimestamps)
+    }
+
+    private func dailyAdjustmentMap() -> [String: Int] {
+        UserDefaults.standard.dictionary(forKey: DefaultsKey.weatherFeedbackDailyAdjustment) as? [String: Int] ?? [:]
+    }
+
+    private func persistDailyAdjustment(dayKey: String, step: Int) {
+        var map = dailyAdjustmentMap()
+        if step == 0 {
+            map.removeValue(forKey: dayKey)
+        } else {
+            map[dayKey] = step
+        }
+        let keysToKeep = Set(previousDayStamps(from: dayKey, count: 14) + [dayKey])
+        map = map.filter { keysToKeep.contains($0.key) }
+        UserDefaults.standard.set(map, forKey: DefaultsKey.weatherFeedbackDailyAdjustment)
     }
 
     private static let dayFormatter: DateFormatter = {

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -30,6 +30,7 @@ swift scripts/fault_injection_matrix_unit_check.swift
 swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift
 swift scripts/season_anti_farming_unit_check.swift
+swift scripts/weather_feedback_loop_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 
 if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then

--- a/scripts/release_regression_checklist_unit_check.swift
+++ b/scripts/release_regression_checklist_unit_check.swift
@@ -32,6 +32,9 @@ assertTrue(checklist.contains("privacy_guard_policies/privacy_sensitive_geo_mask
 assertTrue(checklist.contains("동일 타일 30분 내 반복 이벤트가 0점 처리"), "checklist should include season anti-farming repeat suppression scenario")
 assertTrue(checklist.contains("score_blocked=true"), "checklist should include season anti-farming blocking scenario")
 assertTrue(checklist.contains("season_scoring_policies/season_tile_score_events/season_score_audit_logs"), "checklist should include season anti-farming migration verification")
+assertTrue(checklist.contains("체감 날씨 다름"), "checklist should include weather feedback one-tap scenario")
+assertTrue(checklist.contains("주간 3회 입력"), "checklist should include weather feedback weekly limit scenario")
+assertTrue(checklist.contains("view_weather_feedback_kpis_7d"), "checklist should include weather feedback KPI view verification")
 
 assertTrue(report.contains("## 1. 빌드 체크 결과"), "report must include build results")
 assertTrue(report.contains("## 2. 핵심 시나리오 점검 결과"), "report must include scenario results")

--- a/scripts/weather_feedback_loop_unit_check.swift
+++ b/scripts/weather_feedback_loop_unit_check.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+enum RiskLevel: Int, CaseIterable {
+    case clear = 0
+    case caution = 1
+    case bad = 2
+    case severe = 3
+
+    var downgradedByFeedback: RiskLevel {
+        switch self {
+        case .severe: return .bad
+        case .bad: return .caution
+        case .caution: return .caution
+        case .clear: return .clear
+        }
+    }
+}
+
+struct FeedbackEngine {
+    let weeklyLimit: Int
+
+    func remainingQuota(timestamps: [Date], now: Date, calendar: Calendar) -> Int {
+        guard let interval = calendar.dateInterval(of: .weekOfYear, for: now) else {
+            return weeklyLimit
+        }
+        let used = timestamps.filter { interval.contains($0) }.count
+        return max(0, weeklyLimit - used)
+    }
+
+    func applyFeedback(base: RiskLevel, timestamps: [Date], now: Date, calendar: Calendar) -> (accepted: Bool, adjusted: RiskLevel, remaining: Int) {
+        let remaining = remainingQuota(timestamps: timestamps, now: now, calendar: calendar)
+        guard remaining > 0 else {
+            return (false, base, 0)
+        }
+        let adjusted = base.downgradedByFeedback
+        return (true, adjusted, max(0, remaining - 1))
+    }
+}
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let homeVM = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let metrics = load("dogArea/Source/UserdefaultSetting.swift")
+let spec = load("docs/weather-feedback-loop-v1.md")
+let indoorSpec = load("docs/indoor-weather-mission-v1.md")
+let migration = load("supabase/migrations/20260227203000_weather_feedback_kpis.sql")
+
+assertTrue(homeVM.contains("submitWeatherMismatchFeedback"), "home vm should expose weather mismatch feedback action")
+assertTrue(homeVM.contains("weatherFeedbackRemainingCount"), "home vm should track remaining weather feedback quota")
+assertTrue(homeVM.contains("weeklyFeedbackLimit = 2"), "home vm store should enforce weekly feedback limit")
+assertTrue(homeVM.contains("severe") && homeVM.contains("bad") && homeVM.contains("caution"), "home vm should downgrade severe/bad risks")
+
+assertTrue(homeView.contains("체감 날씨 다름"), "home view should render one-tap weather mismatch action")
+assertTrue(homeView.contains("주간 남은 반영"), "home view should show remaining weekly feedback quota")
+
+assertTrue(metrics.contains("weather_feedback_submitted"), "metric enum should include weather feedback submitted event")
+assertTrue(metrics.contains("weather_feedback_rate_limited"), "metric enum should include weather feedback rate-limit event")
+assertTrue(metrics.contains("weather_risk_reevaluated"), "metric enum should include weather risk reevaluation event")
+
+assertTrue(spec.contains("주간 제한: `2회`"), "weather feedback spec should include weekly limit")
+assertTrue(spec.contains("완전 해제"), "weather feedback spec should forbid full clear by feedback")
+assertTrue(indoorSpec.contains("weather-feedback-loop-v1.md"), "indoor weather spec should link weather feedback loop doc")
+assertTrue(migration.contains("view_weather_feedback_kpis_7d"), "migration should expose weather feedback KPI view")
+assertTrue(migration.contains("weather_feedback_submitted"), "migration should aggregate submitted feedback metric")
+
+var calendar = Calendar(identifier: .gregorian)
+calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+let now = Date(timeIntervalSince1970: 1_771_000_000)
+let engine = FeedbackEngine(weeklyLimit: 2)
+
+let first = engine.applyFeedback(base: .severe, timestamps: [], now: now, calendar: calendar)
+assertTrue(first.accepted, "first feedback this week should be accepted")
+assertTrue(first.adjusted == .bad, "severe should downgrade to bad")
+assertTrue(first.remaining == 1, "remaining quota should decrease after accepted feedback")
+
+let second = engine.applyFeedback(base: .bad, timestamps: [now], now: now.addingTimeInterval(60), calendar: calendar)
+assertTrue(second.accepted, "second feedback this week should be accepted")
+assertTrue(second.adjusted == .caution, "bad should downgrade to caution")
+assertTrue(second.remaining == 0, "remaining quota should reach zero after second feedback")
+
+let third = engine.applyFeedback(base: .bad, timestamps: [now, now.addingTimeInterval(120)], now: now.addingTimeInterval(180), calendar: calendar)
+assertTrue(third.accepted == false, "third feedback in same week should be rate-limited")
+assertTrue(third.adjusted == .bad, "rate-limited feedback should not change risk")
+
+let caution = engine.applyFeedback(base: .caution, timestamps: [], now: now, calendar: calendar)
+assertTrue(caution.adjusted == .caution, "feedback should not fully clear caution risk")
+
+print("PASS: weather feedback loop unit checks")

--- a/supabase/migrations/20260227203000_weather_feedback_kpis.sql
+++ b/supabase/migrations/20260227203000_weather_feedback_kpis.sql
@@ -1,0 +1,50 @@
+-- #151 perceived weather feedback loop metrics
+
+create or replace view public.view_weather_feedback_kpis_7d as
+with metrics as (
+  select
+    event_name,
+    created_at,
+    payload
+  from public.app_metric_events
+  where created_at >= now() - interval '7 days'
+    and event_name in (
+      'weather_feedback_submitted',
+      'weather_feedback_rate_limited',
+      'weather_risk_reevaluated'
+    )
+),
+agg as (
+  select
+    date_trunc('day', created_at) as day_bucket,
+    count(*) filter (where event_name = 'weather_feedback_submitted')::bigint as submitted_count,
+    count(*) filter (where event_name = 'weather_feedback_rate_limited')::bigint as rate_limited_count,
+    count(*) filter (
+      where event_name = 'weather_risk_reevaluated'
+        and coalesce(payload->>'changed', 'false') = 'true'
+    )::bigint as changed_count,
+    count(*) filter (
+      where event_name = 'weather_risk_reevaluated'
+        and coalesce(payload->>'changed', 'false') = 'false'
+    )::bigint as unchanged_count
+  from metrics
+  group by date_trunc('day', created_at)
+)
+select
+  day_bucket,
+  submitted_count,
+  rate_limited_count,
+  changed_count,
+  unchanged_count,
+  case
+    when submitted_count = 0 then null
+    else changed_count::double precision / submitted_count::double precision
+  end as changed_ratio,
+  case
+    when (submitted_count + rate_limited_count) = 0 then null
+    else rate_limited_count::double precision / (submitted_count + rate_limited_count)::double precision
+  end as rate_limited_ratio
+from agg
+order by day_bucket desc;
+
+grant select on public.view_weather_feedback_kpis_7d to anon, authenticated;


### PR DESCRIPTION
## Summary
- add one-tap perceived weather mismatch feedback flow to Home indoor mission card
- implement same-day risk reevaluation with weekly quota guard (2/week) and no full-clear safety rule
- show immediate user-facing feedback result + remaining quota in UI
- add weather feedback metric events (`submitted`, `rate_limited`, `reevaluated`) and Supabase KPI view `view_weather_feedback_kpis_7d`
- update docs/checklists and add dedicated unit checks/report for cycle #151

## Test
- `swift scripts/weather_feedback_loop_unit_check.swift`
- `swift scripts/indoor_weather_mission_unit_check.swift`
- `swift scripts/release_regression_checklist_unit_check.swift`
- `swift scripts/project_stability_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #151
