### PR TITLE
Refactor RivalTabViewModel with dedicated services

### DIFF
--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -8,12 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		02B810B0791CFB600F8406EB /* HomeSelectedPetEmptyStateCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D14629580BEDCDCAE5B9EC3 /* HomeSelectedPetEmptyStateCardView.swift */; };
+		106E27D50C08D7997FD7982D /* RivalNetworkErrorInterpreter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4548C0C604B933CC43644FA /* RivalNetworkErrorInterpreter.swift */; };
 		1CCC7F48BF06FD4BCECF4286 /* TerritoryGoalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5CB737B1C8D8A675B6A43B /* TerritoryGoalView.swift */; };
 		22EA9355CC79568490A94348 /* dogAreaUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626E89852AADA163B53AB03D /* dogAreaUITestsLaunchTests.swift */; };
 		23CB28F896D94B88CEF351F7 /* DesignAuditUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D982F3BFEE53C6D1333FF67 /* DesignAuditUITests.swift */; };
 		260998357CBB95987A042E95 /* PetProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFD83BC3079033CF24E9D6A /* PetProfileImageView.swift */; };
 		28782FDF88C341A3A600D280 /* HomeWeeklyMetricCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA093F2A0E2A16E5E116F3E /* HomeWeeklyMetricCardView.swift */; };
 		2FAF945E5AA7BC004D27C72E /* WalkDetailContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CDB8AB4C8855FE6D106BF3 /* WalkDetailContextProvider.swift */; };
+		30B76E851C27574F5E5AC8A0 /* RivalModerationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722875CA7B7EAB511CCC1590 /* RivalModerationStore.swift */; };
 		316EF137D15633B33FDB93A3 /* ProfileFieldEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C8E7D8185E273FFD5B84579 /* ProfileFieldEditSheet.swift */; };
 		32009EE2A174DAB07F3DD64D /* RivalTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70172018FBBE6C94AB182660 /* RivalTabViewModel.swift */; };
 		37382EBDCEA90A2E818A05BB /* ProfileFieldEditSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF0E17B2BF40E97DBA5E07 /* ProfileFieldEditSheetViewModel.swift */; };
@@ -29,12 +31,14 @@
 		7FA65C0F2ACFFB5E341DAD07 /* AppleSigninButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B330462EB7C7D535B09F1 /* AppleSigninButton.swift */; };
 		82C0FE1F9DF4A147D4C6A02C /* RecoveryActionBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63D5D25262A8E2185005C50 /* RecoveryActionBanner.swift */; };
 		8705C4CE77BEE3DAEF07A78B /* SimpleKeyValueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376D30D4A7542596A014DEE1 /* SimpleKeyValueView.swift */; };
+		8A40430FD15CD439469AC981 /* RivalViewStateResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D5D8D51AC30DA6DB60A871 /* RivalViewStateResolver.swift */; };
 		8AB9332023AB8DBFF5657767 /* HomeHeaderSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBDE81DFC43DCD56546D775 /* HomeHeaderSectionView.swift */; };
 		8DD9CE63EA914575B4763A9F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8458EB9DE9760D52537B4B6 /* Foundation.framework */; };
 		9D8804AD0F127C5DDDAEA597 /* ThumbnailImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2615443270FF3222AEBDE893 /* ThumbnailImageView.swift */; };
 		A0C814D250B8F26BDCC21F66 /* UserProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73B707BA77AC2C69A6BC62B /* UserProfileImageView.swift */; };
 		A83350BB79B3CBB09B4C4963 /* RivalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CE83B02069A8E4171B35DE /* RivalTabView.swift */; };
 		A9F5F361DE66BF266C36FED0 /* PositionMarkerViewWithSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C5F96B5D23BD6D36935CA0 /* PositionMarkerViewWithSelection.swift */; };
