### PR TITLE
refactor: sort area goals ascending and move caricature flow to profile

### DIFF
--- a/docs/area-goal-ascending-order-v1.md
+++ b/docs/area-goal-ascending-order-v1.md
@@ -1,0 +1,18 @@
+# Area Goal Ascending Order v1
+
+## 목적
+- 비교군/다음 목표를 면적 오름차순으로 일관 표시해 목표 체감을 개선한다.
+
+## 정책
+1. 기준 정렬은 `area asc`.
+2. `nextGoal`은 `currentArea`보다 큰 값 중 최소값.
+3. `recentConquered`는 `currentArea`보다 작은 값 중 최대값.
+4. DB/로컬 fallback/뷰모델 계산 로직 모두 같은 방향(오름차순)으로 유지.
+
+## 영향 파일
+- `dogArea/Views/HomeView/AreaMeters.swift`
+- `dogArea/Views/HomeView/HomeViewModel.swift`
+
+## 수용 기준
+- 0 면적 근처에서 다음 목표가 저면적 비교군부터 안내된다.
+- 홈 목표 카드/상세 카탈로그 순서가 서로 모순되지 않는다.

--- a/docs/cycle-159-160-area-sort-and-caricature-profile-integration-2026-03-01.md
+++ b/docs/cycle-159-160-area-sort-and-caricature-profile-integration-2026-03-01.md
@@ -1,0 +1,49 @@
+# Cycle 159-160 - 비교군 오름차순 정렬 + 캐리커처 탭 제거/프로필 통합 (2026-03-01)
+
+## 이슈
+- #187 `[Task][Area] 비교군/다음목표 오름차순 정렬 일관화`
+- #186 `[Task][IA] 캐리커처 전용 탭 제거 + 프로필 편집 플로우 통합`
+
+## 문서 선작성
+- `docs/area-goal-ascending-order-v1.md`
+- `docs/profile-caricature-flow-v2.md`
+
+## 구현 요약
+1. 비교군 오름차순 일관화
+- `AreaMeterCollection`의 커스텀/폴백 데이터를 `area asc`로 통일.
+- 오름차순 기준에 맞게 인접 목표 계산 함수 보정:
+  - `nearistArea(of:)` -> `last(where: < myArea)`
+  - `closeArea(of:)` -> `first(where: > myArea)`
+- `HomeViewModel`에서:
+  - `featuredGoalAreas` 정렬을 오름차순으로 변경
+  - `findIndex`/`updateCurrentMeter` 오름차순 기준으로 보정
+  - `nearlistMore`에서 featured 후보와 일반 후보를 비교해 더 작은(가까운) 다음 목표를 선택
+
+2. 캐리커처 전용 탭 제거 + 프로필 편집 통합
+- 하단 탭 IA를 `홈/산책 목록/지도/설정` 4탭으로 변경.
+- `RootView`에서 이미지 탭 분기 제거.
+- `ProfileFieldEditSheet`에 "캐리커처 생성/재생성" 섹션 추가.
+- `SettingViewModel`에 `regenerateSelectedPetCaricature()` 추가:
+  - feature flag/회원 권한 검증
+  - 선택 반려견 이미지 유효성 검증
+  - processing/ready/failed 상태 반영
+  - 성공/실패 메시지 및 메트릭 기록
+
+## 변경 파일
+- `dogArea/Views/HomeView/AreaMeters.swift`
+- `dogArea/Views/HomeView/HomeViewModel.swift`
+- `dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift`
+- `dogArea/Views/GlobalViews/BaseView/RootView.swift`
+- `dogArea/Views/ProfileSettingView/SettingViewModel.swift`
+- `dogArea/Views/ProfileSettingView/NotificationCenterView.swift`
+
+## 검증
+- `swift scripts/area_reference_db_ui_unit_check.swift` PASS
+- `swift scripts/project_stability_unit_check.swift` PASS
+- `bash scripts/ios_pr_check.sh` PASS
+  - 문서/정적 유닛 체크 통과
+  - iOS build 성공
+  - watchOS build 성공
+
+## 후속 메모
+- `TextToImageView` 파일은 현재 탭 진입점만 제거된 상태이며, 필요 시 파일/뷰모델 정리 사이클에서 제거 가능.

