### PR TITLE
Refactor subview VM boundaries for profile edit and walk detail

### DIFF
--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -13,10 +13,13 @@
 		23CB28F896D94B88CEF351F7 /* DesignAuditUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D982F3BFEE53C6D1333FF67 /* DesignAuditUITests.swift */; };
 		260998357CBB95987A042E95 /* PetProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFD83BC3079033CF24E9D6A /* PetProfileImageView.swift */; };
 		28782FDF88C341A3A600D280 /* HomeWeeklyMetricCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA093F2A0E2A16E5E116F3E /* HomeWeeklyMetricCardView.swift */; };
+		2FAF945E5AA7BC004D27C72E /* WalkDetailContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CDB8AB4C8855FE6D106BF3 /* WalkDetailContextProvider.swift */; };
 		316EF137D15633B33FDB93A3 /* ProfileFieldEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C8E7D8185E273FFD5B84579 /* ProfileFieldEditSheet.swift */; };
+		37382EBDCEA90A2E818A05BB /* ProfileFieldEditSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF0E17B2BF40E97DBA5E07 /* ProfileFieldEditSheetViewModel.swift */; };
 		3B09EF73E528C78FEEE2AB01 /* SeasonProfileFrameStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CEBC83AFF321A2E3D10E8A0 /* SeasonProfileFrameStyle.swift */; };
 		45CA89EBC76C1FE5200FD88D /* HomeSelectedPetContextBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7738E4A04B406F4D70AE19 /* HomeSelectedPetContextBannerView.swift */; };
 		541633F39AA01B555EA4A904 /* HomeRecentConqueredSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3FDEC98167CC2EA0DAFA5E /* HomeRecentConqueredSectionView.swift */; };
+		5951E893E8CBC77DCA82E00F /* WalkDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A775802DB2A590A7C7DA0978 /* WalkDetailViewModel.swift */; };
 		5F3ED37B0435F882BC90593E /* HomePetSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA31AC1DF69B7CA85070D28 /* HomePetSelectorView.swift */; };
 		68DE48DFEF4001E3F518BF10 /* HomeTerritoryHeaderSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FFE492DDD22A6AC1319D9D /* HomeTerritoryHeaderSectionView.swift */; };
 		6B1F802F9363A5DD652CA409 /* AreaDetailListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0C69DBDA661E0970F6A0BB /* AreaDetailListHeaderView.swift */; };
@@ -205,6 +208,7 @@
 		1D982F3BFEE53C6D1333FF67 /* DesignAuditUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignAuditUITests.swift; sourceTree = "<group>"; };
 		21CE83B02069A8E4171B35DE /* RivalTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalTabView.swift; path = dogArea/Views/ProfileSettingView/RivalTabView.swift; sourceTree = "<group>"; };
 		2615443270FF3222AEBDE893 /* ThumbnailImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailImageView.swift; sourceTree = "<group>"; };
+		30BF0E17B2BF40E97DBA5E07 /* ProfileFieldEditSheetViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileFieldEditSheetViewModel.swift; path = dogArea/Views/ProfileSettingView/ProfileFieldEditSheetViewModel.swift; sourceTree = "<group>"; };
 		376D30D4A7542596A014DEE1 /* SimpleKeyValueView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SimpleKeyValueView.swift; sourceTree = "<group>"; };
 		4A1B2C487816AA2CCCA6186F /* HomeStatusBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeStatusBannerView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeStatusBannerView.swift; sourceTree = "<group>"; };
 		4D14629580BEDCDCAE5B9EC3 /* HomeSelectedPetEmptyStateCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSelectedPetEmptyStateCardView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeSelectedPetEmptyStateCardView.swift; sourceTree = "<group>"; };
@@ -213,11 +217,13 @@
 		688E8E192EA6BCB551D19759 /* dogAreaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = dogAreaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C8E7D8185E273FFD5B84579 /* ProfileFieldEditSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileFieldEditSheet.swift; path = dogArea/Views/ProfileSettingView/ProfileFieldEditSheet.swift; sourceTree = "<group>"; };
 		6E3FDEC98167CC2EA0DAFA5E /* HomeRecentConqueredSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeRecentConqueredSectionView.swift; sourceTree = "<group>"; };
+		81CDB8AB4C8855FE6D106BF3 /* WalkDetailContextProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WalkDetailContextProvider.swift; path = dogArea/Views/MapView/WalkDetailContextProvider.swift; sourceTree = "<group>"; };
 		86FFE492DDD22A6AC1319D9D /* HomeTerritoryHeaderSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeTerritoryHeaderSectionView.swift; sourceTree = "<group>"; };
 		8B7738E4A04B406F4D70AE19 /* HomeSelectedPetContextBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSelectedPetContextBannerView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeSelectedPetContextBannerView.swift; sourceTree = "<group>"; };
 		8CEBC83AFF321A2E3D10E8A0 /* SeasonProfileFrameStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SeasonProfileFrameStyle.swift; path = dogArea/Views/ProfileSettingView/SeasonProfileFrameStyle.swift; sourceTree = "<group>"; };
 		92C5F96B5D23BD6D36935CA0 /* PositionMarkerViewWithSelection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PositionMarkerViewWithSelection.swift; sourceTree = "<group>"; };
 		9FFD83BC3079033CF24E9D6A /* PetProfileImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PetProfileImageView.swift; path = dogArea/Views/ProfileSettingView/PetProfileImageView.swift; sourceTree = "<group>"; };
+		A775802DB2A590A7C7DA0978 /* WalkDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WalkDetailViewModel.swift; path = dogArea/Views/MapView/WalkDetailViewModel.swift; sourceTree = "<group>"; };
 		C566C61F8B5520FEC3406DFF /* HomeGoalTrackerCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeGoalTrackerCardView.swift; sourceTree = "<group>"; };
 		C63D5D25262A8E2185005C50 /* RecoveryActionBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RecoveryActionBanner.swift; path = dogArea/Views/MapView/RecoveryActionBanner.swift; sourceTree = "<group>"; };
 		CEBDE81DFC43DCD56546D775 /* HomeHeaderSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeHeaderSectionView.swift; sourceTree = "<group>"; };
@@ -569,6 +575,9 @@
 				21CE83B02069A8E4171B35DE /* RivalTabView.swift */,
 				8CEBC83AFF321A2E3D10E8A0 /* SeasonProfileFrameStyle.swift */,
 				F73B707BA77AC2C69A6BC62B /* UserProfileImageView.swift */,
