### PR TITLE
refactor: 지도 클러스터 계산 서비스 분리

### DIFF
--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		DA3F9BA32AE0F14F0048550C /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9B2AE0F14F0048550C /* MapView.swift */; };
 		DA3F9BA42AE0F14F0048550C /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9C2AE0F14F0048550C /* MapViewModel.swift */; };
 		DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9D2AE0F14F0048550C /* MapModel.swift */; };
+		DAE147B11420000000000001 /* MapClusterAnnotationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE147B01420000000000001 /* MapClusterAnnotationService.swift */; };
 		DA3F9BA62AE0F14F0048550C /* WalkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */; };
 		DA3F9BAE2AE0F2410048550C /* ViewUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */; };
 		DA3F9BD32AE0FF8A0048550C /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9BD22AE0FF8A0048550C /* RootView.swift */; };
@@ -269,6 +270,7 @@
 		DA3F9B9B2AE0F14F0048550C /* MapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		DA3F9B9C2AE0F14F0048550C /* MapViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		DA3F9B9D2AE0F14F0048550C /* MapModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapModel.swift; sourceTree = "<group>"; };
+		DAE147B01420000000000001 /* MapClusterAnnotationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapClusterAnnotationService.swift; sourceTree = "<group>"; };
 		DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalkListView.swift; sourceTree = "<group>"; };
 		DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewUtility.swift; sourceTree = "<group>"; };
 		DA3F9BD22AE0FF8A0048550C /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
@@ -483,6 +485,7 @@
 				DAAE22222AFCC225005FD096 /* WalkDetailView.swift */,
 				DA3F9B9C2AE0F14F0048550C /* MapViewModel.swift */,
 				DA3F9B9D2AE0F14F0048550C /* MapModel.swift */,
+				DAE147B01420000000000001 /* MapClusterAnnotationService.swift */,
 				376D30D4A7542596A014DEE1 /* SimpleKeyValueView.swift */,
 			);
 			path = MapView;
@@ -1023,6 +1026,7 @@
 				DA1731732AE2017500EF10C8 /* SupabaseInfrastructure.swift in Sources */,
 				DAA8E4F92B01A80C00F9190B /* TabAppear.swift in Sources */,
 				DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */,
+				DAE147B11420000000000001 /* MapClusterAnnotationService.swift in Sources */,
 				DA4513832AFB25C2007AD69B /* PositionMarkerView.swift in Sources */,
 				DA8BB9F22B02FE3A00E350C4 /* HomeViewModel.swift in Sources */,
 				DAE147A11420000000000001 /* HomeWeeklyStatisticsService.swift in Sources */,

