### PR TITLE
Refactor HomeViewModel reminder support into dedicated services

### DIFF
--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		5951E893E8CBC77DCA82E00F /* WalkDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A775802DB2A590A7C7DA0978 /* WalkDetailViewModel.swift */; };
 		5F3ED37B0435F882BC90593E /* HomePetSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA31AC1DF69B7CA85070D28 /* HomePetSelectorView.swift */; };
 		68DE48DFEF4001E3F518BF10 /* HomeTerritoryHeaderSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FFE492DDD22A6AC1319D9D /* HomeTerritoryHeaderSectionView.swift */; };
+		6A18F6C8151D05B751F63179 /* HomeQuestReminderSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363FE1044470B273CAB987E0 /* HomeQuestReminderSupport.swift */; };
 		6B1F802F9363A5DD652CA409 /* AreaDetailListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0C69DBDA661E0970F6A0BB /* AreaDetailListHeaderView.swift */; };
 		6B64A696910A6CBB2B3830E0 /* HomeWeeklySnapshotSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59FE8AF61BF3AE3B6C99D77 /* HomeWeeklySnapshotSectionView.swift */; };
 		73816D222BB17958D198D1AC /* HomeStatusBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1B2C487816AA2CCCA6186F /* HomeStatusBannerView.swift */; };
@@ -216,6 +217,7 @@
 		21CE83B02069A8E4171B35DE /* RivalTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalTabView.swift; path = dogArea/Views/ProfileSettingView/RivalTabView.swift; sourceTree = "<group>"; };
 		2615443270FF3222AEBDE893 /* ThumbnailImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailImageView.swift; sourceTree = "<group>"; };
 		30BF0E17B2BF40E97DBA5E07 /* ProfileFieldEditSheetViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileFieldEditSheetViewModel.swift; path = dogArea/Views/ProfileSettingView/ProfileFieldEditSheetViewModel.swift; sourceTree = "<group>"; };
+		363FE1044470B273CAB987E0 /* HomeQuestReminderSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeQuestReminderSupport.swift; path = dogArea/Views/HomeView/HomeQuestReminderSupport.swift; sourceTree = "<group>"; };
 		376D30D4A7542596A014DEE1 /* SimpleKeyValueView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SimpleKeyValueView.swift; sourceTree = "<group>"; };
 		4A1B2C487816AA2CCCA6186F /* HomeStatusBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeStatusBannerView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeStatusBannerView.swift; sourceTree = "<group>"; };
 		4D14629580BEDCDCAE5B9EC3 /* HomeSelectedPetEmptyStateCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSelectedPetEmptyStateCardView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeSelectedPetEmptyStateCardView.swift; sourceTree = "<group>"; };
@@ -596,6 +598,7 @@
 				F2D5D8D51AC30DA6DB60A871 /* RivalViewStateResolver.swift */,
 				E4548C0C604B933CC43644FA /* RivalNetworkErrorInterpreter.swift */,
 				8F2B2A868B6FD9035AC5214F /* RivalHotspotSummaryBuilder.swift */,
+				363FE1044470B273CAB987E0 /* HomeQuestReminderSupport.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1068,6 +1071,7 @@
 				8A40430FD15CD439469AC981 /* RivalViewStateResolver.swift in Sources */,
 				106E27D50C08D7997FD7982D /* RivalNetworkErrorInterpreter.swift in Sources */,
 				C047F1CA5DC13CAE4F03AE90 /* RivalHotspotSummaryBuilder.swift in Sources */,
