### PR TITLE
[P1] Rival fair league matching (14-day activity bands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - 캐리커처 비동기 파이프라인 명세 v1: `docs/caricature-async-pipeline-v1.md`
 - 근처 사용자 익명 핫스팟 명세 v1: `docs/nearby-anonymous-hotspot-v1.md`
 - 라이벌 프라이버시 하드 가드 v1: `docs/rival-privacy-hard-guard-v1.md`
+- 라이벌 공정 리그 매칭 v1: `docs/rival-fair-league-v1.md`
 - 시즌 안티 농사 규칙 v1: `docs/season-anti-farming-v1.md`
 - 체감 날씨 피드백 루프 v1: `docs/weather-feedback-loop-v1.md`
 - Feature Flag/롤아웃 모니터링 명세 v1: `docs/feature-flag-rollout-monitoring-v1.md`

--- a/docs/cycle-149-rival-fair-league-report-2026-02-27.md
+++ b/docs/cycle-149-rival-fair-league-report-2026-02-27.md
@@ -1,0 +1,43 @@
+# Cycle 149 Report — Rival Fair League Matching (2026-02-27)
+
+## 1. 대상
+- Issue: `#149 [P1][Task] 라이벌 공정 매칭 리그(14일 활동량 밴드)`
+- Branch: `codex/cycle-149-rival-league`
+
+## 2. 구현 요약
+- Supabase 리그 매칭 스키마 추가:
+  - `rival_league_policies`
+  - `rival_league_assignments`
+  - `rival_league_history`
+- `rpc_refresh_rival_leagues` 구현:
+  - 최근 14일 활동량 기반 리그 산정
+  - onboarding 보호/주간 재산정/표본 부족 fallback(`effective_league`) 반영
+  - 리그 변화 이력(`rival_league_history`) 기록
+- `rpc_get_my_rival_league` 구현:
+  - 본인 리그/병합 여부/안내 메시지 조회
+- Edge Function `rival-league` 추가:
+  - 앱에서 `get_my_league` 액션으로 리그 조회 가능
+- 분포 모니터링 뷰 `view_rival_league_distribution_current` 추가
+
+## 3. 변경 파일
+- `supabase/migrations/20260227212000_rival_fair_league_matching.sql`
+- `supabase/functions/rival-league/index.ts`
+- `docs/rival-fair-league-v1.md`
+- `docs/release-regression-checklist-v1.md`
+- `docs/supabase-schema-v1.md`
+- `docs/supabase-migration.md`
+- `docs/cycle-149-rival-fair-league-report-2026-02-27.md`
+- `README.md`
+- `scripts/rival_league_matching_unit_check.swift`
+- `scripts/release_regression_checklist_unit_check.swift`
+- `scripts/ios_pr_check.sh`
+
+## 4. 유닛 체크
+- `swift scripts/rival_league_matching_unit_check.swift` -> PASS
+- `swift scripts/release_regression_checklist_unit_check.swift` -> PASS
+- `swift scripts/project_stability_unit_check.swift` -> PASS
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh` -> PASS
+
+## 5. 리스크/후속
+- `rpc_refresh_rival_leagues`는 운영 배치(예: 주 1회 cron) 연결이 필요하며, 현재는 수동/운영 경로에서 호출하는 구조.
+- 라이벌 UI(Stage 3)에서 `guidance_message`, `fallback_applied` 노출 및 리그 이동 히스토리 화면 연결이 후속으로 필요.

--- a/docs/release-regression-checklist-v1.md
+++ b/docs/release-regression-checklist-v1.md
@@ -67,6 +67,9 @@
 - [ ] `체감 날씨 다름` 1탭 입력 시 당일 위험도 재평가 결과가 즉시 노출됨
 - [ ] 체감 피드백 주간 3회 입력 시 3회차가 제한 처리되고 잔여 횟수가 정확히 표시됨
 - [ ] 체감 피드백만으로 위험도 `clear` 완전 해제가 발생하지 않음
+- [ ] 라이벌 리그가 최근 14일 활동량 기준으로 `light/mid/hardcore`에 배정됨
+- [ ] 리그 표본 부족 시 `effective_league` 인접 병합이 적용됨
+- [ ] 리그 변동 시 사용자 안내 메시지/히스토리 데이터가 조회 가능함
 - [ ] nearby 핫스팟에서 표본 미달 셀은 count가 노출되지 않고(percentile-only) 강도만 표시됨
 - [ ] nearby 핫스팟에서 야간(22~06) 지연 60분 정책이 반영됨
 - [ ] 민감 구역 마스킹 대상 셀이 지도 오버레이에 노출되지 않음
@@ -101,6 +104,7 @@
 - [ ] `privacy_guard_policies/privacy_sensitive_geo_masks/privacy_guard_audit_logs` 구조 및 `rpc_get_nearby_hotspots` 확장 컬럼 확인
 - [ ] `season_scoring_policies/season_tile_score_events/season_score_audit_logs` 구조 및 `rpc_score_walk_session_anti_farming` 실행 확인
 - [ ] `view_weather_feedback_kpis_7d` 뷰 조회 및 지표 컬럼(`submitted/rate_limited/changed_ratio`) 확인
+- [ ] `rival_league_policies/rival_league_assignments/rival_league_history` 구조 및 `rpc_refresh_rival_leagues/rpc_get_my_rival_league` 실행 확인
 
 ## 6. 배포 파이프라인 검증 시나리오
 ### 6.1 Workflow 정의/활성 상태

--- a/docs/rival-fair-league-v1.md
+++ b/docs/rival-fair-league-v1.md
@@ -1,0 +1,51 @@
+# Rival Fair League Matching v1 (Issue #149)
+
+## 1. 목표
+최근 14일 활동량 기준으로 라이트/미드/하드코어 리그를 주간 단위로 배정해 공정한 비교 풀을 구성한다.
+
+## 2. 정책
+- 산정 구간: 최근 `14일`
+- 반영 주기: `주 1회` 스냅샷
+- 리그 구간:
+  - `onboarding`: 신규/저활동 보호 구간
+  - `light`: 하위 활동량 밴드
+  - `mid`: 중간 활동량 밴드
+  - `hardcore`: 상위 활동량 밴드
+- 표본 부족 fallback:
+  - 최소 표본(`min_sample_per_league`) 미달 시 인접 리그로 임시 병합(`effective_league`)
+
+## 3. 활동량 스코어
+기본식:
+- `activity_score = (duration_min * duration_weight) + (area_m2 / 10000 * area_weight)`
+
+기본 파라미터:
+- `duration_weight = 0.6`
+- `area_weight = 0.4`
+
+## 4. 스키마
+- `rival_league_policies`: 운영 파라미터
+- `rival_league_assignments`: 사용자 최신 리그 스냅샷
+- `rival_league_history`: 승격/강등/병합 이력
+- `view_rival_league_distribution_current`: 최신 분포 모니터링 뷰
+
+## 5. RPC/Edge Function
+- `rpc_refresh_rival_leagues(target_snapshot_week_start, now_ts)`
+  - 주간 리그 재산정(운영/배치 경로)
+- `rpc_get_my_rival_league(requested_user_id, now_ts)`
+  - 본인 리그/병합 여부/안내 메시지 조회
+- `supabase/functions/rival-league`
+  - `get_my_league` 액션으로 앱 조회 경로 제공
+
+## 6. UX 데이터 계약
+앱은 다음 값을 기반으로 안내 문구를 표시한다.
+- `league`
+- `effective_league`
+- `fallback_applied`
+- `fallback_reason`
+- `guidance_message`
+
+## 7. 검증 체크리스트
+- [ ] 14일 활동량 경계값에서 light/mid/hardcore 분기가 안정적으로 계산
+- [ ] 주간 스냅샷 갱신 시 동일 주간 내 결과가 흔들리지 않음
+- [ ] 표본 부족 리그는 `effective_league`로 인접 병합 처리
+- [ ] 리그 변경 시 `rival_league_history`에 이력 누락 없이 기록

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -212,6 +212,39 @@ limit 7;
 - 위험도 재평가 이벤트에서 `changed_ratio`가 0~1 범위로 계산
 - 제한 발생 시 `rate_limited_ratio`가 증가
 
+### 5.9 라이벌 공정 리그 매칭 검증 (#149)
+주간 스냅샷 재산정:
+```sql
+select *
+from public.rpc_refresh_rival_leagues(
+  date_trunc('week', now())::date,
+  now()
+);
+```
+
+본인 리그 조회:
+```sql
+select *
+from public.rpc_get_my_rival_league(auth.uid(), now());
+```
+
+분포 확인:
+```sql
+select
+  snapshot_week_start,
+  league,
+  effective_league,
+  user_count,
+  fallback_count
+from public.view_rival_league_distribution_current
+order by effective_league, league;
+```
+
+기대값:
+- 리그가 `onboarding/light/mid/hardcore`로 배정됨
+- 표본 부족 리그에서 `fallback_applied` + `effective_league` 병합 반영
+- 변경 사용자는 `rival_league_history`에 이력이 기록됨
+
 ## 6. 운영 체크리스트
 - [ ] `migration list --local` / `migration list --linked` 결과 저장
 - [ ] User A/B 교차 접근 차단 SQL 결과 저장
@@ -221,3 +254,4 @@ limit 7;
 - [ ] 비교군 카탈로그/시드 정합성 SQL 결과 첨부
 - [ ] 시즌 안티 농사 RPC/감사 로그 검증 결과 첨부
 - [ ] 체감 날씨 피드백 KPI 뷰 검증 결과 첨부
+- [ ] 라이벌 리그 스냅샷/분포/히스토리 검증 결과 첨부

--- a/docs/supabase-schema-v1.md
+++ b/docs/supabase-schema-v1.md
@@ -17,6 +17,7 @@
 - 근처 사용자 익명 핫스팟용 데이터 구조
 - 시즌 안티 농사 점수 규칙용 데이터 구조
 - 체감 날씨 피드백 KPI 뷰
+- 라이벌 공정 리그 매칭 구조
 - RLS 정책 원칙
 - Storage 경로 규칙
 - 마이그레이션/롤백 절차
@@ -214,6 +215,20 @@ erDiagram
   - `weather_feedback_submitted/rate_limited/weather_risk_reevaluated` 기반 일자별 지표 집계
   - `changed_ratio`, `rate_limited_ratio`로 오탐/정탐/남용 상태 관측
 
+### 4.8 라이벌 공정 리그 매칭
+- `rival_league_policies`
+  - 14일 활동량/주간 반영/표본 fallback 임계값을 서버 파라미터로 관리
+- `rival_league_assignments`
+  - 사용자 최신 스냅샷 리그(`league`)와 fallback 적용 결과(`effective_league`)
+- `rival_league_history`
+  - 승격/강등/병합 변경 이력
+- `rpc_refresh_rival_leagues`
+  - 주간 리그 재산정 및 히스토리 기록
+- `rpc_get_my_rival_league`
+  - 앱 조회용 본인 리그/안내 메시지 반환
+- `view_rival_league_distribution_current`
+  - 최신 리그 분포/표본 상태 모니터링
+
 ## 5. RLS 정책 원칙
 - 사용자 데이터는 `auth.uid()` 소유 범위로만 접근
 - `area_references`는 읽기 공개(`anon`, `authenticated`)
@@ -243,6 +258,13 @@ erDiagram
   - `select`: 소유자
   - write: 서비스 경로(RPC/service role)
 - `view_weather_feedback_kpis_7d`
+  - `select`: 공개(운영 관측용)
+- `rival_league_policies`
+  - `select`: 공개(정책 조회)
+- `rival_league_assignments`, `rival_league_history`
+  - `select`: 소유자
+  - write: 서비스 경로(RPC/service role)
+- `view_rival_league_distribution_current`
   - `select`: 공개(운영 관측용)
 
 ## 6. Storage 규칙

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -29,6 +29,7 @@ swift scripts/release_regression_checklist_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift
 swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift
+swift scripts/rival_league_matching_unit_check.swift
 swift scripts/season_anti_farming_unit_check.swift
 swift scripts/weather_feedback_loop_unit_check.swift
 swift scripts/project_stability_unit_check.swift

--- a/scripts/release_regression_checklist_unit_check.swift
+++ b/scripts/release_regression_checklist_unit_check.swift
@@ -35,6 +35,9 @@ assertTrue(checklist.contains("season_scoring_policies/season_tile_score_events/
 assertTrue(checklist.contains("체감 날씨 다름"), "checklist should include weather feedback one-tap scenario")
 assertTrue(checklist.contains("주간 3회 입력"), "checklist should include weather feedback weekly limit scenario")
 assertTrue(checklist.contains("view_weather_feedback_kpis_7d"), "checklist should include weather feedback KPI view verification")
+assertTrue(checklist.contains("최근 14일 활동량 기준"), "checklist should include rival 14-day activity league scenario")
+assertTrue(checklist.contains("effective_league"), "checklist should include rival fallback merge scenario")
+assertTrue(checklist.contains("rival_league_policies/rival_league_assignments/rival_league_history"), "checklist should include rival league migration verification")
 
 assertTrue(report.contains("## 1. 빌드 체크 결과"), "report must include build results")
 assertTrue(report.contains("## 2. 핵심 시나리오 점검 결과"), "report must include scenario results")

--- a/scripts/rival_league_matching_unit_check.swift
+++ b/scripts/rival_league_matching_unit_check.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+enum RivalLeague: String {
+    case onboarding
+    case light
+    case mid
+    case hardcore
+}
+
+struct RivalPolicy {
+    let lightMaxPercentile: Double
+    let midMaxPercentile: Double
+    let minSessionsForRanked: Int
+    let minSamplePerLeague: Int
+
+    static let v1 = RivalPolicy(
+        lightMaxPercentile: 0.33,
+        midMaxPercentile: 0.66,
+        minSessionsForRanked: 2,
+        minSamplePerLeague: 3
+    )
+}
+
+struct RivalUserActivity {
+    let id: String
+    let sessionCount: Int
+    let activityScore: Double
+}
+
+struct RivalAssignment {
+    let id: String
+    let league: RivalLeague
+    let effectiveLeague: RivalLeague
+}
+
+func percentileRank(index: Int, total: Int) -> Double {
+    guard total > 1 else { return 1.0 }
+    return Double(index) / Double(total - 1)
+}
+
+func assignLeagues(activities: [RivalUserActivity], policy: RivalPolicy = .v1) -> [RivalAssignment] {
+    let ranked = activities.sorted {
+        if $0.activityScore == $1.activityScore {
+            return $0.id < $1.id
+        }
+        return $0.activityScore < $1.activityScore
+    }
+
+    var base: [(String, RivalLeague)] = []
+    for (index, activity) in ranked.enumerated() {
+        if activity.sessionCount < policy.minSessionsForRanked {
+            base.append((activity.id, .onboarding))
+            continue
+        }
+        let percentile = percentileRank(index: index, total: ranked.count)
+        if percentile <= policy.lightMaxPercentile {
+            base.append((activity.id, .light))
+        } else if percentile <= policy.midMaxPercentile {
+            base.append((activity.id, .mid))
+        } else {
+            base.append((activity.id, .hardcore))
+        }
+    }
+
+    let counts = Dictionary(grouping: base, by: { $0.1 }).mapValues(\.count)
+
+    func fallback(_ league: RivalLeague) -> RivalLeague {
+        guard league != .onboarding else { return .onboarding }
+        guard (counts[league] ?? 0) < policy.minSamplePerLeague else { return league }
+        switch league {
+        case .light, .hardcore:
+            return .mid
+        case .mid:
+            return (counts[.hardcore] ?? 0) >= (counts[.light] ?? 0) ? .hardcore : .light
+        case .onboarding:
+            return .onboarding
+        }
+    }
+
+    return base.map { item in
+        .init(id: item.0, league: item.1, effectiveLeague: fallback(item.1))
+    }
+}
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let migration = load("supabase/migrations/20260227212000_rival_fair_league_matching.sql")
+let edgeFunction = load("supabase/functions/rival-league/index.ts")
+let doc = load("docs/rival-fair-league-v1.md")
+let schemaDoc = load("docs/supabase-schema-v1.md")
+let migrationDoc = load("docs/supabase-migration.md")
+let checklist = load("docs/release-regression-checklist-v1.md")
+let readme = load("README.md")
+
+assertTrue(migration.contains("create table if not exists public.rival_league_policies"), "migration should create rival_league_policies")
+assertTrue(migration.contains("create table if not exists public.rival_league_assignments"), "migration should create rival_league_assignments")
+assertTrue(migration.contains("create table if not exists public.rival_league_history"), "migration should create rival_league_history")
+assertTrue(migration.contains("rpc_refresh_rival_leagues"), "migration should define rival weekly refresh rpc")
+assertTrue(migration.contains("rpc_get_my_rival_league"), "migration should define rival league query rpc")
+assertTrue(migration.contains("view_rival_league_distribution_current"), "migration should expose rival league distribution view")
+
+assertTrue(edgeFunction.contains("get_my_league"), "rival edge function should expose get_my_league action")
+assertTrue(edgeFunction.contains("rpc_get_my_rival_league"), "rival edge function should call rival league rpc")
+
+assertTrue(doc.contains("최근 `14일`"), "rival doc should define 14-day lookback")
+assertTrue(doc.contains("주 1회"), "rival doc should define weekly cadence")
+assertTrue(doc.contains("effective_league"), "rival doc should include fallback effective league contract")
+assertTrue(schemaDoc.contains("라이벌 공정 리그 매칭"), "schema doc should include rival league section")
+assertTrue(migrationDoc.contains("rpc_refresh_rival_leagues"), "ops doc should include rival refresh verification")
+assertTrue(checklist.contains("effective_league"), "release checklist should include rival fallback scenario")
+assertTrue(readme.contains("docs/rival-fair-league-v1.md"), "README should reference rival fair league doc")
+
+let activities: [RivalUserActivity] = [
+    .init(id: "u1", sessionCount: 5, activityScore: 8),
+    .init(id: "u2", sessionCount: 4, activityScore: 12),
+    .init(id: "u3", sessionCount: 4, activityScore: 18),
+    .init(id: "u4", sessionCount: 3, activityScore: 25),
+    .init(id: "u5", sessionCount: 3, activityScore: 27),
+    .init(id: "u6", sessionCount: 1, activityScore: 2),
+    .init(id: "u7", sessionCount: 6, activityScore: 40),
+    .init(id: "u8", sessionCount: 7, activityScore: 60)
+]
+
+let assignments = assignLeagues(activities: activities)
+let onboarding = assignments.filter { $0.league == .onboarding }
+assertTrue(onboarding.count == 1, "low-session users should stay in onboarding league")
+
+let hasFallback = assignments.contains { $0.league != $0.effectiveLeague }
+assertTrue(hasFallback, "insufficient sample leagues should be merged through effective league fallback")
+
+let highActivity = assignments.first(where: { $0.id == "u8" })
+assertTrue(highActivity?.league == .hardcore, "top activity user should be assigned to hardcore league")
+
+print("PASS: rival league matching unit checks")

--- a/supabase/functions/rival-league/index.ts
+++ b/supabase/functions/rival-league/index.ts
@@ -1,0 +1,59 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+
+type Action = "get_my_league";
+
+type RequestDTO = {
+  action?: Action;
+};
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") return json({ error: "METHOD_NOT_ALLOWED" }, 405);
+
+  const supabaseURL = Deno.env.get("SUPABASE_URL");
+  const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  if (!supabaseURL || !supabaseAnonKey) {
+    return json({ error: "SERVER_MISCONFIGURED" }, 500);
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return json({ error: "UNAUTHORIZED" }, 401);
+  }
+  const token = authHeader.replace("Bearer ", "").trim();
+  if (!token) return json({ error: "UNAUTHORIZED" }, 401);
+
+  const userClient = createClient(supabaseURL, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const { data: userResult, error: userError } = await userClient.auth.getUser(token);
+  if (userError || !userResult?.user) {
+    return json({ error: "UNAUTHORIZED" }, 401);
+  }
+
+  let body: RequestDTO;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "INVALID_JSON" }, 400);
+  }
+
+  if (!body.action) return json({ error: "ACTION_REQUIRED" }, 400);
+  if (body.action !== "get_my_league") return json({ error: "UNSUPPORTED_ACTION" }, 400);
+
+  const { data, error } = await userClient.rpc("rpc_get_my_rival_league", {
+    requested_user_id: userResult.user.id,
+    now_ts: new Date().toISOString(),
+  });
+
+  if (error) return json({ error: error.message }, 500);
+
+  const row = Array.isArray(data) && data.length > 0 ? data[0] : null;
+  return json({ league: row });
+});

--- a/supabase/migrations/20260227212000_rival_fair_league_matching.sql
+++ b/supabase/migrations/20260227212000_rival_fair_league_matching.sql
@@ -1,0 +1,526 @@
+-- #149 rival fair league matching (14-day activity band)
+
+create extension if not exists pgcrypto;
+
+create or replace function public.touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create table if not exists public.rival_league_policies (
+  policy_key text primary key,
+  lookback_days integer not null default 14 check (lookback_days between 7 and 30),
+  weekly_refresh_interval_days integer not null default 7 check (weekly_refresh_interval_days between 1 and 14),
+  onboarding_protection_days integer not null default 14 check (onboarding_protection_days between 1 and 30),
+  min_sessions_for_ranked integer not null default 2 check (min_sessions_for_ranked between 1 and 20),
+  min_sample_per_league integer not null default 20 check (min_sample_per_league between 2 and 200),
+  light_max_percentile double precision not null default 0.33 check (light_max_percentile > 0 and light_max_percentile < 1),
+  mid_max_percentile double precision not null default 0.66 check (mid_max_percentile > 0 and mid_max_percentile < 1),
+  area_weight double precision not null default 0.4 check (area_weight >= 0 and area_weight <= 1),
+  duration_weight double precision not null default 0.6 check (duration_weight >= 0 and duration_weight <= 1),
+  updated_at timestamptz not null default now(),
+  constraint rival_league_percentile_order check (light_max_percentile < mid_max_percentile),
+  constraint rival_league_weight_sum check (abs((area_weight + duration_weight) - 1.0) < 0.000001)
+);
+
+insert into public.rival_league_policies (
+  policy_key,
+  lookback_days,
+  weekly_refresh_interval_days,
+  onboarding_protection_days,
+  min_sessions_for_ranked,
+  min_sample_per_league,
+  light_max_percentile,
+  mid_max_percentile,
+  area_weight,
+  duration_weight
+)
+values (
+  'rival_league_v1',
+  14,
+  7,
+  14,
+  2,
+  20,
+  0.33,
+  0.66,
+  0.4,
+  0.6
+)
+on conflict (policy_key) do nothing;
+
+create table if not exists public.rival_league_assignments (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  snapshot_week_start date not null,
+  league text not null check (league in ('onboarding', 'light', 'mid', 'hardcore')),
+  effective_league text not null check (effective_league in ('onboarding', 'light', 'mid', 'hardcore')),
+  activity_score double precision not null default 0,
+  activity_days integer not null default 0,
+  session_count integer not null default 0,
+  percentile_rank double precision not null default 0,
+  fallback_applied boolean not null default false,
+  fallback_reason text,
+  reason text not null default 'weekly_rebalance',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_rival_league_assignments_snapshot
+  on public.rival_league_assignments(snapshot_week_start desc, effective_league, league);
+
+create table if not exists public.rival_league_history (
+  id bigint generated always as identity primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  from_league text check (from_league in ('onboarding', 'light', 'mid', 'hardcore')),
+  to_league text not null check (to_league in ('onboarding', 'light', 'mid', 'hardcore')),
+  from_effective_league text check (from_effective_league in ('onboarding', 'light', 'mid', 'hardcore')),
+  to_effective_league text not null check (to_effective_league in ('onboarding', 'light', 'mid', 'hardcore')),
+  snapshot_week_start date not null,
+  change_reason text not null,
+  activity_score double precision not null default 0,
+  percentile_rank double precision not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_rival_league_history_user_created
+  on public.rival_league_history(user_id, created_at desc);
+create index if not exists idx_rival_league_history_snapshot
+  on public.rival_league_history(snapshot_week_start desc, to_effective_league);
+
+alter table public.rival_league_policies enable row level security;
+alter table public.rival_league_assignments enable row level security;
+alter table public.rival_league_history enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'rival_league_policies'
+      and policyname = 'rival_league_policies_select_all'
+  ) then
+    create policy rival_league_policies_select_all
+      on public.rival_league_policies
+      for select
+      to anon, authenticated
+      using (true);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'rival_league_assignments'
+      and policyname = 'rival_league_assignments_owner_select'
+  ) then
+    create policy rival_league_assignments_owner_select
+      on public.rival_league_assignments
+      for select
+      to authenticated
+      using (user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'rival_league_assignments'
+      and policyname = 'rival_league_assignments_service_write'
+  ) then
+    create policy rival_league_assignments_service_write
+      on public.rival_league_assignments
+      for all
+      using (auth.role() = 'service_role')
+      with check (auth.role() = 'service_role');
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'rival_league_history'
+      and policyname = 'rival_league_history_owner_select'
+  ) then
+    create policy rival_league_history_owner_select
+      on public.rival_league_history
+      for select
+      to authenticated
+      using (user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'rival_league_history'
+      and policyname = 'rival_league_history_service_write'
+  ) then
+    create policy rival_league_history_service_write
+      on public.rival_league_history
+      for all
+      using (auth.role() = 'service_role')
+      with check (auth.role() = 'service_role');
+  end if;
+end $$;
+
+drop trigger if exists trg_rival_league_policies_updated_at on public.rival_league_policies;
+create trigger trg_rival_league_policies_updated_at
+before update on public.rival_league_policies
+for each row execute function public.touch_updated_at();
+
+drop trigger if exists trg_rival_league_assignments_updated_at on public.rival_league_assignments;
+create trigger trg_rival_league_assignments_updated_at
+before update on public.rival_league_assignments
+for each row execute function public.touch_updated_at();
+
+create or replace function public.rpc_refresh_rival_leagues(
+  target_snapshot_week_start date default date_trunc('week', now())::date,
+  now_ts timestamptz default now()
+)
+returns table (
+  snapshot_week_start date,
+  total_users int,
+  onboarding_users int,
+  light_users int,
+  mid_users int,
+  hardcore_users int,
+  fallback_users int
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  policy_row public.rival_league_policies%rowtype;
+begin
+  select *
+  into policy_row
+  from public.rival_league_policies
+  where policy_key = 'rival_league_v1'
+  limit 1;
+
+  if not found then
+    policy_row.lookback_days := 14;
+    policy_row.weekly_refresh_interval_days := 7;
+    policy_row.onboarding_protection_days := 14;
+    policy_row.min_sessions_for_ranked := 2;
+    policy_row.min_sample_per_league := 20;
+    policy_row.light_max_percentile := 0.33;
+    policy_row.mid_max_percentile := 0.66;
+    policy_row.area_weight := 0.4;
+    policy_row.duration_weight := 0.6;
+  end if;
+
+  create temporary table if not exists tmp_prev_rival_league_assignments on commit drop as
+  select
+    user_id,
+    league,
+    effective_league
+  from public.rival_league_assignments;
+  truncate table tmp_prev_rival_league_assignments;
+  insert into tmp_prev_rival_league_assignments (user_id, league, effective_league)
+  select user_id, league, effective_league
+  from public.rival_league_assignments;
+
+  with base_users as (
+    select id as user_id, created_at
+    from auth.users
+  ),
+  activity as (
+    select
+      bu.user_id,
+      bu.created_at,
+      coalesce(count(ws.id), 0)::int as session_count,
+      coalesce(count(distinct (ws.started_at at time zone 'UTC')::date), 0)::int as activity_days,
+      coalesce(sum(ws.duration_sec), 0)::double precision as total_duration_sec,
+      coalesce(sum(ws.area_m2), 0)::double precision as total_area_m2,
+      coalesce(sum(ws.duration_sec), 0)::double precision / 60.0 * policy_row.duration_weight +
+      coalesce(sum(ws.area_m2), 0)::double precision / 10000.0 * policy_row.area_weight as activity_score
+    from base_users bu
+    left join public.walk_sessions ws
+      on ws.owner_user_id = bu.user_id
+     and ws.started_at >= now_ts - make_interval(days => policy_row.lookback_days)
+    group by bu.user_id, bu.created_at
+  ),
+  ranked as (
+    select
+      a.*,
+      case
+        when a.session_count = 0 then 0::double precision
+        else percent_rank() over (order by a.activity_score asc, a.user_id)
+      end as percentile_rank,
+      (
+        a.created_at >= now_ts - make_interval(days => policy_row.onboarding_protection_days)
+        or a.session_count < policy_row.min_sessions_for_ranked
+      ) as is_onboarding
+    from activity a
+  ),
+  classified as (
+    select
+      r.user_id,
+      target_snapshot_week_start as snapshot_week_start,
+      case
+        when r.is_onboarding then 'onboarding'
+        when r.percentile_rank <= policy_row.light_max_percentile then 'light'
+        when r.percentile_rank <= policy_row.mid_max_percentile then 'mid'
+        else 'hardcore'
+      end as league,
+      r.activity_score,
+      r.activity_days,
+      r.session_count,
+      r.percentile_rank,
+      case
+        when r.is_onboarding then 'onboarding_protection'
+        else 'weekly_rebalance'
+      end as reason
+    from ranked r
+  )
+  insert into public.rival_league_assignments (
+    user_id,
+    snapshot_week_start,
+    league,
+    effective_league,
+    activity_score,
+    activity_days,
+    session_count,
+    percentile_rank,
+    fallback_applied,
+    fallback_reason,
+    reason,
+    updated_at
+  )
+  select
+    c.user_id,
+    c.snapshot_week_start,
+    c.league,
+    c.league,
+    c.activity_score,
+    c.activity_days,
+    c.session_count,
+    c.percentile_rank,
+    false,
+    null,
+    c.reason,
+    now_ts
+  from classified c
+  on conflict (user_id) do update set
+    snapshot_week_start = excluded.snapshot_week_start,
+    league = excluded.league,
+    effective_league = excluded.effective_league,
+    activity_score = excluded.activity_score,
+    activity_days = excluded.activity_days,
+    session_count = excluded.session_count,
+    percentile_rank = excluded.percentile_rank,
+    fallback_applied = excluded.fallback_applied,
+    fallback_reason = excluded.fallback_reason,
+    reason = excluded.reason,
+    updated_at = now_ts;
+
+  with league_counts as (
+    select league, count(*)::int as member_count
+    from public.rival_league_assignments
+    where snapshot_week_start = target_snapshot_week_start
+    group by league
+  ),
+  resolved as (
+    select
+      a.user_id,
+      a.league,
+      coalesce(lc.member_count, 0) as league_member_count,
+      case
+        when a.league = 'onboarding' then 'onboarding'
+        when coalesce(lc.member_count, 0) >= policy_row.min_sample_per_league then a.league
+        when a.league = 'light' then 'mid'
+        when a.league = 'hardcore' then 'mid'
+        when a.league = 'mid' then (
+          case
+            when coalesce(lh.member_count, 0) >= coalesce(ll.member_count, 0) then 'hardcore'
+            else 'light'
+          end
+        )
+        else a.league
+      end as effective_league,
+      case
+        when a.league = 'onboarding' then null
+        when coalesce(lc.member_count, 0) >= policy_row.min_sample_per_league then null
+        when a.league in ('light', 'mid', 'hardcore') then 'insufficient_samples'
+        else null
+      end as fallback_reason
+    from public.rival_league_assignments a
+    left join league_counts lc on lc.league = a.league
+    left join league_counts ll on ll.league = 'light'
+    left join league_counts lh on lh.league = 'hardcore'
+    where a.snapshot_week_start = target_snapshot_week_start
+  )
+  update public.rival_league_assignments a
+  set
+    effective_league = r.effective_league,
+    fallback_applied = (r.fallback_reason is not null),
+    fallback_reason = r.fallback_reason,
+    updated_at = now_ts
+  from resolved r
+  where a.user_id = r.user_id
+    and a.snapshot_week_start = target_snapshot_week_start;
+
+  insert into public.rival_league_history (
+    user_id,
+    from_league,
+    to_league,
+    from_effective_league,
+    to_effective_league,
+    snapshot_week_start,
+    change_reason,
+    activity_score,
+    percentile_rank,
+    created_at
+  )
+  select
+    a.user_id,
+    p.league,
+    a.league,
+    p.effective_league,
+    a.effective_league,
+    target_snapshot_week_start,
+    case
+      when p.user_id is null then 'initial_assignment'
+      when p.league is distinct from a.league then 'weekly_rebalance'
+      when p.effective_league is distinct from a.effective_league then 'fallback_rebalance'
+      else 'no_change'
+    end as change_reason,
+    a.activity_score,
+    a.percentile_rank,
+    now_ts
+  from public.rival_league_assignments a
+  left join tmp_prev_rival_league_assignments p
+    on p.user_id = a.user_id
+  where a.snapshot_week_start = target_snapshot_week_start
+    and (
+      p.user_id is null
+      or p.league is distinct from a.league
+      or p.effective_league is distinct from a.effective_league
+    );
+
+  return query
+  select
+    target_snapshot_week_start as snapshot_week_start,
+    count(*)::int as total_users,
+    count(*) filter (where league = 'onboarding')::int as onboarding_users,
+    count(*) filter (where league = 'light')::int as light_users,
+    count(*) filter (where league = 'mid')::int as mid_users,
+    count(*) filter (where league = 'hardcore')::int as hardcore_users,
+    count(*) filter (where fallback_applied)::int as fallback_users
+  from public.rival_league_assignments
+  where snapshot_week_start = target_snapshot_week_start;
+end;
+$$;
+
+create or replace function public.rpc_get_my_rival_league(
+  requested_user_id uuid default auth.uid(),
+  now_ts timestamptz default now()
+)
+returns table (
+  user_id uuid,
+  snapshot_week_start date,
+  league text,
+  effective_league text,
+  fallback_applied boolean,
+  fallback_reason text,
+  activity_score double precision,
+  percentile_rank double precision,
+  sample_count int,
+  guidance_message text,
+  is_stale boolean
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  requester_uid uuid;
+  requester_role text;
+  assignment_row public.rival_league_assignments%rowtype;
+  effective_member_count int := 0;
+begin
+  requester_uid := auth.uid();
+  requester_role := auth.role();
+
+  if requester_role <> 'service_role' then
+    if requested_user_id is null or requester_uid is null or requested_user_id <> requester_uid then
+      raise exception 'permission denied';
+    end if;
+  end if;
+
+  select *
+  into assignment_row
+  from public.rival_league_assignments
+  where user_id = requested_user_id
+  order by snapshot_week_start desc
+  limit 1;
+
+  if not found then
+    return query
+    select
+      requested_user_id,
+      date_trunc('week', now_ts)::date,
+      'onboarding'::text,
+      'onboarding'::text,
+      false,
+      null::text,
+      0::double precision,
+      0::double precision,
+      0::int,
+      '온보딩 보호 리그입니다. 최근 14일 활동이 쌓이면 주간 리그가 배정됩니다.'::text,
+      true;
+    return;
+  end if;
+
+  select count(*)::int
+  into effective_member_count
+  from public.rival_league_assignments
+  where snapshot_week_start = assignment_row.snapshot_week_start
+    and effective_league = assignment_row.effective_league;
+
+  return query
+  select
+    assignment_row.user_id,
+    assignment_row.snapshot_week_start,
+    assignment_row.league,
+    assignment_row.effective_league,
+    assignment_row.fallback_applied,
+    assignment_row.fallback_reason,
+    assignment_row.activity_score,
+    assignment_row.percentile_rank,
+    effective_member_count,
+    case
+      when assignment_row.league = 'onboarding' then '온보딩 보호 리그입니다. 최근 14일 활동이 쌓이면 주간 리그가 배정됩니다.'
+      when assignment_row.fallback_applied then '현재 리그 표본이 부족해 인접 리그와 매칭 중입니다.'
+      else '최근 14일 활동량 기준으로 주간 리그가 배정되었습니다.'
+    end,
+    assignment_row.snapshot_week_start < date_trunc('week', now_ts)::date;
+end;
+$$;
+
+create or replace view public.view_rival_league_distribution_current as
+with latest as (
+  select max(snapshot_week_start) as snapshot_week_start
+  from public.rival_league_assignments
+)
+select
+  a.snapshot_week_start,
+  a.league,
+  a.effective_league,
+  count(*)::bigint as user_count,
+  avg(a.activity_score)::double precision as avg_activity_score,
+  min(a.activity_score)::double precision as min_activity_score,
+  max(a.activity_score)::double precision as max_activity_score,
+  sum(case when a.fallback_applied then 1 else 0 end)::bigint as fallback_count
+from public.rival_league_assignments a
+join latest l on l.snapshot_week_start = a.snapshot_week_start
+group by a.snapshot_week_start, a.league, a.effective_league
+order by a.effective_league, a.league;
+
+grant execute on function public.rpc_refresh_rival_leagues(date, timestamptz) to service_role;
+grant execute on function public.rpc_get_my_rival_league(uuid, timestamptz) to authenticated, service_role;
+grant select on public.view_rival_league_distribution_current to anon, authenticated;


### PR DESCRIPTION
## Summary
- add rival fair league backend schema for 14-day activity-band matching (`policies`, `assignments`, `history`)
- implement weekly league refresh rpc with onboarding protection, percentile banding, and insufficient-sample fallback (`effective_league`)
- implement my-league rpc and edge function (`rival-league/get_my_league`) for app query path
- add distribution monitoring view and docs for ops/release verification
- update regression checklist and add dedicated unit check for rival league matching behavior/contracts

## Test
- `swift scripts/rival_league_matching_unit_check.swift`
- `swift scripts/release_regression_checklist_unit_check.swift`
- `swift scripts/project_stability_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #149