--- a/dogArea/Views/MapView/MapClusterAnnotationService.swift
+++ b/dogArea/Views/MapView/MapClusterAnnotationService.swift
@@ -1,0 +1,142 @@
+//
+//  MapClusterAnnotationService.swift
+//  dogArea
+//
+//  Created by Codex on 3/2/26.
+//
+
+import Foundation
+import MapKit
+
+protocol MapClusterAnnotationServicing {
+    /// 현재 폴리곤 목록과 카메라 거리 기반 설정으로 클러스터 배열을 계산합니다.
+    /// - Parameters:
+    ///   - polygons: 지도에 표시되는 산책 폴리곤 목록입니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 클러스터 셀 크기 비율입니다.
+    ///   - minCellMeters: 셀 크기의 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 크기의 최대값(미터)입니다.
+    /// - Returns: 버킷 병합 결과가 반영된 정렬된 클러스터 목록입니다.
+    func cluster(
+        polygons: [Polygon],
+        cameraDistance: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> [Cluster]
+}
+
+final class MapClusterAnnotationService: MapClusterAnnotationServicing {
+    private struct ClusterBucketKey: Hashable {
+        let x: Int
+        let y: Int
+    }
+
+    /// 현재 폴리곤 목록과 카메라 거리 기반 설정으로 클러스터 배열을 계산합니다.
+    /// - Parameters:
+    ///   - polygons: 지도에 표시되는 산책 폴리곤 목록입니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 클러스터 셀 크기 비율입니다.
+    ///   - minCellMeters: 셀 크기의 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 크기의 최대값(미터)입니다.
+    /// - Returns: 버킷 병합 결과가 반영된 정렬된 클러스터 목록입니다.
+    func cluster(
+        polygons: [Polygon],
+        cameraDistance: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> [Cluster] {
+        let seedClusters = initialClusters(from: polygons)
+        return bucketClusters(
+            from: seedClusters,
+            cameraDistance: cameraDistance,
+            distanceRatio: distanceRatio,
+            minCellMeters: minCellMeters,
+            maxCellMeters: maxCellMeters
+        )
+    }
+
+    /// 폴리곤 중심점을 단일 클러스터로 초기화합니다.
+    /// - Parameter polygons: 산책 폴리곤 목록입니다.
+    /// - Returns: 폴리곤별 단일 멤버 클러스터 배열입니다.
+    private func initialClusters(from polygons: [Polygon]) -> [Cluster] {
+        polygons.compactMap { polygon in
+            guard let mapPolygon = polygon.polygon else { return nil }
+            return Cluster(center: mapPolygon.coordinate, id: polygon.id)
+        }
+    }
+
+    /// 클러스터를 셀 버킷에 할당해 동일 셀 클러스터를 병합합니다.
+    /// - Parameters:
+    ///   - clusters: 초기 클러스터 배열입니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 셀 크기 비율입니다.
+    ///   - minCellMeters: 셀 크기의 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 크기의 최대값(미터)입니다.
+    /// - Returns: 병합/정렬된 클러스터 배열입니다.
+    private func bucketClusters(
+        from clusters: [Cluster],
+        cameraDistance: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> [Cluster] {
+        guard clusters.count > 1 else { return clusters }
+
+        let referenceLatitude = clusters.map(\.center.latitude).reduce(0.0, +) / Double(clusters.count)
+        let cellMeters = clusterCellSizeMeters(
+            cameraDistance: cameraDistance,
+            distanceRatio: distanceRatio,
+            minCellMeters: minCellMeters,
+            maxCellMeters: maxCellMeters
+        )
+        let metersPerMapPoint = MKMetersPerMapPointAtLatitude(referenceLatitude)
+        let cellMapPoints = max(1.0, cellMeters / max(0.0001, metersPerMapPoint))
+
+        var buckets: [ClusterBucketKey: Cluster] = [:]
+        buckets.reserveCapacity(clusters.count)
+
+        for cluster in clusters {
+            let point = MKMapPoint(cluster.center)
+            let key = ClusterBucketKey(
+                x: Int(floor(point.x / cellMapPoints)),
+                y: Int(floor(point.y / cellMapPoints))
+            )
+
+            if var existing = buckets[key] {
+                existing.updateCenter(with: cluster)
+                buckets[key] = existing
+            } else {
+                buckets[key] = cluster
+            }
+        }
+
+        return buckets.values.sorted { lhs, rhs in
+            if lhs.sumLocs.count != rhs.sumLocs.count {
+                return lhs.sumLocs.count > rhs.sumLocs.count
+            }
+            if lhs.center.latitude != rhs.center.latitude {
+                return lhs.center.latitude < rhs.center.latitude
+            }
+            return lhs.center.longitude < rhs.center.longitude
+        }
+    }
+
+    /// 카메라 거리를 기준으로 클러스터 셀 크기를 계산합니다.
+    /// - Parameters:
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 셀 크기 비율입니다.
+    ///   - minCellMeters: 셀 크기의 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 크기의 최대값(미터)입니다.
+    /// - Returns: 최소/최대 범위로 clamp된 셀 크기(미터)입니다.
+    private func clusterCellSizeMeters(
+        cameraDistance: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> Double {
+        let raw = cameraDistance * distanceRatio
+        return min(maxCellMeters, max(minCellMeters, raw))
+    }
+}

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -179,6 +179,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let userSessionStore: UserSessionStoreProtocol
     private let authSessionStore: AuthSessionStoreProtocol
     private let preferenceStore: MapPreferenceStoreProtocol
+    private let clusterAnnotationService: MapClusterAnnotationServicing
     private let eventCenter: AppEventCenterProtocol
     private var lastCaptureHapticAt: Date = .distantPast
     private var lastWarningHapticAt: Date = .distantPast
@@ -271,12 +272,14 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
         authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
         preferenceStore: MapPreferenceStoreProtocol = DefaultMapPreferenceStore.shared,
+        clusterAnnotationService: MapClusterAnnotationServicing = MapClusterAnnotationService(),
         eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared
     ) {
         self.walkRepository = walkRepository
         self.userSessionStore = userSessionStore
         self.authSessionStore = authSessionStore
         self.preferenceStore = preferenceStore
+        self.clusterAnnotationService = clusterAnnotationService
         self.eventCenter = eventCenter
         super.init()
         self.locationManager.delegate = self
@@ -2014,63 +2017,15 @@ extension MapViewModel {
     private func hotspots() async { // 핫스팟 로직 고민해보기
 
     }
-    private struct ClusterBucketKey: Hashable {
-        let x: Int
-        let y: Int
-    }
 
-    private func clusterCellSizeMeters(for distance: Double) -> Double {
-        let raw = distance * clusterCellDistanceRatio
-        return min(clusterCellMaxMeters, max(clusterCellMinMeters, raw))
-    }
-
-    private func initialClusterByPolygon() -> [Cluster] {
-        return self.polygonList.compactMap { polygon in
-            guard let mapPolygon = polygon.polygon else { return nil }
-            return Cluster(center: mapPolygon.coordinate, id: polygon.id)
-        }
-    }
     private func cluster(distance: Double) -> [Cluster] {
-        let startCluster = initialClusterByPolygon()
-        let result = calculateDistance(from: startCluster, threshold: distance)
-        return result
-    }
-    
-    private func calculateDistance(from clusters: [Cluster], threshold: Double) -> [Cluster] {
-        guard clusters.count > 1 else { return clusters }
-
-        let referenceLatitude = clusters.map(\.center.latitude).reduce(0.0, +) / Double(clusters.count)
-        let cellMeters = clusterCellSizeMeters(for: threshold)
-        let metersPerMapPoint = MKMetersPerMapPointAtLatitude(referenceLatitude)
-        let cellMapPoints = max(1.0, cellMeters / max(0.0001, metersPerMapPoint))
-
-        var buckets: [ClusterBucketKey: Cluster] = [:]
-        buckets.reserveCapacity(clusters.count)
-
-        for cluster in clusters {
-            let point = MKMapPoint(cluster.center)
-            let key = ClusterBucketKey(
-                x: Int(floor(point.x / cellMapPoints)),
-                y: Int(floor(point.y / cellMapPoints))
-            )
-
-            if var existing = buckets[key] {
-                existing.updateCenter(with: cluster)
-                buckets[key] = existing
-            } else {
-                buckets[key] = cluster
-            }
-        }
-
-        return buckets.values.sorted { lhs, rhs in
-            if lhs.sumLocs.count != rhs.sumLocs.count {
-                return lhs.sumLocs.count > rhs.sumLocs.count
-            }
-            if lhs.center.latitude != rhs.center.latitude {
-                return lhs.center.latitude < rhs.center.latitude
-            }
-            return lhs.center.longitude < rhs.center.longitude
-        }
+        clusterAnnotationService.cluster(
+            polygons: polygonList,
+            cameraDistance: distance,
+            distanceRatio: clusterCellDistanceRatio,
+            minCellMeters: clusterCellMinMeters,
+            maxCellMeters: clusterCellMaxMeters
+        )
     }
 }
 


### PR DESCRIPTION
## 요약\n- MapViewModel의 클러스터 계산 로직을 MapClusterAnnotationService로 분리\n- updateAnnotations/cluster 흐름과 기존 LOD 설정값(clusterCellDistanceRatio/min/max) 동작 유지\n- 신규 서비스 함수에 Quick Help 문서(파라미터/리턴 의미) 추가\n\n## 테스트\n- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh\n- xcodebuild -quiet -scheme dogArea -destination 'generic/platform=iOS Simulator' build\n- xcodebuild -quiet -scheme 'dogAreaWatch Watch App' -destination 'generic/platform=watchOS Simulator' build\n- xcodebuild -quiet -scheme dogArea -destination 'platform=iOS Simulator,id=C787307E-5F3E-491D-BD28-7E07CA86BABA' -only-testing:dogAreaUITests test\n\n## 비고\n- 병렬 빌드 시 build.db lock 이슈가 있어 최종 검증은 순차 재실행으로 확인