+				6A18F6C8151D05B751F63179 /* HomeQuestReminderSupport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dogArea/Views/HomeView/HomeQuestReminderSupport.swift
+++ b/dogArea/Views/HomeView/HomeQuestReminderSupport.swift
@@ -1,0 +1,135 @@
+import Foundation
+import UserNotifications
+
+/// 퀘스트 리마인드 스케줄 적용 결과입니다.
+enum QuestReminderApplyResult: Equatable {
+    case enabled
+    case disabled
+    case permissionDenied
+    case requiresPermission
+}
+
+/// 퀘스트 리마인드 스케줄링 인터페이스입니다.
+protocol QuestReminderScheduling {
+    /// 하루 1회 퀘스트 리마인드 스케줄을 적용합니다.
+    /// - Parameters:
+    ///   - enabled: 리마인드 활성화 여부입니다.
+    ///   - allowAuthorizationPrompt: 권한 미결정 시 시스템 권한 팝업을 표시할지 여부입니다.
+    ///   - hour: 반복 알림 시각(시)입니다.
+    ///   - minute: 반복 알림 시각(분)입니다.
+    /// - Returns: 리마인드 적용 결과 상태입니다.
+    func applyDailyReminder(
+        enabled: Bool,
+        allowAuthorizationPrompt: Bool,
+        hour: Int,
+        minute: Int
+    ) async -> QuestReminderApplyResult
+}
+
+/// 퀘스트 리마인드 on/off 설정을 로컬에 저장합니다.
+final class QuestReminderPreferenceStore {
+    private let defaults = UserDefaults.standard
+    private let key = "home.quest.reminder.enabled.v1"
+
+    /// 저장된 퀘스트 리마인드 on/off 상태를 반환합니다.
+    var isEnabled: Bool {
+        defaults.object(forKey: key) as? Bool ?? false
+    }
+
+    /// 퀘스트 리마인드 on/off 상태를 저장합니다.
+    /// - Parameter enabled: 저장할 활성화 상태입니다.
+    func setEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: key)
+    }
+}
+
+/// iOS 로컬 알림 기반 퀘스트 리마인더 스케줄러입니다.
+final class LocalQuestReminderScheduler: QuestReminderScheduling {
+    private let center: UNUserNotificationCenter
+    private let requestId = "home.quest.daily.reminder.v1"
+
+    /// 로컬 알림 스케줄러를 초기화합니다.
+    /// - Parameter center: 알림 스케줄링에 사용할 시스템 알림 센터입니다.
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    /// 하루 1회 퀘스트 리마인드 알림을 설정하거나 해제합니다.
+    /// - Parameters:
+    ///   - enabled: 리마인드 활성화 여부입니다.
+    ///   - allowAuthorizationPrompt: 권한 미결정 시 시스템 권한 팝업을 표시할지 여부입니다.
+    ///   - hour: 반복 알림 시각(시)입니다.
+    ///   - minute: 반복 알림 시각(분)입니다.
+    /// - Returns: 리마인드 적용 결과 상태입니다.
+    func applyDailyReminder(
+        enabled: Bool,
+        allowAuthorizationPrompt: Bool,
+        hour: Int,
+        minute: Int
+    ) async -> QuestReminderApplyResult {
+        guard enabled else {
+            center.removePendingNotificationRequests(withIdentifiers: [requestId])
+            center.removeDeliveredNotifications(withIdentifiers: [requestId])
+            return .disabled
+        }
+
+        let authorization = await ensureAuthorization(allowPrompt: allowAuthorizationPrompt)
+        switch authorization {
+        case .enabled:
+            break
+        case .permissionDenied:
+            return .permissionDenied
+        case .requiresPermission:
+            return .requiresPermission
+        case .disabled:
+            return .permissionDenied
+        }
+
+        center.removePendingNotificationRequests(withIdentifiers: [requestId])
+
+        let content = UNMutableNotificationContent()
+        content.title = "오늘 산책 퀘스트 확인할 시간이에요"
+        content.body = "홈에서 오늘 미션을 확인하고, 짧게 기록해 진행도를 올려보세요."
+        content.sound = .default
+
+        var dateComponents = DateComponents()
+        dateComponents.hour = hour
+        dateComponents.minute = minute
+
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+        let request = UNNotificationRequest(identifier: requestId, content: content, trigger: trigger)
+
+        return await withCheckedContinuation { continuation in
+            center.add(request) { error in
+                continuation.resume(returning: error == nil ? .enabled : .permissionDenied)
+            }
+        }
+    }
+
+    /// 알림 권한 상태를 확인하고 필요 시 사용자 권한 요청을 실행합니다.
+    /// - Parameter allowPrompt: 권한 미결정 시 시스템 권한 팝업 표시 여부입니다.
+    /// - Returns: 권한 처리 결과입니다.
+    private func ensureAuthorization(allowPrompt: Bool) async -> QuestReminderApplyResult {
+        let settings = await withCheckedContinuation { continuation in
+            center.getNotificationSettings { settings in
+                continuation.resume(returning: settings)
+            }
+        }
+
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return .enabled
+        case .denied:
+            return .permissionDenied
+        case .notDetermined:
+            guard allowPrompt else { return .requiresPermission }
+            return await withCheckedContinuation { continuation in
+                center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+                    continuation.resume(returning: granted ? .enabled : .permissionDenied)
+                }
+            }
+        @unknown default:
+            return .permissionDenied
+        }
+    }
+}

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -8,7 +8,6 @@
 import Foundation
 import SwiftUI
 import Combine
-import UserNotifications
 
 enum QuestMotionEventType: String, Equatable {
     case progress
@@ -114,117 +113,6 @@ struct WeatherShieldDailySummary: Equatable {
     let dayKey: String
     let applyCount: Int
     let lastAppliedAtText: String
-}
-
-private enum QuestReminderApplyResult: Equatable {
-    case enabled
-    case disabled
-    case permissionDenied
-    case requiresPermission
-}
-
-private protocol QuestReminderScheduling {
-    func applyDailyReminder(
-        enabled: Bool,
-        allowAuthorizationPrompt: Bool,
-        hour: Int,
-        minute: Int
-    ) async -> QuestReminderApplyResult
-}
-
-private final class QuestReminderPreferenceStore {
-    private let defaults = UserDefaults.standard
-    private let key = "home.quest.reminder.enabled.v1"
-
-    /// 저장된 퀘스트 리마인드 on/off 상태를 반환합니다.
-    var isEnabled: Bool {
-        defaults.object(forKey: key) as? Bool ?? false
-    }
-
-    /// 퀘스트 리마인드 on/off 상태를 저장합니다.
-    func setEnabled(_ enabled: Bool) {
-        defaults.set(enabled, forKey: key)
-    }
-}
-
-private final class LocalQuestReminderScheduler: QuestReminderScheduling {
-    private let center: UNUserNotificationCenter
-    private let requestId = "home.quest.daily.reminder.v1"
-
-    init(center: UNUserNotificationCenter = .current()) {
-        self.center = center
-    }
-
-    /// 하루 1회 퀘스트 리마인드 알림을 설정하거나 해제합니다.
-    func applyDailyReminder(
-        enabled: Bool,
-        allowAuthorizationPrompt: Bool,
-        hour: Int,
-        minute: Int
-    ) async -> QuestReminderApplyResult {
-        guard enabled else {
-            center.removePendingNotificationRequests(withIdentifiers: [requestId])
-            center.removeDeliveredNotifications(withIdentifiers: [requestId])
-            return .disabled
-        }
-
-        let authorization = await ensureAuthorization(allowPrompt: allowAuthorizationPrompt)
-        switch authorization {
-        case .enabled:
-            break
-        case .permissionDenied:
-            return .permissionDenied
-        case .requiresPermission:
-            return .requiresPermission
-        case .disabled:
-            return .permissionDenied
-        }
-
-        center.removePendingNotificationRequests(withIdentifiers: [requestId])
-
-        let content = UNMutableNotificationContent()
-        content.title = "오늘 산책 퀘스트 확인할 시간이에요"
-        content.body = "홈에서 오늘 미션을 확인하고, 짧게 기록해 진행도를 올려보세요."
-        content.sound = .default
-
-        var dateComponents = DateComponents()
-        dateComponents.hour = hour
-        dateComponents.minute = minute
-
-        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
-        let request = UNNotificationRequest(identifier: requestId, content: content, trigger: trigger)
-
-        return await withCheckedContinuation { continuation in
-            center.add(request) { error in
-                continuation.resume(returning: error == nil ? .enabled : .permissionDenied)
-            }
-        }
-    }
-
-    /// 알림 권한 상태를 확인하고 필요 시 사용자 권한 요청을 실행합니다.
-    private func ensureAuthorization(allowPrompt: Bool) async -> QuestReminderApplyResult {
-        let settings = await withCheckedContinuation { continuation in
-            center.getNotificationSettings { settings in
-                continuation.resume(returning: settings)
-            }
-        }
-
-        switch settings.authorizationStatus {
-        case .authorized, .provisional, .ephemeral:
-            return .enabled
-        case .denied:
-            return .permissionDenied
-        case .notDetermined:
-            guard allowPrompt else { return .requiresPermission }
-            return await withCheckedContinuation { continuation in
-                center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
-                    continuation.resume(returning: granted ? .enabled : .permissionDenied)
-                }
-            }
-        @unknown default:
-            return .permissionDenied
-        }
-    }
 }
 
 final class HomeViewModel: ObservableObject {


### PR DESCRIPTION
## Summary
- Refactored Home reminder infrastructure out of `HomeViewModel.swift` into dedicated support file
- Added `HomeQuestReminderSupport.swift` containing:
  - `QuestReminderApplyResult`
  - `QuestReminderScheduling`
  - `QuestReminderPreferenceStore`
  - `LocalQuestReminderScheduler`
- Preserved all existing Home reminder behavior and API surface in `HomeViewModel`

## Validation
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
- `xcodebuild -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project dogArea.xcodeproj -scheme dogArea -destination 'id=C787307E-5F3E-491D-BD28-7E07CA86BABA' -only-testing:dogAreaUITests test`
