### PR TITLE
[Task][Quest][Stage 1] 코스 퀘스트 템플릿/난이도 정책 확정

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - 날씨 리스크 모델/Provider 정책 v1: `docs/weather-risk-provider-policy-v1.md`
 - 날씨 치환/스트릭 보호 서버 엔진 v1: `docs/weather-replacement-shield-engine-v1.md`
 - 날씨 연동 UX/fallback/접근성 v1: `docs/weather-ux-fallback-accessibility-v1.md`
+- 퀘스트 Stage1 템플릿/난이도 정책 v1: `docs/quest-stage1-template-difficulty-policy-v1.md`
 - 퀘스트 실패 완충(자동 연장 슬롯) v1: `docs/quest-failure-buffer-v1.md`
 - 퀘스트 Stage3 UX/리마인드 v1: `docs/quest-stage3-ux-reminder-v1.md`
 - 반려견 맞춤 난이도/쉬운 날 모드 v1: `docs/pet-adaptive-quest-difficulty-v1.md`
@@ -62,6 +63,7 @@
 - Cycle #78 결과 보고서(2026-02-26): `docs/cycle-78-auto-end-policy-report-2026-02-26.md`
 - Cycle #148 결과 보고서(2026-02-27): `docs/cycle-148-quest-failure-buffer-report-2026-02-27.md`
 - Cycle #170 결과 보고서(2026-03-01): `docs/cycle-170-quest-stage3-ux-reminder-report-2026-03-01.md`
+- Cycle #127 결과 보고서(2026-03-01): `docs/cycle-127-quest-stage1-policy-report-2026-03-01.md`
 - Cycle #147 결과 보고서(2026-02-27): `docs/cycle-147-pet-adaptive-quest-report-2026-02-27.md`
 - Cycle #145 결과 보고서(2026-02-27): `docs/cycle-145-season-catchup-buff-report-2026-02-27.md`
 - Cycle #124 결과 보고서(2026-02-27): `docs/cycle-124-season-policy-report-2026-02-27.md`

