### PR TITLE
refactor: decouple Map/Home ViewModel runtime stores

### DIFF
--- a/docs/legacy-clean-architecture-roadmap-v1.md
+++ b/docs/legacy-clean-architecture-roadmap-v1.md
@@ -54,3 +54,14 @@
 1. `MapViewModel` UserDefaults/NotificationCenter 접근을 `MapPreferenceStore`로 추출
 2. `HomeViewModel`의 시즌/날씨 정책 로직을 `SeasonPolicyUseCase`로 분리
 3. `UserdefaultSetting`를 Store 단위 파일로 분할(`ProfileStore`, `SeasonStore`, `WalkPreferenceStore`)
+
+## 이번 사이클 계획 (Issue #178 후속)
+- 범위
+  - `MapViewModel`의 `UserDefaults.standard` 직접 접근을 `MapPreferenceStoreProtocol`로 치환
+  - `MapViewModel`/`HomeViewModel`의 `NotificationCenter.default` 직접 접근을 `AppEventCenterProtocol`로 치환
+  - `MapViewModel`/`HomeViewModel`의 `UserdefaultSetting.shared` 직접 접근을 `UserSessionStoreProtocol`로 치환
+- 비범위
+  - `IndoorMissionStore`/`SeasonMotionStore`의 내부 저장 구현(`UserDefaults`) 전면 교체는 다음 사이클
+- 검증
+  - `scripts/map_home_viewmodel_boundary_unit_check.swift` 추가
+  - `bash scripts/ios_pr_check.sh` 통과

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -8,6 +8,7 @@
 import Foundation
 import CryptoKit
 import SwiftUI
+import Combine
 
 class UserdefaultSetting {
     enum keyValue: String {
@@ -86,6 +87,10 @@ class UserdefaultSetting {
         userDefaults.removeObject(forKey: keyValue.walkPointRecordMode.rawValue)
     }
     #endif
+}
+
+extension Notification.Name {
+    static let walkPointRecordedForQuest = Notification.Name("walk.point.recorded.for.quest")
 }
 struct UserInfo: TimeCheckable {
     let id: String
@@ -312,6 +317,185 @@ extension UserdefaultSetting {
         walkSessionMetadataStore.setWalkPointRecordModeRawValue(rawValue)
     }
 
+}
+
+protocol UserSessionStoreProtocol {
+    func currentUserInfo() -> UserInfo?
+    func selectedPet(from userInfo: UserInfo?) -> PetInfo?
+    func setSelectedPetId(_ petId: String, source: String)
+    func suggestedPetForWalkStart(from userInfo: UserInfo?, now: Date) -> PetInfo?
+    func seasonCatchupBuffSnapshot() -> SeasonCatchupBuffSnapshot?
+    func walkStartCountdownEnabled() -> Bool
+    func setWalkStartCountdownEnabled(_ enabled: Bool)
+    func walkPointRecordModeRawValue() -> String
+    func setWalkPointRecordModeRawValue(_ rawValue: String)
+}
+
+final class DefaultUserSessionStore: UserSessionStoreProtocol {
+    static let shared = DefaultUserSessionStore()
+    private let storage: UserdefaultSetting
+
+    init(storage: UserdefaultSetting = .shared) {
+        self.storage = storage
+    }
+
+    func currentUserInfo() -> UserInfo? {
+        storage.getValue()
+    }
+
+    func selectedPet(from userInfo: UserInfo?) -> PetInfo? {
+        storage.selectedPet(from: userInfo)
+    }
+
+    func setSelectedPetId(_ petId: String, source: String) {
+        storage.setSelectedPetId(petId, source: source)
+    }
+
+    func suggestedPetForWalkStart(from userInfo: UserInfo?, now: Date) -> PetInfo? {
+        storage.suggestedPetForWalkStart(from: userInfo, now: now)
+    }
+
+    func seasonCatchupBuffSnapshot() -> SeasonCatchupBuffSnapshot? {
+        storage.seasonCatchupBuffSnapshot()
+    }
+
+    func walkStartCountdownEnabled() -> Bool {
+        storage.walkStartCountdownEnabled()
+    }
+
+    func setWalkStartCountdownEnabled(_ enabled: Bool) {
+        storage.setWalkStartCountdownEnabled(enabled)
+    }
+
+    func walkPointRecordModeRawValue() -> String {
+        storage.walkPointRecordModeRawValue()
+    }
+
+    func setWalkPointRecordModeRawValue(_ rawValue: String) {
+        storage.setWalkPointRecordModeRawValue(rawValue)
+    }
+}
+
+protocol MapPreferenceStoreProtocol {
+    func bool(forKey key: String, default defaultValue: Bool) -> Bool
+    func integer(forKey key: String, default defaultValue: Int) -> Int
+    func double(forKey key: String, default defaultValue: Double) -> Double
+    func string(forKey key: String) -> String?
+    func data(forKey key: String) -> Data?
+    func stringArray(forKey key: String) -> [String]
+    func set(_ value: Bool, forKey key: String)
+    func set(_ value: String?, forKey key: String)
+    func set(_ value: Data?, forKey key: String)
+    func set(_ value: [String], forKey key: String)
+    func removeObject(forKey key: String)
+}
+
+final class DefaultMapPreferenceStore: MapPreferenceStoreProtocol {
+    static let shared = DefaultMapPreferenceStore()
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func bool(forKey key: String, default defaultValue: Bool) -> Bool {
+        guard let value = userDefaults.object(forKey: key) as? Bool else {
+            return defaultValue
+        }
+        return value
+    }
+
+    func integer(forKey key: String, default defaultValue: Int) -> Int {
+        let value = userDefaults.integer(forKey: key)
+        return value > 0 ? value : defaultValue
+    }
+
+    func double(forKey key: String, default defaultValue: Double) -> Double {
+        let value = userDefaults.double(forKey: key)
+        return value > 0 ? value : defaultValue
+    }
+
+    func string(forKey key: String) -> String? {
+        userDefaults.string(forKey: key)
+    }
+
+    func data(forKey key: String) -> Data? {
+        userDefaults.data(forKey: key)
+    }
+
+    func stringArray(forKey key: String) -> [String] {
+        userDefaults.stringArray(forKey: key) ?? []
+    }
+
+    func set(_ value: Bool, forKey key: String) {
+        userDefaults.set(value, forKey: key)
+    }
+
+    func set(_ value: String?, forKey key: String) {
+        if let value {
+            userDefaults.set(value, forKey: key)
+        } else {
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+
+    func set(_ value: Data?, forKey key: String) {
+        if let value {
+            userDefaults.set(value, forKey: key)
+        } else {
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+
+    func set(_ value: [String], forKey key: String) {
+        userDefaults.set(value, forKey: key)
+    }
+
+    func removeObject(forKey key: String) {
+        userDefaults.removeObject(forKey: key)
+    }
+}
+
+protocol AppEventCenterProtocol {
+    func addObserver(
+        forName name: Notification.Name,
+        object: AnyObject?,
+        queue: OperationQueue?,
+        using block: @escaping (Notification) -> Void
+    ) -> NSObjectProtocol
+    func removeObserver(_ observer: NSObjectProtocol)
+    func post(name: Notification.Name, object: AnyObject?, userInfo: [AnyHashable: Any]?)
+    func publisher(for name: Notification.Name, object: AnyObject?) -> AnyPublisher<Notification, Never>
+}
+
+final class DefaultAppEventCenter: AppEventCenterProtocol {
+    static let shared = DefaultAppEventCenter()
+    private let center: NotificationCenter
+
+    init(center: NotificationCenter = .default) {
+        self.center = center
+    }
+
+    func addObserver(
+        forName name: Notification.Name,
+        object: AnyObject?,
+        queue: OperationQueue?,
+        using block: @escaping (Notification) -> Void
+    ) -> NSObjectProtocol {
+        center.addObserver(forName: name, object: object, queue: queue, using: block)
+    }
+
+    func removeObserver(_ observer: NSObjectProtocol) {
+        center.removeObserver(observer)
+    }
+
+    func post(name: Notification.Name, object: AnyObject?, userInfo: [AnyHashable: Any]?) {
+        center.post(name: name, object: object, userInfo: userInfo)
+    }
+
+    func publisher(for name: Notification.Name, object: AnyObject? = nil) -> AnyPublisher<Notification, Never> {
+        center.publisher(for: name, object: object).eraseToAnyPublisher()
+    }
 }
 
 enum AppFeatureFlagKey: String, CaseIterable {

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -9,10 +9,6 @@ import Foundation
 import SwiftUI
 import Combine
 
-extension Notification.Name {
-    static let walkPointRecordedForQuest = Notification.Name("walk.point.recorded.for.quest")
-}
-
 enum QuestMotionEventType: String, Equatable {
     case progress
     case completed
@@ -153,6 +149,8 @@ final class HomeViewModel: ObservableObject {
     private let metricTracker = AppMetricTracker.shared
     private let areaReferenceRepository: AreaReferenceRepository
     private let walkRepository: WalkRepositoryProtocol
+    private let userSessionStore: UserSessionStoreProtocol
+    private let eventCenter: AppEventCenterProtocol
     private let seasonMotionStore = SeasonMotionStore()
     private var featuredGoalAreas: [AreaMeter] = []
     private var areaReferenceTask: Task<Void, Never>? = nil
@@ -220,10 +218,14 @@ final class HomeViewModel: ObservableObject {
 
     init(
         areaReferenceRepository: AreaReferenceRepository = SupabaseAreaReferenceRepository.shared,
-        walkRepository: WalkRepositoryProtocol = WalkRepositoryContainer.shared
+        walkRepository: WalkRepositoryProtocol = WalkRepositoryContainer.shared,
+        userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
+        eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared
     ) {
         self.areaReferenceRepository = areaReferenceRepository
         self.walkRepository = walkRepository
+        self.userSessionStore = userSessionStore
+        self.eventCenter = eventCenter
         bindSelectedPetSync()
         bindTimeBoundaryNotifications()
         bindSeasonCatchupBuffStatusNotifications()
@@ -267,15 +269,15 @@ final class HomeViewModel: ObservableObject {
     }
 
     func reloadUserInfo() {
-        userInfo = UserdefaultSetting.shared.getValue()
-        selectedPet = UserdefaultSetting.shared.selectedPet(from: userInfo)
+        userInfo = userSessionStore.currentUserInfo()
+        selectedPet = userSessionStore.selectedPet(from: userInfo)
         selectedPetId = selectedPet?.petId ?? ""
     }
 
     func selectPet(_ petId: String) {
         guard pets.contains(where: { $0.petId == petId }) else { return }
         isShowingAllRecordsOverride = false
-        UserdefaultSetting.shared.setSelectedPetId(petId, source: "home")
+        userSessionStore.setSelectedPetId(petId, source: "home")
         reloadUserInfo()
         applySelectedPetStatistics()
     }
@@ -316,7 +318,7 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func bindSeasonCatchupBuffStatusNotifications() {
-        NotificationCenter.default.publisher(for: UserdefaultSetting.seasonCatchupBuffDidUpdateNotification)
+        eventCenter.publisher(for: UserdefaultSetting.seasonCatchupBuffDidUpdateNotification, object: nil)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.reloadSeasonCatchupBuffStatus()
@@ -325,7 +327,7 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func bindSelectedPetSync() {
-        NotificationCenter.default.publisher(for: UserdefaultSetting.selectedPetDidChangeNotification)
+        eventCenter.publisher(for: UserdefaultSetting.selectedPetDidChangeNotification, object: nil)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 guard let self else { return }
@@ -337,7 +339,7 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func bindQuestProgressNotifications() {
-        NotificationCenter.default.publisher(for: .walkPointRecordedForQuest)
+        eventCenter.publisher(for: .walkPointRecordedForQuest, object: nil)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.refreshIndoorMissions()
@@ -346,9 +348,8 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func bindTimeBoundaryNotifications() {
-        let center = NotificationCenter.default
-        let timezoneChanged = center.publisher(for: .NSSystemTimeZoneDidChange)
-        let dayChanged = center.publisher(for: .NSCalendarDayChanged)
+        let timezoneChanged = eventCenter.publisher(for: .NSSystemTimeZoneDidChange, object: nil)
+        let dayChanged = eventCenter.publisher(for: .NSCalendarDayChanged, object: nil)
 
         Publishers.Merge(timezoneChanged, dayChanged)
             .receive(on: RunLoop.main)
@@ -371,7 +372,7 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func reloadSeasonCatchupBuffStatus(now: Date = Date()) {
-        guard let snapshot = UserdefaultSetting.shared.seasonCatchupBuffSnapshot() else {
+        guard let snapshot = userSessionStore.seasonCatchupBuffSnapshot() else {
             seasonCatchupBuffStatusMessage = nil
             seasonCatchupBuffStatusWarning = false
             return

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -177,6 +177,9 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let syncOutbox = SyncOutboxStore.shared
     private let syncTransport = SupabaseSyncOutboxTransport()
     private let walkRepository: WalkRepositoryProtocol
+    private let userSessionStore: UserSessionStoreProtocol
+    private let preferenceStore: MapPreferenceStoreProtocol
+    private let eventCenter: AppEventCenterProtocol
     private var lastCaptureHapticAt: Date = .distantPast
     private var lastWarningHapticAt: Date = .distantPast
     private let maxCaptureRipples = 12
@@ -263,8 +266,16 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         }
     }
 
-    init(walkRepository: WalkRepositoryProtocol = WalkRepositoryContainer.shared) {
+    init(
+        walkRepository: WalkRepositoryProtocol = WalkRepositoryContainer.shared,
+        userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
+        preferenceStore: MapPreferenceStoreProtocol = DefaultMapPreferenceStore.shared,
+        eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared
+    ) {
         self.walkRepository = walkRepository
+        self.userSessionStore = userSessionStore
+        self.preferenceStore = preferenceStore
+        self.eventCenter = eventCenter
         super.init()
         self.locationManager.delegate = self
         self.locationManager.allowsBackgroundLocationUpdates = true
@@ -274,20 +285,20 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.reloadPolygonState(restoreLatestPolygon: true)
         self.loadProcessedWatchActions()
 
-        let storedHeatmapEnabled = UserDefaults.standard.object(forKey: heatmapEnabledKey) as? Bool ?? true
-        let storedNearbyHotspotEnabled = UserDefaults.standard.object(forKey: nearbyHotspotEnabledKey) as? Bool ?? true
-        let storedLocationSharingEnabled = UserDefaults.standard.bool(forKey: locationSharingKey)
-        let storedMotionReduced = UserDefaults.standard.bool(forKey: mapMotionReducedKey)
+        let storedHeatmapEnabled = preferenceStore.bool(forKey: heatmapEnabledKey, default: true)
+        let storedNearbyHotspotEnabled = preferenceStore.bool(forKey: nearbyHotspotEnabledKey, default: true)
+        let storedLocationSharingEnabled = preferenceStore.bool(forKey: locationSharingKey, default: false)
+        let storedMotionReduced = preferenceStore.bool(forKey: mapMotionReducedKey, default: false)
 
         self.heatmapEnabled = featureFlags.isEnabled(.heatmapV1) ? storedHeatmapEnabled : false
         let nearbyFeatureOn = featureFlags.isEnabled(.nearbyHotspotV1)
         self.nearbyHotspotEnabled = nearbyFeatureOn ? storedNearbyHotspotEnabled : false
         self.locationSharingEnabled = nearbyFeatureOn ? storedLocationSharingEnabled : false
         self.mapMotionReduced = storedMotionReduced
-        self.walkStartCountdownEnabled = UserdefaultSetting.shared.walkStartCountdownEnabled()
+        self.walkStartCountdownEnabled = userSessionStore.walkStartCountdownEnabled()
         self.walkAutoEndPolicyEnabled = true
         self.walkPointRecordMode = WalkPointRecordMode(
-            rawValue: UserdefaultSetting.shared.walkPointRecordModeRawValue()
+            rawValue: userSessionStore.walkPointRecordModeRawValue()
         ) ?? .manual
         self.prepareRecoverableSessionIfNeeded()
         self.reloadSelectedPetContext()
@@ -305,7 +316,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         timer?.invalidate()
         nearbyTickTimer?.invalidate()
         syncFlushTask?.cancel()
-        lifecycleObservers.forEach { NotificationCenter.default.removeObserver($0) }
+        lifecycleObservers.forEach { eventCenter.removeObserver($0) }
     }
 
     private func applyPolygonList(_ polygons: [Polygon], restoreLatestPolygon: Bool = false) {
@@ -446,12 +457,12 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
 
     func toggleWalkStartCountdown() {
         walkStartCountdownEnabled.toggle()
-        UserdefaultSetting.shared.setWalkStartCountdownEnabled(walkStartCountdownEnabled)
+        userSessionStore.setWalkStartCountdownEnabled(walkStartCountdownEnabled)
     }
 
     func toggleWalkPointRecordMode() {
         walkPointRecordMode = walkPointRecordMode == .manual ? .auto : .manual
-        UserdefaultSetting.shared.setWalkPointRecordModeRawValue(walkPointRecordMode.rawValue)
+        userSessionStore.setWalkPointRecordModeRawValue(walkPointRecordMode.rawValue)
         resetAutoPointRecordState()
     }
 
@@ -603,7 +614,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
 
     func toggleMapMotionReduced() {
         mapMotionReduced.toggle()
-        UserDefaults.standard.set(mapMotionReduced, forKey: mapMotionReducedKey)
+        preferenceStore.set(mapMotionReduced, forKey: mapMotionReducedKey)
     }
 
     var weatherOverlayTintColor: Color {
@@ -839,12 +850,12 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         }
 
         if let selectedPetId = snapshot.selectedPetId {
-            UserdefaultSetting.shared.setSelectedPetId(selectedPetId)
+            userSessionStore.setSelectedPetId(selectedPetId, source: "walk_recovery")
         }
         reloadSelectedPetContext()
         currentWalkingPetName = snapshot.currentWalkingPetName
         walkPointRecordMode = WalkPointRecordMode(rawValue: snapshot.pointRecordMode) ?? .manual
-        UserdefaultSetting.shared.setWalkPointRecordModeRawValue(walkPointRecordMode.rawValue)
+        userSessionStore.setWalkPointRecordModeRawValue(walkPointRecordMode.rawValue)
 
         lastPointEventAt = snapshot.points.last.map { Date(timeIntervalSince1970: $0.createdAt) } ?? Date()
         lastMovementAt = snapshot.lastMovementAt.map { Date(timeIntervalSince1970: $0) } ?? lastPointEventAt
@@ -986,7 +997,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     }
 
     private func decodeActiveWalkSession() -> ActiveWalkSessionSnapshot? {
-        guard let data = UserDefaults.standard.data(forKey: activeWalkSessionStorageKey) else {
+        guard let data = preferenceStore.data(forKey: activeWalkSessionStorageKey) else {
             return nil
         }
         return try? JSONDecoder().decode(ActiveWalkSessionSnapshot.self, from: data)
@@ -1019,13 +1030,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         )
 
         if let data = try? JSONEncoder().encode(snapshot) {
-            UserDefaults.standard.set(data, forKey: activeWalkSessionStorageKey)
+            preferenceStore.set(data, forKey: activeWalkSessionStorageKey)
             lastSnapshotPersistAt = now
         }
     }
 
     private func clearActiveWalkSession() {
-        UserDefaults.standard.removeObject(forKey: activeWalkSessionStorageKey)
+        preferenceStore.removeObject(forKey: activeWalkSessionStorageKey)
         pendingRecoverableSession = nil
         hasRecoverableWalkSession = false
         recoverableWalkSummaryText = ""
@@ -1072,8 +1083,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
 
     private func setupLifecycleObservers() {
         #if canImport(UIKit)
-        let center = NotificationCenter.default
-        let didBecomeActive = center.addObserver(
+        let didBecomeActive = eventCenter.addObserver(
             forName: UIApplication.didBecomeActiveNotification,
             object: nil,
             queue: .main
@@ -1082,21 +1092,21 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             self?.syncVisibilitySettingIfNeeded()
             self?.refreshWeatherOverlayRisk()
         }
-        let willResign = center.addObserver(
+        let willResign = eventCenter.addObserver(
             forName: UIApplication.willResignActiveNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             self?.persistActiveWalkSession(force: true)
         }
-        let willTerminate = center.addObserver(
+        let willTerminate = eventCenter.addObserver(
             forName: UIApplication.willTerminateNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             self?.persistActiveWalkSession(force: true)
         }
-        let petContextChanged = center.addObserver(
+        let petContextChanged = eventCenter.addObserver(
             forName: UserdefaultSetting.selectedPetDidChangeNotification,
             object: nil,
             queue: .main
@@ -1104,7 +1114,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             self?.reloadSelectedPetContext()
         }
         #if canImport(UIKit)
-        let reduceMotionChanged = center.addObserver(
+        let reduceMotionChanged = eventCenter.addObserver(
             forName: UIAccessibility.reduceMotionStatusDidChangeNotification,
             object: nil,
             queue: .main
@@ -1133,7 +1143,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         persistActiveWalkSession(force: true)
         syncWatchContext(force: true)
         compactMapMotionArtifacts(now: recordedAt)
-        NotificationCenter.default.post(
+        eventCenter.post(
             name: .walkPointRecordedForQuest,
             object: nil,
             userInfo: [
@@ -1225,13 +1235,11 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     }
 
     private func lodIntValue(key: String, defaultValue: Int) -> Int {
-        let value = UserDefaults.standard.integer(forKey: key)
-        return value > 0 ? value : defaultValue
+        preferenceStore.integer(forKey: key, default: defaultValue)
     }
 
     private func lodDoubleValue(key: String, defaultValue: Double) -> Double {
-        let value = UserDefaults.standard.double(forKey: key)
-        return value > 0 ? value : defaultValue
+        preferenceStore.double(forKey: key, default: defaultValue)
     }
 
     private var overlayMaxCameraDistance: Double {
@@ -1352,7 +1360,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             return
         }
         self.heatmapEnabled.toggle()
-        UserDefaults.standard.set(self.heatmapEnabled, forKey: heatmapEnabledKey)
+        preferenceStore.set(self.heatmapEnabled, forKey: heatmapEnabledKey)
         if self.heatmapEnabled {
             refreshHeatmap()
         } else {
@@ -1363,12 +1371,12 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     func toggleLocationSharing() {
         guard isNearbyHotspotFeatureAvailable else {
             self.locationSharingEnabled = false
-            UserDefaults.standard.set(false, forKey: locationSharingKey)
+            preferenceStore.set(false, forKey: locationSharingKey)
             self.syncVisibilitySettingIfNeeded()
             return
         }
         self.locationSharingEnabled.toggle()
-        UserDefaults.standard.set(self.locationSharingEnabled, forKey: locationSharingKey)
+        preferenceStore.set(self.locationSharingEnabled, forKey: locationSharingKey)
         metricTracker.track(
             self.locationSharingEnabled ? .nearbyOptInEnabled : .nearbyOptInDisabled,
             userKey: currentMetricUserId(),
@@ -1381,11 +1389,11 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         guard isNearbyHotspotFeatureAvailable else {
             self.nearbyHotspotEnabled = false
             self.nearbyHotspots = []
-            UserDefaults.standard.set(false, forKey: nearbyHotspotEnabledKey)
+            preferenceStore.set(false, forKey: nearbyHotspotEnabledKey)
             return
         }
         self.nearbyHotspotEnabled.toggle()
-        UserDefaults.standard.set(self.nearbyHotspotEnabled, forKey: nearbyHotspotEnabledKey)
+        preferenceStore.set(self.nearbyHotspotEnabled, forKey: nearbyHotspotEnabledKey)
         if nearbyHotspotEnabled == false {
             self.nearbyHotspots = []
         }
@@ -1512,9 +1520,9 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         let heatmapAllowed = featureFlags.isEnabled(.heatmapV1)
         let nearbyAllowed = featureFlags.isEnabled(.nearbyHotspotV1)
         let nearbyAllowedForSession = nearbyAllowed && isNearbySocialAvailableForSession
-        let heatmapPreference = UserDefaults.standard.object(forKey: heatmapEnabledKey) as? Bool ?? true
-        let nearbyPreference = UserDefaults.standard.object(forKey: nearbyHotspotEnabledKey) as? Bool ?? true
-        let sharingPreference = UserDefaults.standard.bool(forKey: locationSharingKey)
+        let heatmapPreference = preferenceStore.bool(forKey: heatmapEnabledKey, default: true)
+        let nearbyPreference = preferenceStore.bool(forKey: nearbyHotspotEnabledKey, default: true)
+        let sharingPreference = preferenceStore.bool(forKey: locationSharingKey, default: false)
 
         self.heatmapEnabled = heatmapAllowed ? heatmapPreference : false
         self.nearbyHotspotEnabled = nearbyAllowedForSession ? nearbyPreference : false
@@ -1528,7 +1536,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
 
         if nearbyAllowedForSession == false {
             self.nearbyHotspots = []
-            UserDefaults.standard.set(false, forKey: locationSharingKey)
+            preferenceStore.set(false, forKey: locationSharingKey)
             self.syncVisibilitySettingIfNeeded()
         }
     }
@@ -1538,7 +1546,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
            let fromEnv = WeatherOverlayRiskLevel(rawValue: env.lowercased()) {
             return (fromEnv, false)
         }
-        if let raw = UserDefaults.standard.string(forKey: weatherRiskOverrideKey),
+        if let raw = preferenceStore.string(forKey: weatherRiskOverrideKey),
            let fromDefaults = WeatherOverlayRiskLevel(rawValue: raw.lowercased()) {
             return (fromDefaults, false)
         }
@@ -1560,29 +1568,29 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     }
 
     private func currentPresenceUserId() -> String? {
-        if let existing = UserDefaults.standard.string(forKey: nearbyPresenceUserIdKey) {
+        if let existing = preferenceStore.string(forKey: nearbyPresenceUserIdKey) {
             return existing
         }
-        guard let raw = UserdefaultSetting.shared.getValue()?.id,
+        guard let raw = userSessionStore.currentUserInfo()?.id,
               raw.isEmpty == false else {
             return nil
         }
         let stable = raw.stableUUIDString
-        UserDefaults.standard.set(stable, forKey: nearbyPresenceUserIdKey)
+        preferenceStore.set(stable, forKey: nearbyPresenceUserIdKey)
         return stable
     }
 
     private func currentMetricUserId() -> String? {
-        guard let raw = UserdefaultSetting.shared.getValue()?.id, raw.isEmpty == false else {
+        guard let raw = userSessionStore.currentUserInfo()?.id, raw.isEmpty == false else {
             return nil
         }
         return raw
     }
 
     func reloadSelectedPetContext() {
-        let userInfo = UserdefaultSetting.shared.getValue()
+        let userInfo = userSessionStore.currentUserInfo()
         self.availablePets = userInfo?.pet ?? []
-        let selectedPet = UserdefaultSetting.shared.selectedPet(from: userInfo)
+        let selectedPet = userSessionStore.selectedPet(from: userInfo)
         self.selectedPetId = selectedPet?.petId
         self.selectedPetName = selectedPet?.petName ?? "강아지"
         if isWalking == false {
@@ -1596,13 +1604,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
 
     func prepareWalkPetSelectionSuggestion() {
         guard isWalking == false else { return }
-        guard let userInfo = UserdefaultSetting.shared.getValue(), userInfo.pet.isEmpty == false else {
+        guard let userInfo = userSessionStore.currentUserInfo(), userInfo.pet.isEmpty == false else {
             reloadSelectedPetContext()
             return
         }
-        if let suggested = UserdefaultSetting.shared.suggestedPetForWalkStart(from: userInfo),
+        if let suggested = userSessionStore.suggestedPetForWalkStart(from: userInfo, now: Date()),
            suggested.petId != selectedPetId {
-            UserdefaultSetting.shared.setSelectedPetId(suggested.petId, source: "walk_start_suggestion")
+            userSessionStore.setSelectedPetId(suggested.petId, source: "walk_start_suggestion")
             metricTracker.track(
                 .petSelectionSuggested,
                 userKey: currentMetricUserId(),
@@ -1623,7 +1631,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         let currentIndex = availablePets.firstIndex(where: { $0.petId == selectedPetId }) ?? -1
         let nextIndex = (currentIndex + 1) % availablePets.count
         let nextPet = availablePets[nextIndex]
-        UserdefaultSetting.shared.setSelectedPetId(nextPet.petId, source: "walk_start_switcher")
+        userSessionStore.setSelectedPetId(nextPet.petId, source: "walk_start_switcher")
         walkStatusMessage = "산책 대상: \(nextPet.petName)"
         reloadSelectedPetContext()
     }
@@ -1665,13 +1673,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     }
 
     private func loadProcessedWatchActions() {
-        let stored = UserDefaults.standard.stringArray(forKey: processedWatchActionStorageKey) ?? []
+        let stored = preferenceStore.stringArray(forKey: processedWatchActionStorageKey)
         self.processedWatchActionOrder = stored
         self.processedWatchActionIds = Set(stored)
     }
 
     private func persistProcessedWatchActions() {
-        UserDefaults.standard.set(self.processedWatchActionOrder, forKey: processedWatchActionStorageKey)
+        preferenceStore.set(self.processedWatchActionOrder, forKey: processedWatchActionStorageKey)
     }
 
     private func shouldProcessWatchAction(actionId: String) -> Bool {

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -50,6 +50,7 @@ swift scripts/walk_repository_backfill_unit_check.swift
 swift scripts/walk_session_pet_canonicalization_unit_check.swift
 swift scripts/presentation_firebase_boundary_unit_check.swift
 swift scripts/supabase_profile_image_upload_unit_check.swift
+swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 
 if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then

--- a/scripts/map_home_viewmodel_boundary_unit_check.swift
+++ b/scripts/map_home_viewmodel_boundary_unit_check.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+func extractTypeBody(source: String, declarationPrefix: String) -> String? {
+    guard let declarationRange = source.range(of: declarationPrefix) else { return nil }
+    guard let openBrace = source[declarationRange.lowerBound...].firstIndex(of: "{") else { return nil }
+
+    var depth = 0
+    var index = openBrace
+    while index < source.endIndex {
+        let ch = source[index]
+        if ch == "{" {
+            depth += 1
+        } else if ch == "}" {
+            depth -= 1
+            if depth == 0 {
+                return String(source[openBrace...index])
+            }
+        }
+        index = source.index(after: index)
+    }
+    return nil
+}
+
+let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
+let homeViewModel = load("dogArea/Views/HomeView/HomeViewModel.swift")
+
+let mapBody = extractTypeBody(source: mapViewModel, declarationPrefix: "class MapViewModel")
+let homeBody = extractTypeBody(source: homeViewModel, declarationPrefix: "final class HomeViewModel")
+
+assertTrue(mapBody != nil, "MapViewModel class body should be detectable")
+assertTrue(homeBody != nil, "HomeViewModel class body should be detectable")
+
+if let mapBody {
+    assertTrue(!mapBody.contains("UserDefaults.standard"), "MapViewModel should not access UserDefaults.standard directly")
+    assertTrue(!mapBody.contains("NotificationCenter.default"), "MapViewModel should not access NotificationCenter.default directly")
+    assertTrue(!mapBody.contains("UserdefaultSetting.shared"), "MapViewModel should not access UserdefaultSetting.shared directly")
+}
+
+if let homeBody {
+    assertTrue(!homeBody.contains("UserDefaults.standard"), "HomeViewModel should not access UserDefaults.standard directly")
+    assertTrue(!homeBody.contains("NotificationCenter.default"), "HomeViewModel should not access NotificationCenter.default directly")
+    assertTrue(!homeBody.contains("UserdefaultSetting.shared"), "HomeViewModel should not access UserdefaultSetting.shared directly")
+}
+
+assertTrue(mapViewModel.contains("MapPreferenceStoreProtocol"), "MapViewModel should depend on MapPreferenceStoreProtocol")
+assertTrue(mapViewModel.contains("UserSessionStoreProtocol"), "MapViewModel should depend on UserSessionStoreProtocol")
+assertTrue(mapViewModel.contains("AppEventCenterProtocol"), "MapViewModel should depend on AppEventCenterProtocol")
+
+assertTrue(homeViewModel.contains("UserSessionStoreProtocol"), "HomeViewModel should depend on UserSessionStoreProtocol")
+assertTrue(homeViewModel.contains("AppEventCenterProtocol"), "HomeViewModel should depend on AppEventCenterProtocol")
+
+print("PASS: map/home viewmodel boundary unit checks")


### PR DESCRIPTION
## Summary
- add `UserSessionStoreProtocol`, `MapPreferenceStoreProtocol`, and `AppEventCenterProtocol` adapters in `UserdefaultSetting.swift`
- switch `MapViewModel` to DI-based access for preference/session/event APIs instead of direct `UserDefaults`/`NotificationCenter`/`UserdefaultSetting.shared` usage
- switch `HomeViewModel` class-level coupling to DI-based event/session stores
- add boundary check script for Map/Home ViewModel direct-coupling regression and include it in `ios_pr_check.sh`
- document this cycle scope in roadmap doc (Issue #178 follow-up)

## Validation
- `swift scripts/map_home_viewmodel_boundary_unit_check.swift`
- `swift scripts/presentation_firebase_boundary_unit_check.swift`
- `swift scripts/project_stability_unit_check.swift`
- `bash scripts/ios_pr_check.sh`