+				30BF0E17B2BF40E97DBA5E07 /* ProfileFieldEditSheetViewModel.swift */,
+				A775802DB2A590A7C7DA0978 /* WalkDetailViewModel.swift */,
+				81CDB8AB4C8855FE6D106BF3 /* WalkDetailContextProvider.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1032,6 +1041,9 @@
 				A83350BB79B3CBB09B4C4963 /* RivalTabView.swift in Sources */,
 				3B09EF73E528C78FEEE2AB01 /* SeasonProfileFrameStyle.swift in Sources */,
 				A0C814D250B8F26BDCC21F66 /* UserProfileImageView.swift in Sources */,
+				37382EBDCEA90A2E818A05BB /* ProfileFieldEditSheetViewModel.swift in Sources */,
+				5951E893E8CBC77DCA82E00F /* WalkDetailViewModel.swift in Sources */,
+				2FAF945E5AA7BC004D27C72E /* WalkDetailContextProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dogArea/Views/MapView/WalkDetailContextProvider.swift
+++ b/dogArea/Views/MapView/WalkDetailContextProvider.swift
@@ -1,0 +1,44 @@
+import UIKit
+
+extension MapViewModel: WalkDetailContextProviding {
+    var walkCreatedAt: TimeInterval {
+        polygon.createdAt
+    }
+
+    var walkDuration: TimeInterval {
+        polygon.walkingTime
+    }
+
+    var walkAreaM2: Double {
+        polygon.walkingArea
+    }
+
+    var walkPointCount: Int {
+        polygon.locations.count
+    }
+
+    var walkPetName: String {
+        currentWalkingPetName
+    }
+
+    /// 면적 텍스트를 지정 단위 기준으로 반환합니다.
+    /// - Parameters:
+    ///   - areaSize: 변환할 면적 값(m²)입니다.
+    ///   - isPyong: 평 단위 사용 여부입니다.
+    /// - Returns: 단위가 반영된 포맷 문자열입니다.
+    func calculatedAreaString(areaSize: Double, isPyong: Bool) -> String {
+        calculatedAreaString(areaSize: Optional(areaSize), isPyong: isPyong)
+    }
+
+    /// 산책 상태 배너 메시지를 갱신합니다.
+    /// - Parameter message: 사용자에게 노출할 메시지입니다.
+    func setWalkStatusMessage(_ message: String) {
+        walkStatusMessage = message
+    }
+
+    /// 지도 뷰모델의 산책 종료 액션을 실행합니다.
+    /// - Parameter image: 종료 시 저장할 산책 결과 이미지입니다.
+    func endWalk(with image: UIImage?) {
+        endWalk(img: image)
+    }
+}

--- a/dogArea/Views/MapView/WalkDetailView.swift
+++ b/dogArea/Views/MapView/WalkDetailView.swift
@@ -12,18 +12,11 @@ struct WalkDetailView: View {
     @EnvironmentObject var loading: LoadingViewModel
     @EnvironmentObject var viewModel: MapViewModel
     @StateObject var mapImageProvider = MapImageProvider()
-
-    @State private var isMeter: Bool = true
-    @State private var capturedWalkPhoto: UIImage? = nil
-    @State private var shareItems: [Any] = []
-    @State private var showShareSheet = false
-    @State private var showCameraPicker = false
-    @State private var showPhotoLibraryPicker = false
-    @State private var toastMessage: String? = nil
+    @StateObject private var detailViewModel = WalkDetailViewModel()
 
     var body: some View {
         VStack {
-            Image(uiImage: previewImage ?? UIImage.emptyImg)
+            Image(uiImage: detailViewModel.previewImage(mapCapturedImage: mapImageProvider.capturedImage) ?? UIImage.emptyImg)
                 .resizable()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .cornerRadius(5)
@@ -37,10 +30,10 @@ struct WalkDetailView: View {
                     }
                 }
             HStack {
-                SimpleKeyValueView(value: ("영역 넓이", viewModel.calculatedAreaString(areaSize: viewModel.polygon.walkingArea,isPyong: !isMeter)))
-                    .onTapGesture {isMeter.toggle()}
+                SimpleKeyValueView(value: ("영역 넓이", detailViewModel.areaValueText()))
+                    .onTapGesture { detailViewModel.toggleAreaUnit() }
                 Spacer()
-                SimpleKeyValueView(value: ("산책 시간", "\(viewModel.polygon.walkingTime .simpleWalkingTimeInterval)"))
+                SimpleKeyValueView(value: ("산책 시간", detailViewModel.durationText()))
             }.frame(maxWidth: .infinity)
                 .padding(.horizontal, 30)
                 .padding(.bottom, 20)
@@ -57,7 +50,7 @@ struct WalkDetailView: View {
                     .background(Color(red: 0.19, green: 0.19, blue: 0.19))
                     .padding(.horizontal, 20)
                 Button(action: {
-                    openCameraOrFallback()
+                    detailViewModel.requestImageInput()
                 }, label: {
                     HStack {
                         Image(systemName: "camera.fill")
@@ -72,10 +65,7 @@ struct WalkDetailView: View {
                     .padding(.top, 10)
                 })
                 Button(action: {
-                    shareItems = prepareShareItems()
-                    if shareItems.isEmpty == false {
-                        showShareSheet = true
-                    }
+                    detailViewModel.prepareShareSheet(mapCapturedImage: mapImageProvider.capturedImage)
                 }, label: {
                     HStack {
                         Image(systemName: "square.and.arrow.up")
@@ -93,16 +83,14 @@ struct WalkDetailView: View {
             }
             Spacer()
             Button(action: {
-                loading.loading()
-                guard let image = buildShareCardImage() else {
-                    loading.failed(msg: "이미지 가져오기 실패")
-                    return
-                }
-                UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
-                loading.success()
-                toastMessage = "저장이 완료되었습니다"
+                _ = detailViewModel.saveShareCardToPhotoLibrary(
+                    mapCapturedImage: mapImageProvider.capturedImage,
+                    onLoading: { loading.loading() },
+                    onFailed: { loading.failed(msg: $0) },
+                    onSuccess: { loading.success() }
+                )
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    self.toastMessage = nil
+                    detailViewModel.clearToastMessage()
                 }
             },
                    label:  {
@@ -115,10 +103,7 @@ struct WalkDetailView: View {
                 .cornerRadius(15)
                 .padding(.horizontal, 70)
             Button(action: {
-                if mapImageProvider.capturedImage == nil {
-                    viewModel.walkStatusMessage = "지도 이미지 없이 산책 기록만 저장했습니다."
-                }
-                viewModel.endWalk(img: mapImageProvider.capturedImage)
+                detailViewModel.confirmWalkEnd(mapCapturedImage: mapImageProvider.capturedImage)
                 dismiss()
             },
                    label:  {
@@ -131,68 +116,26 @@ struct WalkDetailView: View {
                 .padding(.horizontal, 70)
         }.overlay(
             Group {
-                if let toastMessage {
+                if let toastMessage = detailViewModel.toastMessage {
                     SimpleMessageView(message: toastMessage)
                         .transition(.opacity)
                 }
-            }.animation(.easeInOut(duration: 0.2), value: toastMessage)
+            }.animation(.easeInOut(duration: 0.2), value: detailViewModel.toastMessage)
         )
-        .sheet(isPresented: $showShareSheet) {
-            ActivityShareSheet(items: shareItems) { _, completed, _, _ in
-                if completed {
-                    toastMessage = "공유를 완료했습니다"
-                }
+        .sheet(isPresented: $detailViewModel.showShareSheet) {
+            ActivityShareSheet(items: detailViewModel.shareItems) { _, completed, _, _ in
+                detailViewModel.handleShareCompletion(completed: completed)
             }
         }
-        .fullScreenCover(isPresented: $showCameraPicker) {
-            ImagePicker(image: $capturedWalkPhoto, type: .camera)
+        .fullScreenCover(isPresented: $detailViewModel.showCameraPicker) {
+            ImagePicker(image: $detailViewModel.capturedWalkPhoto, type: .camera)
         }
-        .fullScreenCover(isPresented: $showPhotoLibraryPicker) {
-            ImagePicker(image: $capturedWalkPhoto, type: .photoLibrary)
+        .fullScreenCover(isPresented: $detailViewModel.showPhotoLibraryPicker) {
+            ImagePicker(image: $detailViewModel.capturedWalkPhoto, type: .photoLibrary)
         }
-    }
-
-    private var previewImage: UIImage? {
-        capturedWalkPhoto ?? mapImageProvider.capturedImage
-    }
-
-    private func buildShareCardImage() -> UIImage? {
-        guard let baseImage = previewImage else { return nil }
-        return WalkShareCardTemplateBuilder.build(
-            baseImage: baseImage,
-            createdAt: viewModel.polygon.createdAt,
-            duration: viewModel.polygon.walkingTime,
-            areaM2: viewModel.polygon.walkingArea,
-            pointCount: viewModel.polygon.locations.count,
-            petName: viewModel.currentWalkingPetName
-        )
-    }
-
-    private func prepareShareItems() -> [Any] {
-        let summary = WalkShareSummaryBuilder.build(
-            createdAt: viewModel.polygon.createdAt,
-            duration: viewModel.polygon.walkingTime,
-            areaM2: viewModel.polygon.walkingArea,
-            pointCount: viewModel.polygon.locations.count,
-            petName: viewModel.currentWalkingPetName
-        )
-        if let shareCard = buildShareCardImage() {
-            return [summary, shareCard]
+        .onAppear {
+            detailViewModel.bind(context: viewModel)
         }
-        return [summary]
-    }
-
-    private func openCameraOrFallback() {
-        if UIImagePickerController.isSourceTypeAvailable(.camera) {
-            showCameraPicker = true
-            return
-        }
-        if UIImagePickerController.isSourceTypeAvailable(.photoLibrary) {
-            toastMessage = "카메라 미지원 환경이라 앨범 선택으로 전환했어요."
-            showPhotoLibraryPicker = true
-            return
-        }
-        toastMessage = "이미지 입력을 사용할 수 없는 환경입니다."
     }
 }
 //

--- a/dogArea/Views/MapView/WalkDetailViewModel.swift
+++ b/dogArea/Views/MapView/WalkDetailViewModel.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+import UIKit
+
+/// 산책 상세 화면이 의존하는 데이터/액션 컨텍스트 인터페이스입니다.
+protocol WalkDetailContextProviding: AnyObject {
+    /// 현재 종료 대상 산책 생성 시각입니다.
+    var walkCreatedAt: TimeInterval { get }
+    /// 현재 종료 대상 산책 총 시간(초)입니다.
+    var walkDuration: TimeInterval { get }
+    /// 현재 종료 대상 산책 면적(m²)입니다.
+    var walkAreaM2: Double { get }
+    /// 현재 종료 대상 산책 포인트 개수입니다.
+    var walkPointCount: Int { get }
+    /// 현재 산책 반려견 이름입니다.
+    var walkPetName: String { get }
+
+    /// 면적 문자열을 단위 옵션에 맞춰 반환합니다.
+    /// - Parameters:
+    ///   - areaSize: 변환할 면적 값(m²)입니다.
+    ///   - isPyong: 평 단위 사용 여부입니다.
+    /// - Returns: 단위가 반영된 포맷 문자열입니다.
+    func calculatedAreaString(areaSize: Double, isPyong: Bool) -> String
+
+    /// 산책 종료 메시지를 노출합니다.
+    /// - Parameter message: 사용자에게 보여줄 상태 메시지입니다.
+    func setWalkStatusMessage(_ message: String)
+
+    /// 산책을 종료하고 결과 이미지를 저장합니다.
+    /// - Parameter image: 산책 결과 이미지입니다.
+    func endWalk(with image: UIImage?)
+}
+
+@MainActor
+final class WalkDetailViewModel: ObservableObject {
+    @Published var isMeter: Bool = true
+    @Published var capturedWalkPhoto: UIImage? = nil
+    @Published var shareItems: [Any] = []
+    @Published var showShareSheet: Bool = false
+    @Published var showCameraPicker: Bool = false
+    @Published var showPhotoLibraryPicker: Bool = false
+    @Published var toastMessage: String? = nil
+
+    private weak var context: WalkDetailContextProviding?
+
+    /// 산책 상세 전용 뷰모델을 초기화합니다.
+    init() {}
+
+    /// 외부 산책 컨텍스트를 연결합니다.
+    /// - Parameter context: 산책 데이터/종료 액션을 제공하는 컨텍스트입니다.
+    func bind(context: WalkDetailContextProviding) {
+        self.context = context
+    }
+
+    /// 공유/미리보기에서 사용할 우선 이미지를 계산합니다.
+    /// - Parameter mapCapturedImage: 지도 스냅샷으로 캡처된 이미지입니다.
+    /// - Returns: 사용자가 촬영한 이미지가 있으면 우선, 없으면 지도 이미지입니다.
+    func previewImage(mapCapturedImage: UIImage?) -> UIImage? {
+        capturedWalkPhoto ?? mapCapturedImage
+    }
+
+    /// 현재 선택 단위 기준 면적 문자열을 반환합니다.
+    /// - Returns: 화면에 노출할 면적 텍스트입니다.
+    func areaValueText() -> String {
+        guard let context else { return "-" }
+        return context.calculatedAreaString(areaSize: context.walkAreaM2, isPyong: !isMeter)
+    }
+
+    /// 현재 산책 시간 문자열을 반환합니다.
+    /// - Returns: 화면에 노출할 산책 시간 텍스트입니다.
+    func durationText() -> String {
+        guard let context else { return "-" }
+        return context.walkDuration.simpleWalkingTimeInterval
+    }
+
+    /// 면적 단위를 미터/평 기준으로 토글합니다.
+    func toggleAreaUnit() {
+        isMeter.toggle()
+    }
+
+    /// 카메라/앨범 입력 경로를 결정하고 화면 상태를 갱신합니다.
+    /// - Returns: 없음. 필요한 모달 플래그와 토스트 메시지를 갱신합니다.
+    func requestImageInput() {
+        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+            showCameraPicker = true
+            return
+        }
+        if UIImagePickerController.isSourceTypeAvailable(.photoLibrary) {
+            toastMessage = "카메라 미지원 환경이라 앨범 선택으로 전환했어요."
+            showPhotoLibraryPicker = true
+            return
+        }
+        toastMessage = "이미지 입력을 사용할 수 없는 환경입니다."
+    }
+
+    /// 공유 시트에 필요한 아이템을 구성해 표시합니다.
+    /// - Parameter mapCapturedImage: 지도 스냅샷으로 캡처된 이미지입니다.
+    func prepareShareSheet(mapCapturedImage: UIImage?) {
+        shareItems = makeShareItems(mapCapturedImage: mapCapturedImage)
+        showShareSheet = shareItems.isEmpty == false
+    }
+
+    /// 공유 완료 콜백 결과를 처리합니다.
+    /// - Parameter completed: 공유 완료 여부입니다.
+    func handleShareCompletion(completed: Bool) {
+        guard completed else { return }
+        toastMessage = "공유를 완료했습니다"
+    }
+
+    /// 현재 산책 카드를 사진 앱에 저장합니다.
+    /// - Parameters:
+    ///   - mapCapturedImage: 지도 스냅샷으로 캡처된 이미지입니다.
+    ///   - onLoading: 저장 시작 시 호출할 콜백입니다.
+    ///   - onFailed: 저장 실패 시 호출할 콜백입니다.
+    ///   - onSuccess: 저장 성공 시 호출할 콜백입니다.
+    /// - Returns: 저장 성공 여부입니다.
+    @discardableResult
+    func saveShareCardToPhotoLibrary(
+        mapCapturedImage: UIImage?,
+        onLoading: () -> Void,
+        onFailed: (String) -> Void,
+        onSuccess: () -> Void
+    ) -> Bool {
+        onLoading()
+        guard let image = buildShareCardImage(mapCapturedImage: mapCapturedImage) else {
+            onFailed("이미지 가져오기 실패")
+            return false
+        }
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+        onSuccess()
+        toastMessage = "저장이 완료되었습니다"
+        return true
+    }
+
+    /// 산책 종료 확인 액션을 수행합니다.
+    /// - Parameter mapCapturedImage: 지도 스냅샷으로 캡처된 이미지입니다.
+    func confirmWalkEnd(mapCapturedImage: UIImage?) {
+        guard let context else { return }
+        if mapCapturedImage == nil {
+            context.setWalkStatusMessage("지도 이미지 없이 산책 기록만 저장했습니다.")
+        }
+        context.endWalk(with: mapCapturedImage)
+    }
+
+    /// 토스트 메시지를 지웁니다.
+    func clearToastMessage() {
+        toastMessage = nil
+    }
+
+    /// 공유 카드에 사용할 최종 이미지를 생성합니다.
+    /// - Parameter mapCapturedImage: 지도 스냅샷으로 캡처된 이미지입니다.
+    /// - Returns: 공유 카드 이미지 생성 성공 시 `UIImage`, 실패 시 `nil`입니다.
+    private func buildShareCardImage(mapCapturedImage: UIImage?) -> UIImage? {
+        guard let context,
+              let baseImage = previewImage(mapCapturedImage: mapCapturedImage) else { return nil }
+        return WalkShareCardTemplateBuilder.build(
+            baseImage: baseImage,
+            createdAt: context.walkCreatedAt,
+            duration: context.walkDuration,
+            areaM2: context.walkAreaM2,
+            pointCount: context.walkPointCount,
+            petName: context.walkPetName
+        )
+    }
+
+    /// 공유 시트용 아이템 배열(텍스트 요약 + 카드 이미지)을 구성합니다.
+    /// - Parameter mapCapturedImage: 지도 스냅샷으로 캡처된 이미지입니다.
+    /// - Returns: 공유 시트에 전달할 아이템 배열입니다.
+    private func makeShareItems(mapCapturedImage: UIImage?) -> [Any] {
+        guard let context else { return [] }
+        let summary = WalkShareSummaryBuilder.build(
+            createdAt: context.walkCreatedAt,
+            duration: context.walkDuration,
+            areaM2: context.walkAreaM2,
+            pointCount: context.walkPointCount,
+            petName: context.walkPetName
+        )
+        if let shareCard = buildShareCardImage(mapCapturedImage: mapCapturedImage) {
+            return [summary, shareCard]
+        }
+        return [summary]
+    }
+}

--- a/dogArea/Views/ProfileSettingView/ProfileFieldEditSheet.swift
+++ b/dogArea/Views/ProfileSettingView/ProfileFieldEditSheet.swift
@@ -2,68 +2,53 @@ import SwiftUI
 
 struct ProfileFieldEditSheet: View {
     @Environment(\.dismiss) var dismiss
-    @ObservedObject var viewModel: SettingViewModel
+    @StateObject private var sheetViewModel: ProfileFieldEditSheetViewModel
     let onSaved: (String) -> Void
-
-    @State private var profileMessage: String
-    @State private var breed: String
-    @State private var ageYearsText: String
-    @State private var gender: PetGender
-    @State private var errorMessage: String? = nil
-    @State private var caricatureMessage: String? = nil
 
     /// 프로필 편집 시트의 초기 상태를 구성합니다.
     /// - Parameters:
     ///   - viewModel: 사용자/반려견 정보와 저장 액션을 제공하는 설정 뷰모델입니다.
     ///   - onSaved: 저장 성공 시 사용자에게 보여줄 메시지를 전달하는 콜백입니다.
     init(viewModel: SettingViewModel, onSaved: @escaping (String) -> Void) {
-        self.viewModel = viewModel
         self.onSaved = onSaved
-        _profileMessage = State(initialValue: viewModel.userInfo?.profileMessage ?? "")
-        _breed = State(initialValue: viewModel.selectedPet?.breed ?? "")
-        _ageYearsText = State(initialValue: viewModel.selectedPet?.ageYears.map(String.init) ?? "")
-        _gender = State(initialValue: viewModel.selectedPet?.gender ?? .unknown)
+        _sheetViewModel = StateObject(wrappedValue: ProfileFieldEditSheetViewModel(provider: viewModel))
     }
 
     var body: some View {
         NavigationStack {
             Form {
                 Section("사용자") {
-                    TextField("프로필 메시지", text: $profileMessage)
+                    TextField("프로필 메시지", text: $sheetViewModel.profileMessage)
                 }
                 Section("반려견 (선택된 반려견 기준)") {
-                    TextField("견종/믹스/기타 (선택)", text: $breed)
-                    TextField("나이 (0~30)", text: $ageYearsText)
+                    TextField("견종/믹스/기타 (선택)", text: $sheetViewModel.breed)
+                    TextField("나이 (0~30)", text: $sheetViewModel.ageYearsText)
                         .keyboardType(.numberPad)
-                    Picker("성별", selection: $gender) {
+                    Picker("성별", selection: $sheetViewModel.gender) {
                         ForEach(PetGender.allCases, id: \.rawValue) { item in
                             Text(item.title).tag(item)
                         }
                     }
                 }
                 Section("반려견 캐리커처") {
-                    Text("현재 상태: \(viewModel.selectedPet?.caricatureStatus?.rawValue ?? "none")")
+                    Text("현재 상태: \(sheetViewModel.caricatureStatusText)")
                         .font(.appFont(for: .Light, size: 11))
                         .foregroundStyle(Color.appTextDarkGray)
 
-                    Button(viewModel.isCaricatureGenerating ? "생성 중..." : "캐리커처 생성/재생성") {
-                        caricatureMessage = nil
+                    Button(sheetViewModel.isGeneratingCaricature ? "생성 중..." : "캐리커처 생성/재생성") {
                         Task {
-                            let message = await viewModel.regenerateSelectedPetCaricature()
-                            await MainActor.run {
-                                caricatureMessage = message
-                            }
+                            await sheetViewModel.requestCaricatureRegeneration()
                         }
                     }
-                    .disabled(viewModel.isCaricatureGenerating)
+                    .disabled(sheetViewModel.isGeneratingCaricature)
 
-                    if let caricatureMessage {
+                    if let caricatureMessage = sheetViewModel.caricatureMessage {
                         Text(caricatureMessage)
                             .font(.appFont(for: .Regular, size: 12))
                             .foregroundStyle(Color.appTextDarkGray)
                     }
                 }
-                if let errorMessage {
+                if let errorMessage = sheetViewModel.errorMessage {
                     Section {
                         Text(errorMessage)
                             .font(.appFont(for: .Regular, size: 12))
@@ -83,18 +68,9 @@ struct ProfileFieldEditSheet: View {
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("저장") {
-                        let result = viewModel.updateProfileDetails(
-                            profileMessage: profileMessage,
-                            breed: breed,
-                            ageYearsText: ageYearsText,
-                            gender: gender
-                        )
-                        switch result {
-                        case .success:
+                        if sheetViewModel.saveChanges() {
                             onSaved("프로필 정보를 저장했어요.")
                             dismiss()
-                        case .failure(let error):
-                            errorMessage = error.localizedDescription
                         }
                     }
                     .accessibilityIdentifier("sheet.settings.profileEdit.save")

--- a/dogArea/Views/ProfileSettingView/ProfileFieldEditSheetViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/ProfileFieldEditSheetViewModel.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// 프로필 편집 시트가 의존하는 데이터/액션 제공 인터페이스입니다.
+protocol ProfileFieldEditProviding: AnyObject {
+    /// 현재 사용자 프로필 메시지를 반환합니다.
+    var initialProfileMessage: String { get }
+    /// 현재 선택 반려견의 견종 텍스트를 반환합니다.
+    var initialBreed: String { get }
+    /// 현재 선택 반려견의 나이 텍스트를 반환합니다.
+    var initialAgeYearsText: String { get }
+    /// 현재 선택 반려견의 성별을 반환합니다.
+    var initialGender: PetGender { get }
+    /// 현재 선택 반려견의 캐리커처 상태 텍스트를 반환합니다.
+    var selectedPetCaricatureStatusText: String { get }
+
+    /// 사용자/반려견 프로필 편집 내용을 저장합니다.
+    /// - Parameters:
+    ///   - profileMessage: 사용자 프로필 메시지 입력값입니다.
+    ///   - breed: 선택 반려견 견종 입력값입니다.
+    ///   - ageYearsText: 선택 반려견 나이 입력값(문자열)입니다.
+    ///   - gender: 선택 반려견 성별 입력값입니다.
+    /// - Returns: 저장 성공/실패 결과입니다.
+    func saveProfileDetails(
+        profileMessage: String,
+        breed: String,
+        ageYearsText: String,
+        gender: PetGender
+    ) -> Result<Void, Error>
+
+    /// 선택 반려견 캐리커처를 생성/재생성합니다.
+    /// - Returns: 사용자 노출용 처리 결과 메시지입니다.
+    func regenerateSelectedPetCaricature() async -> String
+}
+
+extension SettingViewModel: ProfileFieldEditProviding {
+    var initialProfileMessage: String {
+        userInfo?.profileMessage ?? ""
+    }
+
+    var initialBreed: String {
+        selectedPet?.breed ?? ""
+    }
+
+    var initialAgeYearsText: String {
+        selectedPet?.ageYears.map(String.init) ?? ""
+    }
+
+    var initialGender: PetGender {
+        selectedPet?.gender ?? .unknown
+    }
+
+    var selectedPetCaricatureStatusText: String {
+        selectedPet?.caricatureStatus?.rawValue ?? "none"
+    }
+
+    /// 프로필 편집 입력값을 저장하고 에러 타입을 일반화해 반환합니다.
+    /// - Parameters:
+    ///   - profileMessage: 사용자 프로필 메시지 입력값입니다.
+    ///   - breed: 선택 반려견 견종 입력값입니다.
+    ///   - ageYearsText: 선택 반려견 나이 입력값(문자열)입니다.
+    ///   - gender: 선택 반려견 성별 입력값입니다.
+    /// - Returns: 저장 성공/실패 결과입니다.
+    func saveProfileDetails(
+        profileMessage: String,
+        breed: String,
+        ageYearsText: String,
+        gender: PetGender
+    ) -> Result<Void, Error> {
+        updateProfileDetails(
+            profileMessage: profileMessage,
+            breed: breed,
+            ageYearsText: ageYearsText,
+            gender: gender
+        )
+        .mapError { $0 as Error }
+    }
+}
+
+@MainActor
+final class ProfileFieldEditSheetViewModel: ObservableObject {
+    @Published var profileMessage: String
+    @Published var breed: String
+    @Published var ageYearsText: String
+    @Published var gender: PetGender
+    @Published var errorMessage: String? = nil
+    @Published var caricatureMessage: String? = nil
+    @Published var isGeneratingCaricature: Bool = false
+    @Published private(set) var caricatureStatusText: String
+
+    private let provider: ProfileFieldEditProviding
+
+    /// 프로필 편집 전용 뷰모델을 초기화합니다.
+    /// - Parameter provider: 프로필 편집 데이터/액션을 제공하는 의존성입니다.
+    init(provider: ProfileFieldEditProviding) {
+        self.provider = provider
+        self.profileMessage = provider.initialProfileMessage
+        self.breed = provider.initialBreed
+        self.ageYearsText = provider.initialAgeYearsText
+        self.gender = provider.initialGender
+        self.caricatureStatusText = provider.selectedPetCaricatureStatusText
+    }
+
+    /// 프로필 편집 입력값을 저장합니다.
+    /// - Returns: 저장 성공 여부입니다. 실패 시 `errorMessage`가 갱신됩니다.
+    @discardableResult
+    func saveChanges() -> Bool {
+        errorMessage = nil
+        let result = provider.saveProfileDetails(
+            profileMessage: profileMessage,
+            breed: breed,
+            ageYearsText: ageYearsText,
+            gender: gender
+        )
+
+        switch result {
+        case .success:
+            caricatureStatusText = provider.selectedPetCaricatureStatusText
+            return true
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    /// 캐리커처 생성/재생성을 요청합니다.
+    /// - Returns: 없음. 요청 결과는 `caricatureMessage`와 `caricatureStatusText`에 반영됩니다.
+    func requestCaricatureRegeneration() async {
+        isGeneratingCaricature = true
+        caricatureMessage = nil
+        defer { isGeneratingCaricature = false }
+
+        let message = await provider.regenerateSelectedPetCaricature()
+        caricatureMessage = message
+        caricatureStatusText = provider.selectedPetCaricatureStatusText
+    }
+}


### PR DESCRIPTION
## Summary
- Applied subview ViewModel separation where subview-specific logic met independent lifecycle criteria
- Introduced `ProfileFieldEditSheetViewModel` with protocol-based provider dependency
- Introduced `WalkDetailViewModel` and `WalkDetailContextProviding` bridge for `MapViewModel`
- Kept simple render-only subviews sharing parent state

## Validation
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
- `xcodebuild -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project dogArea.xcodeproj -scheme dogArea -destination 'id=C787307E-5F3E-491D-BD28-7E07CA86BABA' -only-testing:dogAreaUITests test`
