### PR TITLE
refactor: remove deprecated SwiftUI onChange usages

### DIFF
--- a/dogArea/Views/MapView/MapSubViews/MapSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapSubView.swift
@@ -156,7 +156,7 @@ struct MapSubView: View {
             motionNow = now
             viewModel.compactMapMotionArtifacts(now: now)
         }
-        .onChange(of: viewModel.clusterMotionToken) { _ in
+        .onChange(of: viewModel.clusterMotionToken) {
             guard viewModel.clusterMotionTransition != .none else { return }
             withAnimation(.easeOut(duration: viewModel.clusterMotionAnimationDuration)) {
                 clusterPulseActive = true

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -159,13 +159,13 @@ struct MapView : View{
             recomputeBannerQueue()
             tabStatus.appear()
         }
-        .onChange(of: viewModel.walkStatusMessage) { newValue in
+        .onChange(of: viewModel.walkStatusMessage) { _, newValue in
             guard newValue != nil else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
                 viewModel.clearWalkStatusMessage()
             }
         }
-        .onChange(of: viewModel.runtimeGuardStatusText) { newValue in
+        .onChange(of: viewModel.runtimeGuardStatusText) { _, newValue in
             guard newValue.isEmpty == false else { return }
             recomputeBannerQueue()
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
@@ -173,31 +173,31 @@ struct MapView : View{
                 recomputeBannerQueue()
             }
         }
-        .onChange(of: viewModel.syncOutboxLastErrorCodeText) { _ in
+        .onChange(of: viewModel.syncOutboxLastErrorCodeText) {
             recomputeBannerQueue()
         }
-        .onChange(of: viewModel.syncOutboxPendingCount) { _ in
+        .onChange(of: viewModel.syncOutboxPendingCount) {
             recomputeBannerQueue()
         }
-        .onChange(of: viewModel.syncOutboxPermanentFailureCount) { _ in
+        .onChange(of: viewModel.syncOutboxPermanentFailureCount) {
             recomputeBannerQueue()
         }
-        .onChange(of: viewModel.hasRecoverableWalkSession) { _ in
+        .onChange(of: viewModel.hasRecoverableWalkSession) {
             recomputeBannerQueue()
         }
-        .onChange(of: viewModel.isWalking) { _ in
+        .onChange(of: viewModel.isWalking) {
             recomputeBannerQueue()
         }
-        .onChange(of: viewModel.watchSyncStatusText) { _ in
+        .onChange(of: viewModel.watchSyncStatusText) {
             recomputeBannerQueue()
         }
-        .onChange(of: viewModel.latestWatchActionText) { _ in
+        .onChange(of: viewModel.latestWatchActionText) {
             recomputeBannerQueue()
         }
-        .onChange(of: viewModel.polygonList.count) { _ in
+        .onChange(of: viewModel.polygonList.count) {
             recomputeBannerQueue()
         }
-        .onChange(of: viewModel.syncRecoveryToastMessage) { message in
+        .onChange(of: viewModel.syncRecoveryToastMessage) { _, message in
             guard let message else { return }
             viewModel.walkStatusMessage = message
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {

--- a/dogArea/Views/SigningView/PetProfileSettingView.swift
+++ b/dogArea/Views/SigningView/PetProfileSettingView.swift
@@ -92,7 +92,7 @@ struct PetProfileSettingView: View {
                 .padding(.top, 12)
             }
         }
-        .onChange(of: viewModel.loading) { state in
+        .onChange(of: viewModel.loading) { _, state in
             guard didCompleteSignup == false else { return }
             if state == .success {
                 recoveryIssue = nil

--- a/dogArea/Views/WalkListView/WalkListDetailView.swift
+++ b/dogArea/Views/WalkListView/WalkListDetailView.swift
@@ -129,7 +129,8 @@ struct WalkListDetailView: View {
                         SimpleMessageView(message: msg)
                             .transition(.opacity)
                     }
-                }.animation(.easeInOut(duration: 0.2))
+                }
+                .animation(.easeInOut(duration: 0.2), value: showSaveMessage)
             ).navigationBarBackButtonHidden()
         }.padding(.top, 20)
         .sheet(isPresented: $showShareSheet) {


### PR DESCRIPTION
## Summary
- replace deprecated SwiftUI onChange(of:perform:) usages with iOS 17 style closures
- use zero-parameter closures where observed value is unused
- keep behavior identical for status/toast/banner update flows
- replace deprecated animation modifier usage in WalkListDetailView with value-based animation

## Validation
- ./scripts/ios_pr_check.sh
