### PR TITLE
docs: game-layer observability + QA baseline (#206)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - Supabase 마이그레이션/운영 검증 v1: `docs/supabase-migration.md`
 - 릴리즈 회귀 체크리스트 v1: `docs/release-regression-checklist-v1.md`
 - 릴리즈 회귀 실행 리포트(2026-02-26): `docs/release-regression-report-2026-02-26.md`
+- 게임 레이어 공통 관측/QA 기준 v1: `docs/game-layer-observability-qa-v1.md`
 - 다중 반려견 산책 N:M 2차 설계 v2: `docs/multi-pet-session-nm-v2.md`
 - 다견 1차 선택 반려견 UX v1: `docs/multi-dog-selection-ux-v1.md`
 - 선택 반려견 컨텍스트 배지/빈 상태 UX v1: `docs/pet-context-badge-empty-state-v1.md`
@@ -66,6 +67,7 @@
 - Cycle #170 결과 보고서(2026-03-01): `docs/cycle-170-quest-stage3-ux-reminder-report-2026-03-01.md`
 - Cycle #127 결과 보고서(2026-03-01): `docs/cycle-127-quest-stage1-policy-report-2026-03-01.md`
 - Cycle #205 결과 보고서(2026-03-03): `docs/cycle-205-quest-stage2-engine-report-2026-03-03.md`
+- Cycle #206 결과 보고서(2026-03-03): `docs/cycle-206-game-layer-observability-qa-report-2026-03-03.md`
 - Cycle #147 결과 보고서(2026-02-27): `docs/cycle-147-pet-adaptive-quest-report-2026-02-27.md`
 - Cycle #145 결과 보고서(2026-02-27): `docs/cycle-145-season-catchup-buff-report-2026-02-27.md`
 - Cycle #124 결과 보고서(2026-02-27): `docs/cycle-124-season-policy-report-2026-02-27.md`

--- a/docs/cycle-206-game-layer-observability-qa-report-2026-03-03.md
+++ b/docs/cycle-206-game-layer-observability-qa-report-2026-03-03.md
@@ -1,0 +1,32 @@
+# Cycle 206 - Game Layer Observability/QA Baseline (2026-03-03)
+
+## 1. 개요
+- Branch: `codex/game-layer-observability-qa`
+- Issue: `#206`
+- 목적: 게임 레이어 공통 관측 지표/QA 게이트를 단일 문서로 표준화하고 PR 체크에 편입.
+
+## 2. 반영 내용
+1. 공통 운영 기준 문서 신설
+- `docs/game-layer-observability-qa-v1.md`
+- 시즌/퀘스트/라이벌/날씨 도메인 공통 이벤트 키 정의
+- KPI/경보 임계치/릴리즈 블로킹 규칙 정리
+
+2. PR 체크 정합성 강화
+- `scripts/game_layer_observability_qa_unit_check.swift` 추가
+- `scripts/ios_pr_check.sh`에 신규 체크 연결
+
+3. 문서 인덱스 업데이트
+- `README.md` 문서 목록에 본 명세/사이클 리포트 링크 추가
+
+## 3. 수용 기준 대응
+- 공통 관측 지표 문서화: 완료
+- QA 시나리오/릴리즈 게이트 명세: 완료
+- 자동 검증 파이프라인 연결: 완료
+
+## 4. 실행 검증
+- `swift scripts/game_layer_observability_qa_unit_check.swift` -> PASS
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh` -> PASS
+
+## 5. 다음 단계
+- #123 에픽 본문에서 `공통 QA/관측 지표 정의` 항목의 추적 이슈를 `#206`으로 동기화
+- 운영 대시보드(7d/24h KPI) 실제 쿼리 뷰 연결 여부를 후속 사이클에서 점검

--- a/docs/game-layer-observability-qa-v1.md
+++ b/docs/game-layer-observability-qa-v1.md
@@ -1,0 +1,78 @@
+# Game Layer Observability & QA v1
+
+## 1. 목적
+시즌/퀘스트/라이벌/날씨 연동 기능의 운영 품질을 단일 기준으로 점검할 수 있도록 공통 이벤트, KPI, 경보 임계치, QA 게이트를 고정한다.
+
+## 2. 범위
+- 대상 도메인: `Season`, `Quest`, `Rival`, `Weather`
+- 운영 계층: 앱 이벤트, Supabase RPC/배치, 릴리즈 게이트
+- 제외: 실시간 PvP 룸 매칭, 공개 소셜 피드
+
+## 3. 공통 이벤트 규약
+### 3.1 필수 공통 필드
+- `event_name`: snake_case 이벤트 키
+- `occurred_at`: epoch seconds(UTC)
+- `user_scope`: `guest|member`
+- `session_id`: 추적 가능한 세션 키(없으면 `null`)
+- `request_id`: 멱등/재처리 추적 키(없으면 `null`)
+- `result`: `success|failure|blocked`
+- `error_code`: 실패 시 서버/클라이언트 코드
+
+### 3.2 도메인별 필수 이벤트
+- Season
+- `season_score_applied`
+- `season_decay_applied`
+- `season_reward_claimed`
+- Quest
+- `quest_progress_applied`
+- `quest_reward_claimed`
+- `quest_reroll_applied`
+- `quest_claim_duplicate_blocked`
+- Rival
+- `rival_privacy_opt_in_completed`
+- `rival_leaderboard_fetched`
+- `rival_privacy_guard_blocked`
+- Weather
+- `weather_replacement_applied`
+- `weather_shield_consumed`
+- `weather_feedback_submitted`
+
+## 4. KPI 대시보드 기준
+### 4.1 핵심 KPI
+| KPI | 정의 | 목표 |
+| --- | --- | --- |
+| `quest_completion_rate_7d` | 최근 7일 퀘스트 완료율 | `>= 0.35` |
+| `quest_claim_duplicate_rate_7d` | 중복 클레임 차단/요청 비율 | `<= 0.005` |
+| `season_participation_rate_7d` | 시즌 참여 사용자 비율 | `>= 0.30` |
+| `rival_opt_in_rate_7d` | 라이벌 동의 완료율 | `>= 0.25` |
+| `weather_replacement_acceptance_rate_7d` | 악천후 치환 퀘스트 수락율 | `>= 0.40` |
+| `sync_auth_refresh_failure_rate_24h` | 세션 리프레시 실패율 | `<= 0.01` |
+
+### 4.2 운영 경보(Alerts)
+- `quest_claim_duplicate_rate_7d > 0.01`: 중복 클레임 경보(P1)
+- `season_participation_rate_7d < 0.20`: 참여율 하락 경보(P2)
+- `rival_privacy_guard_blocked` 24h 급증(평균 대비 2배 이상): 프라이버시 정책 경보(P1)
+- `weather_feedback_submitted` 24h 급감(평균 대비 50% 이하): 피드백 파이프라인 경보(P2)
+- `sync_auth_refresh_failure_rate_24h > 0.03`: 인증 세션 경보(P1)
+
+## 5. QA 시나리오 게이트
+### 5.1 공통 E2E
+1. 로그인(이메일) 후 앱 재실행 시 자동 로그인 유지 확인
+2. 산책 이벤트 재처리 시 퀘스트 진행도 멱등 반영 확인
+3. 동시 클레임 경쟁 요청에서 단일 수령 보장 확인
+4. 날씨 치환 적용/미적용 경계값에서 결과 일관성 확인
+5. 라이벌 동의/비동의 상태에서 접근 제어 및 로그 적재 확인
+
+### 5.2 릴리즈 블로킹 규칙
+- P0: 데이터 소유권 위반, 중복 보상 지급, 인증 세션 붕괴
+- P1: KPI 경보 임계치 초과가 24시간 이상 지속
+- 배포 전 조건: `ios_pr_check` + 최소 1건의 로그인 포함 UI 스모크
+
+## 6. 운영 런북 연결
+- 마이그레이션/운영 SQL: `docs/supabase-migration.md`
+- 릴리즈 회귀 게이트: `docs/release-regression-checklist-v1.md`
+- 에픽 추적: `#123`, 실행 태스크: `#206`
+
+## 7. 변경 관리
+- 본 문서 변경 시 `scripts/game_layer_observability_qa_unit_check.swift`를 함께 갱신한다.
+- KPI 목표값은 운영 데이터 기반으로 조정하되, 변경 사유를 사이클 리포트에 기록한다.

--- a/scripts/game_layer_observability_qa_unit_check.swift
+++ b/scripts/game_layer_observability_qa_unit_check.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// 조건이 거짓일 때 즉시 실패 코드로 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 불리언 조건입니다.
+///   - message: 실패 시 stderr에 출력할 설명 메시지입니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 상대 경로의 텍스트 파일을 UTF-8 문자열로 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: 로드된 파일의 문자열 본문입니다.
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let spec = load("docs/game-layer-observability-qa-v1.md")
+let report = load("docs/cycle-206-game-layer-observability-qa-report-2026-03-03.md")
+let readme = load("README.md")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(spec.contains("## 3. 공통 이벤트 규약"), "spec should include common event contract section")
+assertTrue(spec.contains("quest_progress_applied"), "spec should define quest progress event key")
+assertTrue(spec.contains("season_score_applied"), "spec should define season score event key")
+assertTrue(spec.contains("rival_privacy_guard_blocked"), "spec should define rival privacy guard event key")
+assertTrue(spec.contains("weather_feedback_submitted"), "spec should define weather feedback event key")
+assertTrue(spec.contains("sync_auth_refresh_failure_rate_24h"), "spec should include auth refresh KPI")
+assertTrue(spec.contains("릴리즈 블로킹 규칙"), "spec should include release blocking section")
+
+assertTrue(report.contains("Issue: `#206`"), "cycle report should link issue 206")
+assertTrue(report.contains("docs/game-layer-observability-qa-v1.md"), "cycle report should reference spec document")
+
+assertTrue(readme.contains("docs/game-layer-observability-qa-v1.md"), "README should list observability QA spec")
+assertTrue(readme.contains("docs/cycle-206-game-layer-observability-qa-report-2026-03-03.md"), "README should list cycle 206 report")
+
+assertTrue(prCheck.contains("scripts/game_layer_observability_qa_unit_check.swift"), "ios_pr_check should include observability QA unit check")
+
+print("PASS: game layer observability qa unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -32,6 +32,7 @@ swift scripts/quest_stage1_policy_unit_check.swift
 swift scripts/quest_stage2_engine_unit_check.swift
 swift scripts/season_motion_pack_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift
+swift scripts/game_layer_observability_qa_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift
 swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift


### PR DESCRIPTION
## Summary
- add cross-layer observability/QA baseline document for Season/Quest/Rival/Weather
- add cycle 206 report document
- add `game_layer_observability_qa_unit_check.swift` and wire into `ios_pr_check`
- update README doc index

## Validation
- `swift scripts/game_layer_observability_qa_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #206