### PR TITLE
[Cycle #133] 날씨 리스크/Provider 정책 v1 확정

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - 시즌 안티 농사 규칙 v1: `docs/season-anti-farming-v1.md`
 - 시즌 복귀 캐치업 버프 v1: `docs/season-comeback-catchup-buff-v1.md`
 - 체감 날씨 피드백 루프 v1: `docs/weather-feedback-loop-v1.md`
+- 날씨 리스크 모델/Provider 정책 v1: `docs/weather-risk-provider-policy-v1.md`
 - 날씨 연동 UX/fallback/접근성 v1: `docs/weather-ux-fallback-accessibility-v1.md`
 - 퀘스트 실패 완충(자동 연장 슬롯) v1: `docs/quest-failure-buffer-v1.md`
 - 반려견 맞춤 난이도/쉬운 날 모드 v1: `docs/pet-adaptive-quest-difficulty-v1.md`
@@ -56,6 +57,7 @@
 - Cycle #147 결과 보고서(2026-02-27): `docs/cycle-147-pet-adaptive-quest-report-2026-02-27.md`
 - Cycle #145 결과 보고서(2026-02-27): `docs/cycle-145-season-catchup-buff-report-2026-02-27.md`
 - Cycle #135 결과 보고서(2026-02-27): `docs/cycle-135-weather-ux-fallback-report-2026-02-27.md`
+- Cycle #133 결과 보고서(2026-02-27): `docs/cycle-133-weather-risk-policy-report-2026-02-27.md`
 - Cycle #138 결과 보고서(2026-02-27): `docs/cycle-138-pet-context-badge-report-2026-02-27.md`
 - Cycle #139 결과 보고서(2026-02-27): `docs/cycle-139-area-reference-db-ui-report-2026-02-27.md`
 

--- a/docs/cycle-133-weather-risk-policy-report-2026-02-27.md
+++ b/docs/cycle-133-weather-risk-policy-report-2026-02-27.md
@@ -1,0 +1,32 @@
+# Cycle 133 Report — Weather Risk Provider Policy v1 (2026-02-27)
+
+## 1. 대상
+- Issue: `#133 [Task][Weather][Stage 1] 날씨 리스크 모델/Provider 정책 확정`
+- Branch: `codex/cycle-133-weather-risk-policy`
+
+## 2. 구현 요약
+- 날씨 리스크/Provider 정책 문서 확정
+  - Primary/Secondary Provider 어댑터 설계
+  - 공통 DTO 계약 및 격자 키(geohash7) 기반 조회 원칙
+  - 리스크 단계/임계값/결정적 판정 규칙
+  - timeout/재시도/fallback/캐시 TTL(2h)/갱신 주기(1h) 정의
+  - 신뢰도 로그 필드와 QA 재현 시나리오 정리
+- 정책 검증 스크립트 추가
+  - 문서 핵심 항목 누락 방지 검사
+  - 리스크 판정 함수 결정성(동일 입력 동일 출력) 검사
+  - 기존 코드의 fallback 상태 노출 연계 확인
+
+## 3. 변경 파일
+- `docs/weather-risk-provider-policy-v1.md`
+- `docs/cycle-133-weather-risk-policy-report-2026-02-27.md`
+- `scripts/weather_risk_policy_stage1_unit_check.swift`
+- `scripts/ios_pr_check.sh`
+- `README.md`
+
+## 4. 검증
+- `swift scripts/weather_risk_policy_stage1_unit_check.swift` -> PASS
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh` -> PASS
+
+## 5. 리스크/후속
+- Stage 1은 정책 확정 범위이므로 실제 외부 Provider SDK 호출/캐시 저장소 구현은 Stage 2(#134)에서 수행한다.
+- 임계값은 운영 데이터 기반으로 재조정 가능하므로, KPI 대시보드와 사용자 피드백 수집 루프를 함께 운영한다.

--- a/docs/weather-risk-provider-policy-v1.md
+++ b/docs/weather-risk-provider-policy-v1.md
@@ -1,0 +1,86 @@
+# Weather Risk Provider Policy v1 (Issue #133)
+
+## 1. 목표
+- 날씨 리스크 판정을 재현 가능한 규칙으로 표준화한다.
+- Provider 장애/지연 상황에서도 퀘스트/스트릭 UX가 끊기지 않도록 fallback 체계를 정의한다.
+
+## 2. Provider 어댑터 설계
+- Primary Provider: Open-Meteo 기반(격자 예보)
+- Secondary Provider: Meteostat 또는 동일 스키마 어댑터
+- 계약(공통 DTO):
+  - `gridKey` (원본 좌표 저장 금지)
+  - `observedAt` (UTC epoch)
+  - `precipitationMMPerHour`
+  - `temperatureC`
+  - `windMps`
+  - `confidence` (`high|medium|low`)
+
+Adapter 규칙:
+- Primary timeout/5xx/스키마 오류 시 Secondary 재시도
+- 둘 다 실패 시 마지막 정상 캐시 + 보수적 판정
+
+## 3. 리스크 단계 v1
+- `clear` (정상)
+- `caution` (주의)
+- `bad` (위험)
+- `severe` (고위험)
+
+판정 입력 지표:
+- 강수 (`mm/h`)
+- 고온/저온 (`°C`)
+- 풍속 (`m/s`)
+
+기본 임계값(운영 시작값):
+- 강수:
+  - `>= 12`: severe
+  - `>= 6`: bad
+  - `>= 1`: caution
+- 기온:
+  - `>= 33` 또는 `<= -8`: severe
+  - `>= 30` 또는 `<= -3`: bad
+  - `>= 28` 또는 `<= 0`: caution
+- 풍속:
+  - `>= 14`: severe
+  - `>= 10`: bad
+  - `>= 6`: caution
+
+최종 리스크:
+- 지표별 리스크의 `최댓값`을 사용
+- 동일 입력은 항상 동일 결과(결정적 함수)
+
+## 4. 시간대/지역 규칙
+- 사용자 로컬 타임존의 현재 시각을 기준으로 가장 가까운 1시간 슬롯 예보를 선택
+- 지역 식별은 좌표 자체가 아닌 `gridKey(geohash7)` 사용
+- 저장/로그에 원본 위경도는 남기지 않는다
+
+## 5. fallback/지연 정책
+- 요청 타임아웃: `2.5s`
+- 재시도: Primary 1회, Secondary 1회
+- API 실패 시 동작:
+  1. `cache_age <= 2h`: 캐시값 사용
+  2. `cache_age > 2h`: `clear`로 강등하지 않고 최소 `caution` 유지
+- fallback 상태는 UI에 명시적으로 표기 (`Fallback` 배지)
+
+## 6. 캐시 TTL/신뢰도 로그
+- 데이터 갱신 주기: `1h`
+- 캐시 TTL: `2h`
+- cache TTL: `2h`
+- 로그 필드:
+  - `provider` (`primary|secondary|cache|fallback`)
+  - `latencyMs`
+  - `gridKey`
+  - `riskLevel`
+  - `confidence`
+  - `cacheAgeSec`
+  - `decisionReason`
+
+## 7. QA 재현 시나리오
+1. 강우/폭염/한파/강풍 각각 단일 지표로 리스크 상승 검증
+2. Primary timeout + Secondary 성공 시 Secondary 판정 사용 확인
+3. Provider 모두 실패 + 캐시 90분: 캐시 판정 사용 확인
+4. Provider 모두 실패 + 캐시 3시간: `caution` 이상 보수 판정 확인
+5. 동일 입력 100회 반복 시 동일 결과 확인
+
+## 8. Stage 연결
+- Stage 2(#134): 위 정책을 엔진/스토어에 반영하고 Shield 집계와 결합
+- Stage 3(#135): 사용자 안내/접근성/fallback 배지 UX 반영 (완료)

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -36,6 +36,7 @@ swift scripts/rival_privacy_hard_guard_unit_check.swift
 swift scripts/rival_league_matching_unit_check.swift
 swift scripts/season_anti_farming_unit_check.swift
 swift scripts/season_comeback_catchup_unit_check.swift
+swift scripts/weather_risk_policy_stage1_unit_check.swift
 swift scripts/weather_ux_stage3_unit_check.swift
 swift scripts/weather_feedback_loop_unit_check.swift
 swift scripts/quest_failure_buffer_unit_check.swift

--- a/scripts/weather_risk_policy_stage1_unit_check.swift
+++ b/scripts/weather_risk_policy_stage1_unit_check.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+enum Risk: Int {
+    case clear = 0
+    case caution = 1
+    case bad = 2
+    case severe = 3
+}
+
+struct ProviderResult {
+    let precipitationMMPerHour: Double
+    let temperatureC: Double
+    let windMps: Double
+}
+
+struct RiskEngine {
+    func score(_ data: ProviderResult) -> Risk {
+        let precip = riskForPrecip(data.precipitationMMPerHour)
+        let temp = riskForTemperature(data.temperatureC)
+        let wind = riskForWind(data.windMps)
+        return [precip, temp, wind].max(by: { $0.rawValue < $1.rawValue }) ?? .clear
+    }
+
+    private func riskForPrecip(_ v: Double) -> Risk {
+        if v >= 12 { return .severe }
+        if v >= 6 { return .bad }
+        if v >= 1 { return .caution }
+        return .clear
+    }
+
+    private func riskForTemperature(_ v: Double) -> Risk {
+        if v >= 33 || v <= -8 { return .severe }
+        if v >= 30 || v <= -3 { return .bad }
+        if v >= 28 || v <= 0 { return .caution }
+        return .clear
+    }
+
+    private func riskForWind(_ v: Double) -> Risk {
+        if v >= 14 { return .severe }
+        if v >= 10 { return .bad }
+        if v >= 6 { return .caution }
+        return .clear
+    }
+}
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let doc = load("docs/weather-risk-provider-policy-v1.md")
+let homeVM = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let mapVM = load("dogArea/Views/MapView/MapViewModel.swift")
+let report = load("docs/cycle-133-weather-risk-policy-report-2026-02-27.md")
+
+assertTrue(doc.contains("Primary Provider"), "policy doc should define primary provider")
+assertTrue(doc.contains("Secondary Provider"), "policy doc should define secondary provider")
+assertTrue(doc.contains("cache TTL: `2h`"), "policy doc should define cache ttl")
+assertTrue(doc.contains("데이터 갱신 주기: `1h`"), "policy doc should define refresh cadence")
+assertTrue(doc.contains("geohash7"), "policy doc should define grid key policy")
+assertTrue(doc.contains("Fallback"), "policy doc should define fallback behavior")
+
+assertTrue(homeVM.contains("IndoorWeatherRiskLevel"), "home vm should expose weather risk levels")
+assertTrue(homeVM.contains("fallback"), "home vm should include fallback source")
+assertTrue(mapVM.contains("weatherOverlayFallbackActive"), "map vm should expose fallback badge state")
+assertTrue(report.contains("#133"), "cycle report should reference issue #133")
+
+let engine = RiskEngine()
+assertTrue(engine.score(.init(precipitationMMPerHour: 0, temperatureC: 21, windMps: 1)) == .clear, "clear baseline should stay clear")
+assertTrue(engine.score(.init(precipitationMMPerHour: 2, temperatureC: 21, windMps: 1)) == .caution, "light rain should be caution")
+assertTrue(engine.score(.init(precipitationMMPerHour: 7, temperatureC: 21, windMps: 1)) == .bad, "heavy rain should be bad")
+assertTrue(engine.score(.init(precipitationMMPerHour: 13, temperatureC: 21, windMps: 1)) == .severe, "extreme rain should be severe")
+assertTrue(engine.score(.init(precipitationMMPerHour: 0, temperatureC: 34, windMps: 1)) == .severe, "extreme heat should be severe")
+assertTrue(engine.score(.init(precipitationMMPerHour: 0, temperatureC: -4, windMps: 1)) == .bad, "cold wave should be bad")
+assertTrue(engine.score(.init(precipitationMMPerHour: 0, temperatureC: 21, windMps: 11)) == .bad, "strong wind should be bad")
+
+let deterministicInput = ProviderResult(precipitationMMPerHour: 6.2, temperatureC: 27, windMps: 5)
+let first = engine.score(deterministicInput)
+for _ in 0..<100 {
+    assertTrue(engine.score(deterministicInput) == first, "same input should produce same risk")
+}
+
+print("PASS: weather risk policy stage1 unit checks")


### PR DESCRIPTION
## 요약
- Weather Stage 1 정책 문서(`docs/weather-risk-provider-policy-v1.md`)를 추가해 Provider 어댑터/리스크 단계/시간대·지역 규칙/fallback/TTL/log 계약을 확정했습니다.
- 정책 누락 방지 및 판정 결정성 검증 스크립트(`scripts/weather_risk_policy_stage1_unit_check.swift`)를 추가했습니다.
- 사이클 리포트와 README 인덱스를 업데이트했습니다.

## 문서
- docs/weather-risk-provider-policy-v1.md
- docs/cycle-133-weather-risk-policy-report-2026-02-27.md

## 검증
- swift scripts/weather_risk_policy_stage1_unit_check.swift
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #133
