### PR TITLE
feat: add rival tab stage1 skeleton and consent flow

### DIFF
--- a/docs/cycle-163-rival-tab-stage1-ui-2026-03-01.md
+++ b/docs/cycle-163-rival-tab-stage1-ui-2026-03-01.md
@@ -1,0 +1,39 @@
+# Cycle 163 - Rival Tab Stage 1 UI (2026-03-01)
+
+## 이슈
+- #192 `[Task][Rival][Stage 1 UI] 라이벌 탭 5탭 스켈레톤 + 동의/핫스팟 UX`
+- 상위 연계: #132
+
+## 구현 요약
+1. 5탭 IA 반영
+- `홈 / 산책 목록 / 지도 / 라이벌 / 설정` 구조로 루트 탭 분기 전환.
+- 기존 `설정`(NotificationCenterView)을 5번째 탭으로 이동.
+
+2. 라이벌 탭 스켈레톤 추가
+- 신규 `RivalTabView` + `RivalTabViewModel` 추가(기존 파일 내 확장).
+- 상태 배지, 프라이버시 카드, 핫스팟 카드, 리더보드 스켈레톤 카드 구성.
+
+3. 동의/권한/게스트 분기
+- 회원/게스트 분기: 게스트는 회원 전환 CTA 제공.
+- 위치 권한 분기: denied 상태에서 시스템 설정 이동 경로 제공.
+- 동의 시트: `동의하고 시작`으로 익명 공유 ON, `공유 중지`로 OFF.
+
+4. 핫스팟 조회/폴링
+- 공유 ON + 권한 허용 상태에서 핫스팟 조회.
+- 10초 간격 폴링, 수동 새로고침 CTA 제공.
+- 지도 이동 CTA(`지도에서 보기`)를 통해 중앙 지도 탭으로 전환.
+
+## 변경 파일
+1. `dogArea/Views/GlobalViews/BaseView/RootView.swift`
+2. `dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift`
+3. `dogArea/Views/ProfileSettingView/NotificationCenterView.swift`
+
+## 테스트
+1. 문서/유닛 체크
+- `DOGAREA_SKIP_BUILD=1 ./scripts/ios_pr_check.sh` 통과
+
+2. iOS 빌드
+- `xcodebuild -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build` 성공
+
+## 비고
+- 이번 사이클은 Stage 1 UI 범위이며, 신고/차단/리더보드 실데이터 연동은 상위 #132/#131 단계에서 이어서 구현.

--- a/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
+++ b/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
@@ -32,10 +32,18 @@ struct CustomTabBar: View {
       })
       .frame(maxWidth: .infinity)
       
+      // Rival button
+      SystemTabButtonView(
+        selectedTab: $selectedTab,
+        systemIconName: "person.2.fill",
+        tabId: 3,
+        titleName: "라이벌"
+      )
+
       // Settings button
       TabButtonView(selectedTab: $selectedTab,
                     imageName: ("settingBtn","settingBtnGray"),
-                    tabId: 3,
+                    tabId: 4,
                     titleName: "설정")
       
     }.padding(.horizontal,30)
@@ -95,5 +103,33 @@ struct TabButtonView: View {
       .onTapGesture {selectedTab=tabId}
       .labelStyle(TabStyle())
       .frame(maxWidth: .infinity)
+  }
+}
+
+struct SystemTabButtonView: View {
+  @Binding var selectedTab: Int
+  let systemIconName: String
+  let tabId: Int
+  let titleName: String
+
+  var body: some View {
+    Label(
+      title: {
+        Text(titleName)
+          .foregroundStyle(Color.black)
+      },
+      icon: {
+        Image(systemName: systemIconName)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 24, height: 24)
+          .foregroundStyle(selectedTab == tabId ? Color.appGreen : Color.appTextDarkGray)
+      }
+    )
+    .padding(.horizontal, 5)
+    .font(.regular12)
+    .onTapGesture { selectedTab = tabId }
+    .labelStyle(TabStyle())
+    .frame(maxWidth: .infinity)
   }
 }

