### PR TITLE
chore: temporarily disable apple sign in and keep email auth only

### DIFF
--- a/docs/cycle-158-temp-disable-apple-login-email-only-2026-03-01.md
+++ b/docs/cycle-158-temp-disable-apple-login-email-only-2026-03-01.md
@@ -1,0 +1,33 @@
+# Cycle 158 - Apple 로그인 임시 비활성화 (Email only) (2026-03-01)
+
+## 목적
+- Apple Developer signing 준비 전까지 인증 진입을 이메일 로그인/회원가입으로 단순화.
+- Sign in with Apple entitlement로 인한 서명 충돌 가능성을 제거.
+
+## 변경 사항
+1. SignIn 화면 정책 변경
+- `SignInView`에 `isAppleSignInTemporarilyDisabled` 플래그 추가 (기본값 `true`).
+- 기본 UX는 이메일 로그인/회원가입만 노출.
+- Apple 로그인은 준비 중 안내 문구로 대체.
+
+2. 타입 정합성 수정
+- `SigningViewModel`의 입력 타입을 `AppleUserInfo` -> `AuthUserInfo`로 교체.
+
+3. Entitlement 정리
+- Debug/Release entitlements에서 `com.apple.developer.applesignin` 제거.
+
+## 파일
+- `dogArea/Views/SigningView/SignInView.swift`
+- `dogArea/Views/SigningView/SigningViewModel.swift`
+- `dogArea/dogAreaDebug.entitlements`
+- `dogArea/dogAreaRelease.entitlements`
+
+## 검증
+- `bash scripts/ios_pr_check.sh` 실행
+  - 문서/정적 유닛 체크: PASS
+  - iOS 빌드: PASS
+  - watchOS 빌드: PASS
+
+## 롤백 방법
+- `SignInView` 생성 시 `isAppleSignInTemporarilyDisabled: false`로 주입.
+- entitlements에 `com.apple.developer.applesignin` 키 재추가.

--- a/dogArea/Views/SigningView/SignInView.swift
+++ b/dogArea/Views/SigningView/SignInView.swift
@@ -12,6 +12,9 @@ import SwiftUI
 struct SignInView: View {
     @Environment(\.colorScheme) var scheme
 
+    /// Apple Developer 서명 준비 전까지 Apple 로그인 노출을 차단합니다.
+    private let isAppleSignInTemporarilyDisabled: Bool
+
     @State private var userId: AuthUserInfo? = nil
     @State private var path = NavigationPath()
     @State private var email: String = ""
@@ -31,11 +34,13 @@ struct SignInView: View {
         authService: AppleCredentialAuthServiceProtocol = DeviceAppleCredentialAuthService.shared,
         profileRepository: ProfileRepository = DefaultProfileRepository.shared,
         authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
+        isAppleSignInTemporarilyDisabled: Bool = true,
         authUseCase: AuthUseCaseProtocol? = nil
     ) {
         self.allowDismiss = allowDismiss
         self.onAuthenticated = onAuthenticated
         self.onDismiss = onDismiss
+        self.isAppleSignInTemporarilyDisabled = isAppleSignInTemporarilyDisabled
         self.authUseCase = authUseCase ?? DefaultAuthUseCase(
             authRepository: DefaultAuthRepository(credentialService: authService),
             profileRepository: profileRepository,
@@ -48,20 +53,27 @@ struct SignInView: View {
             VStack(spacing: 14) {
                 TitleTextView(title: "로그인/회원가입", subTitle: "계정 정보가 필요해요!")
 
-                AppleSigninButton(
-                    authUseCase: authUseCase,
-                    onOutcome: applyAuthOutcome,
-                    onError: { authErrorMessage = $0 }
-                )
+                if isAppleSignInTemporarilyDisabled == false {
+                    AppleSigninButton(
+                        authUseCase: authUseCase,
+                        onOutcome: applyAuthOutcome,
+                        onError: { authErrorMessage = $0 }
+                    )
 
-                HStack {
-                    Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
-                    Text("또는 이메일")
-                        .font(.appFont(for: .Light, size: 12))
+                    HStack {
+                        Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
+                        Text("또는 이메일")
+                            .font(.appFont(for: .Light, size: 12))
+                            .foregroundStyle(Color.appTextDarkGray)
+                        Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
+                    }
+                    .padding(.horizontal, 20)
+                } else {
+                    Text("Apple 로그인은 준비 중입니다. 현재 이메일 로그인/회원가입만 사용할 수 있어요.")
+                        .font(.appFont(for: .Regular, size: 12))
                         .foregroundStyle(Color.appTextDarkGray)
-                    Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
+                        .padding(.horizontal, 20)
                 }
-                .padding(.horizontal, 20)
 
                 VStack(spacing: 8) {
                     TextField("이메일", text: $email)

--- a/dogArea/Views/SigningView/SigningViewModel.swift
+++ b/dogArea/Views/SigningView/SigningViewModel.swift
@@ -18,7 +18,7 @@ class SigningViewModel: ObservableObject {
     @Published var petGender: PetGender = .unknown
     @Published var userProfile: UIImage? = nil
     @Published var petProfile: UIImage? = nil
-    var appleInfo: AppleUserInfo
+    var appleInfo: AuthUserInfo
     private var userId:String = ""
     private var petURL: String? = nil
     private var profileURL: String? = nil
@@ -28,7 +28,7 @@ class SigningViewModel: ObservableObject {
     private let featureFlags = FeatureFlagStore.shared
     private let metricTracker = AppMetricTracker.shared
     init(
-        info: AppleUserInfo,
+        info: AuthUserInfo,
         profileRepository: ProfileRepository = DefaultProfileRepository.shared,
         imageRepository: ProfileImageRepository = SupabaseProfileImageRepository.shared
     ) {

--- a/dogArea/dogAreaDebug.entitlements
+++ b/dogArea/dogAreaDebug.entitlements
@@ -2,9 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
 </dict>
 </plist>

--- a/dogArea/dogAreaRelease.entitlements
+++ b/dogArea/dogAreaRelease.entitlements
@@ -2,9 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- temporarily hide Apple sign-in in `SignInView` and keep email login/signup as default path
- replace stale `AppleUserInfo` type usage in `SigningViewModel` with `AuthUserInfo`
- remove `com.apple.developer.applesignin` entitlement from Debug/Release until signing is ready
- add cycle report documentation

## Validation
- bash scripts/ios_pr_check.sh
  - unit/doc checks pass
  - iOS build succeeded
  - watchOS build succeeded