--- a/docs/profile-caricature-flow-v2.md
+++ b/docs/profile-caricature-flow-v2.md
@@ -1,0 +1,23 @@
+# Profile Caricature Flow v2
+
+## 목적
+- 캐리커처 기능을 전용 탭에서 제거하고 프로필 생성/수정 컨텍스트로 통합한다.
+
+## IA 변경
+- 하단 탭: `홈 / 산책 목록 / 지도 / 설정`
+- 캐리커처 생성 진입: `설정 > 프로필 편집`
+
+## UX 정책
+1. 프로필 생성 시(회원가입) 반려견 이미지가 있으면 비동기 캐리커처 큐잉.
+2. 프로필 편집에서 선택 반려견 기준으로 "캐리커처 생성/재생성" 제공.
+3. 상태(`processing/ready/failed`)와 결과 메시지를 사용자에게 명시.
+
+## 영향 파일
+- `dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift`
+- `dogArea/Views/GlobalViews/BaseView/RootView.swift`
+- `dogArea/Views/ProfileSettingView/NotificationCenterView.swift`
+- `dogArea/Views/ProfileSettingView/SettingViewModel.swift`
+
+## 수용 기준
+- 앱 탭에서 이미지 전용 탭이 사라진다.
+- 프로필 편집에서 캐리커처 생성이 동작하고 상태가 반영된다.

--- a/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
+++ b/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
@@ -32,16 +32,10 @@ struct CustomTabBar: View {
       })
       .frame(maxWidth: .infinity)
       
-      // Ranking button
-      TabButtonView(selectedTab: $selectedTab,
-                    imageName: ("imageBtn","imageBtnGray"),
-                    tabId: 3,
-                    titleName: "이미지")
-      
       // Settings button
       TabButtonView(selectedTab: $selectedTab,
                     imageName: ("settingBtn","settingBtnGray"),
-                    tabId: 4,
+                    tabId: 3,
                     titleName: "설정")
       
     }.padding(.horizontal,30)

