### PR TITLE
Fix map Equatable breakages and warning cleanup

### DIFF
--- a/dogArea/Source/Cluster.swift
+++ b/dogArea/Source/Cluster.swift
@@ -12,7 +12,8 @@ struct Cluster: Equatable, CustomStringConvertible {
         return "센터 : \(self.center)\n 하위 클러스터 : \(sumLocs.count)개"
     }
     static func == (lhs: Cluster, rhs: Cluster) -> Bool {
-        lhs.center == rhs.center
+        lhs.center.latitude == rhs.center.latitude &&
+        lhs.center.longitude == rhs.center.longitude
     }
     var sumLocs: [(CLLocationCoordinate2D, UUID)]
     var center: CLLocationCoordinate2D
@@ -30,7 +31,7 @@ struct Cluster: Equatable, CustomStringConvertible {
         center = CLLocationCoordinate2D(latitude: sumloc.latitude / Double(count), longitude: sumloc.longitude / Double(count))
     }
 }
-final class Hiarachical: Operation {
+final class Hiarachical: Operation, @unchecked Sendable {
     private var polygons: [Polygon]
     private var distance: Double
     var clusters: [Cluster]

--- a/dogArea/Source/Domain/Map/Models/MapModel.swift
+++ b/dogArea/Source/Domain/Map/Models/MapModel.swift
@@ -160,6 +160,18 @@ struct HeatmapCellDTO: Identifiable, Equatable {
         let level = Int(ceil(score * 5.0) - 1.0)
         return min(4, max(0, level))
     }
+
+    /// Compares two heatmap cells by geohash, normalized score, and center coordinate values.
+    /// - Parameters:
+    ///   - lhs: The left-hand heatmap cell to compare.
+    ///   - rhs: The right-hand heatmap cell to compare.
+    /// - Returns: `true` when all semantic fields represent the same heatmap cell.
+    static func == (lhs: HeatmapCellDTO, rhs: HeatmapCellDTO) -> Bool {
+        lhs.geohash == rhs.geohash &&
+        lhs.score == rhs.score &&
+        lhs.centerCoordinate.latitude == rhs.centerCoordinate.latitude &&
+        lhs.centerCoordinate.longitude == rhs.centerCoordinate.longitude
+    }
 }
 
 struct NearbyHotspotDTO: Identifiable, Equatable {
@@ -169,6 +181,19 @@ struct NearbyHotspotDTO: Identifiable, Equatable {
     let centerCoordinate: CLLocationCoordinate2D
 
     var id: String { geohash }
+
+    /// Compares two nearby hotspots by bucket identity, metrics, and center coordinate values.
+    /// - Parameters:
+    ///   - lhs: The left-hand hotspot to compare.
+    ///   - rhs: The right-hand hotspot to compare.
+    /// - Returns: `true` when both hotspots describe the same aggregated result.
+    static func == (lhs: NearbyHotspotDTO, rhs: NearbyHotspotDTO) -> Bool {
+        lhs.geohash == rhs.geohash &&
+        lhs.count == rhs.count &&
+        lhs.intensity == rhs.intensity &&
+        lhs.centerCoordinate.latitude == rhs.centerCoordinate.latitude &&
+        lhs.centerCoordinate.longitude == rhs.centerCoordinate.longitude
+    }
 }
 
 enum HeatmapEngine {

--- a/dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift
+++ b/dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift
@@ -15,9 +15,9 @@ enum AlertActionType{
     case deletePolygon(UUID)
     var model: AlertModel {
         switch self {
-        case .custom(let model, let leftAction, let rightAction):
+        case .custom(let model, _, _):
             return model
-        case .customThreeButton(let model, let leftAction, let middleAction, let rightAction):
+        case .customThreeButton(let model, _, _, _):
             return model
         case .addPoint:
             return AlertModel(title: "영역 표시", message: "영역을 표시하겠습니까?", configure: .defaultType)

--- a/dogArea/Views/HomeView/AreaMeters.swift
+++ b/dogArea/Views/HomeView/AreaMeters.swift
@@ -37,7 +37,7 @@ struct AreaMeterCollection {
       if let customAreas, customAreas.isEmpty == false {
           return customAreas.sorted { $0.area < $1.area }
       }
-      var area: [AreaMeter] = [.init("강원특별자치도 홍천군" , 1820.58),
+      let area: [AreaMeter] = [.init("강원특별자치도 홍천군" , 1820.58),
         .init("강원특별자치도 인제군",1646.19),
         .init("경상북도 안동시",1522.21),
         .init("강원특별자치도 평창군",1464.19),

--- a/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
@@ -18,9 +18,6 @@ struct MapAlertSubView: View {
         ca = CustomAlert(presentAlert: $myAlert.isAlert,
                          alertModel: myAlert.alertType.model,
                          leftButtonAction: {
-          if let cam = viewModel.cameraPosition.camera {
-//            print("\(cam.centerCoordinate.latitude), \(cam.centerCoordinate.longitude)")
-          }
           viewModel.addLocation()
         },rightButtonAction: {
 //            print("right")

--- a/dogArea/Views/MapView/MapSubViews/MapSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapSubView.swift
@@ -54,7 +54,7 @@ struct MapSubView: View {
                 Annotation("", coordinate: currentLoc.coordinate) {
                     Circle().foregroundStyle(Color.appHotPink)
                         .frame(width: 20, height: 20)
-                        .animation(.linear(duration: 1), value: currentLoc.coordinate)
+                        .animation(.linear(duration: 1), value: currentLoc.timestamp)
                         .shadow(radius: 5)
                 }
             }

--- a/dogArea/Views/WalkListView/WalkListSubView/SimpleMapView.swift
+++ b/dogArea/Views/WalkListView/WalkListSubView/SimpleMapView.swift
@@ -35,8 +35,3 @@ struct SimpleMapView: View {
         }
     }
 }
-extension CLLocationCoordinate2D : Equatable {
-    public static func == (lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
-        lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
-    }    
-}


### PR DESCRIPTION
## Summary
- remove imported-type CLLocationCoordinate2D Equatable extension to satisfy Swift warning guidance
- add explicit Equatable comparison for map DTOs using latitude/longitude values
- resolve remaining warning cleanups in Cluster, Alert configure, AreaMeters, and Map alert subview
- update map location animation value to CLLocation.timestamp to avoid Equatable constraint on coordinate type

## Validation
- ./scripts/ios_pr_check.sh (PASS)
