### PR TITLE
feat: quest stage2 progress/claim backend + auth session auto-restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - 날씨 치환/스트릭 보호 서버 엔진 v1: `docs/weather-replacement-shield-engine-v1.md`
 - 날씨 연동 UX/fallback/접근성 v1: `docs/weather-ux-fallback-accessibility-v1.md`
 - 퀘스트 Stage1 템플릿/난이도 정책 v1: `docs/quest-stage1-template-difficulty-policy-v1.md`
+- 퀘스트 Stage2 진행/클레임 백엔드 엔진 v1: `docs/quest-stage2-progress-claim-engine-v1.md`
 - 퀘스트 실패 완충(자동 연장 슬롯) v1: `docs/quest-failure-buffer-v1.md`
 - 퀘스트 Stage3 UX/리마인드 v1: `docs/quest-stage3-ux-reminder-v1.md`
 - 반려견 맞춤 난이도/쉬운 날 모드 v1: `docs/pet-adaptive-quest-difficulty-v1.md`
@@ -64,6 +65,7 @@
 - Cycle #148 결과 보고서(2026-02-27): `docs/cycle-148-quest-failure-buffer-report-2026-02-27.md`
 - Cycle #170 결과 보고서(2026-03-01): `docs/cycle-170-quest-stage3-ux-reminder-report-2026-03-01.md`
 - Cycle #127 결과 보고서(2026-03-01): `docs/cycle-127-quest-stage1-policy-report-2026-03-01.md`
+- Cycle #205 결과 보고서(2026-03-03): `docs/cycle-205-quest-stage2-engine-report-2026-03-03.md`
 - Cycle #147 결과 보고서(2026-02-27): `docs/cycle-147-pet-adaptive-quest-report-2026-02-27.md`
 - Cycle #145 결과 보고서(2026-02-27): `docs/cycle-145-season-catchup-buff-report-2026-02-27.md`
 - Cycle #124 결과 보고서(2026-02-27): `docs/cycle-124-season-policy-report-2026-02-27.md`

