### PR TITLE
Refactor map area calculation into dedicated service

### DIFF
--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		DA3F9BA32AE0F14F0048550C /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9B2AE0F14F0048550C /* MapView.swift */; };
 		DA3F9BA42AE0F14F0048550C /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9C2AE0F14F0048550C /* MapViewModel.swift */; };
 		DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9D2AE0F14F0048550C /* MapModel.swift */; };
+		DAE148A11420000000000001 /* MapAreaCalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE148A01420000000000001 /* MapAreaCalculationService.swift */; };
 		DAE147B11420000000000001 /* MapClusterAnnotationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE147B01420000000000001 /* MapClusterAnnotationService.swift */; };
 		DA3F9BA62AE0F14F0048550C /* WalkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */; };
 		DA3F9BAE2AE0F2410048550C /* ViewUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */; };
@@ -270,6 +271,7 @@
 		DA3F9B9B2AE0F14F0048550C /* MapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		DA3F9B9C2AE0F14F0048550C /* MapViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		DA3F9B9D2AE0F14F0048550C /* MapModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapModel.swift; sourceTree = "<group>"; };
+		DAE148A01420000000000001 /* MapAreaCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapAreaCalculationService.swift; sourceTree = "<group>"; };
 		DAE147B01420000000000001 /* MapClusterAnnotationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapClusterAnnotationService.swift; sourceTree = "<group>"; };
 		DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalkListView.swift; sourceTree = "<group>"; };
 		DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewUtility.swift; sourceTree = "<group>"; };
@@ -485,6 +487,7 @@
 				DAAE22222AFCC225005FD096 /* WalkDetailView.swift */,
 				DA3F9B9C2AE0F14F0048550C /* MapViewModel.swift */,
 				DA3F9B9D2AE0F14F0048550C /* MapModel.swift */,
+				DAE148A01420000000000001 /* MapAreaCalculationService.swift */,
 				DAE147B01420000000000001 /* MapClusterAnnotationService.swift */,
 				376D30D4A7542596A014DEE1 /* SimpleKeyValueView.swift */,
 			);
@@ -1026,6 +1029,7 @@
 				DA1731732AE2017500EF10C8 /* SupabaseInfrastructure.swift in Sources */,
 				DAA8E4F92B01A80C00F9190B /* TabAppear.swift in Sources */,
 				DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */,
+				DAE148A11420000000000001 /* MapAreaCalculationService.swift in Sources */,
 				DAE147B11420000000000001 /* MapClusterAnnotationService.swift in Sources */,
 				DA4513832AFB25C2007AD69B /* PositionMarkerView.swift in Sources */,
 				DA8BB9F22B02FE3A00E350C4 /* HomeViewModel.swift in Sources */,

