### PR TITLE
refactor: split auth use case and add supabase email auth flow

### DIFF
--- a/docs/cycle-157-auth-clean-architecture-email-flow-report-2026-03-01.md
+++ b/docs/cycle-157-auth-clean-architecture-email-flow-report-2026-03-01.md
@@ -1,0 +1,39 @@
+# Cycle 157 - Auth 클린 아키텍처 분리 + Email 로그인/회원가입 플로우 정리 (2026-03-01)
+
+## 목적
+- SignIn 화면의 인증 분기(Apple/Email)를 Presentation 레이어에서 직접 처리하지 않고 UseCase로 단일화.
+- 인증 관련 의존성을 protocol/service 단위로 분리해 테스트 가능성과 교체 가능성을 높임.
+
+## 변경 사항
+1. 인증 도메인 타입/계약 추가
+- `AuthRequest`
+- `AuthUseCaseOutcome`
+- `AuthenticatedUserIdentity`
+
+2. 인증 레이어 분리
+- `AuthSessionStoreProtocol` / `DefaultAuthSessionStore`
+- `AuthRepositoryProtocol` / `DefaultAuthRepository`
+- `AuthUseCaseProtocol` / `DefaultAuthUseCase`
+
+3. SignIn 화면 구조 변경
+- `SignInView`가 `AuthUseCaseProtocol`에만 의존하도록 전환.
+- Apple 로그인과 Email 로그인/회원가입이 동일한 유즈케이스 결과(`AuthUseCaseOutcome`)를 사용.
+- 결과 처리 분기를 `applyAuthOutcome` 단일 함수로 통합.
+
+4. 인프라 어댑터 유지
+- `DeviceAppleCredentialAuthService`는 `AppleCredentialAuthServiceProtocol` 구현체로 유지.
+- Email 로그인/회원가입은 Supabase Auth REST를 통해 처리.
+
+## 파일
+- `dogArea/Source/ProfileRepository.swift`
+- `dogArea/Views/SigningView/SignInView.swift`
+
+## 검증
+- `bash scripts/ios_pr_check.sh`
+  - 문서/정적 유닛 체크: PASS
+  - iOS build: PASS
+  - watchOS build: PASS
+
+## 남은 작업
+- Apple OAuth 완전 연동(client id/secret 포함) 시 `signInWithApple` 최소검증 로직을 Supabase OAuth 교환 플로우로 교체.
+- Auth 레이어를 `Source/Auth/*`로 파일 분리(현재는 전환 속도 우선으로 `ProfileRepository.swift`에 공존).