--- a/docs/cycle-205-quest-stage2-engine-report-2026-03-03.md
+++ b/docs/cycle-205-quest-stage2-engine-report-2026-03-03.md
@@ -1,0 +1,71 @@
+# Cycle 205 - Quest Stage2 진행/클레임 백엔드 엔진 (2026-03-03)
+
+## 1) 이슈
+- 대상: #128 `[Task][Quest][Stage 2] 퀘스트 진행 엔진/클레임 백엔드 구현`
+
+## 2) 구현 범위
+### A. Supabase 마이그레이션
+- 신규: `supabase/migrations/20260303120000_quest_stage2_progress_claim_engine.sql`
+
+포함 내용:
+1. 퀘스트 핵심 스키마
+- `quest_templates`
+- `quest_instances`
+- `quest_progress`
+- `quest_claims`
+- `quest_claim_audit_logs`(감사 로그)
+
+2. 서버 RPC
+- `rpc_issue_quest_instances`
+- `rpc_apply_quest_progress_event`
+- `rpc_claim_quest_reward`
+- `rpc_transition_quest_status`
+
+3. 안정성 규칙
+- 진행도 멱등 키: `(quest_instance_id, event_id)`
+- 클레임 중복 방지: `quest_claims.quest_instance_id unique`
+- reroll 1일 1회 제한: `quest_claim_audit_logs` 기준 서버 강제
+
+### B. Supabase Functions
+1. 신규 edge function
+- `supabase/functions/quest-engine/index.ts`
+- 액션: `issue_quests`, `ingest_walk_event`, `claim_reward`, `transition_status`, `list_active`
+
+2. 기존 파이프라인 연계
+- `supabase/functions/sync-walk/index.ts`
+- `points` stage에서 활성 퀘스트에 `rpc_apply_quest_progress_event` 호출
+- 응답에 `quest_progress_summary` 추가
+
+### C. 문서/체크
+- 신규 문서: `docs/quest-stage2-progress-claim-engine-v1.md`
+- 운영 검증 섹션 추가: `docs/supabase-migration.md` (5.14)
+- 신규 체크: `scripts/quest_stage2_engine_unit_check.swift`
+- 체크 파이프라인 연결: `scripts/ios_pr_check.sh`
+- README 링크 추가
+
+## 3) 요구사항 매핑
+1. 스키마 설계
+- 4개 핵심 테이블(`quest_templates`, `quest_instances`, `quest_progress`, `quest_claims`) 추가로 충족
+
+2. 산책 이벤트 기반 진행도 업데이트
+- `sync-walk` points stage에서 quest RPC 연계로 충족
+
+3. 완료 판정/보상 클레임 API
+- `rpc_apply_quest_progress_event` + `rpc_claim_quest_reward`로 충족
+
+4. reroll/만료/대체퀘스트 상태 전이
+- `rpc_transition_quest_status(expire|reroll|replace)`로 충족
+
+5. 중복 클레임 방지/감사 로그
+- `quest_claims` 유니크 + `quest_claim_audit_logs`로 충족
+
+## 4) 테스트
+1. 단일 체크
+- `swift scripts/quest_stage2_engine_unit_check.swift` -> PASS
+
+2. PR 체크
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh` -> PASS
+- `bash scripts/ios_pr_check.sh` -> PASS
+
+## 5) 후속
+- 배포 시 `supabase db push --linked`로 마이그레이션 적용 후 SQL 시나리오(중복 이벤트/클레임 경쟁/상태 전이) 실측 검증 필요.

--- a/docs/quest-stage2-progress-claim-engine-v1.md
+++ b/docs/quest-stage2-progress-claim-engine-v1.md
@@ -1,0 +1,70 @@
+# Quest Stage2 Progress/Claim Engine v1
+
+## 1. 목적
+Stage1 정책(#127)을 서버 런타임으로 연결해 퀘스트 인스턴스 발급/진행도 반영/보상 클레임을 일관된 계약으로 제공한다.
+
+연결 이슈:
+- Stage2: #128
+- 선행: #127, #170
+
+## 2. 스키마
+1. `quest_templates`
+- 퀘스트 템플릿 카탈로그
+- `quest_scope`, `quest_type`, `base_target_value`, 보상 스냅샷 소스
+
+2. `quest_instances`
+- 사용자별 발급 인스턴스
+- 생성 시 `target_value_snapshot`/보상 스냅샷 고정
+- 상태: `generated -> active -> completed -> claimed | expired | rerolled | alternative`
+
+3. `quest_progress`
+- 이벤트 소싱 기반 진행도 증분 로그
+- 멱등 키: `unique (quest_instance_id, event_id)`
+
+4. `quest_claims`
+- 보상 수령 원장
+- 중복 클레임 방지: `unique (quest_instance_id)`
+
+5. `quest_claim_audit_logs`
+- 클레임/상태전이 감사 로그
+- `claim_confirmed`, `duplicate_claim_blocked`, `claim_rejected`, `reroll_transition`, `replace_transition`, `expire_transition`
+
+## 3. RPC 계약
+1. `rpc_issue_quest_instances`
+- 일/주 퀘스트 인스턴스 발급
+- `cycle_key` 단위 멱등 upsert
+
+2. `rpc_apply_quest_progress_event`
+- 이벤트 기반 진행도 반영
+- 동일 `event_id` 재처리 시 진행도 증가 0건 보장
+
+3. `rpc_claim_quest_reward`
+- 완료 인스턴스 서버 검증 후 클레임 확정
+- 동시 요청 경쟁에서도 중복 수령 0건 (`quest_claims` 유니크 + row lock)
+
+4. `rpc_transition_quest_status`
+- `expire`, `reroll`, `replace` 상태 전이
+- reroll 1일 1회 제한은 감사 로그 기반으로 서버 강제
+
+## 4. Edge Function
+- `supabase/functions/quest-engine`
+- 액션:
+  - `issue_quests`
+  - `ingest_walk_event`
+  - `claim_reward`
+  - `transition_status`
+  - `list_active`
+
+## 5. Walk 이벤트 파이프라인 연계
+- `supabase/functions/sync-walk/index.ts` points stage에서 활성 퀘스트를 조회해 `rpc_apply_quest_progress_event` 호출
+- 응답에 `quest_progress_summary`를 추가해 서버 확정 진행도와 앱 UI 동기화
+
+## 6. 수용 기준 매핑
+1. 동일 이벤트 재처리 시 진행도 중복 증가 0건
+- `quest_progress`의 `(quest_instance_id, event_id)` 유니크로 보장
+
+2. 동시 클레임 경쟁 조건에서도 중복 수령 0건
+- `quest_claims.quest_instance_id` 유니크 + `rpc_claim_quest_reward` row lock/감사 로그로 보장
+
+3. 만료/reroll/대체 상태 전이 명세 일치
+- `rpc_transition_quest_status`에서 `expire|reroll|replace` 전이를 단일 경로로 강제

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -442,6 +442,92 @@ order by season_key desc;
 - 정산 재실행 시 `season_rewards` 중복 발급이 발생하지 않음
 - 리더보드 정렬이 정책 순서(`score -> active tile -> capture -> contribution time`)와 일치
 
+### 5.14 퀘스트 Stage2 진행/클레임 엔진 검증 (#128)
+일일 퀘스트 발급(멱등) 검증:
+```sql
+select *
+from public.rpc_issue_quest_instances(
+  ':user_uuid'::uuid,
+  'daily',
+  null,
+  null,
+  now()
+);
+```
+
+동일 이벤트 재처리 멱등 검증:
+```sql
+select *
+from public.rpc_apply_quest_progress_event(
+  ':user_uuid'::uuid,
+  ':quest_instance_uuid'::uuid,
+  'walk-session-1:points:42:walk_duration',
+  'walk_sync_points',
+  12,
+  jsonb_build_object('walk_session_id', ':walk_session_uuid'),
+  now()
+);
+```
+
+동일 요청 재호출 후 진행도 중복 검증:
+```sql
+select
+  quest_instance_id,
+  event_id,
+  count(*) as row_count
+from public.quest_progress
+where quest_instance_id = ':quest_instance_uuid'::uuid
+  and event_id = 'walk-session-1:points:42:walk_duration'
+group by quest_instance_id, event_id;
+```
+
+클레임 경쟁 조건 검증(동일 instance에 동시 호출):
+```sql
+select *
+from public.rpc_claim_quest_reward(
+  ':user_uuid'::uuid,
+  ':quest_instance_uuid'::uuid,
+  'claim-request-1',
+  now()
+);
+```
+
+중복 클레임 원장 확인:
+```sql
+select
+  quest_instance_id,
+  count(*) as claim_row_count
+from public.quest_claims
+where quest_instance_id = ':quest_instance_uuid'::uuid
+group by quest_instance_id;
+```
+
+상태 전이 검증(expire/reroll/replace):
+```sql
+select * from public.rpc_transition_quest_status(':user_uuid'::uuid, ':quest_instance_uuid'::uuid, 'expire', null, now());
+select * from public.rpc_transition_quest_status(':user_uuid'::uuid, ':quest_instance_uuid'::uuid, 'reroll', null, now());
+select * from public.rpc_transition_quest_status(':user_uuid'::uuid, ':quest_instance_uuid'::uuid, 'replace', 'daily.walk_duration.normal', now());
+```
+
+감사 로그 확인:
+```sql
+select
+  action,
+  detail,
+  created_at
+from public.quest_claim_audit_logs
+where owner_user_id = ':user_uuid'::uuid
+order by created_at desc
+limit 30;
+```
+
+기대값:
+- `quest_progress`에 `(quest_instance_id, event_id)` 중복이 0건
+- `quest_claims`에 `quest_instance_id`당 1행만 존재(중복 수령 0건)
+- `quest_claim_audit_logs`에 `claim_confirmed/duplicate_claim_blocked`가 요청 결과와 일치
+- `reroll_transition`은 사용자당 UTC 일자 기준 1회만 허용
+- `expire/reroll/replace` 상태 전이가 RPC 응답 `previous_status/current_status`와 동일
+
 ## 6. 운영 체크리스트
 - [ ] `migration list --local` / `migration list --linked` 결과 저장
 - [ ] User A/B 교차 접근 차단 SQL 결과 저장
@@ -452,6 +538,7 @@ order by season_key desc;
 - [ ] 시즌 안티 농사 RPC/감사 로그 검증 결과 첨부
 - [ ] 시즌 Stage1 정책 파라미터 검증 결과 첨부
 - [ ] 시즌 Stage2 집계/감쇠/정산/보상 파이프라인 검증 결과 첨부
+- [ ] 퀘스트 Stage2 발급/진행/클레임/상태전이 검증 결과 첨부
 - [ ] 체감 날씨 피드백 KPI 뷰 검증 결과 첨부
 - [ ] 날씨 치환/Shield RPC 및 이력 원장 검증 결과 첨부
 - [ ] 라이벌 리그 스냅샷/분포/히스토리 검증 결과 첨부

--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -95,18 +95,120 @@ enum SupabaseHTTPError: Error, LocalizedError {
     }
 }
 
+private struct SupabaseAuthUserDTO: Decodable {
+    let id: String?
+    let email: String?
+}
+
+private struct SupabaseAuthResponseDTO: Decodable {
+    let user: SupabaseAuthUserDTO?
+    let id: String?
+    let email: String?
+    let message: String?
+    let error: String?
+    let errorDescription: String?
+    let accessToken: String?
+    let refreshToken: String?
+    let expiresIn: Int?
+    let expiresAt: TimeInterval?
+    let tokenType: String?
+
+    enum CodingKeys: String, CodingKey {
+        case user
+        case id
+        case email
+        case message
+        case error
+        case errorDescription = "error_description"
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case expiresIn = "expires_in"
+        case expiresAt = "expires_at"
+        case tokenType = "token_type"
+    }
+}
+
+private struct SupabaseRefreshTokenRequestDTO: Encodable {
+    let refreshToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case refreshToken = "refresh_token"
+    }
+}
+
+private enum SupabaseRefreshCredentialOutcome {
+    case success(AuthCredentialResult)
+    case retryableFailure
+    case terminalFailure
+}
+
+private extension SupabaseAuthResponseDTO {
+    /// 디코딩된 Auth 응답을 앱 인증 결과 모델로 변환합니다.
+    /// - Parameters:
+    ///   - fallbackEmail: 응답에 이메일이 없을 때 사용할 대체 이메일입니다.
+    ///   - now: 토큰 만료시각 계산 기준 시각입니다.
+    /// - Returns: 변환 가능한 경우 사용자 식별 정보와 세션 토큰을 반환합니다.
+    func toCredentialResult(fallbackEmail: String?, now: Date) -> AuthCredentialResult? {
+        let userId = user?.id ?? id
+        guard let userId, userId.isEmpty == false else {
+            return nil
+        }
+        let email = user?.email ?? email ?? fallbackEmail
+        return AuthCredentialResult(
+            identity: AuthenticatedUserIdentity(userId: userId, email: email),
+            tokenSession: toTokenSession(now: now)
+        )
+    }
+
+    /// 디코딩된 Auth 응답에서 토큰 세션을 계산합니다.
+    /// - Parameter now: `expires_in` 기반 만료시각 계산 기준 시각입니다.
+    /// - Returns: 토큰 필드가 모두 유효하면 `AuthTokenSession`을 반환합니다.
+    func toTokenSession(now: Date) -> AuthTokenSession? {
+        guard
+            let accessToken,
+            let refreshToken,
+            let tokenType,
+            accessToken.isEmpty == false,
+            refreshToken.isEmpty == false,
+            tokenType.isEmpty == false
+        else {
+            return nil
+        }
+        let resolvedExpiresAt: TimeInterval
+        if let expiresAt {
+            resolvedExpiresAt = expiresAt
+        } else if let expiresIn {
+            resolvedExpiresAt = now.timeIntervalSince1970 + TimeInterval(expiresIn)
+        } else {
+            return nil
+        }
+        guard resolvedExpiresAt > now.timeIntervalSince1970 else {
+            return nil
+        }
+        return AuthTokenSession(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiresAt: resolvedExpiresAt,
+            tokenType: tokenType
+        )
+    }
+}
+
 struct SupabaseHTTPClient {
     static let live = SupabaseHTTPClient()
 
     private let session: URLSession
     private let configLoader: () -> SupabaseRuntimeConfig?
+    private let authSessionStore: AuthSessionStoreProtocol
 
     init(
         session: URLSession = .shared,
-        configLoader: @escaping () -> SupabaseRuntimeConfig? = { SupabaseRuntimeConfig.load() }
+        configLoader: @escaping () -> SupabaseRuntimeConfig? = { SupabaseRuntimeConfig.load() },
+        authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared
     ) {
         self.session = session
         self.configLoader = configLoader
+        self.authSessionStore = authSessionStore
     }
 
     func request<T: Encodable>(
@@ -141,7 +243,7 @@ struct SupabaseHTTPClient {
         request.httpMethod = method.rawValue
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(config.anonKey, forHTTPHeaderField: "apikey")
-        request.setValue("Bearer \(config.anonKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(await authorizationHeaderValue(config: config), forHTTPHeaderField: "Authorization")
         request.httpBody = bodyData
 
         let (data, response) = try await session.data(for: request)
@@ -152,6 +254,89 @@ struct SupabaseHTTPClient {
             throw SupabaseHTTPError.unexpectedStatusCode(statusCode)
         }
         return data
+    }
+
+    /// 현재 저장된 사용자 세션을 기준으로 Authorization 헤더 값을 계산합니다.
+    /// - Parameter config: Supabase 런타임 기본 구성입니다.
+    /// - Returns: 사용자 토큰이 유효하면 사용자 Bearer, 아니면 anon Bearer 값을 반환합니다.
+    private func authorizationHeaderValue(config: SupabaseRuntimeConfig) async -> String {
+        guard let accessToken = await validAccessToken(config: config) else {
+            return "Bearer \(config.anonKey)"
+        }
+        return "Bearer \(accessToken)"
+    }
+
+    /// 저장된 access token의 유효성을 확인하고 필요 시 refresh를 수행합니다.
+    /// - Parameter config: Supabase 런타임 기본 구성입니다.
+    /// - Returns: 요청에 사용할 수 있는 access token 문자열 또는 `nil`입니다.
+    private func validAccessToken(config: SupabaseRuntimeConfig) async -> String? {
+        let now = Date().timeIntervalSince1970
+        if let tokenSession = authSessionStore.currentTokenSession(),
+           tokenSession.isValid(at: now) {
+            return tokenSession.accessToken
+        }
+        guard let current = authSessionStore.currentTokenSession(),
+              current.refreshToken.isEmpty == false else {
+            return nil
+        }
+        let refreshOutcome = await refreshCredential(config: config, refreshToken: current.refreshToken)
+        switch refreshOutcome {
+        case .success(let refreshed):
+            authSessionStore.persist(refreshed.identity)
+            if let tokenSession = refreshed.tokenSession {
+                authSessionStore.persist(tokenSession: tokenSession)
+                return tokenSession.accessToken
+            }
+            authSessionStore.clearTokenSession()
+            return nil
+        case .retryableFailure:
+            return nil
+        case .terminalFailure:
+            authSessionStore.clearTokenSession()
+            return nil
+        }
+    }
+
+    /// refresh token으로 새 세션 토큰을 발급받고 사용자 식별 정보를 복원합니다.
+    /// - Parameters:
+    ///   - config: Supabase 런타임 기본 구성입니다.
+    ///   - refreshToken: 만료된 access token과 짝을 이루는 refresh token입니다.
+    /// - Returns: refresh 성공/실패 성격(재시도 가능 여부 포함)을 반환합니다.
+    private func refreshCredential(
+        config: SupabaseRuntimeConfig,
+        refreshToken: String
+    ) async -> SupabaseRefreshCredentialOutcome {
+        let endpoint = SupabaseEndpoint.auth(path: "token", query: "grant_type=refresh_token")
+        let url = endpoint.resolveURL(baseURL: config.baseURL)
+        var request = URLRequest(url: url)
+        request.httpMethod = HTTPMethod.post.rawValue
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(config.anonKey, forHTTPHeaderField: "apikey")
+        request.setValue("Bearer \(config.anonKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try? JSONEncoder().encode(
+            SupabaseRefreshTokenRequestDTO(refreshToken: refreshToken)
+        )
+
+        guard let (data, response) = try? await session.data(for: request),
+              let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+            return .retryableFailure
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            if statusCode == 400 || statusCode == 401 {
+                return .terminalFailure
+            }
+            return .retryableFailure
+        }
+
+        guard let decoded = try? JSONDecoder().decode(SupabaseAuthResponseDTO.self, from: data),
+              let credential = decoded.toCredentialResult(
+                fallbackEmail: authSessionStore.currentIdentity()?.email,
+                now: Date()
+              ) else {
+            return .terminalFailure
+        }
+        return .success(credential)
     }
 }
 
@@ -926,29 +1111,6 @@ enum SupabaseAuthError: LocalizedError {
 final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol {
     static let shared = DeviceAppleCredentialAuthService()
 
-    private struct AuthUserDTO: Decodable {
-        let id: String?
-        let email: String?
-    }
-
-    private struct AuthResponseDTO: Decodable {
-        let user: AuthUserDTO?
-        let id: String?
-        let email: String?
-        let message: String?
-        let error: String?
-        let errorDescription: String?
-
-        enum CodingKeys: String, CodingKey {
-            case user
-            case id
-            case email
-            case message
-            case error
-            case errorDescription = "error_description"
-        }
-    }
-
     /// Apple 로그인 토큰의 최소 유효성(빈 값 여부)을 확인합니다.
     func signInWithApple(identityToken: String) async throws {
         if identityToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -957,7 +1119,11 @@ final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol
     }
 
     /// Supabase Auth `token?grant_type=password` 엔드포인트로 이메일 로그인을 수행합니다.
-    func signInWithEmail(email: String, password: String) async throws -> AuthenticatedUserIdentity {
+    /// - Parameters:
+    ///   - email: 로그인 이메일입니다.
+    ///   - password: 로그인 비밀번호입니다.
+    /// - Returns: 사용자 식별 정보와 선택적 토큰 세션입니다.
+    func signInWithEmail(email: String, password: String) async throws -> AuthCredentialResult {
         let payload = [
             "email": email,
             "password": password
@@ -966,7 +1132,11 @@ final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol
     }
 
     /// Supabase Auth `signup` 엔드포인트로 이메일 회원가입을 수행합니다.
-    func signUpWithEmail(email: String, password: String) async throws -> AuthenticatedUserIdentity {
+    /// - Parameters:
+    ///   - email: 회원가입 이메일입니다.
+    ///   - password: 회원가입 비밀번호입니다.
+    /// - Returns: 사용자 식별 정보와 선택적 토큰 세션입니다.
+    func signUpWithEmail(email: String, password: String) async throws -> AuthCredentialResult {
         let payload = [
             "email": email,
             "password": password
@@ -979,7 +1149,7 @@ final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol
         path: String,
         query: String?,
         payload: [String: String]
-    ) async throws -> AuthenticatedUserIdentity {
+    ) async throws -> AuthCredentialResult {
         guard let config = SupabaseRuntimeConfig.load() else {
             throw SupabaseAuthError.notConfigured
         }
@@ -998,7 +1168,7 @@ final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol
             throw SupabaseAuthError.responseDecodeFailed
         }
 
-        let decoded = try? JSONDecoder().decode(AuthResponseDTO.self, from: data)
+        let decoded = try? JSONDecoder().decode(SupabaseAuthResponseDTO.self, from: data)
         guard (200..<300).contains(statusCode) else {
             if statusCode == 400 || statusCode == 401 {
                 throw SupabaseAuthError.invalidCredentials
@@ -1010,12 +1180,13 @@ final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol
             throw SupabaseAuthError.requestFailed(description)
         }
 
-        let userId = decoded?.user?.id ?? decoded?.id
-        let userEmail = decoded?.user?.email ?? decoded?.email ?? payload["email"]
-        guard let userId, userId.isEmpty == false else {
+        guard let result = decoded?.toCredentialResult(
+            fallbackEmail: payload["email"],
+            now: Date()
+        ) else {
             throw SupabaseAuthError.responseDecodeFailed
         }
-        return AuthenticatedUserIdentity(userId: userId, email: userEmail)
+        return result
     }
 }
 

--- a/dogArea/Source/ProfileRepository.swift
+++ b/dogArea/Source/ProfileRepository.swift
@@ -6,6 +6,30 @@ struct AuthenticatedUserIdentity: Equatable {
     let email: String?
 }
 
+/// Supabase 토큰 세션(Access/Refresh)의 로컬 보관 모델입니다.
+struct AuthTokenSession: Codable, Equatable {
+    let accessToken: String
+    let refreshToken: String
+    let expiresAt: TimeInterval
+    let tokenType: String
+
+    /// 현재 시각과 유효시간 버퍼를 기준으로 토큰 사용 가능 여부를 반환합니다.
+    /// - Parameters:
+    ///   - now: 비교 기준 epoch seconds입니다.
+    ///   - leeway: 만료 직전 경계 오차를 흡수하기 위한 버퍼(초)입니다.
+    /// - Returns: 현재 토큰을 바로 사용해도 되는지 여부입니다.
+    func isValid(at now: TimeInterval, leeway: TimeInterval = 30) -> Bool {
+        guard accessToken.isEmpty == false else { return false }
+        return expiresAt - leeway > now
+    }
+}
+
+/// 인증 요청 처리 결과(식별자 + 세션 토큰)를 나타냅니다.
+struct AuthCredentialResult: Equatable {
+    let identity: AuthenticatedUserIdentity
+    let tokenSession: AuthTokenSession?
+}
+
 /// 로그인 입력의 채널/의도를 표현합니다.
 enum AuthRequest: Equatable {
     case apple(identityToken: String, appleUserId: String, nameHint: String?)
@@ -23,8 +47,17 @@ struct AuthUseCaseOutcome: Equatable {
 protocol AuthSessionStoreProtocol {
     /// 현재 인증된 사용자 식별 정보를 로컬에 저장합니다.
     func persist(_ identity: AuthenticatedUserIdentity)
+    /// 현재 인증된 토큰 세션을 로컬에 저장합니다.
+    /// - Parameter tokenSession: Access/Refresh token과 만료 정보를 담은 세션입니다.
+    func persist(tokenSession: AuthTokenSession)
     /// 로컬에 저장된 사용자 식별 정보를 조회합니다.
+    /// - Returns: 사용자 식별 정보가 존재하면 해당 값을 반환하고, 없으면 `nil`을 반환합니다.
     func currentIdentity() -> AuthenticatedUserIdentity?
+    /// 로컬에 저장된 토큰 세션 정보를 조회합니다.
+    /// - Returns: 토큰 세션이 존재하면 해당 값을 반환하고, 없으면 `nil`을 반환합니다.
+    func currentTokenSession() -> AuthTokenSession?
+    /// 토큰 세션 정보만 제거합니다.
+    func clearTokenSession()
     /// 로컬 인증 식별 정보를 제거합니다.
     func clear()
 }
@@ -35,6 +68,10 @@ final class DefaultAuthSessionStore: AuthSessionStoreProtocol {
     private enum Key {
         static let userId = "auth.session.user_id.v1"
         static let email = "auth.session.email.v1"
+        static let accessToken = "auth.session.access_token.v1"
+        static let refreshToken = "auth.session.refresh_token.v1"
+        static let expiresAt = "auth.session.expires_at.v1"
+        static let tokenType = "auth.session.token_type.v1"
     }
 
     private let defaults: UserDefaults
@@ -49,6 +86,15 @@ final class DefaultAuthSessionStore: AuthSessionStoreProtocol {
         defaults.set(identity.email, forKey: Key.email)
     }
 
+    /// 현재 인증된 토큰 세션을 로컬에 저장합니다.
+    /// - Parameter tokenSession: Access/Refresh token과 만료 정보를 담은 세션입니다.
+    func persist(tokenSession: AuthTokenSession) {
+        defaults.set(tokenSession.accessToken, forKey: Key.accessToken)
+        defaults.set(tokenSession.refreshToken, forKey: Key.refreshToken)
+        defaults.set(tokenSession.expiresAt, forKey: Key.expiresAt)
+        defaults.set(tokenSession.tokenType, forKey: Key.tokenType)
+    }
+
     /// 로컬에 저장된 사용자 식별 정보를 조회합니다.
     func currentIdentity() -> AuthenticatedUserIdentity? {
         guard let userId = defaults.string(forKey: Key.userId), userId.isEmpty == false else {
@@ -60,16 +106,50 @@ final class DefaultAuthSessionStore: AuthSessionStoreProtocol {
         )
     }
 
+    /// 로컬에 저장된 토큰 세션 정보를 조회합니다.
+    /// - Returns: 토큰 세션이 존재하면 해당 값을 반환하고, 없으면 `nil`을 반환합니다.
+    func currentTokenSession() -> AuthTokenSession? {
+        guard
+            let accessToken = defaults.string(forKey: Key.accessToken),
+            let refreshToken = defaults.string(forKey: Key.refreshToken),
+            let tokenType = defaults.string(forKey: Key.tokenType),
+            accessToken.isEmpty == false,
+            refreshToken.isEmpty == false,
+            tokenType.isEmpty == false
+        else {
+            return nil
+        }
+        let expiresAt = defaults.double(forKey: Key.expiresAt)
+        guard expiresAt > 0 else { return nil }
+        return AuthTokenSession(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiresAt: expiresAt,
+            tokenType: tokenType
+        )
+    }
+
+    /// 토큰 세션 정보만 제거합니다.
+    func clearTokenSession() {
+        defaults.removeObject(forKey: Key.accessToken)
+        defaults.removeObject(forKey: Key.refreshToken)
+        defaults.removeObject(forKey: Key.expiresAt)
+        defaults.removeObject(forKey: Key.tokenType)
+    }
+
     /// 로컬 인증 식별 정보를 제거합니다.
     func clear() {
         defaults.removeObject(forKey: Key.userId)
         defaults.removeObject(forKey: Key.email)
+        clearTokenSession()
     }
 }
 
 protocol AuthRepositoryProtocol {
     /// 입력된 인증 요청을 실제 인증 서비스로 위임하고 식별 정보를 반환합니다.
-    func authenticate(_ request: AuthRequest) async throws -> (identity: AuthenticatedUserIdentity, displayNameHint: String?)
+    /// - Parameter request: 인증 채널/의도를 포함한 인증 요청입니다.
+    /// - Returns: 인증에 성공한 사용자 식별 정보와 선택적 세션 토큰입니다.
+    func authenticate(_ request: AuthRequest) async throws -> (credential: AuthCredentialResult, displayNameHint: String?)
 }
 
 final class DefaultAuthRepository: AuthRepositoryProtocol {
@@ -80,20 +160,25 @@ final class DefaultAuthRepository: AuthRepositoryProtocol {
     }
 
     /// 입력된 인증 요청을 실제 인증 서비스로 위임하고 식별 정보를 반환합니다.
-    func authenticate(_ request: AuthRequest) async throws -> (identity: AuthenticatedUserIdentity, displayNameHint: String?) {
+    /// - Parameter request: 인증 채널/의도를 포함한 인증 요청입니다.
+    /// - Returns: 인증에 성공한 사용자 식별 정보와 선택적 세션 토큰입니다.
+    func authenticate(_ request: AuthRequest) async throws -> (credential: AuthCredentialResult, displayNameHint: String?) {
         switch request {
         case let .apple(identityToken, appleUserId, nameHint):
             try await credentialService.signInWithApple(identityToken: identityToken)
             return (
-                AuthenticatedUserIdentity(userId: appleUserId, email: nil),
+                AuthCredentialResult(
+                    identity: AuthenticatedUserIdentity(userId: appleUserId, email: nil),
+                    tokenSession: nil
+                ),
                 nameHint?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
             )
         case let .emailSignIn(email, password):
-            let identity = try await credentialService.signInWithEmail(email: email, password: password)
-            return (identity, email.emailNameHint)
+            let credential = try await credentialService.signInWithEmail(email: email, password: password)
+            return (credential, email.emailNameHint)
         case let .emailSignUp(email, password):
-            let identity = try await credentialService.signUpWithEmail(email: email, password: password)
-            return (identity, email.emailNameHint)
+            let credential = try await credentialService.signUpWithEmail(email: email, password: password)
+            return (credential, email.emailNameHint)
         }
     }
 }
@@ -121,12 +206,15 @@ final class DefaultAuthUseCase: AuthUseCaseProtocol {
     /// 인증 요청을 처리하고 기존 사용자/온보딩 필요 여부를 판정합니다.
     func execute(_ request: AuthRequest) async throws -> AuthUseCaseOutcome {
         let result = try await authRepository.authenticate(request)
-        sessionStore.persist(result.identity)
+        sessionStore.persist(result.credential.identity)
+        if let tokenSession = result.credential.tokenSession {
+            sessionStore.persist(tokenSession: tokenSession)
+        }
 
         let localProfileId = profileRepository.fetchUserInfo()?.id
-        let requiresOnboarding = localProfileId != result.identity.userId
+        let requiresOnboarding = localProfileId != result.credential.identity.userId
         return AuthUseCaseOutcome(
-            identity: result.identity,
+            identity: result.credential.identity,
             displayNameHint: result.displayNameHint,
             requiresOnboarding: requiresOnboarding
         )
@@ -136,10 +224,18 @@ final class DefaultAuthUseCase: AuthUseCaseProtocol {
 protocol AppleCredentialAuthServiceProtocol {
     /// Apple identity token 기반 로그인 검증을 수행합니다.
     func signInWithApple(identityToken: String) async throws
-    /// 이메일/비밀번호로 로그인하고 사용자 식별 정보를 반환합니다.
-    func signInWithEmail(email: String, password: String) async throws -> AuthenticatedUserIdentity
-    /// 이메일/비밀번호로 회원가입을 수행하고 사용자 식별 정보를 반환합니다.
-    func signUpWithEmail(email: String, password: String) async throws -> AuthenticatedUserIdentity
+    /// 이메일/비밀번호로 로그인하고 사용자 식별 정보 및 세션 토큰을 반환합니다.
+    /// - Parameters:
+    ///   - email: 로그인 이메일입니다.
+    ///   - password: 로그인 비밀번호입니다.
+    /// - Returns: 로그인 사용자 식별 정보 및 선택적 세션 토큰입니다.
+    func signInWithEmail(email: String, password: String) async throws -> AuthCredentialResult
+    /// 이메일/비밀번호로 회원가입을 수행하고 사용자 식별 정보 및 세션 토큰을 반환합니다.
+    /// - Parameters:
+    ///   - email: 회원가입 이메일입니다.
+    ///   - password: 회원가입 비밀번호입니다.
+    /// - Returns: 가입된 사용자 식별 정보 및 선택적 세션 토큰입니다.
+    func signUpWithEmail(email: String, password: String) async throws -> AuthCredentialResult
 }
 
 protocol ProfileImageRepository {

--- a/scripts/auth_session_autologin_unit_check.swift
+++ b/scripts/auth_session_autologin_unit_check.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let auth = load("dogArea/Source/ProfileRepository.swift")
+let infra = load("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+
+assertTrue(auth.contains("struct AuthTokenSession"), "auth store should define token session model")
+assertTrue(auth.contains("persist(tokenSession:"), "auth session store should persist token sessions")
+assertTrue(auth.contains("currentTokenSession()"), "auth session store should read token sessions")
+assertTrue(auth.contains("clearTokenSession()"), "auth session store should clear only token sessions")
+assertTrue(auth.contains("AuthCredentialResult"), "auth layer should return credential result containing session")
+assertTrue(auth.contains("sessionStore.persist(tokenSession:"), "auth use case should store token session on login")
+
+assertTrue(infra.contains("authorizationHeaderValue"), "supabase http client should resolve authorization header from session")
+assertTrue(infra.contains("grant_type=refresh_token"), "supabase http client should refresh expired access tokens")
+assertTrue(infra.contains("SupabaseRefreshTokenRequestDTO"), "supabase http client should send refresh token payload")
+assertTrue(infra.contains("authSessionStore.persist(tokenSession:"), "refresh flow should persist rotated token session")
+
+print("PASS: auth session autologin unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -29,6 +29,7 @@ swift scripts/userdefault_store_split_unit_check.swift
 swift scripts/map_motion_pack_unit_check.swift
 swift scripts/quest_motion_pack_unit_check.swift
 swift scripts/quest_stage1_policy_unit_check.swift
+swift scripts/quest_stage2_engine_unit_check.swift
 swift scripts/season_motion_pack_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift
@@ -56,6 +57,7 @@ swift scripts/walk_repository_backfill_unit_check.swift
 swift scripts/walk_session_pet_canonicalization_unit_check.swift
 swift scripts/presentation_firebase_boundary_unit_check.swift
 swift scripts/supabase_profile_image_upload_unit_check.swift
+swift scripts/auth_session_autologin_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/project_stability_unit_check.swift

--- a/scripts/quest_stage2_engine_unit_check.swift
+++ b/scripts/quest_stage2_engine_unit_check.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// 조건식을 검증하고 실패 시 오류 메시지를 출력한 뒤 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 조건식입니다.
+///   - message: 검증 실패 시 출력할 메시지입니다.
+/// - Returns: 반환값은 없으며 실패 시 프로세스를 종료합니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 파일을 UTF-8 문자열로 읽어옵니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: UTF-8 디코딩된 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let migration = load("supabase/migrations/20260303120000_quest_stage2_progress_claim_engine.sql")
+let syncWalk = load("supabase/functions/sync-walk/index.ts")
+let questEngine = load("supabase/functions/quest-engine/index.ts")
+let doc = load("docs/quest-stage2-progress-claim-engine-v1.md")
+let report = load("docs/cycle-205-quest-stage2-engine-report-2026-03-03.md")
+let readme = load("README.md")
+
+assertTrue(migration.contains("create table if not exists public.quest_templates"), "migration should create quest_templates table")
+assertTrue(migration.contains("create table if not exists public.quest_instances"), "migration should create quest_instances table")
+assertTrue(migration.contains("create table if not exists public.quest_progress"), "migration should create quest_progress table")
+assertTrue(migration.contains("create table if not exists public.quest_claims"), "migration should create quest_claims table")
+
+assertTrue(migration.contains("create or replace function public.rpc_issue_quest_instances"), "migration should provide quest issue rpc")
+assertTrue(migration.contains("create or replace function public.rpc_apply_quest_progress_event"), "migration should provide quest progress rpc")
+assertTrue(migration.contains("create or replace function public.rpc_claim_quest_reward"), "migration should provide quest claim rpc")
+assertTrue(migration.contains("create or replace function public.rpc_transition_quest_status"), "migration should provide quest transition rpc")
+
+assertTrue(migration.contains("unique (quest_instance_id, event_id)"), "migration should enforce quest progress idempotency key")
+assertTrue(migration.contains("unique (quest_instance_id)"), "migration should enforce single claim per quest instance")
+assertTrue(migration.contains("duplicate_claim_blocked"), "migration should record duplicate claim blocked audit action")
+assertTrue(migration.contains("reroll_transition"), "migration should record reroll transition audit action")
+
+assertTrue(syncWalk.contains("rpc_apply_quest_progress_event"), "sync-walk should push quest progress events")
+assertTrue(syncWalk.contains("quest_progress_summary"), "sync-walk response should expose quest progress summary")
+
+assertTrue(questEngine.contains("issue_quests"), "quest engine should expose issue action")
+assertTrue(questEngine.contains("ingest_walk_event"), "quest engine should expose ingest action")
+assertTrue(questEngine.contains("claim_reward"), "quest engine should expose claim action")
+assertTrue(questEngine.contains("transition_status"), "quest engine should expose transition action")
+assertTrue(questEngine.contains("rpc_claim_quest_reward"), "quest engine should call claim rpc")
+
+assertTrue(doc.contains("멱등"), "quest stage2 doc should describe idempotent progress processing")
+assertTrue(doc.contains("중복 클레임"), "quest stage2 doc should describe duplicate claim prevention")
+assertTrue(doc.contains("reroll 1일 1회"), "quest stage2 doc should describe reroll daily limit")
+
+assertTrue(report.contains("#128"), "cycle report should reference issue #128")
+assertTrue(report.contains("quest_stage2_engine_unit_check"), "cycle report should include stage2 unit check command")
+assertTrue(readme.contains("docs/quest-stage2-progress-claim-engine-v1.md"), "README should reference stage2 quest engine doc")
+
+print("PASS: quest stage2 engine unit checks")

--- a/supabase/functions/quest-engine/README.md
+++ b/supabase/functions/quest-engine/README.md
@@ -1,0 +1,42 @@
+# quest-engine Edge Function
+
+퀘스트 Stage2 백엔드 엔진(RPC) 진입점입니다.
+
+## Action
+- `issue_quests`
+- `ingest_walk_event`
+- `claim_reward`
+- `transition_status`
+- `list_active`
+
+## Request Example
+```json
+{
+  "action": "issue_quests",
+  "scope": "daily"
+}
+```
+
+```json
+{
+  "action": "ingest_walk_event",
+  "instanceId": "00000000-0000-0000-0000-000000000000",
+  "eventId": "session-uuid:points:42:walk_duration",
+  "eventType": "walk_sync_points",
+  "deltaValue": 12,
+  "payload": {
+    "walk_session_id": "00000000-0000-0000-0000-000000000000"
+  }
+}
+```
+
+## Response Example
+```json
+{
+  "progress": {
+    "quest_instance_id": "00000000-0000-0000-0000-000000000000",
+    "idempotent": false,
+    "status": "completed"
+  }
+}
+```

--- a/supabase/functions/quest-engine/index.ts
+++ b/supabase/functions/quest-engine/index.ts
@@ -1,0 +1,190 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+
+type Action =
+  | "issue_quests"
+  | "ingest_walk_event"
+  | "claim_reward"
+  | "transition_status"
+  | "list_active";
+
+type QuestScope = "daily" | "weekly";
+type TransitionAction = "expire" | "reroll" | "replace";
+
+type RequestDTO = {
+  action?: Action;
+  scope?: QuestScope;
+  cycleKey?: string;
+  expiresAt?: string;
+  instanceId?: string;
+  eventId?: string;
+  eventType?: string;
+  deltaValue?: number;
+  payload?: Record<string, unknown>;
+  requestId?: string;
+  transitionAction?: TransitionAction;
+  replacementTemplateId?: string;
+};
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const asString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+
+const toNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+};
+
+const toUUIDOrNull = (value: unknown): string | null => {
+  const raw = asString(value);
+  if (!raw) return null;
+  const normalized = raw.toLowerCase();
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+  return uuidPattern.test(normalized) ? normalized : null;
+};
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") return json({ error: "METHOD_NOT_ALLOWED" }, 405);
+
+  const supabaseURL = Deno.env.get("SUPABASE_URL");
+  const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  if (!supabaseURL || !supabaseAnonKey) {
+    return json({ error: "SERVER_MISCONFIGURED" }, 500);
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return json({ error: "UNAUTHORIZED" }, 401);
+  }
+
+  const token = authHeader.replace("Bearer ", "").trim();
+  if (!token) return json({ error: "UNAUTHORIZED" }, 401);
+
+  const userClient = createClient(supabaseURL, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const { data: userResult, error: userError } = await userClient.auth.getUser(token);
+  if (userError || !userResult?.user) {
+    return json({ error: "UNAUTHORIZED" }, 401);
+  }
+  const userId = userResult.user.id;
+
+  let body: RequestDTO;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "INVALID_JSON" }, 400);
+  }
+
+  if (!body.action) return json({ error: "ACTION_REQUIRED" }, 400);
+
+  const nowISO = new Date().toISOString();
+
+  switch (body.action) {
+    case "issue_quests": {
+      const scope = asString(body.scope) ?? "daily";
+      const cycleKey = asString(body.cycleKey);
+      const expiresAt = asString(body.expiresAt);
+
+      const { data, error } = await userClient.rpc("rpc_issue_quest_instances", {
+        target_user_id: userId,
+        target_scope: scope,
+        target_cycle_key: cycleKey,
+        expires_at: expiresAt,
+        now_ts: nowISO,
+      });
+      if (error) return json({ error: error.message }, 500);
+
+      return json({ quests: Array.isArray(data) ? data : [] });
+    }
+
+    case "ingest_walk_event": {
+      const instanceId = toUUIDOrNull(body.instanceId);
+      const eventId = asString(body.eventId);
+      if (!instanceId || !eventId) {
+        return json({ error: "INVALID_PAYLOAD" }, 400);
+      }
+
+      const { data, error } = await userClient.rpc("rpc_apply_quest_progress_event", {
+        target_user_id: userId,
+        target_instance_id: instanceId,
+        event_id: eventId,
+        event_type: asString(body.eventType) ?? "walk_event",
+        delta_value: Math.max(0, toNumber(body.deltaValue, 1)),
+        payload: asRecord(body.payload),
+        now_ts: nowISO,
+      });
+      if (error) return json({ error: error.message }, 500);
+
+      const row = Array.isArray(data) && data.length > 0 ? data[0] : null;
+      return json({ progress: row });
+    }
+
+    case "claim_reward": {
+      const instanceId = toUUIDOrNull(body.instanceId);
+      if (!instanceId) return json({ error: "INVALID_PAYLOAD" }, 400);
+
+      const { data, error } = await userClient.rpc("rpc_claim_quest_reward", {
+        target_user_id: userId,
+        target_instance_id: instanceId,
+        request_id: asString(body.requestId),
+        now_ts: nowISO,
+      });
+      if (error) return json({ error: error.message }, 500);
+
+      const row = Array.isArray(data) && data.length > 0 ? data[0] : null;
+      return json({ claim: row });
+    }
+
+    case "transition_status": {
+      const instanceId = toUUIDOrNull(body.instanceId);
+      const transitionAction = asString(body.transitionAction);
+      if (!instanceId || !transitionAction) {
+        return json({ error: "INVALID_PAYLOAD" }, 400);
+      }
+
+      const { data, error } = await userClient.rpc("rpc_transition_quest_status", {
+        target_user_id: userId,
+        target_instance_id: instanceId,
+        transition_action: transitionAction,
+        replacement_template_id: asString(body.replacementTemplateId),
+        now_ts: nowISO,
+      });
+      if (error) return json({ error: error.message }, 500);
+
+      const row = Array.isArray(data) && data.length > 0 ? data[0] : null;
+      return json({ transition: row });
+    }
+
+    case "list_active": {
+      const { data, error } = await userClient
+        .from("quest_instances")
+        .select("id,template_id,quest_scope,quest_type,title_snapshot,target_value_snapshot,progress_value,status,cycle_key,expires_at,completed_at,claimed_at")
+        .eq("owner_user_id", userId)
+        .in("status", ["active", "completed"])
+        .order("created_at", { ascending: false })
+        .limit(30);
+
+      if (error) return json({ error: error.message }, 500);
+      return json({ quests: data ?? [] });
+    }
+
+    default:
+      return json({ error: "UNSUPPORTED_ACTION" }, 400);
+  }
+});

--- a/supabase/functions/sync-walk/index.ts
+++ b/supabase/functions/sync-walk/index.ts
@@ -52,6 +52,18 @@ type SeasonPipelineSummaryDTO = {
   run_status: string;
 };
 
+type QuestProgressSummaryDTO = {
+  quest_instance_id: string;
+  owner_user_id: string;
+  event_id: string;
+  idempotent: boolean;
+  previous_progress: number;
+  current_progress: number;
+  target_progress: number;
+  status: string;
+  completed_at: string | null;
+};
+
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
     status,
@@ -319,6 +331,62 @@ Deno.serve(async (req) => {
       weatherReplacementSummary = weatherReplacementRows[0] as WeatherReplacementSummaryDTO;
     }
 
+    const uniqueTileCount = Math.max(0, Math.trunc(toNumber(payload.unique_tile_count, rows.length > 0 ? 1 : 0)));
+    const deltaByQuestType: Record<string, number> = {
+      walk_duration: Math.max(0, durationSec / 60.0),
+      linked_path: Math.max(0, rows.length - 1),
+      new_tile: uniqueTileCount,
+      streak_days: 0,
+    };
+
+    const questProgressSummary: QuestProgressSummaryDTO[] = [];
+    const { data: activeQuestRows, error: activeQuestError } = await userClient
+      .from("quest_instances")
+      .select("id,quest_type")
+      .eq("owner_user_id", userId)
+      .in("status", ["generated", "active", "completed"])
+      .limit(20);
+
+    if (activeQuestError) {
+      console.warn("quest active list query failed", activeQuestError.message);
+    } else if (Array.isArray(activeQuestRows) && activeQuestRows.length > 0) {
+      const questEventBaseId = `${walkSessionId}:points:${rows.length}:${Math.trunc(createdEpoch)}`;
+      for (const questRow of activeQuestRows) {
+        const record = asRecord(questRow);
+        const questInstanceId = toUUIDOrNull(record.id);
+        const questType = asString(record.quest_type);
+        if (!questInstanceId || !questType) continue;
+
+        const delta = deltaByQuestType[questType] ?? 0;
+        if (delta <= 0) continue;
+
+        const { data: progressRows, error: progressError } = await userClient.rpc(
+          "rpc_apply_quest_progress_event",
+          {
+            target_user_id: userId,
+            target_instance_id: questInstanceId,
+            event_id: `${questEventBaseId}:${questType}`,
+            event_type: "walk_sync_points",
+            delta_value: delta,
+            payload: {
+              walk_session_id: walkSessionId,
+              point_count: rows.length,
+              unique_tile_count: uniqueTileCount,
+            },
+            now_ts: new Date().toISOString(),
+          },
+        );
+
+        if (progressError) {
+          console.warn("quest progress rpc failed", progressError.message);
+          continue;
+        }
+        if (Array.isArray(progressRows) && progressRows.length > 0) {
+          questProgressSummary.push(progressRows[0] as QuestProgressSummaryDTO);
+        }
+      }
+    }
+
     return json({
       ok: true,
       stage,
@@ -327,6 +395,7 @@ Deno.serve(async (req) => {
       season_score_summary: seasonScoreSummary,
       season_pipeline_summary: seasonPipelineSummary,
       weather_replacement_summary: weatherReplacementSummary,
+      quest_progress_summary: questProgressSummary,
     });
   }
 

--- a/supabase/migrations/20260303120000_quest_stage2_progress_claim_engine.sql
+++ b/supabase/migrations/20260303120000_quest_stage2_progress_claim_engine.sql
@@ -1,0 +1,1205 @@
+-- #128 quest stage2 progress/claim backend engine
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.quest_templates (
+  id text primary key,
+  quest_scope text not null default 'daily' check (quest_scope in ('daily', 'weekly')),
+  quest_type text not null,
+  title text not null,
+  description text not null default '',
+  base_target_value double precision not null check (base_target_value > 0),
+  reward_points integer not null default 0 check (reward_points >= 0),
+  reward_tokens integer not null default 0 check (reward_tokens >= 0),
+  reroll_group text not null default 'general',
+  is_active boolean not null default true,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.quest_instances (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  template_id text not null references public.quest_templates(id) on delete restrict,
+  quest_scope text not null check (quest_scope in ('daily', 'weekly')),
+  quest_type text not null,
+  title_snapshot text not null,
+  description_snapshot text not null default '',
+  target_value_snapshot double precision not null check (target_value_snapshot > 0),
+  reward_points_snapshot integer not null default 0 check (reward_points_snapshot >= 0),
+  reward_tokens_snapshot integer not null default 0 check (reward_tokens_snapshot >= 0),
+  progress_value double precision not null default 0 check (progress_value >= 0),
+  status text not null default 'generated'
+    check (status in ('generated', 'active', 'completed', 'claimed', 'expired', 'rerolled', 'alternative', 'replaced')),
+  cycle_key text not null,
+  replacement_source_instance_id uuid references public.quest_instances(id) on delete set null,
+  rerolled_from_instance_id uuid references public.quest_instances(id) on delete set null,
+  expires_at timestamptz not null,
+  completed_at timestamptz,
+  claimed_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.quest_progress (
+  id bigint generated always as identity primary key,
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  quest_instance_id uuid not null references public.quest_instances(id) on delete cascade,
+  event_id text not null,
+  event_type text not null default 'walk_event',
+  delta_value double precision not null default 0 check (delta_value >= 0),
+  payload jsonb not null default '{}'::jsonb,
+  recorded_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  unique (quest_instance_id, event_id)
+);
+
+create table if not exists public.quest_claims (
+  id bigint generated always as identity primary key,
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  quest_instance_id uuid not null references public.quest_instances(id) on delete cascade,
+  request_id text not null,
+  claim_status text not null default 'pending' check (claim_status in ('pending', 'claimed', 'rejected')),
+  reward_points integer not null default 0 check (reward_points >= 0),
+  reward_tokens integer not null default 0 check (reward_tokens >= 0),
+  reason text,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  claimed_at timestamptz,
+  unique (quest_instance_id),
+  unique (owner_user_id, request_id)
+);
+
+create table if not exists public.quest_claim_audit_logs (
+  id bigint generated always as identity primary key,
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  quest_instance_id uuid not null references public.quest_instances(id) on delete cascade,
+  action text not null,
+  detail text,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists idx_quest_instances_owner_template_cycle
+  on public.quest_instances(owner_user_id, template_id, cycle_key);
+create index if not exists idx_quest_instances_owner_status
+  on public.quest_instances(owner_user_id, status, expires_at asc);
+create index if not exists idx_quest_instances_scope_cycle
+  on public.quest_instances(quest_scope, cycle_key, status);
+
+create index if not exists idx_quest_progress_owner_created
+  on public.quest_progress(owner_user_id, created_at desc);
+create index if not exists idx_quest_progress_instance_created
+  on public.quest_progress(quest_instance_id, created_at desc);
+
+create index if not exists idx_quest_claims_owner_created
+  on public.quest_claims(owner_user_id, created_at desc);
+create index if not exists idx_quest_claim_audit_owner_action_created
+  on public.quest_claim_audit_logs(owner_user_id, action, created_at desc);
+
+alter table public.quest_templates enable row level security;
+alter table public.quest_instances enable row level security;
+alter table public.quest_progress enable row level security;
+alter table public.quest_claims enable row level security;
+alter table public.quest_claim_audit_logs enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_templates'
+      and policyname = 'quest_templates_public_select'
+  ) then
+    create policy quest_templates_public_select
+      on public.quest_templates
+      for select
+      to anon, authenticated
+      using (is_active = true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_templates'
+      and policyname = 'quest_templates_service_write'
+  ) then
+    create policy quest_templates_service_write
+      on public.quest_templates
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_instances'
+      and policyname = 'quest_instances_owner_select'
+  ) then
+    create policy quest_instances_owner_select
+      on public.quest_instances
+      for select
+      to authenticated
+      using (owner_user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_instances'
+      and policyname = 'quest_instances_service_write'
+  ) then
+    create policy quest_instances_service_write
+      on public.quest_instances
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_progress'
+      and policyname = 'quest_progress_owner_select'
+  ) then
+    create policy quest_progress_owner_select
+      on public.quest_progress
+      for select
+      to authenticated
+      using (owner_user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_progress'
+      and policyname = 'quest_progress_service_write'
+  ) then
+    create policy quest_progress_service_write
+      on public.quest_progress
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_claims'
+      and policyname = 'quest_claims_owner_select'
+  ) then
+    create policy quest_claims_owner_select
+      on public.quest_claims
+      for select
+      to authenticated
+      using (owner_user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_claims'
+      and policyname = 'quest_claims_service_write'
+  ) then
+    create policy quest_claims_service_write
+      on public.quest_claims
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_claim_audit_logs'
+      and policyname = 'quest_claim_audit_logs_owner_select'
+  ) then
+    create policy quest_claim_audit_logs_owner_select
+      on public.quest_claim_audit_logs
+      for select
+      to authenticated
+      using (owner_user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'quest_claim_audit_logs'
+      and policyname = 'quest_claim_audit_logs_service_write'
+  ) then
+    create policy quest_claim_audit_logs_service_write
+      on public.quest_claim_audit_logs
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end $$;
+
+drop trigger if exists trg_quest_templates_updated_at on public.quest_templates;
+create trigger trg_quest_templates_updated_at
+before update on public.quest_templates
+for each row execute function public.touch_updated_at();
+
+drop trigger if exists trg_quest_instances_updated_at on public.quest_instances;
+create trigger trg_quest_instances_updated_at
+before update on public.quest_instances
+for each row execute function public.touch_updated_at();
+
+drop trigger if exists trg_quest_claims_updated_at on public.quest_claims;
+create trigger trg_quest_claims_updated_at
+before update on public.quest_claims
+for each row execute function public.touch_updated_at();
+
+insert into public.quest_templates (
+  id,
+  quest_scope,
+  quest_type,
+  title,
+  description,
+  base_target_value,
+  reward_points,
+  reward_tokens,
+  reroll_group,
+  is_active,
+  metadata
+)
+values
+  (
+    'daily.walk_duration.normal',
+    'daily',
+    'walk_duration',
+    '산책 30분 달성',
+    '오늘 누적 산책 시간을 30분 이상 달성하세요.',
+    30,
+    120,
+    8,
+    'daily_core',
+    true,
+    jsonb_build_object('tier', 'Normal')
+  ),
+  (
+    'daily.new_tile.easy',
+    'daily',
+    'new_tile',
+    '새 타일 3개 개척',
+    '새로운 산책 타일을 3개 이상 점령하세요.',
+    3,
+    90,
+    6,
+    'daily_core',
+    true,
+    jsonb_build_object('tier', 'Easy')
+  ),
+  (
+    'daily.linked_path.normal',
+    'daily',
+    'linked_path',
+    '연결 경로 8칸',
+    '연속된 경로를 8칸 이상 연결하세요.',
+    8,
+    110,
+    7,
+    'daily_core',
+    true,
+    jsonb_build_object('tier', 'Normal')
+  ),
+  (
+    'weekly.streak_days.hard',
+    'weekly',
+    'streak_days',
+    '주간 5일 연속 산책',
+    '이번 주 5일 이상 산책을 유지하세요.',
+    5,
+    500,
+    24,
+    'weekly_core',
+    true,
+    jsonb_build_object('tier', 'Hard')
+  )
+on conflict (id) do update
+set
+  quest_scope = excluded.quest_scope,
+  quest_type = excluded.quest_type,
+  title = excluded.title,
+  description = excluded.description,
+  base_target_value = excluded.base_target_value,
+  reward_points = excluded.reward_points,
+  reward_tokens = excluded.reward_tokens,
+  reroll_group = excluded.reroll_group,
+  is_active = excluded.is_active,
+  metadata = excluded.metadata,
+  updated_at = now();
+
+create or replace function public.quest_cycle_key(
+  scope text,
+  now_ts timestamptz default now()
+)
+returns text
+language sql
+stable
+as $$
+  select case lower(coalesce(scope, 'daily'))
+    when 'weekly' then to_char(date_trunc('week', timezone('utc', now_ts))::date, 'IYYY-"W"IW')
+    else to_char((timezone('utc', now_ts))::date, 'YYYY-MM-DD')
+  end;
+$$;
+
+create or replace function public.quest_scope_expires_at(
+  scope text,
+  now_ts timestamptz default now()
+)
+returns timestamptz
+language sql
+stable
+as $$
+  select case lower(coalesce(scope, 'daily'))
+    when 'weekly' then date_trunc('week', timezone('utc', now_ts)) + interval '7 days' - interval '1 second'
+    else date_trunc('day', timezone('utc', now_ts)) + interval '1 day' - interval '1 second'
+  end;
+$$;
+
+create or replace function public.rpc_issue_quest_instances(
+  target_user_id uuid default auth.uid(),
+  target_scope text default 'daily',
+  target_cycle_key text default null,
+  expires_at timestamptz default null,
+  now_ts timestamptz default now()
+)
+returns table (
+  quest_instance_id uuid,
+  owner_user_id uuid,
+  template_id text,
+  quest_type text,
+  target_value_snapshot double precision,
+  progress_value double precision,
+  status text,
+  cycle_key text,
+  expires_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  requester_uid uuid;
+  requester_role text;
+  effective_user_id uuid;
+  normalized_scope text;
+  effective_cycle_key text;
+  effective_expires_at timestamptz;
+begin
+  requester_uid := auth.uid();
+  requester_role := auth.role();
+  effective_user_id := coalesce(target_user_id, requester_uid);
+  normalized_scope := lower(coalesce(target_scope, 'daily'));
+
+  if normalized_scope not in ('daily', 'weekly') then
+    raise exception 'invalid target_scope: %', normalized_scope;
+  end if;
+
+  if requester_role <> 'service_role' then
+    if requester_uid is null or effective_user_id is null or requester_uid <> effective_user_id then
+      raise exception 'unauthorized quest issue request';
+    end if;
+  end if;
+
+  effective_cycle_key := coalesce(nullif(trim(target_cycle_key), ''), public.quest_cycle_key(normalized_scope, now_ts));
+  effective_expires_at := coalesce(expires_at, public.quest_scope_expires_at(normalized_scope, now_ts));
+
+  insert into public.quest_instances (
+    owner_user_id,
+    template_id,
+    quest_scope,
+    quest_type,
+    title_snapshot,
+    description_snapshot,
+    target_value_snapshot,
+    reward_points_snapshot,
+    reward_tokens_snapshot,
+    progress_value,
+    status,
+    cycle_key,
+    expires_at,
+    metadata
+  )
+  select
+    effective_user_id,
+    t.id,
+    t.quest_scope,
+    t.quest_type,
+    t.title,
+    t.description,
+    t.base_target_value,
+    t.reward_points,
+    t.reward_tokens,
+    0,
+    'active',
+    effective_cycle_key,
+    effective_expires_at,
+    jsonb_build_object(
+      'issued_by', 'rpc_issue_quest_instances',
+      'issued_at', now_ts,
+      'snapshot_fixed', true
+    )
+  from public.quest_templates t
+  where t.is_active = true
+    and t.quest_scope = normalized_scope
+  on conflict (owner_user_id, template_id, cycle_key) do update
+  set
+    updated_at = now(),
+    expires_at = greatest(public.quest_instances.expires_at, excluded.expires_at),
+    status = case
+      when public.quest_instances.status in ('generated', 'active') then public.quest_instances.status
+      when public.quest_instances.status = 'completed' then 'completed'
+      when public.quest_instances.status = 'claimed' then 'claimed'
+      else public.quest_instances.status
+    end;
+
+  return query
+  select
+    qi.id,
+    qi.owner_user_id,
+    qi.template_id,
+    qi.quest_type,
+    qi.target_value_snapshot,
+    qi.progress_value,
+    qi.status,
+    qi.cycle_key,
+    qi.expires_at
+  from public.quest_instances qi
+  where qi.owner_user_id = effective_user_id
+    and qi.quest_scope = normalized_scope
+    and qi.cycle_key = effective_cycle_key
+  order by qi.template_id asc;
+end;
+$$;
+
+create or replace function public.rpc_apply_quest_progress_event(
+  target_user_id uuid default auth.uid(),
+  target_instance_id uuid default null,
+  event_id text default null,
+  event_type text default 'walk_event',
+  delta_value double precision default 1,
+  payload jsonb default '{}'::jsonb,
+  now_ts timestamptz default now()
+)
+returns table (
+  quest_instance_id uuid,
+  owner_user_id uuid,
+  event_id text,
+  idempotent boolean,
+  previous_progress double precision,
+  current_progress double precision,
+  target_progress double precision,
+  status text,
+  completed_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  requester_uid uuid;
+  requester_role text;
+  effective_user_id uuid;
+  normalized_event_id text;
+  normalized_event_type text;
+  normalized_delta double precision;
+  instance_row public.quest_instances%rowtype;
+  inserted_progress_id bigint;
+  next_progress double precision;
+  next_status text;
+  next_completed_at timestamptz;
+begin
+  requester_uid := auth.uid();
+  requester_role := auth.role();
+  effective_user_id := coalesce(target_user_id, requester_uid);
+  normalized_event_id := nullif(trim(coalesce(event_id, '')), '');
+  normalized_event_type := coalesce(nullif(trim(event_type), ''), 'walk_event');
+  normalized_delta := greatest(coalesce(delta_value, 0), 0);
+
+  if requester_role <> 'service_role' then
+    if requester_uid is null or effective_user_id is null or requester_uid <> effective_user_id then
+      raise exception 'unauthorized quest progress request';
+    end if;
+  end if;
+
+  if target_instance_id is null then
+    raise exception 'target_instance_id is required';
+  end if;
+
+  if normalized_event_id is null then
+    raise exception 'event_id is required';
+  end if;
+
+  select *
+  into instance_row
+  from public.quest_instances
+  where id = target_instance_id
+  for update;
+
+  if instance_row.id is null then
+    raise exception 'quest instance not found: %', target_instance_id;
+  end if;
+
+  if requester_role <> 'service_role' and instance_row.owner_user_id <> effective_user_id then
+    raise exception 'forbidden quest instance access';
+  end if;
+
+  if normalized_delta <= 0 then
+    return query
+    select
+      instance_row.id,
+      instance_row.owner_user_id,
+      normalized_event_id,
+      true,
+      instance_row.progress_value,
+      instance_row.progress_value,
+      instance_row.target_value_snapshot,
+      instance_row.status,
+      instance_row.completed_at;
+    return;
+  end if;
+
+  if instance_row.status not in ('generated', 'active', 'completed') then
+    return query
+    select
+      instance_row.id,
+      instance_row.owner_user_id,
+      normalized_event_id,
+      true,
+      instance_row.progress_value,
+      instance_row.progress_value,
+      instance_row.target_value_snapshot,
+      instance_row.status,
+      instance_row.completed_at;
+    return;
+  end if;
+
+  insert into public.quest_progress (
+    owner_user_id,
+    quest_instance_id,
+    event_id,
+    event_type,
+    delta_value,
+    payload,
+    recorded_at
+  )
+  values (
+    instance_row.owner_user_id,
+    instance_row.id,
+    normalized_event_id,
+    normalized_event_type,
+    normalized_delta,
+    coalesce(payload, '{}'::jsonb),
+    now_ts
+  )
+  on conflict (quest_instance_id, event_id) do nothing
+  returning id into inserted_progress_id;
+
+  if inserted_progress_id is null then
+    return query
+    select
+      instance_row.id,
+      instance_row.owner_user_id,
+      normalized_event_id,
+      true,
+      instance_row.progress_value,
+      instance_row.progress_value,
+      instance_row.target_value_snapshot,
+      instance_row.status,
+      instance_row.completed_at;
+    return;
+  end if;
+
+  next_progress := least(instance_row.target_value_snapshot, instance_row.progress_value + normalized_delta);
+  next_status := case
+    when next_progress >= instance_row.target_value_snapshot then 'completed'
+    when instance_row.status = 'generated' then 'active'
+    else instance_row.status
+  end;
+
+  update public.quest_instances
+  set
+    progress_value = next_progress,
+    status = next_status,
+    completed_at = case
+      when next_status = 'completed' then coalesce(completed_at, now_ts)
+      else completed_at
+    end,
+    updated_at = now()
+  where id = instance_row.id
+  returning completed_at into next_completed_at;
+
+  return query
+  select
+    instance_row.id,
+    instance_row.owner_user_id,
+    normalized_event_id,
+    false,
+    instance_row.progress_value,
+    next_progress,
+    instance_row.target_value_snapshot,
+    next_status,
+    next_completed_at;
+end;
+$$;
+
+create or replace function public.rpc_claim_quest_reward(
+  target_user_id uuid default auth.uid(),
+  target_instance_id uuid default null,
+  request_id text default null,
+  now_ts timestamptz default now()
+)
+returns table (
+  quest_instance_id uuid,
+  owner_user_id uuid,
+  claim_id bigint,
+  claim_status text,
+  already_claimed boolean,
+  reward_points integer,
+  reward_tokens integer,
+  claimed_at timestamptz,
+  audit_action text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  requester_uid uuid;
+  requester_role text;
+  effective_user_id uuid;
+  normalized_request_id text;
+  instance_row public.quest_instances%rowtype;
+  claim_row public.quest_claims%rowtype;
+begin
+  requester_uid := auth.uid();
+  requester_role := auth.role();
+  effective_user_id := coalesce(target_user_id, requester_uid);
+  normalized_request_id := coalesce(nullif(trim(coalesce(request_id, '')), ''), gen_random_uuid()::text);
+
+  if requester_role <> 'service_role' then
+    if requester_uid is null or effective_user_id is null or requester_uid <> effective_user_id then
+      raise exception 'unauthorized quest claim request';
+    end if;
+  end if;
+
+  if target_instance_id is null then
+    raise exception 'target_instance_id is required';
+  end if;
+
+  select *
+  into instance_row
+  from public.quest_instances
+  where id = target_instance_id
+  for update;
+
+  if instance_row.id is null then
+    raise exception 'quest instance not found: %', target_instance_id;
+  end if;
+
+  if requester_role <> 'service_role' and instance_row.owner_user_id <> effective_user_id then
+    raise exception 'forbidden quest instance access';
+  end if;
+
+  if instance_row.status = 'claimed' then
+    select *
+    into claim_row
+    from public.quest_claims
+    where quest_instance_id = instance_row.id
+    limit 1;
+
+    insert into public.quest_claim_audit_logs (
+      owner_user_id,
+      quest_instance_id,
+      action,
+      detail,
+      payload
+    )
+    values (
+      instance_row.owner_user_id,
+      instance_row.id,
+      'duplicate_claim_blocked',
+      'already claimed instance',
+      jsonb_build_object('request_id', normalized_request_id)
+    );
+
+    return query
+    select
+      instance_row.id,
+      instance_row.owner_user_id,
+      claim_row.id,
+      coalesce(claim_row.claim_status, 'claimed'),
+      true,
+      coalesce(claim_row.reward_points, instance_row.reward_points_snapshot),
+      coalesce(claim_row.reward_tokens, instance_row.reward_tokens_snapshot),
+      coalesce(claim_row.claimed_at, instance_row.claimed_at),
+      'duplicate_claim_blocked';
+    return;
+  end if;
+
+  if instance_row.status <> 'completed' then
+    insert into public.quest_claim_audit_logs (
+      owner_user_id,
+      quest_instance_id,
+      action,
+      detail,
+      payload
+    )
+    values (
+      instance_row.owner_user_id,
+      instance_row.id,
+      'claim_rejected',
+      'instance is not completed',
+      jsonb_build_object('request_id', normalized_request_id, 'status', instance_row.status)
+    );
+
+    return query
+    select
+      instance_row.id,
+      instance_row.owner_user_id,
+      null::bigint,
+      'rejected',
+      false,
+      instance_row.reward_points_snapshot,
+      instance_row.reward_tokens_snapshot,
+      null::timestamptz,
+      'claim_rejected';
+    return;
+  end if;
+
+  insert into public.quest_claims (
+    owner_user_id,
+    quest_instance_id,
+    request_id,
+    claim_status,
+    reward_points,
+    reward_tokens,
+    payload
+  )
+  values (
+    instance_row.owner_user_id,
+    instance_row.id,
+    normalized_request_id,
+    'pending',
+    instance_row.reward_points_snapshot,
+    instance_row.reward_tokens_snapshot,
+    jsonb_build_object('requested_at', now_ts)
+  )
+  on conflict (quest_instance_id) do nothing
+  returning * into claim_row;
+
+  if claim_row.id is null then
+    select *
+    into claim_row
+    from public.quest_claims
+    where quest_instance_id = instance_row.id
+    limit 1;
+
+    insert into public.quest_claim_audit_logs (
+      owner_user_id,
+      quest_instance_id,
+      action,
+      detail,
+      payload
+    )
+    values (
+      instance_row.owner_user_id,
+      instance_row.id,
+      'duplicate_claim_blocked',
+      'concurrent claim conflict',
+      jsonb_build_object('request_id', normalized_request_id)
+    );
+
+    return query
+    select
+      instance_row.id,
+      instance_row.owner_user_id,
+      claim_row.id,
+      coalesce(claim_row.claim_status, 'claimed'),
+      true,
+      coalesce(claim_row.reward_points, instance_row.reward_points_snapshot),
+      coalesce(claim_row.reward_tokens, instance_row.reward_tokens_snapshot),
+      coalesce(claim_row.claimed_at, instance_row.claimed_at),
+      'duplicate_claim_blocked';
+    return;
+  end if;
+
+  update public.quest_claims
+  set
+    claim_status = 'claimed',
+    claimed_at = now_ts,
+    updated_at = now(),
+    payload = coalesce(payload, '{}'::jsonb) || jsonb_build_object('confirmed_at', now_ts)
+  where id = claim_row.id
+  returning * into claim_row;
+
+  update public.quest_instances
+  set
+    status = 'claimed',
+    claimed_at = coalesce(claimed_at, now_ts),
+    updated_at = now()
+  where id = instance_row.id;
+
+  insert into public.quest_claim_audit_logs (
+    owner_user_id,
+    quest_instance_id,
+    action,
+    detail,
+    payload
+  )
+  values (
+    instance_row.owner_user_id,
+    instance_row.id,
+    'claim_confirmed',
+    'claim confirmed by server validation',
+    jsonb_build_object('request_id', normalized_request_id, 'claim_id', claim_row.id)
+  );
+
+  return query
+  select
+    instance_row.id,
+    instance_row.owner_user_id,
+    claim_row.id,
+    claim_row.claim_status,
+    false,
+    claim_row.reward_points,
+    claim_row.reward_tokens,
+    claim_row.claimed_at,
+    'claim_confirmed';
+end;
+$$;
+
+create or replace function public.rpc_transition_quest_status(
+  target_user_id uuid default auth.uid(),
+  target_instance_id uuid default null,
+  transition_action text default null,
+  replacement_template_id text default null,
+  now_ts timestamptz default now()
+)
+returns table (
+  quest_instance_id uuid,
+  previous_status text,
+  current_status text,
+  replacement_instance_id uuid,
+  transition_action text,
+  reroll_allowed boolean
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  requester_uid uuid;
+  requester_role text;
+  effective_user_id uuid;
+  normalized_action text;
+  normalized_replacement_template_id text;
+  instance_row public.quest_instances%rowtype;
+  previous_status_text text;
+  replacement_template_row public.quest_templates%rowtype;
+  created_replacement_id uuid;
+  reroll_used_today boolean;
+  cycle_date date;
+begin
+  requester_uid := auth.uid();
+  requester_role := auth.role();
+  effective_user_id := coalesce(target_user_id, requester_uid);
+  normalized_action := lower(coalesce(transition_action, ''));
+  normalized_replacement_template_id := nullif(trim(coalesce(replacement_template_id, '')), '');
+
+  if requester_role <> 'service_role' then
+    if requester_uid is null or effective_user_id is null or requester_uid <> effective_user_id then
+      raise exception 'unauthorized quest transition request';
+    end if;
+  end if;
+
+  if target_instance_id is null then
+    raise exception 'target_instance_id is required';
+  end if;
+
+  if normalized_action not in ('expire', 'reroll', 'replace') then
+    raise exception 'invalid transition_action: %', transition_action;
+  end if;
+
+  select *
+  into instance_row
+  from public.quest_instances
+  where id = target_instance_id
+  for update;
+
+  if instance_row.id is null then
+    raise exception 'quest instance not found: %', target_instance_id;
+  end if;
+
+  if requester_role <> 'service_role' and instance_row.owner_user_id <> effective_user_id then
+    raise exception 'forbidden quest instance access';
+  end if;
+
+  previous_status_text := instance_row.status;
+
+  if normalized_action = 'expire' then
+    update public.quest_instances
+    set
+      status = case
+        when status = 'claimed' then status
+        else 'expired'
+      end,
+      updated_at = now()
+    where id = instance_row.id
+    returning * into instance_row;
+
+    insert into public.quest_claim_audit_logs (
+      owner_user_id,
+      quest_instance_id,
+      action,
+      detail,
+      payload
+    )
+    values (
+      instance_row.owner_user_id,
+      instance_row.id,
+      'expire_transition',
+      'quest moved to expired status',
+      jsonb_build_object('requested_at', now_ts)
+    );
+
+    return query
+    select
+      instance_row.id,
+      previous_status_text,
+      instance_row.status,
+      null::uuid,
+      normalized_action,
+      true;
+    return;
+  end if;
+
+  if normalized_action = 'reroll' then
+    cycle_date := (timezone('utc', now_ts))::date;
+
+    select exists(
+      select 1
+      from public.quest_claim_audit_logs l
+      where l.owner_user_id = instance_row.owner_user_id
+        and l.action = 'reroll_transition'
+        and (timezone('utc', l.created_at))::date = cycle_date
+    )
+    into reroll_used_today;
+
+    if reroll_used_today then
+      return query
+      select
+        instance_row.id,
+        previous_status_text,
+        instance_row.status,
+        null::uuid,
+        normalized_action,
+        false;
+      return;
+    end if;
+
+    update public.quest_instances
+    set
+      status = case
+        when status = 'claimed' then status
+        else 'rerolled'
+      end,
+      updated_at = now()
+    where id = instance_row.id
+    returning * into instance_row;
+
+    if normalized_replacement_template_id is not null then
+      select *
+      into replacement_template_row
+      from public.quest_templates t
+      where t.id = normalized_replacement_template_id
+        and t.is_active = true
+      limit 1;
+    else
+      select *
+      into replacement_template_row
+      from public.quest_templates t
+      where t.quest_scope = instance_row.quest_scope
+        and t.is_active = true
+        and t.id <> instance_row.template_id
+      order by t.id asc
+      limit 1;
+    end if;
+
+    if replacement_template_row.id is not null and instance_row.status <> 'claimed' then
+      insert into public.quest_instances (
+        owner_user_id,
+        template_id,
+        quest_scope,
+        quest_type,
+        title_snapshot,
+        description_snapshot,
+        target_value_snapshot,
+        reward_points_snapshot,
+        reward_tokens_snapshot,
+        progress_value,
+        status,
+        cycle_key,
+        expires_at,
+        rerolled_from_instance_id,
+        metadata
+      )
+      values (
+        instance_row.owner_user_id,
+        replacement_template_row.id,
+        replacement_template_row.quest_scope,
+        replacement_template_row.quest_type,
+        replacement_template_row.title,
+        replacement_template_row.description,
+        replacement_template_row.base_target_value,
+        replacement_template_row.reward_points,
+        replacement_template_row.reward_tokens,
+        0,
+        'active',
+        instance_row.cycle_key,
+        instance_row.expires_at,
+        instance_row.id,
+        jsonb_build_object('transition', 'reroll', 'source_instance_id', instance_row.id, 'requested_at', now_ts)
+      )
+      on conflict (owner_user_id, template_id, cycle_key) do update
+      set
+        status = 'active',
+        updated_at = now(),
+        rerolled_from_instance_id = excluded.rerolled_from_instance_id
+      returning id into created_replacement_id;
+    end if;
+
+    insert into public.quest_claim_audit_logs (
+      owner_user_id,
+      quest_instance_id,
+      action,
+      detail,
+      payload
+    )
+    values (
+      instance_row.owner_user_id,
+      instance_row.id,
+      'reroll_transition',
+      'daily reroll consumed',
+      jsonb_build_object('replacement_instance_id', created_replacement_id)
+    );
+
+    return query
+    select
+      instance_row.id,
+      previous_status_text,
+      instance_row.status,
+      created_replacement_id,
+      normalized_action,
+      true;
+    return;
+  end if;
+
+  -- replace transition: move current to alternative and create replacement quest snapshot
+  update public.quest_instances
+  set
+    status = case
+      when status = 'claimed' then status
+      else 'alternative'
+    end,
+    updated_at = now()
+  where id = instance_row.id
+  returning * into instance_row;
+
+  if normalized_replacement_template_id is not null then
+    select *
+    into replacement_template_row
+    from public.quest_templates t
+    where t.id = normalized_replacement_template_id
+      and t.is_active = true
+    limit 1;
+  else
+    select *
+    into replacement_template_row
+    from public.quest_templates t
+    where t.quest_scope = instance_row.quest_scope
+      and t.is_active = true
+      and t.id <> instance_row.template_id
+    order by t.id asc
+    limit 1;
+  end if;
+
+  if replacement_template_row.id is not null and instance_row.status <> 'claimed' then
+    insert into public.quest_instances (
+      owner_user_id,
+      template_id,
+      quest_scope,
+      quest_type,
+      title_snapshot,
+      description_snapshot,
+      target_value_snapshot,
+      reward_points_snapshot,
+      reward_tokens_snapshot,
+      progress_value,
+      status,
+      cycle_key,
+      expires_at,
+      replacement_source_instance_id,
+      metadata
+    )
+    values (
+      instance_row.owner_user_id,
+      replacement_template_row.id,
+      replacement_template_row.quest_scope,
+      replacement_template_row.quest_type,
+      replacement_template_row.title,
+      replacement_template_row.description,
+      replacement_template_row.base_target_value,
+      replacement_template_row.reward_points,
+      replacement_template_row.reward_tokens,
+      0,
+      'active',
+      instance_row.cycle_key,
+      instance_row.expires_at,
+      instance_row.id,
+      jsonb_build_object('transition', 'replace', 'source_instance_id', instance_row.id, 'requested_at', now_ts)
+    )
+    on conflict (owner_user_id, template_id, cycle_key) do update
+    set
+      status = 'active',
+      updated_at = now(),
+      replacement_source_instance_id = excluded.replacement_source_instance_id
+    returning id into created_replacement_id;
+  end if;
+
+  insert into public.quest_claim_audit_logs (
+    owner_user_id,
+    quest_instance_id,
+    action,
+    detail,
+    payload
+  )
+  values (
+    instance_row.owner_user_id,
+    instance_row.id,
+    'replace_transition',
+    'quest replaced with alternative quest',
+    jsonb_build_object('replacement_instance_id', created_replacement_id)
+  );
+
+  return query
+  select
+    instance_row.id,
+    previous_status_text,
+    instance_row.status,
+    created_replacement_id,
+    normalized_action,
+    true;
+end;
+$$;
+
+revoke all on function public.rpc_issue_quest_instances(uuid, text, text, timestamptz, timestamptz) from public;
+revoke all on function public.rpc_apply_quest_progress_event(uuid, uuid, text, text, double precision, jsonb, timestamptz) from public;
+revoke all on function public.rpc_claim_quest_reward(uuid, uuid, text, timestamptz) from public;
+revoke all on function public.rpc_transition_quest_status(uuid, uuid, text, text, timestamptz) from public;
+
+grant execute on function public.rpc_issue_quest_instances(uuid, text, text, timestamptz, timestamptz) to authenticated, service_role;
+grant execute on function public.rpc_apply_quest_progress_event(uuid, uuid, text, text, double precision, jsonb, timestamptz) to authenticated, service_role;
+grant execute on function public.rpc_claim_quest_reward(uuid, uuid, text, timestamptz) to authenticated, service_role;
+grant execute on function public.rpc_transition_quest_status(uuid, uuid, text, text, timestamptz) to authenticated, service_role;


### PR DESCRIPTION
## Summary
- implement Quest Stage2 backend engine (schema, RPC, edge function, sync-walk ingestion)
- add quest stage2 docs, migration verification, and unit checks
- add auth token session persistence/restore and refresh-token renewal path for automatic sign-in continuity

## Validation
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
- `bash scripts/ios_pr_check.sh`
- `DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... xcodebuild -only-testing:dogAreaUITests/DesignAuditUITests/testDesignAudit_LightMode test`

Closes #128