--- a/dogArea/Views/MapView/MapAreaCalculationService.swift
+++ b/dogArea/Views/MapView/MapAreaCalculationService.swift
@@ -1,0 +1,73 @@
+//
+//  MapAreaCalculationService.swift
+//  dogArea
+//
+//  Created by Codex on 3/3/26.
+//
+
+import Foundation
+
+protocol MapAreaCalculationServicing {
+    /// 산책 좌표 목록으로 다각형 면적(m²)을 계산합니다.
+    /// - Parameter points: 다각형 경계를 이루는 위치 목록입니다.
+    /// - Returns: 좌표 평면 근사식으로 계산한 절대 면적 값(m²)입니다.
+    func calculateArea(points: [Location]) -> Double
+
+    /// 면적 값을 UI 표시용 문자열로 포맷합니다.
+    /// - Parameters:
+    ///   - area: 표시할 원본 면적 값(m²)입니다.
+    ///   - isPyong: `true`면 평 단위, `false`면 제곱미터 단위를 사용합니다.
+    /// - Returns: 단위 규칙(㎡/만㎡/k㎡/평/만평)이 반영된 문자열입니다.
+    func formattedAreaString(area: Double, isPyong: Bool) -> String
+}
+
+final class MapAreaCalculationService: MapAreaCalculationServicing {
+    /// 산책 좌표 목록으로 다각형 면적(m²)을 계산합니다.
+    /// - Parameter points: 다각형 경계를 이루는 위치 목록입니다.
+    /// - Returns: 좌표 평면 근사식으로 계산한 절대 면적 값(m²)입니다.
+    func calculateArea(points: [Location]) -> Double {
+        guard points.count >= 3 else { return 0 }
+        let earthRadius = 6_371_000.0
+        var area: Double = 0
+
+        for index in 0..<points.count {
+            let currentPoint = points[index]
+            let nextPoint = points[(index + 1) % points.count]
+
+            let latitude1 = currentPoint.coordinate.latitude * .pi / 180
+            let longitude1 = currentPoint.coordinate.longitude * .pi / 180
+            let latitude2 = nextPoint.coordinate.latitude * .pi / 180
+            let longitude2 = nextPoint.coordinate.longitude * .pi / 180
+
+            let x1 = earthRadius * cos(latitude1) * cos(longitude1)
+            let y1 = earthRadius * cos(latitude1) * sin(longitude1)
+            let x2 = earthRadius * cos(latitude2) * cos(longitude2)
+            let y2 = earthRadius * cos(latitude2) * sin(longitude2)
+
+            area += (x1 * y2 - x2 * y1) / 2
+        }
+        return abs(area)
+    }
+
+    /// 면적 값을 UI 표시용 문자열로 포맷합니다.
+    /// - Parameters:
+    ///   - area: 표시할 원본 면적 값(m²)입니다.
+    ///   - isPyong: `true`면 평 단위, `false`면 제곱미터 단위를 사용합니다.
+    /// - Returns: 단위 규칙(㎡/만㎡/k㎡/평/만평)이 반영된 문자열입니다.
+    func formattedAreaString(area: Double, isPyong: Bool) -> String {
+        if isPyong {
+            if area / 3.3 > 10_000 {
+                return String(format: "%.1f", area / 33_333) + "만 평"
+            }
+            return String(format: "%.1f", area / 3.3) + "평"
+        }
+
+        if area > 100_000.0 {
+            return String(format: "%.2f", area / 1_000_000) + "k㎡"
+        }
+        if area > 10_000.0 {
+            return String(format: "%.2f", area / 10_000) + "만 ㎡"
+        }
+        return String(format: "%.2f", area) + "㎡"
+    }
+}

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -179,6 +179,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let userSessionStore: UserSessionStoreProtocol
     private let authSessionStore: AuthSessionStoreProtocol
     private let preferenceStore: MapPreferenceStoreProtocol
+    private let areaCalculationService: MapAreaCalculationServicing
     private let clusterAnnotationService: MapClusterAnnotationServicing
     private let eventCenter: AppEventCenterProtocol
     private var lastCaptureHapticAt: Date = .distantPast
@@ -272,6 +273,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
         authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
         preferenceStore: MapPreferenceStoreProtocol = DefaultMapPreferenceStore.shared,
