### PR TITLE
refactor: 홈 날씨 상태 요약 빌더 분리

### DIFF
--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		DA8BB9F22B02FE3A00E350C4 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8BB9F12B02FE3A00E350C4 /* HomeViewModel.swift */; };
 		DA8BB9F52B032AB000E350C4 /* Calender.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8BB9F42B032AB000E350C4 /* Calender.swift */; };
 		DAE147A11420000000000001 /* HomeWeeklyStatisticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE147A01420000000000001 /* HomeWeeklyStatisticsService.swift */; };
+		DAE147A31420000000000001 /* HomeWeatherMissionStatusBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE147A21420000000000001 /* HomeWeatherMissionStatusBuilder.swift */; };
 		DA933BE92ADD04E70029856C /* CustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA933BE82ADD04E70029856C /* CustomAlertView.swift */; };
 		DA95CC6C2ADE0682004AD94D /* OpenAIClient.h in Headers */ = {isa = PBXBuildFile; fileRef = DA95CC6B2ADE0682004AD94D /* OpenAIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA95CC6F2ADE0682004AD94D /* OpenAIClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA95CC692ADE0682004AD94D /* OpenAIClient.framework */; };
@@ -292,6 +293,7 @@
 		DA8BB9F12B02FE3A00E350C4 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		DA8BB9F42B032AB000E350C4 /* Calender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calender.swift; sourceTree = "<group>"; };
 		DAE147A01420000000000001 /* HomeWeeklyStatisticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeeklyStatisticsService.swift; sourceTree = "<group>"; };
+		DAE147A21420000000000001 /* HomeWeatherMissionStatusBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherMissionStatusBuilder.swift; sourceTree = "<group>"; };
 		DA933BE82ADD04E70029856C /* CustomAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertView.swift; sourceTree = "<group>"; };
 		DA95CC692ADE0682004AD94D /* OpenAIClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OpenAIClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA95CC6B2ADE0682004AD94D /* OpenAIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenAIClient.h; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 				DA3EB0792B0344CD00AEA65D /* AreaDetailView.swift */,
 				DA8BB9F12B02FE3A00E350C4 /* HomeViewModel.swift */,
 				DAE147A01420000000000001 /* HomeWeeklyStatisticsService.swift */,
+				DAE147A21420000000000001 /* HomeWeatherMissionStatusBuilder.swift */,
 			);
 			path = HomeView;
 			sourceTree = "<group>";
@@ -1023,6 +1026,7 @@
 				DA4513832AFB25C2007AD69B /* PositionMarkerView.swift in Sources */,
 				DA8BB9F22B02FE3A00E350C4 /* HomeViewModel.swift in Sources */,
 				DAE147A11420000000000001 /* HomeWeeklyStatisticsService.swift in Sources */,
+				DAE147A31420000000000001 /* HomeWeatherMissionStatusBuilder.swift in Sources */,
 				DAED25022AFA1D430044715A /* SplashView.swift in Sources */,
 				DA99F9E62AFA4F3E00B1483F /* Color.swift in Sources */,
 				DA3F9BD32AE0FF8A0048550C /* RootView.swift in Sources */,

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -164,6 +164,7 @@ final class HomeViewModel: ObservableObject {
     private let userSessionStore: UserSessionStoreProtocol
     private let eventCenter: AppEventCenterProtocol
     private let weeklyStatisticsService: HomeWeeklyStatisticsServicing
+    private let weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding
     private let seasonMotionStore = SeasonMotionStore()
     private let questReminderScheduler: QuestReminderScheduling
     private let questReminderPreferenceStore = QuestReminderPreferenceStore()
@@ -175,12 +176,6 @@ final class HomeViewModel: ObservableObject {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.dateFormat = "M/d HH:mm"
-        return formatter
-    }()
-    private static let weatherAppliedTimeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "HH:mm"
         return formatter
     }()
 
@@ -238,13 +233,15 @@ final class HomeViewModel: ObservableObject {
         walkRepository: WalkRepositoryProtocol = WalkRepositoryContainer.shared,
         userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
         eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared,
-        weeklyStatisticsService: HomeWeeklyStatisticsServicing = HomeWeeklyStatisticsService()
+        weeklyStatisticsService: HomeWeeklyStatisticsServicing = HomeWeeklyStatisticsService(),
+        weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding = HomeWeatherMissionStatusBuilder()
     ) {
         self.areaReferenceRepository = areaReferenceRepository
         self.walkRepository = walkRepository
         self.userSessionStore = userSessionStore
         self.eventCenter = eventCenter
         self.weeklyStatisticsService = weeklyStatisticsService
+        self.weatherMissionStatusBuilder = weatherMissionStatusBuilder
         self.questReminderScheduler = LocalQuestReminderScheduler()
         self.questReminderEnabled = false
         self.questReminderEnabled = questReminderPreferenceStore.isEnabled
@@ -641,11 +638,14 @@ final class HomeViewModel: ObservableObject {
         questAlternativeActionSuggestion = makeQuestAlternativeActionSuggestion(for: indoorMissionBoard)
         weatherFeedbackRemainingCount = indoorMissionStore.weatherFeedbackRemainingCount(now: now)
         let weatherStatus = indoorMissionStore.weatherStatus(now: now)
-        weatherShieldDailySummary = indoorMissionStore.weatherShieldDailySummary(now: now)
-        weatherMissionStatusSummary = makeWeatherMissionStatusSummary(
+        let shieldDailySummary = indoorMissionStore.weatherShieldDailySummary(now: now)
+        weatherShieldDailySummary = shieldDailySummary
+        weatherMissionStatusSummary = weatherMissionStatusBuilder.makeStatusSummary(
             board: indoorMissionBoard,
             status: weatherStatus,
-            now: now
+            now: now,
+            shieldApplyCount: shieldDailySummary?.applyCount ?? 0,
+            localizedCopy: localizedCopy(ko:en:)
         )
         if indoorMissionBoard.isIndoorReplacementActive {
             let exposureKey = "\(indoorMissionBoard.dayKey)|\(indoorMissionBoard.riskLevel.rawValue)"
@@ -1028,74 +1028,6 @@ final class HomeViewModel: ObservableObject {
                 shieldApplied: false
             )
         }
-    }
-
-    private func makeWeatherMissionStatusSummary(
-        board: IndoorMissionBoard,
-        status: IndoorWeatherStatus,
-        now: Date
-    ) -> WeatherMissionStatusSummary {
-        let badgeText: String
-        if status.source == .fallback {
-            badgeText = localizedCopy(ko: "기본 모드", en: "Base Mode")
-        } else if board.riskLevel == .clear {
-            badgeText = localizedCopy(ko: "정상", en: "Normal")
-        } else {
-            badgeText = localizedCopy(ko: "치환", en: "Replaced")
-        }
-
-        let reasonText: String
-        if status.source == .fallback {
-            reasonText = localizedCopy(
-                ko: "날씨 연동이 아직 준비되지 않아 기본 퀘스트로 진행합니다.",
-                en: "Weather integration is not ready yet. Running default quests."
-            )
-        } else if board.riskLevel == .clear {
-            reasonText = localizedCopy(
-                ko: "날씨 안정 단계로 기본 퀘스트를 진행합니다.",
-                en: "Stable weather. Running default quests."
-            )
-        } else {
-            reasonText = localizedCopy(
-                ko: "\(board.riskLevel.displayTitle) 단계로 일부 실외 목표를 실내 미션으로 치환했어요.",
-                en: "Risk \(board.riskLevel.rawValue) replaced some outdoor goals with indoor missions."
-            )
-        }
-
-        let appliedTimestamp = status.lastUpdatedAt ?? now.timeIntervalSince1970
-        let appliedTime = Self.weatherAppliedTimeFormatter.string(from: Date(timeIntervalSince1970: appliedTimestamp))
-        let shieldCount = weatherShieldDailySummary?.applyCount ?? indoorMissionStore.weatherShieldDailySummary(now: now)?.applyCount ?? 0
-        let shieldText = localizedCopy(
-            ko: "보호 사용 \(shieldCount)회",
-            en: "Shield used \(shieldCount)x"
-        )
-        let fallbackNotice: String?
-        if status.source == .fallback {
-            fallbackNotice = localizedCopy(
-                ko: "연동 전에도 산책/기록/퀘스트는 정상적으로 계속됩니다.",
-                en: "Walk, logs, and quests continue normally even before weather integration."
-            )
-        } else {
-            fallbackNotice = nil
-        }
-
-        let appliedAtText = localizedCopy(
-            ko: "적용 시점 \(appliedTime)",
-            en: "Applied at \(appliedTime)"
-        )
-        let accessibilityText = "\(badgeText). \(reasonText). \(appliedAtText). \(shieldText)"
-
-        return WeatherMissionStatusSummary(
-            badgeText: badgeText,
-            title: localizedCopy(ko: "오늘 날씨 연동 상태", en: "Today's Weather Status"),
-            reasonText: reasonText,
-            appliedAtText: appliedAtText,
-            shieldUsageText: shieldText,
-            fallbackNotice: fallbackNotice,
-            accessibilityText: accessibilityText,
-            isFallback: status.source == .fallback,
-            riskLevel: board.riskLevel
-        )
     }
 
     private func currentCalendar() -> Calendar {

--- a/dogArea/Views/HomeView/HomeWeatherMissionStatusBuilder.swift
+++ b/dogArea/Views/HomeView/HomeWeatherMissionStatusBuilder.swift
@@ -1,0 +1,114 @@
+//
+//  HomeWeatherMissionStatusBuilder.swift
+//  dogArea
+//
+//  Created by Codex on 3/2/26.
+//
+
+import Foundation
+
+/// 홈 실내 미션 카드의 날씨 상태 요약 문자열을 생성하는 빌더 계약입니다.
+protocol HomeWeatherMissionStatusBuilding {
+    /// 실내 미션 보드/날씨 상태/로케일을 바탕으로 사용자 노출용 상태 요약을 생성합니다.
+    /// - Parameters:
+    ///   - board: 현재 실내 미션 보드 상태입니다.
+    ///   - status: 날씨 연동 소스 및 최신 반영 시각을 포함한 상태입니다.
+    ///   - now: 현재 시각입니다.
+    ///   - shieldApplyCount: 당일 날씨 보호 적용 횟수입니다.
+    ///   - localizedCopy: 한/영 문구를 현재 로케일에 맞춰 선택하는 함수입니다.
+    /// - Returns: 홈 카드에서 바로 렌더링 가능한 `WeatherMissionStatusSummary`입니다.
+    func makeStatusSummary(
+        board: IndoorMissionBoard,
+        status: IndoorWeatherStatus,
+        now: Date,
+        shieldApplyCount: Int,
+        localizedCopy: (_ ko: String, _ en: String) -> String
+    ) -> WeatherMissionStatusSummary
+}
+
+final class HomeWeatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding {
+    private static let appliedTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    /// 실내 미션 보드/날씨 상태/로케일을 바탕으로 사용자 노출용 상태 요약을 생성합니다.
+    /// - Parameters:
+    ///   - board: 현재 실내 미션 보드 상태입니다.
+    ///   - status: 날씨 연동 소스 및 최신 반영 시각을 포함한 상태입니다.
+    ///   - now: 현재 시각입니다.
+    ///   - shieldApplyCount: 당일 날씨 보호 적용 횟수입니다.
+    ///   - localizedCopy: 한/영 문구를 현재 로케일에 맞춰 선택하는 함수입니다.
+    /// - Returns: 홈 카드에서 바로 렌더링 가능한 `WeatherMissionStatusSummary`입니다.
+    func makeStatusSummary(
+        board: IndoorMissionBoard,
+        status: IndoorWeatherStatus,
+        now: Date,
+        shieldApplyCount: Int,
+        localizedCopy: (_ ko: String, _ en: String) -> String
+    ) -> WeatherMissionStatusSummary {
+        let badgeText: String
+        if status.source == .fallback {
+            badgeText = localizedCopy("기본 모드", "Base Mode")
+        } else if board.riskLevel == .clear {
+            badgeText = localizedCopy("정상", "Normal")
+        } else {
+            badgeText = localizedCopy("치환", "Replaced")
+        }
+
+        let reasonText: String
+        if status.source == .fallback {
+            reasonText = localizedCopy(
+                "날씨 연동이 아직 준비되지 않아 기본 퀘스트로 진행합니다.",
+                "Weather integration is not ready yet. Running default quests."
+            )
+        } else if board.riskLevel == .clear {
+            reasonText = localizedCopy(
+                "날씨 안정 단계로 기본 퀘스트를 진행합니다.",
+                "Stable weather. Running default quests."
+            )
+        } else {
+            reasonText = localizedCopy(
+                "\(board.riskLevel.displayTitle) 단계로 일부 실외 목표를 실내 미션으로 치환했어요.",
+                "Risk \(board.riskLevel.rawValue) replaced some outdoor goals with indoor missions."
+            )
+        }
+
+        let appliedTimestamp = status.lastUpdatedAt ?? now.timeIntervalSince1970
+        let appliedTime = Self.appliedTimeFormatter.string(from: Date(timeIntervalSince1970: appliedTimestamp))
+        let shieldText = localizedCopy(
+            "보호 사용 \(shieldApplyCount)회",
+            "Shield used \(shieldApplyCount)x"
+        )
+
+        let fallbackNotice: String?
+        if status.source == .fallback {
+            fallbackNotice = localizedCopy(
+                "연동 전에도 산책/기록/퀘스트는 정상적으로 계속됩니다.",
+                "Walk, logs, and quests continue normally even before weather integration."
+            )
+        } else {
+            fallbackNotice = nil
+        }
+
+        let appliedAtText = localizedCopy(
+            "적용 시점 \(appliedTime)",
+            "Applied at \(appliedTime)"
+        )
+        let accessibilityText = "\(badgeText). \(reasonText). \(appliedAtText). \(shieldText)"
+
+        return WeatherMissionStatusSummary(
+            badgeText: badgeText,
+            title: localizedCopy("오늘 날씨 연동 상태", "Today's Weather Status"),
+            reasonText: reasonText,
+            appliedAtText: appliedAtText,
+            shieldUsageText: shieldText,
+            fallbackNotice: fallbackNotice,
+            accessibilityText: accessibilityText,
+            isFallback: status.source == .fallback,
+            riskLevel: board.riskLevel
+        )
+    }
+}


### PR DESCRIPTION
## 요약\n- HomeViewModel의 날씨 상태 요약 조합 로직을 HomeWeatherMissionStatusBuilder로 분리\n- HomeViewModel은 실내 미션 상태 조합/상태 저장 책임만 유지\n- 신규 빌더 함수에 Quick Help 주석(파라미터/리턴 의미) 추가\n\n## 테스트\n- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh\n- xcodebuild -quiet -scheme dogArea -destination 'generic/platform=iOS Simulator' build\n- xcodebuild -quiet -scheme 'dogAreaWatch Watch App' -destination 'generic/platform=watchOS Simulator' build\n- xcodebuild -quiet -scheme dogArea -destination 'platform=iOS Simulator,id=C787307E-5F3E-491D-BD28-7E07CA86BABA' -only-testing:dogAreaUITests test