+		C047F1CA5DC13CAE4F03AE90 /* RivalHotspotSummaryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2B2A868B6FD9035AC5214F /* RivalHotspotSummaryBuilder.swift */; };
 		CEDA085DD93B4102FE55229E /* HomeGoalTrackerCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C566C61F8B5520FEC3406DFF /* HomeGoalTrackerCardView.swift */; };
 		DA16C1D92B05DCC8008FC133 /* CornerShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA16C1D82B05DCC8008FC133 /* CornerShape.swift */; };
 		DA16C1DC2B05E4DF008FC133 /* TimeCheckable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA16C1DB2B05E4DF008FC133 /* TimeCheckable.swift */; };
@@ -221,10 +225,12 @@
 		6C8E7D8185E273FFD5B84579 /* ProfileFieldEditSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileFieldEditSheet.swift; path = dogArea/Views/ProfileSettingView/ProfileFieldEditSheet.swift; sourceTree = "<group>"; };
 		6E3FDEC98167CC2EA0DAFA5E /* HomeRecentConqueredSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeRecentConqueredSectionView.swift; sourceTree = "<group>"; };
 		70172018FBBE6C94AB182660 /* RivalTabViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalTabViewModel.swift; path = dogArea/Views/ProfileSettingView/RivalTabViewModel.swift; sourceTree = "<group>"; };
+		722875CA7B7EAB511CCC1590 /* RivalModerationStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalModerationStore.swift; path = dogArea/Views/ProfileSettingView/RivalModerationStore.swift; sourceTree = "<group>"; };
 		81CDB8AB4C8855FE6D106BF3 /* WalkDetailContextProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WalkDetailContextProvider.swift; path = dogArea/Views/MapView/WalkDetailContextProvider.swift; sourceTree = "<group>"; };
 		86FFE492DDD22A6AC1319D9D /* HomeTerritoryHeaderSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeTerritoryHeaderSectionView.swift; sourceTree = "<group>"; };
 		8B7738E4A04B406F4D70AE19 /* HomeSelectedPetContextBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSelectedPetContextBannerView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeSelectedPetContextBannerView.swift; sourceTree = "<group>"; };
 		8CEBC83AFF321A2E3D10E8A0 /* SeasonProfileFrameStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SeasonProfileFrameStyle.swift; path = dogArea/Views/ProfileSettingView/SeasonProfileFrameStyle.swift; sourceTree = "<group>"; };
+		8F2B2A868B6FD9035AC5214F /* RivalHotspotSummaryBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalHotspotSummaryBuilder.swift; path = dogArea/Views/ProfileSettingView/RivalHotspotSummaryBuilder.swift; sourceTree = "<group>"; };
 		92C5F96B5D23BD6D36935CA0 /* PositionMarkerViewWithSelection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PositionMarkerViewWithSelection.swift; sourceTree = "<group>"; };
 		9FFD83BC3079033CF24E9D6A /* PetProfileImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PetProfileImageView.swift; path = dogArea/Views/ProfileSettingView/PetProfileImageView.swift; sourceTree = "<group>"; };
 		A775802DB2A590A7C7DA0978 /* WalkDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WalkDetailViewModel.swift; path = dogArea/Views/MapView/WalkDetailViewModel.swift; sourceTree = "<group>"; };
@@ -329,6 +335,8 @@
 		DAE142001420000000000001 /* AppHapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHapticFeedback.swift; sourceTree = "<group>"; };
 		DAED24FA2AFA1C980044715A /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		DAED25012AFA1D430044715A /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
+		E4548C0C604B933CC43644FA /* RivalNetworkErrorInterpreter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalNetworkErrorInterpreter.swift; path = dogArea/Views/ProfileSettingView/RivalNetworkErrorInterpreter.swift; sourceTree = "<group>"; };
+		F2D5D8D51AC30DA6DB60A871 /* RivalViewStateResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalViewStateResolver.swift; path = dogArea/Views/ProfileSettingView/RivalViewStateResolver.swift; sourceTree = "<group>"; };
 		F54DF2E65C59A1E8B1F95D8A /* TerritoryGoalViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerritoryGoalViewModel.swift; sourceTree = "<group>"; };
 		F59FE8AF61BF3AE3B6C99D77 /* HomeWeeklySnapshotSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeWeeklySnapshotSectionView.swift; sourceTree = "<group>"; };
 		F73B707BA77AC2C69A6BC62B /* UserProfileImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserProfileImageView.swift; path = dogArea/Views/ProfileSettingView/UserProfileImageView.swift; sourceTree = "<group>"; };
@@ -584,6 +592,10 @@
 				81CDB8AB4C8855FE6D106BF3 /* WalkDetailContextProvider.swift */,
 				70172018FBBE6C94AB182660 /* RivalTabViewModel.swift */,
 				19B0F89F9FF220625F0008DB /* RivalTabModels.swift */,
