### PR TITLE
docs: finalize season weekly policy stage1 (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - 라이벌 공정 리그 매칭 v1: `docs/rival-fair-league-v1.md`
 - 시즌 안티 농사 규칙 v1: `docs/season-anti-farming-v1.md`
 - 시즌 복귀 캐치업 버프 v1: `docs/season-comeback-catchup-buff-v1.md`
+- 시즌 주간 정책 Stage1 v1: `docs/season-weekly-policy-stage1-v1.md`
 - 체감 날씨 피드백 루프 v1: `docs/weather-feedback-loop-v1.md`
 - 날씨 리스크 모델/Provider 정책 v1: `docs/weather-risk-provider-policy-v1.md`
 - 날씨 치환/스트릭 보호 서버 엔진 v1: `docs/weather-replacement-shield-engine-v1.md`
@@ -57,6 +58,7 @@
 - Cycle #148 결과 보고서(2026-02-27): `docs/cycle-148-quest-failure-buffer-report-2026-02-27.md`
 - Cycle #147 결과 보고서(2026-02-27): `docs/cycle-147-pet-adaptive-quest-report-2026-02-27.md`
 - Cycle #145 결과 보고서(2026-02-27): `docs/cycle-145-season-catchup-buff-report-2026-02-27.md`
+- Cycle #124 결과 보고서(2026-02-27): `docs/cycle-124-season-policy-report-2026-02-27.md`
 - Cycle #135 결과 보고서(2026-02-27): `docs/cycle-135-weather-ux-fallback-report-2026-02-27.md`
 - Cycle #133 결과 보고서(2026-02-27): `docs/cycle-133-weather-risk-policy-report-2026-02-27.md`
 - Cycle #134 결과 보고서(2026-02-27): `docs/cycle-134-weather-stage2-engine-report-2026-02-27.md`

--- a/docs/cycle-124-season-policy-report-2026-02-27.md
+++ b/docs/cycle-124-season-policy-report-2026-02-27.md
@@ -1,0 +1,35 @@
+# Cycle 124 Report — Season Weekly Policy Stage 1 (2026-02-27)
+
+## 1. 대상
+- Issue: `#124 [Task][Season][Stage 1] 주간 시즌 규칙/점수/감쇠 정책 확정`
+- Branch: `codex/cycle-124-season-policy-stage1`
+
+## 2. 구현 요약
+- 시즌 Stage1 정책 문서 신규 작성
+  - 주간 시즌 캘린더/정산 지연창(2시간) 확정
+  - 점수 산식(신규 점령 +5, 동일 타일 유지 일 1회 +1) 명시
+  - 감쇠 규칙(48시간 유예 후 하루 -2, 하한 0) 명시
+  - 동점 처리 우선순위(활성 타일 -> 신규 점령 -> 마지막 기여 시각 -> user_id) 확정
+  - 티어 컷(80/180/320/520) 및 보상(배지/프레임) 고정
+- 운영 문서 연결
+  - 스키마 명세에 Stage1 정책 고정 섹션 추가
+  - 운영 검증 문서에 Stage1 정책 확인 SQL/기대값 추가
+- 자동 검증 추가
+  - Stage1 정책 문서/운영문서/README 링크 검증 스크립트 추가
+  - 산식/감쇠/동점/티어 경계값 결정성 체크 포함
+
+## 3. 변경 파일
+- `docs/season-weekly-policy-stage1-v1.md`
+- `docs/cycle-124-season-policy-report-2026-02-27.md`
+- `docs/supabase-schema-v1.md`
+- `docs/supabase-migration.md`
+- `scripts/season_policy_stage1_unit_check.swift`
+- `scripts/ios_pr_check.sh`
+- `README.md`
+
+## 4. 검증
+- `swift scripts/season_policy_stage1_unit_check.swift` -> PASS
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh` -> PASS
+
+## 5. 리스크/후속
+- Stage1은 정책 고정 문서 중심이며, 시즌 스냅샷/보상 발급 영속화 테이블(`season_runs`, `season_user_scores`, `season_rewards`)은 Stage2(#125)에서 구현 필요.

--- a/docs/season-weekly-policy-stage1-v1.md
+++ b/docs/season-weekly-policy-stage1-v1.md
@@ -1,0 +1,100 @@
+# Season Weekly Policy Stage 1 v1
+
+## 1. 목적
+주간 시즌 점수/감쇠/정산/동점 규칙을 v1으로 고정해, 서버 구현(Stage 2)과 앱 UI(Stage 3)의 기준선을 일치시킨다.
+
+연결 이슈:
+- 정책 확정: #124
+- 상위 Epic: #123
+
+## 2. 시즌 캘린더/정산 윈도우
+- 시즌 주기: 사용자 로컬 타임존 기준 `월요일 00:00` ~ `일요일 23:59:59`
+- 정산 시작: 시즌 종료 후 `+2시간` (지연 업로드 흡수)
+- 정산 잠금: 정산 스냅샷 확정 이후 수정 금지(다음 시즌 반영)
+
+운영 파라미터:
+- `season_settlement_delay_hours = 2`
+- `season_timezone_mode = user_local`
+
+## 3. 점수 산식(v1)
+기본 이벤트 점수:
+- 신규 타일 점령: `+5`
+- 동일 타일 유지 방문(일 1회): `+1`
+- 동일 타일 당일 2회 이상 유지 방문: `+0`
+
+세션 점수:
+- `session_score = sum(tile_event_score)`
+
+주간 점수:
+- `season_week_score = sum(session_score) - decay_penalty`
+
+운영 파라미터:
+- `new_tile_score = 5`
+- `hold_tile_daily_score = 1`
+- `hold_tile_daily_cap = 1`
+
+## 4. 감쇠 규칙(v1)
+- 마지막 방문 기준 `48시간` 경과 시 감쇠 시작
+- 감쇠량: 타일 점수 하루 `-2`
+- 하한: `0` 미만으로 내려가지 않음
+
+식:
+- `age_hours = now - last_visited_at`
+- `decay_days = floor((age_hours - 48) / 24) + 1` (`age_hours > 48`일 때)
+- `tile_effective_score = max(0, tile_raw_score - 2 * decay_days)`
+
+운영 파라미터:
+- `decay_grace_hours = 48`
+- `decay_per_day = 2`
+- `decay_floor = 0`
+
+## 5. 동점 처리(v1)
+동점 정렬 우선순위:
+1. 활성 타일 수(`active_tile_count`) 내림차순
+2. 신규 점령 수(`new_tile_capture_count`) 내림차순
+3. 마지막 기여 시각(`last_contribution_at`) 오름차순(더 이른 기여 우선)
+4. 사용자 ID 오름차순(완전 결정성 보장)
+
+## 6. 티어/보상(v1)
+티어:
+- `Bronze`: 80점 이상
+- `Silver`: 180점 이상
+- `Gold`: 320점 이상
+- `Platinum`: 520점 이상
+
+보상:
+- 티어 배지(시즌 배지)
+- 프로필 프레임
+
+주의:
+- 시즌 중 티어 임계값 변경 금지
+- 보상은 정산 스냅샷 기준 1회 발급
+
+## 7. 예시 계산
+### 7.1 신규 점령 10개
+- 점수: `10 * 5 = 50`
+
+### 7.2 3일 미방문 감쇠
+- 타일 원점수: 12점
+- 마지막 방문 후 72시간 경과
+- 감쇠 시작 48시간 이후 1일 경과 -> `-2`
+- 유효점수: `12 - 2 = 10`
+
+### 7.3 시즌 종료 직전 업로드
+- `일요일 23:58`에 산책 종료, 업로드는 `월요일 00:30`
+- 정산 지연창(2시간) 내 업로드이므로 직전 시즌 반영
+- `월요일 02:00` 이후 도착분은 다음 시즌 반영
+
+## 8. 운영 파라미터 목록
+- 점수: `new_tile_score`, `hold_tile_daily_score`, `hold_tile_daily_cap`
+- 감쇠: `decay_grace_hours`, `decay_per_day`, `decay_floor`
+- 정산: `season_settlement_delay_hours`, `season_timezone_mode`
+- 랭크: `tier_threshold_bronze/silver/gold/platinum`
+- 동점: `tiebreaker_order`
+
+## 9. 검증 체크리스트
+- [ ] 신규 타일 10개 케이스가 50점으로 일치
+- [ ] 72시간 미방문 타일이 규칙대로 감쇠
+- [ ] 정산 지연창 내 업로드 반영 여부 일치
+- [ ] 동점 3중 비교 + 최종 결정키(user_id)로 순서가 고정
+- [ ] 티어 컷(80/180/320/520) 경계값이 일관

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -340,6 +340,37 @@ order by day_key desc, risk_level asc;
 - 같은 주차에서 `weekly_shield_limit=1`을 초과하지 않음
 - `weather_replacement_histories`에 원/치환 퀘스트 ID와 사유가 누락 없이 저장됨
 
+### 5.12 시즌 Stage1 정책 검증 (#124)
+시즌 점수/감쇠/티어 파라미터 확인:
+```sql
+select
+  policy_key,
+  base_tile_score,
+  new_route_bonus_weight,
+  repeat_cooldown_minutes,
+  suspicious_repeat_threshold
+from public.season_scoring_policies
+where policy_key = 'season_tile_anti_farming_v1';
+```
+
+복귀/보정 파라미터 확인:
+```sql
+select
+  policy_key,
+  inactivity_threshold_hours,
+  buff_active_hours,
+  score_boost_rate,
+  weekly_issue_limit,
+  season_end_block_hours
+from public.season_catchup_buff_policies
+where policy_key = 'season_comeback_catchup_v1';
+```
+
+기대값:
+- 운영 파라미터가 Stage1 정책 문서(`docs/season-weekly-policy-stage1-v1.md`)의 기본값 범위를 벗어나지 않음
+- 시즌 종료 지연창(`2h`) 운영 규칙이 앱/운영 문서와 일치
+- 티어 컷(80/180/320/520) 및 동점 우선순위가 문서/클라이언트 표시 로직과 동일
+
 ## 6. 운영 체크리스트
 - [ ] `migration list --local` / `migration list --linked` 결과 저장
 - [ ] User A/B 교차 접근 차단 SQL 결과 저장
@@ -348,6 +379,7 @@ order by day_key desc, risk_level asc;
 - [ ] User/Pet 확장 필드 정합성 SQL 결과 첨부
 - [ ] 비교군 카탈로그/시드 정합성 SQL 결과 첨부
 - [ ] 시즌 안티 농사 RPC/감사 로그 검증 결과 첨부
+- [ ] 시즌 Stage1 정책 파라미터 검증 결과 첨부
 - [ ] 체감 날씨 피드백 KPI 뷰 검증 결과 첨부
 - [ ] 날씨 치환/Shield RPC 및 이력 원장 검증 결과 첨부
 - [ ] 라이벌 리그 스냅샷/분포/히스토리 검증 결과 첨부

--- a/docs/supabase-schema-v1.md
+++ b/docs/supabase-schema-v1.md
@@ -249,6 +249,19 @@ erDiagram
 - `view_rival_league_distribution_current`
   - 최신 리그 분포/표본 상태 모니터링
 
+### 4.10 주간 시즌 정책 고정(Stage 1)
+- 정책 문서: `docs/season-weekly-policy-stage1-v1.md`
+- v1 고정값:
+  - 신규 타일 점령 `+5`
+  - 동일 타일 유지 방문(일 1회) `+1`
+  - 48시간 유예 후 하루 `-2` 감쇠(하한 0)
+  - 동점 정렬: `active_tile_count -> new_tile_capture_count -> last_contribution_at -> user_id`
+  - 티어 컷: `Bronze 80 / Silver 180 / Gold 320 / Platinum 520`
+- 서버 파라미터 연결:
+  - 점수/억제 정책: `season_scoring_policies`
+  - 복귀/보정 정책: `season_catchup_buff_policies`
+  - Stage2 구현 시 `season_runs`, `season_user_scores`, `season_rewards`로 정산 스냅샷/보상 영속화 확장
+
 ## 5. RLS 정책 원칙
 - 사용자 데이터는 `auth.uid()` 소유 범위로만 접근
 - `area_references`는 읽기 공개(`anon`, `authenticated`)

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -36,6 +36,7 @@ swift scripts/rival_privacy_hard_guard_unit_check.swift
 swift scripts/rival_league_matching_unit_check.swift
 swift scripts/season_anti_farming_unit_check.swift
 swift scripts/season_comeback_catchup_unit_check.swift
+swift scripts/season_policy_stage1_unit_check.swift
 swift scripts/weather_risk_policy_stage1_unit_check.swift
 swift scripts/weather_stage2_engine_unit_check.swift
 swift scripts/weather_ux_stage3_unit_check.swift

--- a/scripts/season_policy_stage1_unit_check.swift
+++ b/scripts/season_policy_stage1_unit_check.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+struct Stage1Policy {
+    let newTileScore: Int
+    let holdTileDailyScore: Int
+    let holdTileDailyCap: Int
+    let decayGraceHours: Int
+    let decayPerDay: Int
+    let bronze: Int
+    let silver: Int
+    let gold: Int
+    let platinum: Int
+
+    static let v1 = Stage1Policy(
+        newTileScore: 5,
+        holdTileDailyScore: 1,
+        holdTileDailyCap: 1,
+        decayGraceHours: 48,
+        decayPerDay: 2,
+        bronze: 80,
+        silver: 180,
+        gold: 320,
+        platinum: 520
+    )
+}
+
+enum TileEvent {
+    case newTile
+    case holdTileDailyVisit(countToday: Int)
+}
+
+func score(for events: [TileEvent], policy: Stage1Policy = .v1) -> Int {
+    var total = 0
+    for event in events {
+        switch event {
+        case .newTile:
+            total += policy.newTileScore
+        case let .holdTileDailyVisit(countToday):
+            if countToday <= policy.holdTileDailyCap {
+                total += policy.holdTileDailyScore
+            }
+        }
+    }
+    return total
+}
+
+func applyDecay(rawScore: Int, ageHours: Int, policy: Stage1Policy = .v1) -> Int {
+    guard ageHours > policy.decayGraceHours else {
+        return rawScore
+    }
+
+    let overdueHours = ageHours - policy.decayGraceHours
+    let decayDays = (overdueHours - 1) / 24 + 1
+    let decayed = rawScore - decayDays * policy.decayPerDay
+    return max(0, decayed)
+}
+
+struct RankRow {
+    let userID: UUID
+    let activeTileCount: Int
+    let newTileCaptureCount: Int
+    let lastContributionAt: Date
+}
+
+func sortedRank(_ rows: [RankRow]) -> [RankRow] {
+    rows.sorted {
+        if $0.activeTileCount != $1.activeTileCount {
+            return $0.activeTileCount > $1.activeTileCount
+        }
+        if $0.newTileCaptureCount != $1.newTileCaptureCount {
+            return $0.newTileCaptureCount > $1.newTileCaptureCount
+        }
+        if $0.lastContributionAt != $1.lastContributionAt {
+            return $0.lastContributionAt < $1.lastContributionAt
+        }
+        return $0.userID.uuidString < $1.userID.uuidString
+    }
+}
+
+func tier(for score: Int, policy: Stage1Policy = .v1) -> String {
+    if score >= policy.platinum { return "Platinum" }
+    if score >= policy.gold { return "Gold" }
+    if score >= policy.silver { return "Silver" }
+    if score >= policy.bronze { return "Bronze" }
+    return "Rookie"
+}
+
+let doc = load("docs/season-weekly-policy-stage1-v1.md")
+let schemaDoc = load("docs/supabase-schema-v1.md")
+let migrationDoc = load("docs/supabase-migration.md")
+let readme = load("README.md")
+let report = load("docs/cycle-124-season-policy-report-2026-02-27.md")
+
+assertTrue(doc.contains("신규 타일 점령: `+5`"), "policy doc should define new tile score")
+assertTrue(doc.contains("동일 타일 유지 방문(일 1회): `+1`"), "policy doc should define hold tile score")
+assertTrue(doc.contains("48시간"), "policy doc should define decay grace")
+assertTrue(doc.contains("하루 `-2`"), "policy doc should define decay value")
+assertTrue(doc.contains("활성 타일 수"), "policy doc should define tiebreak order")
+assertTrue(doc.contains("`Bronze`: 80점 이상"), "policy doc should define tier thresholds")
+
+assertTrue(schemaDoc.contains("주간 시즌 정책 고정(Stage 1)"), "schema doc should include stage1 season policy section")
+assertTrue(migrationDoc.contains("시즌 Stage1 정책 검증 (#124)"), "migration ops doc should include stage1 verification")
+assertTrue(readme.contains("docs/season-weekly-policy-stage1-v1.md"), "README should reference stage1 season policy doc")
+assertTrue(report.contains("#124"), "cycle report should reference issue #124")
+
+let exampleA = Array(repeating: TileEvent.newTile, count: 10)
+assertTrue(score(for: exampleA) == 50, "10 new tiles should score 50")
+
+assertTrue(applyDecay(rawScore: 12, ageHours: 48) == 12, "48h should not decay yet")
+assertTrue(applyDecay(rawScore: 12, ageHours: 72) == 10, "72h should decay by 2")
+assertTrue(applyDecay(rawScore: 3, ageHours: 120) == 0, "decay floor should clamp at zero")
+
+let formatter = ISO8601DateFormatter()
+let rows = [
+    RankRow(
+        userID: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+        activeTileCount: 12,
+        newTileCaptureCount: 5,
+        lastContributionAt: formatter.date(from: "2026-02-24T08:00:00Z")!
+    ),
+    RankRow(
+        userID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+        activeTileCount: 12,
+        newTileCaptureCount: 5,
+        lastContributionAt: formatter.date(from: "2026-02-24T08:00:00Z")!
+    ),
+    RankRow(
+        userID: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
+        activeTileCount: 10,
+        newTileCaptureCount: 9,
+        lastContributionAt: formatter.date(from: "2026-02-24T07:00:00Z")!
+    )
+]
+
+let ranked = sortedRank(rows)
+assertTrue(ranked.first?.userID.uuidString == "00000000-0000-0000-0000-000000000001", "tie should be deterministically resolved by user id")
+assertTrue(ranked.last?.userID.uuidString == "00000000-0000-0000-0000-000000000003", "lower active tile count should rank lower")
+
+assertTrue(tier(for: 79) == "Rookie", "79 should be rookie")
+assertTrue(tier(for: 80) == "Bronze", "80 should be bronze")
+assertTrue(tier(for: 180) == "Silver", "180 should be silver")
+assertTrue(tier(for: 320) == "Gold", "320 should be gold")
+assertTrue(tier(for: 520) == "Platinum", "520 should be platinum")
+
+print("PASS: season policy stage1 unit checks")


### PR DESCRIPTION
## Summary
- add Stage1 weekly season policy document with fixed scoring, decay, settlement window, tie-break, and tier thresholds
- extend schema/migration operation docs to include Stage1 policy verification guidance
- add Stage1 unit check and wire it into `ios_pr_check.sh`, plus cycle #124 report and README links

## Testing
- swift scripts/season_policy_stage1_unit_check.swift
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #124