--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -31,6 +31,7 @@ enum HTTPMethod: String {
 enum SupabaseEndpoint {
     case function(name: String)
     case rest(path: String, query: String? = nil)
+    case auth(path: String, query: String? = nil)
 
     func resolveURL(baseURL: URL) -> URL {
         switch self {
@@ -51,6 +52,20 @@ enum SupabaseEndpoint {
             return components?.url
                 ?? baseURL
                     .appendingPathComponent("rest", isDirectory: true)
+                    .appendingPathComponent("v1", isDirectory: true)
+                    .appendingPathComponent(path, isDirectory: false)
+        case .auth(let path, let query):
+            var components = URLComponents(
+                url: baseURL
+                    .appendingPathComponent("auth", isDirectory: true)
+                    .appendingPathComponent("v1", isDirectory: true)
+                    .appendingPathComponent(path, isDirectory: false),
+                resolvingAgainstBaseURL: false
+            )
+            components?.percentEncodedQuery = query
+            return components?.url
+                ?? baseURL
+                    .appendingPathComponent("auth", isDirectory: true)
                     .appendingPathComponent("v1", isDirectory: true)
                     .appendingPathComponent(path, isDirectory: false)
         }
@@ -681,7 +696,7 @@ final class SupabaseAreaReferenceRepository: AreaReferenceRepository, AreaRefere
             let referencesData = try await client.request(
                 .rest(
                     path: "area_references",
-                    query: "select=id,catalog_id,reference_name,area_m2,is_featured,display_order,is_active&is_active=eq.true&order=display_order.asc,area_m2.desc"
+                    query: "select=id,catalog_id,reference_name,area_m2,is_featured,display_order,is_active&is_active=eq.true&order=display_order.asc,area_m2.asc"
                 ),
                 method: .get,
                 body: Optional<String>.none
@@ -724,13 +739,13 @@ final class SupabaseAreaReferenceRepository: AreaReferenceRepository, AreaRefere
                 let sectionItems = items
                     .filter { $0.catalogId == catalog.id }
                     .sorted { lhs, rhs in
-                        if lhs.isFeatured == rhs.isFeatured {
-                            if lhs.displayOrder == rhs.displayOrder {
-                                return lhs.areaM2 > rhs.areaM2
+                        if lhs.displayOrder == rhs.displayOrder {
+                            if lhs.areaM2 == rhs.areaM2 {
+                                return lhs.referenceName < rhs.referenceName
                             }
-                            return lhs.displayOrder < rhs.displayOrder
+                            return lhs.areaM2 < rhs.areaM2
                         }
-                        return lhs.isFeatured && !rhs.isFeatured
+                        return lhs.displayOrder < rhs.displayOrder
                     }
                 return AreaReferenceSection(
                     id: catalog.id,
@@ -744,12 +759,12 @@ final class SupabaseAreaReferenceRepository: AreaReferenceRepository, AreaRefere
 
         let allAreas = items
             .map { AreaMeter($0.referenceName, $0.areaM2) }
-            .sorted { $0.area > $1.area }
+            .sorted { $0.area < $1.area }
 
         let featuredAreas = items
             .filter(\.isFeatured)
             .map { AreaMeter($0.referenceName, $0.areaM2) }
-            .sorted { $0.area > $1.area }
+            .sorted { $0.area < $1.area }
 
         return AreaReferenceSnapshot(
             source: .remote,
@@ -767,7 +782,7 @@ final class SupabaseAreaReferenceRepository: AreaReferenceRepository, AreaRefere
                 catalogId: "legacy",
                 referenceName: area.areaName,
                 areaM2: area.area,
-                isFeatured: index < 10,
+                isFeatured: index >= max(legacy.count - 10, 0),
                 displayOrder: index
             )
         }
@@ -775,7 +790,7 @@ final class SupabaseAreaReferenceRepository: AreaReferenceRepository, AreaRefere
         return AreaReferenceSnapshot(
             source: .fallback,
             allAreas: legacy,
-            featuredAreas: Array(legacy.prefix(10)),
+            featuredAreas: Array(legacy.suffix(10)),
             sections: [
                 AreaReferenceSection(
                     id: "legacy",
@@ -813,13 +828,122 @@ enum SupabaseAssetError: LocalizedError {
     }
 }
 
+enum SupabaseAuthError: LocalizedError {
+    case notConfigured
+    case invalidCredentials
+    case userAlreadyExists
+    case responseDecodeFailed
+    case requestFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Supabase 설정이 누락되어 로그인할 수 없습니다."
+        case .invalidCredentials:
+            return "이메일 또는 비밀번호가 올바르지 않습니다."
+        case .userAlreadyExists:
+            return "이미 가입된 이메일입니다. 로그인을 시도해주세요."
+        case .responseDecodeFailed:
+            return "인증 응답을 해석하지 못했습니다."
+        case .requestFailed(let message):
+            return message
+        }
+    }
+}
+
 final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol {
     static let shared = DeviceAppleCredentialAuthService()
 
+    private struct AuthUserDTO: Decodable {
+        let id: String?
+        let email: String?
+    }
+
+    private struct AuthResponseDTO: Decodable {
+        let user: AuthUserDTO?
+        let id: String?
+        let email: String?
+        let message: String?
+        let error: String?
+        let errorDescription: String?
+
+        enum CodingKeys: String, CodingKey {
+            case user
+            case id
+            case email
+            case message
+            case error
+            case errorDescription = "error_description"
+        }
+    }
+
+    /// Apple 로그인 토큰의 최소 유효성(빈 값 여부)을 확인합니다.
     func signInWithApple(identityToken: String) async throws {
         if identityToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             throw SupabaseAssetError.serverError("Apple identity token is missing.")
         }
+    }
+
+    /// Supabase Auth `token?grant_type=password` 엔드포인트로 이메일 로그인을 수행합니다.
+    func signInWithEmail(email: String, password: String) async throws -> AuthenticatedUserIdentity {
+        let payload = [
+            "email": email,
+            "password": password
+        ]
+        return try await requestAuthIdentity(path: "token", query: "grant_type=password", payload: payload)
+    }
+
+    /// Supabase Auth `signup` 엔드포인트로 이메일 회원가입을 수행합니다.
+    func signUpWithEmail(email: String, password: String) async throws -> AuthenticatedUserIdentity {
+        let payload = [
+            "email": email,
+            "password": password
+        ]
+        return try await requestAuthIdentity(path: "signup", query: nil, payload: payload)
+    }
+
+    /// 공통 Auth 요청을 수행하고 응답에서 사용자 식별 정보를 추출합니다.
+    private func requestAuthIdentity(
+        path: String,
+        query: String?,
+        payload: [String: String]
+    ) async throws -> AuthenticatedUserIdentity {
+        guard let config = SupabaseRuntimeConfig.load() else {
+            throw SupabaseAuthError.notConfigured
+        }
+
+        let endpoint = SupabaseEndpoint.auth(path: path, query: query)
+        let url = endpoint.resolveURL(baseURL: config.baseURL)
+        var request = URLRequest(url: url)
+        request.httpMethod = HTTPMethod.post.rawValue
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(config.anonKey, forHTTPHeaderField: "apikey")
+        request.setValue("Bearer \(config.anonKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+            throw SupabaseAuthError.responseDecodeFailed
+        }
+
+        let decoded = try? JSONDecoder().decode(AuthResponseDTO.self, from: data)
+        guard (200..<300).contains(statusCode) else {
+            if statusCode == 400 || statusCode == 401 {
+                throw SupabaseAuthError.invalidCredentials
+            }
+            let description = decoded?.errorDescription ?? decoded?.message ?? decoded?.error ?? "인증에 실패했습니다. (\(statusCode))"
+            if description.localizedCaseInsensitiveContains("already") {
+                throw SupabaseAuthError.userAlreadyExists
+            }
+            throw SupabaseAuthError.requestFailed(description)
+        }
+
+        let userId = decoded?.user?.id ?? decoded?.id
+        let userEmail = decoded?.user?.email ?? decoded?.email ?? payload["email"]
+        guard let userId, userId.isEmpty == false else {
+            throw SupabaseAuthError.responseDecodeFailed
+        }
+        return AuthenticatedUserIdentity(userId: userId, email: userEmail)
     }
 }
 

--- a/dogArea/Source/ProfileRepository.swift
+++ b/dogArea/Source/ProfileRepository.swift
@@ -1,7 +1,145 @@
 import Foundation
 
+/// Supabase 인증을 통해 확정된 사용자 식별 정보입니다.
+struct AuthenticatedUserIdentity: Equatable {
+    let userId: String
+    let email: String?
+}
+
+/// 로그인 입력의 채널/의도를 표현합니다.
+enum AuthRequest: Equatable {
+    case apple(identityToken: String, appleUserId: String, nameHint: String?)
+    case emailSignIn(email: String, password: String)
+    case emailSignUp(email: String, password: String)
+}
+
+/// 인증 수행 후 화면 전환 결정을 담는 결과입니다.
+struct AuthUseCaseOutcome: Equatable {
+    let identity: AuthenticatedUserIdentity
+    let displayNameHint: String?
+    let requiresOnboarding: Bool
+}
+
+protocol AuthSessionStoreProtocol {
+    /// 현재 인증된 사용자 식별 정보를 로컬에 저장합니다.
+    func persist(_ identity: AuthenticatedUserIdentity)
+    /// 로컬에 저장된 사용자 식별 정보를 조회합니다.
+    func currentIdentity() -> AuthenticatedUserIdentity?
+    /// 로컬 인증 식별 정보를 제거합니다.
+    func clear()
+}
+
+final class DefaultAuthSessionStore: AuthSessionStoreProtocol {
+    static let shared = DefaultAuthSessionStore()
+
+    private enum Key {
+        static let userId = "auth.session.user_id.v1"
+        static let email = "auth.session.email.v1"
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// 현재 인증된 사용자 식별 정보를 로컬에 저장합니다.
+    func persist(_ identity: AuthenticatedUserIdentity) {
+        defaults.set(identity.userId, forKey: Key.userId)
+        defaults.set(identity.email, forKey: Key.email)
+    }
+
+    /// 로컬에 저장된 사용자 식별 정보를 조회합니다.
+    func currentIdentity() -> AuthenticatedUserIdentity? {
+        guard let userId = defaults.string(forKey: Key.userId), userId.isEmpty == false else {
+            return nil
+        }
+        return AuthenticatedUserIdentity(
+            userId: userId,
+            email: defaults.string(forKey: Key.email)
+        )
+    }
+
+    /// 로컬 인증 식별 정보를 제거합니다.
+    func clear() {
+        defaults.removeObject(forKey: Key.userId)
+        defaults.removeObject(forKey: Key.email)
+    }
+}
+
+protocol AuthRepositoryProtocol {
+    /// 입력된 인증 요청을 실제 인증 서비스로 위임하고 식별 정보를 반환합니다.
+    func authenticate(_ request: AuthRequest) async throws -> (identity: AuthenticatedUserIdentity, displayNameHint: String?)
+}
+
+final class DefaultAuthRepository: AuthRepositoryProtocol {
+    private let credentialService: AppleCredentialAuthServiceProtocol
+
+    init(credentialService: AppleCredentialAuthServiceProtocol = DeviceAppleCredentialAuthService.shared) {
+        self.credentialService = credentialService
+    }
+
+    /// 입력된 인증 요청을 실제 인증 서비스로 위임하고 식별 정보를 반환합니다.
+    func authenticate(_ request: AuthRequest) async throws -> (identity: AuthenticatedUserIdentity, displayNameHint: String?) {
+        switch request {
+        case let .apple(identityToken, appleUserId, nameHint):
+            try await credentialService.signInWithApple(identityToken: identityToken)
+            return (
+                AuthenticatedUserIdentity(userId: appleUserId, email: nil),
+                nameHint?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+            )
+        case let .emailSignIn(email, password):
+            let identity = try await credentialService.signInWithEmail(email: email, password: password)
+            return (identity, email.emailNameHint)
+        case let .emailSignUp(email, password):
+            let identity = try await credentialService.signUpWithEmail(email: email, password: password)
+            return (identity, email.emailNameHint)
+        }
+    }
+}
+
+protocol AuthUseCaseProtocol {
+    /// 인증 요청을 처리하고 기존 사용자/온보딩 필요 여부를 판정합니다.
+    func execute(_ request: AuthRequest) async throws -> AuthUseCaseOutcome
+}
+
+final class DefaultAuthUseCase: AuthUseCaseProtocol {
+    private let authRepository: AuthRepositoryProtocol
+    private let profileRepository: ProfileRepository
+    private let sessionStore: AuthSessionStoreProtocol
+
+    init(
+        authRepository: AuthRepositoryProtocol = DefaultAuthRepository(),
+        profileRepository: ProfileRepository = DefaultProfileRepository.shared,
+        sessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared
+    ) {
+        self.authRepository = authRepository
+        self.profileRepository = profileRepository
+        self.sessionStore = sessionStore
+    }
+
+    /// 인증 요청을 처리하고 기존 사용자/온보딩 필요 여부를 판정합니다.
+    func execute(_ request: AuthRequest) async throws -> AuthUseCaseOutcome {
+        let result = try await authRepository.authenticate(request)
+        sessionStore.persist(result.identity)
+
+        let localProfileId = profileRepository.fetchUserInfo()?.id
+        let requiresOnboarding = localProfileId != result.identity.userId
+        return AuthUseCaseOutcome(
+            identity: result.identity,
+            displayNameHint: result.displayNameHint,
+            requiresOnboarding: requiresOnboarding
+        )
+    }
+}
+
 protocol AppleCredentialAuthServiceProtocol {
+    /// Apple identity token 기반 로그인 검증을 수행합니다.
     func signInWithApple(identityToken: String) async throws
+    /// 이메일/비밀번호로 로그인하고 사용자 식별 정보를 반환합니다.
+    func signInWithEmail(email: String, password: String) async throws -> AuthenticatedUserIdentity
+    /// 이메일/비밀번호로 회원가입을 수행하고 사용자 식별 정보를 반환합니다.
+    func signUpWithEmail(email: String, password: String) async throws -> AuthenticatedUserIdentity
 }
 
 protocol ProfileImageRepository {
@@ -23,6 +161,18 @@ protocol ProfileRepository {
         selectedPetId: String?
     ) -> UserInfo?
     func setSelectedPetId(_ petId: String, source: String)
+}
+
+private extension String {
+    /// 이메일 앞부분을 사용자 이름 힌트로 변환합니다.
+    var emailNameHint: String? {
+        split(separator: "@").first.map(String.init)?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    /// 공백 제거 후 빈 문자열이면 `nil`로 변환합니다.
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
 }
 
 final class DefaultProfileRepository: ProfileRepository {

--- a/dogArea/Views/SigningView/SignInView.swift
+++ b/dogArea/Views/SigningView/SignInView.swift
@@ -8,41 +8,114 @@
 import Foundation
 import AuthenticationServices
 import SwiftUI
+
 struct SignInView: View {
     @Environment(\.colorScheme) var scheme
-    @State var userId: AppleUserInfo? = nil
-    @State var path = NavigationPath()
+
+    @State private var userId: AuthUserInfo? = nil
+    @State private var path = NavigationPath()
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var emailAuthLoading: Bool = false
+    @State private var authErrorMessage: String? = nil
+
     let allowDismiss: Bool
     let onAuthenticated: () -> Void
     let onDismiss: () -> Void
-    private let authService: AppleCredentialAuthServiceProtocol
-    private let profileRepository: ProfileRepository
+    private let authUseCase: AuthUseCaseProtocol
 
     init(
         allowDismiss: Bool = false,
         onAuthenticated: @escaping () -> Void = {},
         onDismiss: @escaping () -> Void = {},
         authService: AppleCredentialAuthServiceProtocol = DeviceAppleCredentialAuthService.shared,
-        profileRepository: ProfileRepository = DefaultProfileRepository.shared
+        profileRepository: ProfileRepository = DefaultProfileRepository.shared,
+        authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
+        authUseCase: AuthUseCaseProtocol? = nil
     ) {
         self.allowDismiss = allowDismiss
         self.onAuthenticated = onAuthenticated
         self.onDismiss = onDismiss
-        self.authService = authService
-        self.profileRepository = profileRepository
+        self.authUseCase = authUseCase ?? DefaultAuthUseCase(
+            authRepository: DefaultAuthRepository(credentialService: authService),
+            profileRepository: profileRepository,
+            sessionStore: authSessionStore
+        )
     }
 
     var body: some View {
         NavigationStack(path: $path) {
-            VStack {
+            VStack(spacing: 14) {
                 TitleTextView(title: "로그인/회원가입", subTitle: "계정 정보가 필요해요!")
-                Spacer()
+
                 AppleSigninButton(
-                    userId: $userId,
-                    onAuthenticated: onAuthenticated,
-                    authService: authService,
-                    profileRepository: profileRepository
+                    authUseCase: authUseCase,
+                    onOutcome: applyAuthOutcome,
+                    onError: { authErrorMessage = $0 }
                 )
+
+                HStack {
+                    Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
+                    Text("또는 이메일")
+                        .font(.appFont(for: .Light, size: 12))
+                        .foregroundStyle(Color.appTextDarkGray)
+                    Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
+                }
+                .padding(.horizontal, 20)
+
+                VStack(spacing: 8) {
+                    TextField("이메일", text: $email)
+                        .keyboardType(.emailAddress)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(Color.white)
+                        .cornerRadius(10)
+
+                    SecureField("비밀번호", text: $password)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(Color.white)
+                        .cornerRadius(10)
+
+                    HStack(spacing: 10) {
+                        Button("이메일 로그인") {
+                            runEmailAuth(isSignup: false)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Color.appGreen)
+                        .foregroundStyle(Color.white)
+                        .cornerRadius(10)
+                        .disabled(emailAuthLoading)
+
+                        Button("이메일 회원가입") {
+                            runEmailAuth(isSignup: true)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Color.appYellow)
+                        .foregroundStyle(Color.appTextDarkGray)
+                        .cornerRadius(10)
+                        .disabled(emailAuthLoading)
+                    }
+                }
+                .padding(.horizontal, 20)
+
+                if emailAuthLoading {
+                    ProgressView("이메일 인증 처리 중...")
+                        .font(.appFont(for: .Regular, size: 12))
+                }
+
+                if let authErrorMessage, authErrorMessage.isEmpty == false {
+                    Text(authErrorMessage)
+                        .font(.appFont(for: .Regular, size: 12))
+                        .foregroundStyle(Color.appRed)
+                        .padding(.horizontal, 20)
+                }
+
+                Spacer()
             }
             .navigationDestination(item: $userId, destination: { info in
                 ProfileSettingsView(
@@ -64,15 +137,61 @@ struct SignInView: View {
             }
         }
     }
+
+    /// 이메일 로그인/회원가입 요청을 실행하고 결과에 따라 인증 플로우를 분기합니다.
+    private func runEmailAuth(isSignup: Bool) {
+        authErrorMessage = nil
+
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedPassword = password.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard normalizedEmail.isEmpty == false, normalizedPassword.isEmpty == false else {
+            authErrorMessage = "이메일과 비밀번호를 모두 입력해주세요."
+            return
+        }
+
+        emailAuthLoading = true
+        Task {
+            do {
+                let request: AuthRequest = isSignup
+                    ? .emailSignUp(email: normalizedEmail, password: normalizedPassword)
+                    : .emailSignIn(email: normalizedEmail, password: normalizedPassword)
+                let outcome = try await authUseCase.execute(request)
+
+                await MainActor.run {
+                    emailAuthLoading = false
+                    applyAuthOutcome(outcome)
+                }
+            } catch {
+                await MainActor.run {
+                    emailAuthLoading = false
+                    authErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    /// 유즈케이스 결과에 따라 앱 진입 또는 프로필 온보딩 화면으로 분기합니다.
+    private func applyAuthOutcome(_ outcome: AuthUseCaseOutcome) {
+        if outcome.requiresOnboarding == false {
+            onAuthenticated()
+            return
+        }
+        userId = .init(
+            createdAt: Date().timeIntervalSince1970,
+            id: outcome.identity.userId,
+            name: outcome.displayNameHint
+        )
+    }
 }
-struct AppleSigninButton : View{
-    @Binding var userId: AppleUserInfo?
-    let onAuthenticated: () -> Void
-    let authService: AppleCredentialAuthServiceProtocol
-    let profileRepository: ProfileRepository
+
+struct AppleSigninButton: View {
+    let authUseCase: AuthUseCaseProtocol
+    let onOutcome: (AuthUseCaseOutcome) -> Void
+    let onError: (String) -> Void
     @State private var isAuthenticating: Bool = false
 
-    var body: some View{
+    var body: some View {
         VStack(spacing: 8) {
             SignInWithAppleButton(
                 onRequest: { request in
@@ -82,70 +201,64 @@ struct AppleSigninButton : View{
                     switch result {
                     case .success(let authResults):
                         isAuthenticating = true
-                        switch authResults.credential{
+                        switch authResults.credential {
                         case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                            let userInfo = profileRepository.fetchUserInfo()
-                            let userIdentifier = appleIDCredential.user
                             let fullName = appleIDCredential.fullName
-                            let name =  (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
-                            if userInfo?.id == userIdentifier {
+                            let name = (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
+                            guard let identityTokenData = appleIDCredential.identityToken,
+                                  let identityToken = String(data: identityTokenData, encoding: .utf8) else {
                                 isAuthenticating = false
-                                onAuthenticated()
-                            } else {
-                                guard let identityTokenData = appleIDCredential.identityToken,
-                                      let identityToken = String(data: identityTokenData, encoding: .utf8) else {
-                                    isAuthenticating = false
-                                    print("identity token missing")
-                                    return
-                                }
-                                if appleIDCredential.authorizationCode == nil {
-                                    print("authorization code missing")
-                                }
-                                Task {
-                                    do {
-                                        try await authService.signInWithApple(identityToken: identityToken)
-                                        await MainActor.run {
-                                            isAuthenticating = false
-                                            userId = .init(
-                                                createdAt: Date().timeIntervalSince1970,
-                                                id: appleIDCredential.user,
-                                                name: name
-                                            )
-                                        }
-                                    } catch {
-                                        await MainActor.run {
-                                            isAuthenticating = false
-                                            print(error.localizedDescription)
-                                        }
+                                onError("Apple identity token이 없습니다.")
+                                return
+                            }
+                            Task {
+                                do {
+                                    let outcome = try await authUseCase.execute(
+                                        .apple(
+                                            identityToken: identityToken,
+                                            appleUserId: appleIDCredential.user,
+                                            nameHint: name.isEmpty ? nil : name
+                                        )
+                                    )
+                                    await MainActor.run {
+                                        isAuthenticating = false
+                                        onOutcome(outcome)
+                                    }
+                                } catch {
+                                    await MainActor.run {
+                                        isAuthenticating = false
+                                        onError(error.localizedDescription)
                                     }
                                 }
                             }
-                            
+
                         default:
                             isAuthenticating = false
                             break
                         }
                     case .failure(let error):
                         isAuthenticating = false
-                        print(error.localizedDescription)
+                        onError(error.localizedDescription)
                     }
                 }
             )
-            .frame(width : UIScreen.main.bounds.width * 0.9, height:50)
+            .frame(width: UIScreen.main.bounds.width * 0.9, height: 50)
             .cornerRadius(5)
 
             if isAuthenticating {
-                ProgressView("로그인 처리 중...")
+                ProgressView("Apple 로그인 처리 중...")
                     .font(.appFont(for: .Regular, size: 12))
             }
         }
 
     }
 }
-#Preview{
+
+#Preview {
     SignInView()
 }
-struct AppleUserInfo: Identifiable, Hashable, TimeCheckable {
+
+struct AuthUserInfo: Identifiable, Hashable, TimeCheckable {
     var createdAt: TimeInterval
     let id: String
     let name: String?


### PR DESCRIPTION
## Summary
- add auth clean-architecture contracts (AuthRepositoryProtocol, AuthUseCaseProtocol, AuthSessionStoreProtocol)
- route SignIn Apple/Email auth through a single AuthUseCase outcome path
- add Supabase auth endpoint support and email sign-in/sign-up adapter methods
- document cycle result in docs/cycle-157-auth-clean-architecture-email-flow-report-2026-03-01.md

## Validation
- bash scripts/ios_pr_check.sh
  - unit/doc checks pass
  - iOS build succeeded
  - watchOS build succeeded

## Notes
- Apple OAuth token exchange is still planned follow-up (client id/secret provisioning required).