--- a/docs/cycle-127-quest-stage1-policy-report-2026-03-01.md
+++ b/docs/cycle-127-quest-stage1-policy-report-2026-03-01.md
@@ -1,0 +1,28 @@
+# Cycle #127 Quest Stage1 Policy Report (2026-03-01)
+
+## 1. 요약
+- 이슈: #127
+- 목표: 코스 퀘스트 템플릿/난이도 정책 문서 확정
+- 결과: 정책 문서(v1)와 정적 검증 스크립트 추가 완료
+
+## 2. 산출물
+- 정책 문서: `docs/quest-stage1-template-difficulty-policy-v1.md`
+- 검증 스크립트: `scripts/quest_stage1_policy_unit_check.swift`
+- CI 연결: `scripts/ios_pr_check.sh`
+
+## 3. 구현 포인트
+- 퀘스트 타입 4종(`new_tile`, `linked_path`, `walk_duration`, `streak_days`) 정의
+- 난이도 티어(`Easy/Normal/Hard`)와 보상 계수 표준화
+- 일일 3개/주간 2개 생성 규칙 명시
+- 중복 제한(최근 5슬롯 동일 타입 최대 2회)과 당일 중복 금지 규칙 명시
+- 날씨/권한 이슈 대응 대체 퀘스트 슬롯(`status=alternative`) 정의
+- seed 기반 재현 가능한 생성 예시 포함
+
+## 4. 테스트
+1. `swift scripts/quest_stage1_policy_unit_check.swift`
+2. `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
+
+## 5. 수용 기준 대응
+- 활동량 상/중/하 난이도 편차: 버킷 보정 및 clamp 규칙으로 충족
+- 동일 타입 반복 출현률 제한: 최근 슬롯 상한/당일 중복 금지로 충족
+- 문서만으로 재현 가능: 입력/seed/출력 예시로 충족

--- a/docs/quest-stage1-template-difficulty-policy-v1.md
+++ b/docs/quest-stage1-template-difficulty-policy-v1.md
@@ -1,0 +1,85 @@
+# Quest Stage1 Template & Difficulty Policy v1
+
+## 1. 목적
+- 일일/주간 퀘스트를 사용자 활동량에 맞춰 안정적으로 생성한다.
+- 퀘스트 정책 문서만으로 동일 입력에서 동일 결과를 재현할 수 있게 한다.
+
+## 2. 퀘스트 타입 정의 (Quest DSL v1)
+| type | 설명 | 기본 단위 | 완료 판정 기준 |
+| --- | --- | --- | --- |
+| `new_tile` | 신규 타일 개척 | tile count | 기준 시간창 내 신규 타일 수 달성 |
+| `linked_path` | 연속 경로 연결 | segment count | 연속 경로 길이/연결 수 달성 |
+| `walk_duration` | 산책 시간 달성 | minute | 단일 또는 누적 산책 시간 달성 |
+| `streak_days` | 연속일 유지 | day | 연속 산책 일수 달성 |
+
+## 3. 난이도 티어 및 보상 계수
+| tier | 목표 계수(베이스 대비) | 시즌 점수 계수 | 꾸미기 토큰 |
+| --- | --- | --- | --- |
+| `Easy` | 0.8x | 1.0x | +5 |
+| `Normal` | 1.0x | 1.2x | +8 |
+| `Hard` | 1.25x | 1.5x | +12 |
+
+### 3.1 활동량 버킷
+- 저활동(`low`): 최근 7일 일평균 이벤트 수 하위 30%
+- 중활동(`mid`): 최근 7일 일평균 이벤트 수 31~70%
+- 고활동(`high`): 최근 7일 일평균 이벤트 수 상위 30%
+
+### 3.2 목표값 계산 규칙
+1. `base_target = percentile(activity_7d, 50)`
+2. `bucket_adjust = {low: -15%, mid: 0%, high: +20%}`
+3. `tier_adjust = {Easy: 0.8, Normal: 1.0, Hard: 1.25}`
+4. `final_target = clamp(round(base_target * (1 + bucket_adjust) * tier_adjust), min, max)`
+
+## 4. 생성 규칙
+- 일일 퀘스트 3개: `Easy 1`, `Normal 2`
+- 주간 퀘스트 2개: `Normal 1`, `Hard 1`
+- 생성 시점 스냅샷: 생성된 인스턴스는 목표값 snapshot 고정
+- 무료 reroll: 일일 퀘스트 1일 1회 무료
+
+## 5. 중복/불가능 퀘스트 방지 규칙
+### 5.1 반복 출현률 제한
+- 한 사용자 기준 최근 5개 일일 슬롯에서 동일 `type`은 최대 2회
+- 동일 날 3개 슬롯 내 동일 `type` 중복 금지
+
+### 5.2 불가능 조건 필터
+- 날씨 차단: 악천후 단계에서 실외 의존 퀘스트(`new_tile`, `linked_path`) 제외
+- 권한 차단: 위치 권한 미허용 상태에서 위치 의존 퀘스트 제외
+- 활성 펫 차단: `selectedPetId` 부재 시 펫 기준 퀘스트 제외
+
+## 6. 대체 퀘스트 슬롯 정의
+| slot reason | 기존 후보 | 대체 후보 | 만료 |
+| --- | --- | --- | --- |
+| weather_blocked | `new_tile`, `linked_path` | `walk_duration` | 당일 23:59 |
+| permission_blocked | 위치 의존 전체 | `walk_duration`, `streak_days` | 권한 복구 또는 당일 종료 |
+
+- 대체 슬롯은 원본 슬롯 ID를 유지하고 `status=alternative` 상태 전이만 수행한다.
+- 대체 슬롯은 보상 계수를 하향하지 않는다(실패 경험 완충 목적).
+
+## 7. 재현 가능한 생성 예시
+### 7.1 저활동 사용자 일일 3개 예시
+- 입력: `activity_7d_avg=18`, `bucket=low`, `seed=20260301`
+- 출력:
+  1. `Easy/walk_duration/target=14m`
+  2. `Normal/new_tile/target=5`
+  3. `Normal/streak_days/target=2`
+
+### 7.2 고활동 사용자 일일 3개 예시
+- 입력: `activity_7d_avg=82`, `bucket=high`, `seed=20260301`
+- 출력:
+  1. `Easy/new_tile/target=9`
+  2. `Normal/linked_path/target=7`
+  3. `Normal/walk_duration/target=40m`
+
+### 7.3 reroll 예시
+- 입력: 동일 seed, `reroll_count_today=0`
+- 결과: 기존 슬롯과 동일 `type` 재등장 금지 + 불가능 조건 필터 재평가
+
+## 8. 수용 기준 매핑
+- 활동량 상/중/하 사용자 난이도 편차 허용 범위: 7일 평균 기반 버킷 보정 + min/max clamp
+- 동일 타입 반복 출현률 제한 규칙 충족: 최근 5슬롯 2회 상한 + 당일 중복 금지
+- 정책 문서만으로 예시 퀘스트 재현 가능: seed/입력/출력 표준화
+
+## 9. Stage2 인계 항목
+- 스키마: `quest_templates`, `quest_instances`, `quest_progress`, `quest_claims`
+- 상태 전이: `generated -> active -> completed -> claimed | expired | alternative`
+- 서버 강제 규칙: reroll 1일 1회, 목표 snapshot 고정, 멱등 진행도 집계

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -28,6 +28,7 @@ swift scripts/swift_stability_unit_check.swift
 swift scripts/userdefault_store_split_unit_check.swift
 swift scripts/map_motion_pack_unit_check.swift
 swift scripts/quest_motion_pack_unit_check.swift
+swift scripts/quest_stage1_policy_unit_check.swift
 swift scripts/season_motion_pack_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift

--- a/scripts/quest_stage1_policy_unit_check.swift
+++ b/scripts/quest_stage1_policy_unit_check.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// 조건식을 검증하고 실패 시 오류 메시지를 출력한 뒤 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 조건입니다.
+///   - message: 실패 시 출력할 메시지입니다.
+/// - Returns: 반환값은 없으며 실패 시 프로세스를 종료합니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 지정한 상대 경로의 UTF-8 텍스트 파일 내용을 읽어 문자열로 반환합니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: 파일의 UTF-8 문자열 본문입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let policy = load("docs/quest-stage1-template-difficulty-policy-v1.md")
+let report = load("docs/cycle-127-quest-stage1-policy-report-2026-03-01.md")
+
+assertTrue(policy.contains("`new_tile`"), "Policy should define new_tile quest type")
+assertTrue(policy.contains("`linked_path`"), "Policy should define linked_path quest type")
+assertTrue(policy.contains("`walk_duration`"), "Policy should define walk_duration quest type")
+assertTrue(policy.contains("`streak_days`"), "Policy should define streak_days quest type")
+
+assertTrue(policy.contains("Easy"), "Policy should define Easy tier")
+assertTrue(policy.contains("Normal"), "Policy should define Normal tier")
+assertTrue(policy.contains("Hard"), "Policy should define Hard tier")
+
+assertTrue(policy.contains("일일 퀘스트 3개"), "Policy should define daily generation count")
+assertTrue(policy.contains("주간 퀘스트 2개"), "Policy should define weekly generation count")
+assertTrue(policy.contains("최근 5개 일일 슬롯"), "Policy should define repeat limit window")
+assertTrue(policy.contains("대체 퀘스트 슬롯"), "Policy should define alternative quest slot")
+assertTrue(policy.contains("seed=20260301"), "Policy should provide reproducible seed examples")
+
+assertTrue(report.contains("#127"), "Cycle report should reference issue #127")
+assertTrue(report.contains("quest_stage1_policy_unit_check"), "Cycle report should include validation command")
+
+print("PASS: quest stage1 policy unit checks")


### PR DESCRIPTION
## Summary
- Issue #127 요구사항에 맞춰 Quest Stage1 정책 문서를 확정했습니다.

## Changes
- `docs/quest-stage1-template-difficulty-policy-v1.md` 신규 추가
- `docs/cycle-127-quest-stage1-policy-report-2026-03-01.md` 신규 추가
- `scripts/quest_stage1_policy_unit_check.swift` 신규 추가 및 `scripts/ios_pr_check.sh` 연결
- README 문서 인덱스에 Stage1 정책/리포트 링크 추가

## Unit Tests
- [x] `swift scripts/quest_stage1_policy_unit_check.swift`
- [x] `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

## Fault Injection Evidence (Required for release-related PR)
- Fault matrix link: N/A (문서 정책 이슈)
- Runbook/result link: N/A
- P0 status: `PASS`
- P1 status: `PASS`
- If any `P0 FAIL`, release decision must be `NO-GO`.

## Related Issues
- Closes #127