+        areaCalculationService: MapAreaCalculationServicing = MapAreaCalculationService(),
         clusterAnnotationService: MapClusterAnnotationServicing = MapClusterAnnotationService(),
         eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared
     ) {
@@ -279,6 +281,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.userSessionStore = userSessionStore
         self.authSessionStore = authSessionStore
         self.preferenceStore = preferenceStore
+        self.areaCalculationService = areaCalculationService
         self.clusterAnnotationService = clusterAnnotationService
         self.eventCenter = eventCenter
         super.init()
@@ -1890,49 +1893,16 @@ extension MapViewModel {
         timer = nil
     }
     func calculateArea() -> Double {
-         let points = self.polygon.locations
+        let points = self.polygon.locations
         return calculateArea(points: points)
     }
 
     func calculateArea(points: [Location]) -> Double {
-        guard points.count >= 3 else {return 0}
-        let earthRadius = 6371000.0  // in meters
-        var area: Double = 0
-        for i in 0..<points.count {
-            let currentPoint = points[i]
-            let nextPoint = points[(i + 1) % points.count]
-            
-            let latitude1 = currentPoint.coordinate.latitude * .pi / 180
-            let longitude1 = currentPoint.coordinate.longitude * .pi / 180
-            let latitude2 = nextPoint.coordinate.latitude * .pi / 180
-            let longitude2 = nextPoint.coordinate.longitude * .pi / 180
-            
-            let x1 = earthRadius * cos(latitude1) * cos(longitude1)
-            let y1 = earthRadius * cos(latitude1) * sin(longitude1)
-            let x2 = earthRadius * cos(latitude2) * cos(longitude2)
-            let y2 = earthRadius * cos(latitude2) * sin(longitude2)
-            
-            area += (x1 * y2 - x2 * y1) / 2
-        }
-        return abs(area)
+        areaCalculationService.calculateArea(points: points)
     }
     func calculatedAreaString(areaSize: Double? = nil , isPyong: Bool = false) -> String {
         let area = areaSize ?? calculateArea()
-        var str = String(format: "%.2f" , area) + "㎡"
-        if area > 10000.0 {
-            str = String(format: "%.2f" , area/10000) + "만 ㎡"
-        }
-        if area > 100000.0 {
-            str = String(format: "%.2f" , area/1000000) + "k㎡"
-        }
-        if isPyong {
-            if area/3.3 > 10000 {
-                str = String(format: "%.1f" , area/33333) + "만 평"
-            } else {
-                str = String(format: "%.1f" , area/3.3) + "평"
-            }
-        }
-        return str
+        return areaCalculationService.formattedAreaString(area: area, isPyong: isPyong)
     }
 }
 //MARK: - CLLocation 관련 로직

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -57,6 +57,7 @@ swift scripts/walk_session_pet_canonicalization_unit_check.swift
 swift scripts/presentation_firebase_boundary_unit_check.swift
 swift scripts/supabase_profile_image_upload_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
+swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 
 if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then

--- a/scripts/map_area_calculation_service_unit_check.swift
+++ b/scripts/map_area_calculation_service_unit_check.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if condition == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let service = load("dogArea/Views/MapView/MapAreaCalculationService.swift")
+let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
+
+assertTrue(service.contains("protocol MapAreaCalculationServicing"), "MapAreaCalculationServicing protocol should exist")
+assertTrue(service.contains("func calculateArea(points: [Location]) -> Double"), "service should expose calculateArea API")
+assertTrue(service.contains("func formattedAreaString(area: Double, isPyong: Bool) -> String"), "service should expose formattedAreaString API")
+assertTrue(service.contains("/// - Parameter points:"), "service calculateArea should include Quick Help parameter docs")
+assertTrue(service.contains("/// - Returns:"), "service APIs should include Quick Help return docs")
+
+assertTrue(mapViewModel.contains("private let areaCalculationService: MapAreaCalculationServicing"), "MapViewModel should depend on area calculation protocol")
+assertTrue(mapViewModel.contains("areaCalculationService: MapAreaCalculationServicing = MapAreaCalculationService()"), "MapViewModel init should inject default service")
+assertTrue(mapViewModel.contains("areaCalculationService.calculateArea(points: points)"), "MapViewModel should delegate area calculation to service")
+assertTrue(mapViewModel.contains("areaCalculationService.formattedAreaString(area: area, isPyong: isPyong)"), "MapViewModel should delegate area formatting to service")
+
+print("PASS: map area calculation service unit checks")


### PR DESCRIPTION
## Summary
- extract area/formatting logic from MapViewModel into MapAreaCalculationService
- inject MapAreaCalculationServicing into MapViewModel to keep existing API while reducing VM responsibility
- add map_area_calculation_service_unit_check.swift and wire it into ios_pr_check

## Test
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
- `xcodebuild -quiet -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -quiet -skipPackagePluginValidation -project dogArea.xcodeproj -scheme "dogAreaWatch Watch App" -configuration Debug -destination "generic/platform=watchOS Simulator" CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -quiet -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -destination "id=5C467C08-292A-4B12-9979-9B9BBADB2968" -only-testing:dogAreaUITests test`
- `bash scripts/ios_pr_check.sh`