--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -49,8 +49,18 @@ struct RootView: View {
             }
             else if self.selectedTab == 3 {
                 NavigationView {
-                    notificationCenterView.frame(maxWidth: .infinity,maxHeight: .infinity)
+                    RivalTabView(
+                        onOpenMap: { selectedTab = 2 },
+                        onOpenSettings: { selectedTab = 4 }
+                    )
+                        .frame(maxWidth: .infinity,maxHeight: .infinity)
                         .navigationBarHidden(selectedTab == 3)
+                }
+            }
+            else if self.selectedTab == 4 {
+                NavigationView {
+                    notificationCenterView.frame(maxWidth: .infinity,maxHeight: .infinity)
+                        .navigationBarHidden(selectedTab == 4)
                 }
             }
             if tabStatus.isTabAppear {

--- a/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
+++ b/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
@@ -7,6 +7,10 @@
 
 import SwiftUI
 import Kingfisher
+import CoreLocation
+#if canImport(UIKit)
+import UIKit
+#endif
 struct NotificationCenterView: View {
     @StateObject var viewModel = SettingViewModel()
     @EnvironmentObject var loading: LoadingViewModel
@@ -411,5 +415,659 @@ private struct SeasonProfileFrameStyle {
         case .none:
             return .init(stroke: Color.appTextDarkGray, fill: Color.appYellowPale)
         }
+    }
+}
+
+struct RivalTabView: View {
+    @EnvironmentObject private var authFlow: AuthFlowCoordinator
+    @StateObject private var viewModel = RivalTabViewModel()
+    @State private var isConsentSheetPresented: Bool = false
+
+    let onOpenMap: () -> Void
+    let onOpenSettings: () -> Void
+
+    init(
+        onOpenMap: @escaping () -> Void = {},
+        onOpenSettings: @escaping () -> Void = {}
+    ) {
+        self.onOpenMap = onOpenMap
+        self.onOpenSettings = onOpenSettings
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                TitleTextView(title: "라이벌", subTitle: "근처 산책 열기를 익명으로 확인해요")
+                statusBadgeRow
+                privacyCard
+                hotspotCard
+                leaderboardSkeletonCard
+                footerButtons
+            }
+            .padding(.bottom, 24)
+        }
+        .background(Color.appYellowPale.opacity(0.35))
+        .onAppear {
+            viewModel.start()
+        }
+        .onDisappear {
+            viewModel.stop()
+        }
+        .sheet(isPresented: $isConsentSheetPresented) {
+            consentSheet
+        }
+        .overlay(alignment: .top) {
+            if let message = viewModel.toastMessage {
+                SimpleMessageView(message: message)
+                    .padding(.top, 8)
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+                            viewModel.clearToast()
+                        }
+                    }
+            }
+        }
+    }
+
+    private var statusBadgeRow: some View {
+        HStack(spacing: 8) {
+            rivalBadge(
+                text: viewModel.sharingBadgeText,
+                color: viewModel.sharingBadgeColor
+            )
+            rivalBadge(
+                text: viewModel.permissionBadgeText,
+                color: viewModel.permissionBadgeColor
+            )
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private var privacyCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("익명 위치 공유")
+                .font(.appFont(for: .SemiBold, size: 20))
+            Text("닉네임/강아지명/정밀 좌표는 노출되지 않아요")
+                .font(.appFont(for: .Regular, size: 13))
+                .foregroundStyle(Color.appTextDarkGray)
+
+            if viewModel.screenState == .guestLocked {
+                Button("로그인하고 라이벌 시작") {
+                    _ = authFlow.requestAccess(feature: .nearbySocial)
+                }
+                .font(.appFont(for: .SemiBold, size: 13))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(Color.appYellow)
+                .cornerRadius(8)
+            } else if viewModel.locationSharingEnabled {
+                Button(viewModel.isWorking ? "처리 중..." : "공유 중지") {
+                    viewModel.disableSharing()
+                }
+                .disabled(viewModel.isWorking)
+                .font(.appFont(for: .SemiBold, size: 13))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(Color.appTextLightGray)
+                .cornerRadius(8)
+            } else {
+                Button("익명 공유 시작") {
+                    switch viewModel.permissionState {
+                    case .authorized:
+                        isConsentSheetPresented = true
+                    case .notDetermined:
+                        viewModel.requestLocationPermission()
+                    case .denied:
+                        viewModel.openSystemSettings()
+                    }
+                }
+                .font(.appFont(for: .SemiBold, size: 13))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(Color.appYellow)
+                .cornerRadius(8)
+            }
+        }
+        .padding(12)
+        .background(Color.white)
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.appTextDarkGray.opacity(0.25), lineWidth: 0.8)
+        )
+        .padding(.horizontal, 16)
+    }
+
+    private var hotspotCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("근처 익명 핫스팟")
+                .font(.appFont(for: .SemiBold, size: 20))
+
+            switch viewModel.screenState {
+            case .guestLocked:
+                Text("회원 가입 후 이용할 수 있어요")
+                    .font(.appFont(for: .Regular, size: 12))
+                    .foregroundStyle(Color.appTextDarkGray)
+            case .permissionRequired:
+                Text("근처 익명 핫스팟을 보려면 위치 권한이 필요해요")
+                    .font(.appFont(for: .Regular, size: 12))
+                    .foregroundStyle(Color.appTextDarkGray)
+                Button("설정 열기") {
+                    viewModel.openSystemSettings()
+                }
+                .font(.appFont(for: .SemiBold, size: 12))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color.appYellowPale)
+                .cornerRadius(8)
+            case .consentRequired:
+                Text("익명 공유 동의 후 핫스팟을 볼 수 있어요")
+                    .font(.appFont(for: .Regular, size: 12))
+                    .foregroundStyle(Color.appTextDarkGray)
+            case .loading:
+                ProgressView()
+            case .ready, .offlineCached:
+                Text("활성 핫스팟 \(viewModel.hotspots.count)개")
+                    .font(.appFont(for: .Regular, size: 12))
+                    .foregroundStyle(Color.appTextDarkGray)
+                Text("최고 강도: \(viewModel.maxIntensityText)")
+                    .font(.appFont(for: .Regular, size: 12))
+                    .foregroundStyle(Color.appTextDarkGray)
+                Text("마지막 업데이트: \(viewModel.lastUpdatedText)")
+                    .font(.appFont(for: .Light, size: 11))
+                    .foregroundStyle(Color.appTextDarkGray)
+                HStack(spacing: 8) {
+                    Button(viewModel.isWorking ? "새로고침 중..." : "새로고침") {
+                        viewModel.refreshHotspots(force: true)
+                    }
+                    .disabled(viewModel.isWorking)
+                    .font(.appFont(for: .SemiBold, size: 12))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.appYellowPale)
+                    .cornerRadius(8)
+
+                    Button("지도에서 보기") {
+                        onOpenMap()
+                    }
+                    .font(.appFont(for: .SemiBold, size: 12))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.appYellow)
+                    .cornerRadius(8)
+                }
+            case .offlineEmpty:
+                Text("네트워크 연결 후 다시 시도해주세요")
+                    .font(.appFont(for: .Regular, size: 12))
+                    .foregroundStyle(Color.appTextDarkGray)
+                Button("다시 시도") {
+                    viewModel.refreshHotspots(force: true)
+                }
+                .font(.appFont(for: .SemiBold, size: 12))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color.appYellowPale)
+                .cornerRadius(8)
+            case .errorRetryable:
+                Text("일시적으로 불안정해요. 잠시 후 다시 시도해주세요.")
+                    .font(.appFont(for: .Regular, size: 12))
+                    .foregroundStyle(Color.appTextDarkGray)
+                Button("다시 시도") {
+                    viewModel.refreshHotspots(force: true)
+                }
+                .font(.appFont(for: .SemiBold, size: 12))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color.appYellowPale)
+                .cornerRadius(8)
+            case .empty:
+                Text("근처 활성 핫스팟이 아직 없어요")
+                    .font(.appFont(for: .Regular, size: 12))
+                    .foregroundStyle(Color.appTextDarkGray)
+                Button("새로고침") {
+                    viewModel.refreshHotspots(force: true)
+                }
+                .font(.appFont(for: .SemiBold, size: 12))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color.appYellowPale)
+                .cornerRadius(8)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white)
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.appTextDarkGray.opacity(0.25), lineWidth: 0.8)
+        )
+        .padding(.horizontal, 16)
+    }
+
+    private var leaderboardSkeletonCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("주간 라이벌 요약")
+                    .font(.appFont(for: .SemiBold, size: 20))
+                Spacer()
+                Text("준비 중")
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.appTextLightGray.opacity(0.35))
+                    .cornerRadius(8)
+            }
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.appTextLightGray.opacity(0.3))
+                .frame(height: 14)
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.appTextLightGray.opacity(0.3))
+                .frame(height: 14)
+            Button("전체 보기") {
+                viewModel.showToast("리더보드는 다음 단계에서 열립니다.")
+            }
+            .font(.appFont(for: .SemiBold, size: 12))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Color.appYellowPale)
+            .cornerRadius(8)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white)
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.appTextDarkGray.opacity(0.25), lineWidth: 0.8)
+        )
+        .padding(.horizontal, 16)
+    }
+
+    private var footerButtons: some View {
+        Button("설정에서 상세 관리") {
+            onOpenSettings()
+        }
+        .font(.appFont(for: .SemiBold, size: 12))
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.appYellowPale)
+        .cornerRadius(8)
+    }
+
+    private var consentSheet: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("익명 위치 공유 동의")
+                .font(.appFont(for: .SemiBold, size: 22))
+            Text("닉네임/강아지명/정밀 좌표는 표시되지 않고, 10분 TTL 집계로만 사용돼요.")
+                .font(.appFont(for: .Regular, size: 13))
+                .foregroundStyle(Color.appTextDarkGray)
+            Text("언제든 라이벌 탭에서 공유를 끌 수 있어요.")
+                .font(.appFont(for: .Regular, size: 13))
+                .foregroundStyle(Color.appTextDarkGray)
+
+            HStack(spacing: 10) {
+                Button("취소") {
+                    isConsentSheetPresented = false
+                }
+                .font(.appFont(for: .SemiBold, size: 13))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color.appYellowPale)
+                .cornerRadius(8)
+
+                Button(viewModel.isWorking ? "처리 중..." : "동의하고 시작") {
+                    isConsentSheetPresented = false
+                    viewModel.enableSharingWithConsent()
+                }
+                .disabled(viewModel.isWorking)
+                .font(.appFont(for: .SemiBold, size: 13))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color.appYellow)
+                .cornerRadius(8)
+            }
+            Spacer()
+        }
+        .padding(16)
+        .presentationDetents([.medium])
+    }
+
+    private func rivalBadge(text: String, color: Color) -> some View {
+        Text(text)
+            .font(.appFont(for: .SemiBold, size: 11))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.25))
+            .cornerRadius(8)
+    }
+}
+
+@MainActor
+final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLocationManagerDelegate {
+    enum PermissionState {
+        case notDetermined
+        case authorized
+        case denied
+    }
+
+    enum ScreenState {
+        case guestLocked
+        case permissionRequired
+        case consentRequired
+        case loading
+        case ready
+        case empty
+        case offlineCached
+        case offlineEmpty
+        case errorRetryable
+    }
+
+    @Published private(set) var permissionState: PermissionState = .notDetermined
+    @Published private(set) var screenState: ScreenState = .guestLocked
+    @Published private(set) var locationSharingEnabled: Bool = false
+    @Published private(set) var hotspots: [NearbyHotspotDTO] = []
+    @Published private(set) var isWorking: Bool = false
+    @Published private(set) var lastUpdatedText: String = "-"
+    @Published private(set) var maxIntensityText: String = "없음"
+    @Published var toastMessage: String? = nil
+
+    private let nearbyService: NearbyPresenceServiceProtocol
+    private let preferenceStore: MapPreferenceStoreProtocol
+    private let locationManager: CLLocationManager
+    private let sessionProvider: () -> AppSessionState
+    private let locationSharingKey = "nearby.locationSharingEnabled"
+    private var pollingTimer: Timer? = nil
+    private var lastRefreshAt: Date = .distantPast
+
+    /// 라이벌 탭 상태를 제어하는 뷰모델을 초기화합니다.
+    init(
+        nearbyService: NearbyPresenceServiceProtocol = NearbyPresenceService(),
+        preferenceStore: MapPreferenceStoreProtocol = DefaultMapPreferenceStore.shared,
+        locationManager: CLLocationManager = CLLocationManager(),
+        sessionProvider: @escaping () -> AppSessionState = { AppFeatureGate.currentSession() }
+    ) {
+        self.nearbyService = nearbyService
+        self.preferenceStore = preferenceStore
+        self.locationManager = locationManager
+        self.sessionProvider = sessionProvider
+        super.init()
+    }
+
+    deinit {
+        pollingTimer?.invalidate()
+    }
+
+    /// 탭 진입 시 권한/공유 상태를 불러오고 폴링을 시작합니다.
+    func start() {
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        if CLLocationManager.locationServicesEnabled() {
+            locationManager.startUpdatingLocation()
+        }
+        locationSharingEnabled = preferenceStore.bool(forKey: locationSharingKey, default: false)
+        updatePermissionState()
+        refreshViewState()
+        startPollingIfNeeded()
+        refreshHotspots(force: true)
+    }
+
+    /// 탭 이탈 시 폴링/위치 업데이트를 중단합니다.
+    func stop() {
+        pollingTimer?.invalidate()
+        pollingTimer = nil
+        locationManager.stopUpdatingLocation()
+    }
+
+    /// 위치 권한 요청을 수행합니다.
+    func requestLocationPermission() {
+        locationManager.requestWhenInUseAuthorization()
+    }
+
+    /// 동의 시트 완료 후 익명 공유를 활성화합니다.
+    func enableSharingWithConsent() {
+        guard currentUserId != nil else {
+            showToast("회원 전용 기능입니다. 로그인 후 다시 시도해주세요.")
+            refreshViewState()
+            return
+        }
+
+        isWorking = true
+        Task {
+            defer { isWorking = false }
+            do {
+                try await nearbyService.setVisibility(userId: currentUserId ?? "", enabled: true)
+                preferenceStore.set(true, forKey: locationSharingKey)
+                locationSharingEnabled = true
+                showToast("익명 공유가 시작됐어요")
+                refreshViewState()
+                refreshHotspots(force: true)
+            } catch {
+                preferenceStore.set(false, forKey: locationSharingKey)
+                locationSharingEnabled = false
+                refreshViewState()
+                showToast("설정 반영 실패, 다시 시도해주세요")
+            }
+        }
+    }
+
+    /// 익명 공유를 비활성화하고 핫스팟을 초기화합니다.
+    func disableSharing() {
+        guard let userId = currentUserId else {
+            preferenceStore.set(false, forKey: locationSharingKey)
+            locationSharingEnabled = false
+            hotspots = []
+            refreshViewState()
+            return
+        }
+
+        isWorking = true
+        let previous = locationSharingEnabled
+        preferenceStore.set(false, forKey: locationSharingKey)
+        locationSharingEnabled = false
+        hotspots = []
+        refreshViewState()
+        showToast("익명 공유를 중지했어요")
+
+        Task {
+            defer { isWorking = false }
+            do {
+                try await nearbyService.setVisibility(userId: userId, enabled: false)
+            } catch {
+                preferenceStore.set(previous, forKey: locationSharingKey)
+                locationSharingEnabled = previous
+                refreshViewState()
+                showToast("설정 반영 실패, 다시 시도해주세요")
+            }
+        }
+    }
+
+    /// 핫스팟을 새로 조회하고 카드 상태를 갱신합니다.
+    func refreshHotspots(force: Bool = false) {
+        guard screenState != .guestLocked else { return }
+        guard permissionState == .authorized else {
+            refreshViewState()
+            return
+        }
+        guard locationSharingEnabled else {
+            refreshViewState()
+            return
+        }
+        guard let coordinate = locationManager.location?.coordinate else {
+            screenState = hotspots.isEmpty ? .empty : .ready
+            return
+        }
+
+        if force == false && Date().timeIntervalSince(lastRefreshAt) < 1.0 {
+            return
+        }
+
+        isWorking = true
+        if hotspots.isEmpty {
+            screenState = .loading
+        }
+        let userId = currentUserId
+        Task {
+            defer { isWorking = false }
+            do {
+                let fetched = try await nearbyService.getHotspots(
+                    userId: userId,
+                    centerLatitude: coordinate.latitude,
+                    centerLongitude: coordinate.longitude,
+                    radiusKm: 1.0
+                )
+                hotspots = fetched
+                lastRefreshAt = Date()
+                updateHotspotSummary()
+                if fetched.isEmpty {
+                    screenState = .empty
+                } else {
+                    screenState = .ready
+                }
+            } catch {
+                if isConnectivityError(error) {
+                    screenState = hotspots.isEmpty ? .offlineEmpty : .offlineCached
+                } else {
+                    screenState = .errorRetryable
+                }
+            }
+        }
+    }
+
+    /// 권한 안내 카드에서 시스템 설정 화면을 엽니다.
+    func openSystemSettings() {
+#if canImport(UIKit)
+        guard let url = URL(string: UIApplication.openSettingsURLString),
+              UIApplication.shared.canOpenURL(url) else {
+            return
+        }
+        UIApplication.shared.open(url)
+#endif
+    }
+
+    /// 짧은 사용자 피드백 메시지를 노출합니다.
+    func showToast(_ message: String) {
+        toastMessage = message
+    }
+
+    /// 노출 중인 토스트를 제거합니다.
+    func clearToast() {
+        toastMessage = nil
+    }
+
+    var sharingBadgeText: String {
+        locationSharingEnabled ? "공유 중" : "비공개"
+    }
+
+    var sharingBadgeColor: Color {
+        locationSharingEnabled ? Color.appGreen : Color.appTextLightGray
+    }
+
+    var permissionBadgeText: String {
+        permissionState == .authorized ? "위치 허용" : "권한 필요"
+    }
+
+    var permissionBadgeColor: Color {
+        permissionState == .authorized ? Color.appGreen : Color.appRed
+    }
+
+    private var currentUserId: String? {
+        guard case .member(let userId) = sessionProvider() else { return nil }
+        return userId
+    }
+
+    /// 권한 상태를 iOS 시스템 값에서 앱 상태로 변환합니다.
+    private func updatePermissionState() {
+        switch locationManager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            permissionState = .authorized
+        case .notDetermined:
+            permissionState = .notDetermined
+        case .denied, .restricted:
+            permissionState = .denied
+        @unknown default:
+            permissionState = .denied
+        }
+    }
+
+    /// 인증/권한/공유 상태를 바탕으로 라이벌 화면 상태를 결정합니다.
+    private func refreshViewState() {
+        guard currentUserId != nil else {
+            screenState = .guestLocked
+            return
+        }
+        guard permissionState == .authorized else {
+            screenState = .permissionRequired
+            return
+        }
+        guard locationSharingEnabled else {
+            screenState = .consentRequired
+            return
+        }
+        if hotspots.isEmpty {
+            screenState = .empty
+        } else {
+            screenState = .ready
+        }
+    }
+
+    /// 핫스팟 요약 텍스트를 계산해 카드에 표시합니다.
+    private func updateHotspotSummary() {
+        guard let maximum = hotspots.map(\.intensity).max() else {
+            maxIntensityText = "없음"
+            lastUpdatedText = "-"
+            return
+        }
+        if maximum >= 0.67 {
+            maxIntensityText = "높음"
+        } else if maximum >= 0.34 {
+            maxIntensityText = "보통"
+        } else {
+            maxIntensityText = "낮음"
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        lastUpdatedText = formatter.string(from: Date())
+    }
+
+    /// 주기 조회 타이머를 시작해 공유 중 상태에서 10초마다 핫스팟을 갱신합니다.
+    private func startPollingIfNeeded() {
+        pollingTimer?.invalidate()
+        pollingTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.refreshHotspots(force: false)
+            }
+        }
+    }
+
+    /// 네트워크 계열 오류 여부를 판별합니다.
+    private func isConnectivityError(_ error: Error) -> Bool {
+        if error is URLError {
+            return true
+        }
+        if let supabaseError = error as? SupabaseHTTPError {
+            switch supabaseError {
+            case .unexpectedStatusCode(let code):
+                return code == 429 || (500...599).contains(code)
+            default:
+                return false
+            }
+        }
+        return false
+    }
+
+    /// 위치 권한이 바뀌면 화면 상태를 즉시 재계산합니다.
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        updatePermissionState()
+        refreshViewState()
+        refreshHotspots(force: true)
+    }
+
+    /// 새 좌표를 받으면 공유 상태에서만 핫스팟을 즉시 갱신합니다.
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard locations.isEmpty == false,
+              locationSharingEnabled else { return }
+        refreshHotspots(force: false)
     }
 }


### PR DESCRIPTION
## Summary
- switch root IA to 5 tabs: `홈 / 산책 목록 / 지도 / 라이벌 / 설정`
- add Rival tab skeleton UI with privacy badge/state cards
- add consent sheet and location permission flow for anonymous sharing opt-in
- wire hotspot fetch + 10s polling + refresh/"지도에서 보기" actions
- add cycle documentation for this implementation

## Files
- dogArea/Views/GlobalViews/BaseView/RootView.swift
- dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
- dogArea/Views/ProfileSettingView/NotificationCenterView.swift
- docs/cycle-163-rival-tab-stage1-ui-2026-03-01.md

## Validation
- `DOGAREA_SKIP_BUILD=1 ./scripts/ios_pr_check.sh`
- `xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`

## Notes
- Scope is Stage 1 UI only. Report/block and full leaderboard UX remain in #132 follow-up.

Refs #192