+				722875CA7B7EAB511CCC1590 /* RivalModerationStore.swift */,
+				F2D5D8D51AC30DA6DB60A871 /* RivalViewStateResolver.swift */,
+				E4548C0C604B933CC43644FA /* RivalNetworkErrorInterpreter.swift */,
+				8F2B2A868B6FD9035AC5214F /* RivalHotspotSummaryBuilder.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1052,6 +1064,10 @@
 				2FAF945E5AA7BC004D27C72E /* WalkDetailContextProvider.swift in Sources */,
 				32009EE2A174DAB07F3DD64D /* RivalTabViewModel.swift in Sources */,
 				E1996670DB5AF8DEE4111010 /* RivalTabModels.swift in Sources */,
+				30B76E851C27574F5E5AC8A0 /* RivalModerationStore.swift in Sources */,
+				8A40430FD15CD439469AC981 /* RivalViewStateResolver.swift in Sources */,
+				106E27D50C08D7997FD7982D /* RivalNetworkErrorInterpreter.swift in Sources */,
+				C047F1CA5DC13CAE4F03AE90 /* RivalHotspotSummaryBuilder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dogArea/Views/ProfileSettingView/RivalHotspotSummaryBuilder.swift
+++ b/dogArea/Views/ProfileSettingView/RivalHotspotSummaryBuilder.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// 핫스팟 카드 상단 요약 데이터입니다.
+struct RivalHotspotSummary {
+    let maxIntensityText: String
+    let lastUpdatedText: String
+    let previewRows: [RivalTabViewModel.HotspotPreviewRow]
+}
+
+/// 핫스팟 목록을 UI 요약 데이터로 변환합니다.
+enum RivalHotspotSummaryBuilder {
+    /// 핫스팟 목록으로 카드 요약 정보를 생성합니다.
+    /// - Parameters:
+    ///   - hotspots: 원본 핫스팟 목록입니다.
+    ///   - referenceDate: 마지막 업데이트 시각 텍스트 계산 기준 시각입니다.
+    /// - Returns: 카드에 렌더링할 최대 강도/업데이트 시각/프리뷰 행 묶음입니다.
+    static func build(
+        from hotspots: [NearbyHotspotDTO],
+        referenceDate: Date = Date()
+    ) -> RivalHotspotSummary {
+        guard let maximum = hotspots.map(\.intensity).max() else {
+            return RivalHotspotSummary(maxIntensityText: "없음", lastUpdatedText: "-", previewRows: [])
+        }
+
+        let maxIntensityText: String
+        if maximum >= 0.67 {
+            maxIntensityText = "높음"
+        } else if maximum >= 0.34 {
+            maxIntensityText = "보통"
+        } else {
+            maxIntensityText = "낮음"
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        let lastUpdatedText = formatter.string(from: referenceDate)
+
+        let previewRows = hotspots
+            .sorted(by: { $0.intensity > $1.intensity })
+            .prefix(3)
+            .map { hotspot in
+                RivalTabViewModel.HotspotPreviewRow(
+                    title: "격자 \(hotspot.geohash.prefix(5))",
+                    value: "\(Int(hotspot.intensity * 100))% · \(hotspot.count)명"
+                )
+            }
+
+        return RivalHotspotSummary(
+            maxIntensityText: maxIntensityText,
+            lastUpdatedText: lastUpdatedText,
+            previewRows: previewRows
+        )
+    }
+}

--- a/dogArea/Views/ProfileSettingView/RivalModerationStore.swift
+++ b/dogArea/Views/ProfileSettingView/RivalModerationStore.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// 라이벌 탭의 숨김/차단 익명코드 스냅샷입니다.
+struct RivalModerationSnapshot {
+    let hiddenAliases: [String]
+    let blockedAliases: [String]
+}
+
+/// 라이벌 모더레이션 로컬 저장소 인터페이스입니다.
+protocol RivalModerationStoreProtocol {
+    /// 로컬에 저장된 숨김/차단 목록을 불러옵니다.
+    /// - Returns: 숨김/차단 익명코드 스냅샷입니다.
+    func loadSnapshot() -> RivalModerationSnapshot
+
+    /// 숨김/차단 목록을 로컬에 저장합니다.
+    /// - Parameter snapshot: 저장할 모더레이션 스냅샷입니다.
+    func saveSnapshot(_ snapshot: RivalModerationSnapshot)
+
+    /// 신고/차단/숨김 이력을 로컬 로그에 누적합니다.
+    /// - Parameters:
+    ///   - action: 기록할 액션 타입입니다(`report`/`block`/`hide`).
+    ///   - aliasCode: 대상 익명코드입니다.
+    ///   - reason: 신고 사유 원문값입니다. 신고가 아니면 `nil`입니다.
+    func appendLog(action: String, aliasCode: String, reason: String?)
+}
+
+final class RivalModerationStore: RivalModerationStoreProtocol {
+    private let preferenceStore: MapPreferenceStoreProtocol
+    private let hiddenAliasKey: String
+    private let blockedAliasKey: String
+    private let moderationLogKey: String
+
+    /// 라이벌 모더레이션 저장소를 초기화합니다.
+    /// - Parameters:
+    ///   - preferenceStore: UserDefaults 래퍼 저장소입니다.
+    ///   - hiddenAliasKey: 숨김 목록 키입니다.
+    ///   - blockedAliasKey: 차단 목록 키입니다.
+    ///   - moderationLogKey: 모더레이션 로그 키입니다.
+    init(
+        preferenceStore: MapPreferenceStoreProtocol,
+        hiddenAliasKey: String = "rival.hidden.alias.codes.v1",
+        blockedAliasKey: String = "rival.blocked.alias.codes.v1",
+        moderationLogKey: String = "rival.moderation.logs.v1"
+    ) {
+        self.preferenceStore = preferenceStore
+        self.hiddenAliasKey = hiddenAliasKey
+        self.blockedAliasKey = blockedAliasKey
+        self.moderationLogKey = moderationLogKey
+    }
+
+    /// 로컬에 저장된 숨김/차단 목록을 불러옵니다.
+    /// - Returns: 숨김/차단 익명코드 스냅샷입니다.
+    func loadSnapshot() -> RivalModerationSnapshot {
+        let hidden = Array(Set(preferenceStore.stringArray(forKey: hiddenAliasKey))).sorted()
+        let blocked = Array(Set(preferenceStore.stringArray(forKey: blockedAliasKey))).sorted()
+        return RivalModerationSnapshot(hiddenAliases: hidden, blockedAliases: blocked)
+    }
+
+    /// 숨김/차단 목록을 로컬에 저장합니다.
+    /// - Parameter snapshot: 저장할 모더레이션 스냅샷입니다.
+    func saveSnapshot(_ snapshot: RivalModerationSnapshot) {
+        preferenceStore.set(snapshot.hiddenAliases.sorted(), forKey: hiddenAliasKey)
+        preferenceStore.set(snapshot.blockedAliases.sorted(), forKey: blockedAliasKey)
+    }
+
+    /// 신고/차단/숨김 이력을 로컬 로그에 누적합니다.
+    /// - Parameters:
+    ///   - action: 기록할 액션 타입입니다(`report`/`block`/`hide`).
+    ///   - aliasCode: 대상 익명코드입니다.
+    ///   - reason: 신고 사유 원문값입니다. 신고가 아니면 `nil`입니다.
+    func appendLog(action: String, aliasCode: String, reason: String?) {
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        var logs: [RivalModerationLogEntry] = []
+        if let data = preferenceStore.data(forKey: moderationLogKey),
+           let decoded = try? decoder.decode([RivalModerationLogEntry].self, from: data) {
+            logs = decoded
+        }
+
+        let entry = RivalModerationLogEntry(
+            action: action,
+            aliasCode: aliasCode,
+            reason: reason,
+            createdAt: Date().timeIntervalSince1970
+        )
+        logs.append(entry)
+        if logs.count > 200 {
+            logs.removeFirst(logs.count - 200)
+        }
+        let encoded = try? encoder.encode(logs)
+        preferenceStore.set(encoded, forKey: moderationLogKey)
+    }
+}

--- a/dogArea/Views/ProfileSettingView/RivalNetworkErrorInterpreter.swift
+++ b/dogArea/Views/ProfileSettingView/RivalNetworkErrorInterpreter.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// 라이벌 탭 네트워크 오류를 사용자 메시지/정책으로 해석합니다.
+enum RivalNetworkErrorInterpreter {
+    /// 익명 공유 설정 실패 오류를 사용자 안내 메시지로 변환합니다.
+    /// - Parameter error: 변환할 원본 오류입니다.
+    /// - Returns: 사용자에게 노출할 안내 문구입니다.
+    static func visibilityFailureMessage(from error: Error) -> String {
+        guard let supabaseError = error as? SupabaseHTTPError else {
+            return "설정 반영 실패, 다시 시도해주세요."
+        }
+        switch supabaseError {
+        case .notConfigured:
+            return "Supabase 설정이 누락되어 있어요. 설정 파일을 확인해주세요."
+        case .unexpectedStatusCode(let statusCode):
+            switch statusCode {
+            case 400, 401, 403:
+                return "인증 세션 확인이 필요해요. 다시 로그인 후 시도해주세요."
+            case 404:
+                return "근처 공유 기능이 아직 서버에 배포되지 않았어요."
+            case 500...599:
+                return "서버 설정이 준비되지 않았어요. 잠시 후 다시 시도해주세요."
+            default:
+                return "설정 반영 실패(\(statusCode))"
+            }
+        case .invalidURL, .invalidBody, .invalidResponse:
+            return "요청 형식 확인이 필요해요. 앱을 재시작 후 다시 시도해주세요."
+        }
+    }
+
+    /// 오류가 연결성(오프라인/서버 가용성) 계열인지 판정합니다.
+    /// - Parameter error: 판정할 오류입니다.
+    /// - Returns: 연결성 오류면 `true`, 아니면 `false`입니다.
+    static func isConnectivityError(_ error: Error) -> Bool {
+        if error is URLError {
+            return true
+        }
+        if let supabaseError = error as? SupabaseHTTPError {
+            switch supabaseError {
+            case .unexpectedStatusCode(let code):
+                return code == 429 || (500...599).contains(code)
+            default:
+                return false
+            }
+        }
+        return false
+    }
+}

--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -61,13 +61,11 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
     private let nearbyService: NearbyPresenceServiceProtocol
     private let rivalLeagueService: RivalLeagueServiceProtocol
     private let preferenceStore: MapPreferenceStoreProtocol
+    private let moderationStore: RivalModerationStoreProtocol
     private let locationManager: CLLocationManager
     private let authSessionStore: AuthSessionStoreProtocol
     private let sessionProvider: () -> AppSessionState
     private let locationSharingKey = "nearby.locationSharingEnabled.v1"
-    private let hiddenAliasKey = "rival.hidden.alias.codes.v1"
-    private let blockedAliasKey = "rival.blocked.alias.codes.v1"
-    private let moderationLogKey = "rival.moderation.logs.v1"
     private var pollingTimer: Timer? = nil
     private var lastRefreshAt: Date = .distantPast
     private var lastLeaderboardRefreshAt: Date = .distantPast
@@ -78,6 +76,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
         nearbyService: NearbyPresenceServiceProtocol = NearbyPresenceService(),
         rivalLeagueService: RivalLeagueServiceProtocol = RivalLeagueService(),
         preferenceStore: MapPreferenceStoreProtocol = DefaultMapPreferenceStore.shared,
+        moderationStore: RivalModerationStoreProtocol? = nil,
         locationManager: CLLocationManager = CLLocationManager(),
         authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
         sessionProvider: @escaping () -> AppSessionState = { AppFeatureGate.currentSession() }
@@ -85,6 +84,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
         self.nearbyService = nearbyService
         self.rivalLeagueService = rivalLeagueService
         self.preferenceStore = preferenceStore
+        self.moderationStore = moderationStore ?? RivalModerationStore(preferenceStore: preferenceStore)
         self.locationManager = locationManager
         self.authSessionStore = authSessionStore
         self.sessionProvider = sessionProvider
@@ -152,7 +152,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
                 preferenceStore.set(false, forKey: locationSharingKey)
                 locationSharingEnabled = false
                 refreshViewState()
-                showToast(visibilityFailureMessage(from: error))
+                showToast(RivalNetworkErrorInterpreter.visibilityFailureMessage(from: error))
             }
         }
     }
@@ -185,7 +185,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
                 preferenceStore.set(previous, forKey: locationSharingKey)
                 locationSharingEnabled = previous
                 refreshViewState()
-                showToast(visibilityFailureMessage(from: error))
+                showToast(RivalNetworkErrorInterpreter.visibilityFailureMessage(from: error))
             }
         }
     }
@@ -233,7 +233,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
                     screenState = .ready
                 }
             } catch {
-                if isConnectivityError(error) {
+                if RivalNetworkErrorInterpreter.isConnectivityError(error) {
                     screenState = hotspots.isEmpty ? .offlineEmpty : .offlineCached
                 } else {
                     screenState = .errorRetryable
@@ -410,86 +410,26 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
 
     /// 인증/권한/공유 상태를 바탕으로 라이벌 화면 상태를 결정합니다.
     private func refreshViewState() {
-        guard currentUserId != nil else {
-            screenState = .guestLocked
-            leaderboardState = .guestLocked
-            return
-        }
-        guard permissionState == .authorized else {
-            screenState = .permissionRequired
-            leaderboardState = .permissionRequired
-            return
-        }
-        guard locationSharingEnabled else {
-            screenState = .consentRequired
-            leaderboardState = .consentRequired
-            return
-        }
-        if hotspots.isEmpty {
-            screenState = .empty
-        } else {
-            screenState = .ready
-        }
-        if compareScope == .friend {
-            leaderboardState = .friendPreview
-        } else if leaderboardEntries.isEmpty {
-            leaderboardState = .empty
-        } else {
-            leaderboardState = .ready
-        }
-    }
-
-    /// 익명 공유 설정 실패를 사용자 액션으로 이어질 수 있는 문구로 변환합니다.
-    private func visibilityFailureMessage(from error: Error) -> String {
-        guard let supabaseError = error as? SupabaseHTTPError else {
-            return "설정 반영 실패, 다시 시도해주세요."
-        }
-        switch supabaseError {
-        case .notConfigured:
-            return "Supabase 설정이 누락되어 있어요. 설정 파일을 확인해주세요."
-        case .unexpectedStatusCode(let statusCode):
-            switch statusCode {
-            case 400, 401, 403:
-                return "인증 세션 확인이 필요해요. 다시 로그인 후 시도해주세요."
-            case 404:
-                return "근처 공유 기능이 아직 서버에 배포되지 않았어요."
-            case 500...599:
-                return "서버 설정이 준비되지 않았어요. 잠시 후 다시 시도해주세요."
-            default:
-                return "설정 반영 실패(\(statusCode))"
-            }
-        case .invalidURL, .invalidBody, .invalidResponse:
-            return "요청 형식 확인이 필요해요. 앱을 재시작 후 다시 시도해주세요."
-        }
+        let resolved = RivalViewStateResolver.resolve(
+            RivalViewStateInput(
+                hasAuthenticatedUser: currentUserId != nil,
+                permissionState: permissionState,
+                locationSharingEnabled: locationSharingEnabled,
+                hasHotspots: hotspots.isEmpty == false,
+                compareScope: compareScope,
+                hasLeaderboardEntries: leaderboardEntries.isEmpty == false
+            )
+        )
+        screenState = resolved.screen
+        leaderboardState = resolved.leaderboard
     }
 
     /// 핫스팟 요약 텍스트를 계산해 카드에 표시합니다.
     private func updateHotspotSummary() {
-        guard let maximum = hotspots.map(\.intensity).max() else {
-            maxIntensityText = "없음"
-            lastUpdatedText = "-"
-            hotspotPreviewRows = []
-            return
-        }
-        if maximum >= 0.67 {
-            maxIntensityText = "높음"
-        } else if maximum >= 0.34 {
-            maxIntensityText = "보통"
-        } else {
-            maxIntensityText = "낮음"
-        }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        lastUpdatedText = formatter.string(from: Date())
-        hotspotPreviewRows = hotspots
-            .sorted(by: { $0.intensity > $1.intensity })
-            .prefix(3)
-            .map { hotspot in
-                HotspotPreviewRow(
-                    title: "격자 \(hotspot.geohash.prefix(5))",
-                    value: "\(Int(hotspot.intensity * 100))% · \(hotspot.count)명"
-                )
-            }
+        let summary = RivalHotspotSummaryBuilder.build(from: hotspots)
+        maxIntensityText = summary.maxIntensityText
+        lastUpdatedText = summary.lastUpdatedText
+        hotspotPreviewRows = summary.previewRows
     }
 
     /// 주기 조회 타이머를 시작해 공유 중 상태에서 10초마다 핫스팟을 갱신합니다.
@@ -505,14 +445,19 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
 
     /// 저장된 숨김/차단 익명 코드 목록을 불러옵니다.
     private func loadModerationPreferences() {
-        hiddenAliases = Array(Set(preferenceStore.stringArray(forKey: hiddenAliasKey))).sorted()
-        blockedAliases = Array(Set(preferenceStore.stringArray(forKey: blockedAliasKey))).sorted()
+        let snapshot = moderationStore.loadSnapshot()
+        hiddenAliases = snapshot.hiddenAliases
+        blockedAliases = snapshot.blockedAliases
     }
 
     /// 현재 숨김/차단 익명 코드 목록을 로컬 설정에 저장합니다.
     private func persistModerationPreferences() {
-        preferenceStore.set(hiddenAliases.sorted(), forKey: hiddenAliasKey)
-        preferenceStore.set(blockedAliases.sorted(), forKey: blockedAliasKey)
+        moderationStore.saveSnapshot(
+            RivalModerationSnapshot(
+                hiddenAliases: hiddenAliases,
+                blockedAliases: blockedAliases
+            )
+        )
     }
 
     /// 리더보드 원본 데이터에 숨김/차단 필터를 적용해 사용자 노출 목록을 갱신합니다.
@@ -533,41 +478,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
 
     /// 신고/차단/숨김 이력을 로컬 JSON 로그에 누적합니다.
     private func appendModerationLog(action: String, aliasCode: String, reason: String?) {
-        let decoder = JSONDecoder()
-        let encoder = JSONEncoder()
-        var logs: [RivalModerationLogEntry] = []
-        if let data = preferenceStore.data(forKey: moderationLogKey),
-           let decoded = try? decoder.decode([RivalModerationLogEntry].self, from: data) {
-            logs = decoded
-        }
-        let entry = RivalModerationLogEntry(
-            action: action,
-            aliasCode: aliasCode,
-            reason: reason,
-            createdAt: Date().timeIntervalSince1970
-        )
-        logs.append(entry)
-        if logs.count > 200 {
-            logs.removeFirst(logs.count - 200)
-        }
-        let encoded = try? encoder.encode(logs)
-        preferenceStore.set(encoded, forKey: moderationLogKey)
-    }
-
-    /// 네트워크 계열 오류 여부를 판별합니다.
-    private func isConnectivityError(_ error: Error) -> Bool {
-        if error is URLError {
-            return true
-        }
-        if let supabaseError = error as? SupabaseHTTPError {
-            switch supabaseError {
-            case .unexpectedStatusCode(let code):
-                return code == 429 || (500...599).contains(code)
-            default:
-                return false
-            }
-        }
-        return false
+        moderationStore.appendLog(action: action, aliasCode: aliasCode, reason: reason)
     }
 
     /// 위치 권한이 바뀌면 화면 상태를 즉시 재계산합니다.
@@ -586,4 +497,3 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
         refreshLeaderboard(force: false)
     }
 }
-

--- a/dogArea/Views/ProfileSettingView/RivalViewStateResolver.swift
+++ b/dogArea/Views/ProfileSettingView/RivalViewStateResolver.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// 라이벌 화면 상태 판정 입력값입니다.
+struct RivalViewStateInput {
+    let hasAuthenticatedUser: Bool
+    let permissionState: RivalTabViewModel.PermissionState
+    let locationSharingEnabled: Bool
+    let hasHotspots: Bool
+    let compareScope: RivalCompareScope
+    let hasLeaderboardEntries: Bool
+}
+
+/// 라이벌 화면의 Screen/Leaderboard 상태를 계산하는 정책 객체입니다.
+enum RivalViewStateResolver {
+    /// 화면 상태를 입력값 기반으로 계산합니다.
+    /// - Parameter input: 인증/권한/공유/데이터 보유 여부를 담은 입력값입니다.
+    /// - Returns: 메인 카드 상태(`screen`)와 리더보드 상태(`leaderboard`)의 튜플입니다.
+    static func resolve(_ input: RivalViewStateInput) -> (
+        screen: RivalTabViewModel.ScreenState,
+        leaderboard: RivalTabViewModel.LeaderboardState
+    ) {
+        guard input.hasAuthenticatedUser else {
+            return (.guestLocked, .guestLocked)
+        }
+        guard input.permissionState == .authorized else {
+            return (.permissionRequired, .permissionRequired)
+        }
+        guard input.locationSharingEnabled else {
+            return (.consentRequired, .consentRequired)
+        }
+
+        let screen: RivalTabViewModel.ScreenState = input.hasHotspots ? .ready : .empty
+        let leaderboard: RivalTabViewModel.LeaderboardState
+        if input.compareScope == .friend {
+            leaderboard = .friendPreview
+        } else if input.hasLeaderboardEntries {
+            leaderboard = .ready
+        } else {
+            leaderboard = .empty
+        }
+        return (screen, leaderboard)
+    }
+}


### PR DESCRIPTION
## Summary
- Split bulky `RivalTabViewModel` responsibilities into dedicated services
- Added `RivalModerationStore` for hidden/blocked alias persistence and moderation log append
- Added `RivalViewStateResolver` for screen/leaderboard state policy resolution
- Added `RivalNetworkErrorInterpreter` for connectivity classification and user-facing failure messaging
- Added `RivalHotspotSummaryBuilder` for hotspot summary text/preview row derivation
- Kept existing behavior and public UI contract unchanged

## Validation
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
- `xcodebuild -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project dogArea.xcodeproj -scheme dogArea -destination 'id=C787307E-5F3E-491D-BD28-7E07CA86BABA' -only-testing:dogAreaUITests test`