--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -19,13 +19,11 @@ struct RootView: View {
     private var homeView: HomeView
     private var walkListView: WalkListView    
     private var mapView: MapView
-    private var textToImageView: TextToImageView
     private var notificationCenterView: NotificationCenterView
     init() {
         self.homeView = HomeView()
         self.walkListView = WalkListView()
         self.mapView = MapView()
-        self.textToImageView = TextToImageView()
         self.notificationCenterView = NotificationCenterView()
     }
     var body: some View {
@@ -51,14 +49,8 @@ struct RootView: View {
             }
             else if self.selectedTab == 3 {
                 NavigationView {
-                    textToImageView.frame(maxWidth: .infinity,maxHeight: .infinity)
-                        .navigationBarHidden(selectedTab == 3)
-                }
-            }
-            else if self.selectedTab == 4 {
-                NavigationView {
                     notificationCenterView.frame(maxWidth: .infinity,maxHeight: .infinity)
-                        .navigationBarHidden(selectedTab == 4)
+                        .navigationBarHidden(selectedTab == 3)
                 }
             }
             if tabStatus.isTabAppear {

--- a/dogArea/Views/HomeView/AreaMeters.swift
+++ b/dogArea/Views/HomeView/AreaMeters.swift
@@ -35,7 +35,7 @@ struct AreaMeterCollection {
 
     var areas: [AreaMeter] {
       if let customAreas, customAreas.isEmpty == false {
-          return customAreas.sorted { $0.area > $1.area }
+          return customAreas.sorted { $0.area < $1.area }
       }
       var area: [AreaMeter] = [.init("강원특별자치도 홍천군" , 1820.58),
         .init("강원특별자치도 인제군",1646.19),
@@ -276,10 +276,12 @@ struct AreaMeterCollection {
                                .init("애버랜드", 0.99),
                                .init("바티칸 시국", 0.44),
                                .init("롯데월드", 0.11)]
-        return area.map{AreaMeter($0.areaName, $0.area * 1000000)}
+        return area
+            .map { AreaMeter($0.areaName, $0.area * 1000000) }
+            .sorted { $0.area < $1.area }
    }
     func nearistArea(of myarea: Double) -> AreaMeter? {
-        return areas.first{$0.area < myarea}
+        return areas.last { $0.area < myarea }
     }
     func nearistArea(since: AreaMeterDTO? = nil, from myarea: Double) -> [AreaMeter] {
         guard let since else {
@@ -288,7 +290,7 @@ struct AreaMeterCollection {
         return areas.filter { $0.area < myarea && $0.area > since.area }
     }
     func closeArea(of myarea: Double) -> AreaMeter? {
-        return areas.last{$0.area > myarea}
+        return areas.first { $0.area > myarea }
     }
 }
 
@@ -356,4 +358,3 @@ struct AreaReferenceSnapshot {
 protocol AreaReferenceRepository {
     func fetchSnapshot() async -> AreaReferenceSnapshot
 }
-

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -268,7 +268,7 @@ final class HomeViewModel: ObservableObject {
             guard Task.isCancelled == false else { return }
             await MainActor.run {
                 self.krAreas = AreaMeterCollection(areas: snapshot.allAreas)
-                self.featuredGoalAreas = snapshot.featuredAreas.sorted { $0.area > $1.area }
+                self.featuredGoalAreas = snapshot.featuredAreas.sorted { $0.area < $1.area }
                 self.featuredAreaCount = self.featuredGoalAreas.count
                 self.areaReferenceSections = snapshot.sections
                 self.areaReferenceSourceLabel = snapshot.source == .remote ? "DB 비교군" : "로컬 비교군 (Fallback)"
@@ -487,7 +487,7 @@ final class HomeViewModel: ObservableObject {
 
     private func findIndex() -> Int {
         guard let i = krAreas.areas.firstIndex(where: {
-            $0.area < myArea.area
+            $0.area > myArea.area
         }) else { return krAreas.areas.count }
         return i
     }
@@ -504,10 +504,12 @@ final class HomeViewModel: ObservableObject {
     }
 
     func nearlistMore() -> AreaMeter? {
-        if let featuredNext = featuredGoalAreas.last(where: { $0.area > myArea.area }) {
-            return featuredNext
+        let featuredNext = featuredGoalAreas.first(where: { $0.area > myArea.area })
+        let defaultNext = krAreas.closeArea(of: myArea.area)
+        if let featuredNext, let defaultNext {
+            return featuredNext.area <= defaultNext.area ? featuredNext : defaultNext
         }
-        return krAreas.closeArea(of: myArea.area)
+        return featuredNext ?? defaultNext
     }
 
     private func shouldUpdateMeter() -> Bool {
@@ -525,7 +527,7 @@ final class HomeViewModel: ObservableObject {
     private func updateCurrentMeter() {
         if shouldUpdateMeter() {
             let currents = krAreas.nearistArea(since: walkRepository.fetchAreas().last, from: myArea.area)
-            for c in currents.reversed() {
+            for c in currents {
                 if walkRepository.saveArea(.init(areaName: c.areaName, area: c.area, createdAt: Date().timeIntervalSince1970)) {
                 }
             }

--- a/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
+++ b/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
@@ -178,6 +178,7 @@ struct ProfileFieldEditSheet: View {
     @State private var ageYearsText: String
     @State private var gender: PetGender
     @State private var errorMessage: String? = nil
+    @State private var caricatureMessage: String? = nil
 
     init(viewModel: SettingViewModel, onSaved: @escaping (String) -> Void) {
         self.viewModel = viewModel
@@ -202,6 +203,28 @@ struct ProfileFieldEditSheet: View {
                         ForEach(PetGender.allCases, id: \.rawValue) { item in
                             Text(item.title).tag(item)
                         }
+                    }
+                }
+                Section("반려견 캐리커처") {
+                    Text("현재 상태: \(viewModel.selectedPet?.caricatureStatus?.rawValue ?? "none")")
+                        .font(.appFont(for: .Light, size: 11))
+                        .foregroundStyle(Color.appTextDarkGray)
+
+                    Button(viewModel.isCaricatureGenerating ? "생성 중..." : "캐리커처 생성/재생성") {
+                        caricatureMessage = nil
+                        Task {
+                            let message = await viewModel.regenerateSelectedPetCaricature()
+                            await MainActor.run {
+                                caricatureMessage = message
+                            }
+                        }
+                    }
+                    .disabled(viewModel.isCaricatureGenerating)
+
+                    if let caricatureMessage {
+                        Text(caricatureMessage)
+                            .font(.appFont(for: .Regular, size: 12))
+                            .foregroundStyle(Color.appTextDarkGray)
                     }
                 }
                 if let errorMessage {

--- a/dogArea/Views/ProfileSettingView/SettingViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/SettingViewModel.swift
@@ -37,8 +37,12 @@ final class SettingViewModel: ObservableObject {
     @Published var selectedPetId: String = ""
     @Published var selectedPet: PetInfo? = nil
     @Published var seasonProfileSummary: SeasonProfileSummary? = nil
+    @Published var isCaricatureGenerating: Bool = false
     private let profileRepository: ProfileRepository
     private let walkRepository: WalkRepositoryProtocol
+    private let featureFlags = FeatureFlagStore.shared
+    private let metricTracker = AppMetricTracker.shared
+    private let caricatureClient = CaricatureEdgeClient()
     private var cancellables: Set<AnyCancellable> = []
 
     var pets: [PetInfo] {
@@ -121,6 +125,67 @@ final class SettingViewModel: ObservableObject {
         }
         reloadUserInfo()
         return .success(())
+    }
+
+    /// 프로필 편집 화면에서 선택된 반려견의 캐리커처를 생성/재생성합니다.
+    @MainActor
+    func regenerateSelectedPetCaricature() async -> String {
+        guard featureFlags.isEnabled(.caricatureAsyncV1) else {
+            return "캐리커처 기능이 아직 비활성화되어 있어요."
+        }
+        guard AppFeatureGate.isAllowed(.aiGeneration, session: AppFeatureGate.currentSession()) else {
+            return "회원 전용 기능입니다. 로그인 후 다시 시도해주세요."
+        }
+        guard let currentUser = profileRepository.fetchUserInfo(),
+              let targetPet = profileRepository.selectedPet(from: currentUser) else {
+            return "반려견 정보를 찾을 수 없어 캐리커처를 생성할 수 없습니다."
+        }
+        guard let sourceImageURL = targetPet.petProfile ?? targetPet.caricatureURL,
+              sourceImageURL.isEmpty == false else {
+            return "선택된 반려견 사진이 없어 캐리커처를 생성할 수 없습니다."
+        }
+
+        isCaricatureGenerating = true
+        UserdefaultSetting.shared.updateFirstPetCaricature(status: .processing)
+        reloadUserInfo()
+        defer { isCaricatureGenerating = false }
+
+        do {
+            let response = try await caricatureClient.requestCaricature(
+                petId: targetPet.petId,
+                userId: currentUser.id,
+                sourceImageURL: sourceImageURL,
+                requestId: UUID().uuidString.lowercased()
+            )
+            guard let caricatureURL = response.caricatureURL,
+                  caricatureURL.isEmpty == false else {
+                throw CaricatureEdgeClient.RequestError.invalidResponse
+            }
+            UserdefaultSetting.shared.updateFirstPetCaricature(
+                status: .ready,
+                caricatureURL: caricatureURL,
+                provider: response.provider
+            )
+            reloadUserInfo()
+            metricTracker.track(
+                .caricatureSuccess,
+                userKey: currentUser.id,
+                featureKey: .caricatureAsyncV1,
+                payload: ["provider": response.provider ?? "unknown"]
+            )
+            return "캐리커처 생성이 완료되어 프로필에 반영됐어요."
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            UserdefaultSetting.shared.updateFirstPetCaricature(status: .failed)
+            reloadUserInfo()
+            metricTracker.track(
+                .caricatureFailed,
+                userKey: currentUser.id,
+                featureKey: .caricatureAsyncV1,
+                payload: ["error": message]
+            )
+            return "캐리커처 생성에 실패했습니다: \(message)"
+        }
     }
 
     private func normalizeOptionalText(_ value: String) -> String? {


### PR DESCRIPTION
## Summary
- unify area comparison/goal ordering to ascending area order in `AreaMeters` + `HomeViewModel`
- fix next-goal selection to avoid large-area jumps by choosing the closer candidate
- remove dedicated caricature tab from bottom navigation (4-tab IA)
- integrate caricature generation/regeneration action into profile edit flow
- add planning/result docs for both tasks

## Linked Issues
- closes #186
- closes #187

## Validation
- swift scripts/area_reference_db_ui_unit_check.swift
- swift scripts/project_stability_unit_check.swift
- bash scripts/ios_pr_check.sh (unit/doc checks + iOS build + watchOS build)

## Notes
- `TextToImageView` file remains in source but no longer has a tab entry point.
