### PR TITLE
fix: resolve device QA issues (weather/auth/safe-area/home)

### DIFF
--- a/dogArea/Resource/Color.swift
+++ b/dogArea/Resource/Color.swift
@@ -25,6 +25,10 @@ extension Color {
     static let appBackground: Color = Color(red: 0.96, green: 0.95, blue: 0.90)
     static let appSurface: Color = Color.white
     static let appInk: Color = Color(red: 0.11, green: 0.13, blue: 0.17)
+    static let appTabScaffoldBackground: Color = Color.appDynamicHex(
+        light: 0xFAFAF8,
+        dark: 0x1E293B
+    )
 
     /// 16진수 RGB 값을 SwiftUI 색상으로 변환합니다.
     /// - Parameters:

--- a/dogArea/Source/Domain/Home/Services/HomeWeatherMissionStatusBuilder.swift
+++ b/dogArea/Source/Domain/Home/Services/HomeWeatherMissionStatusBuilder.swift
@@ -61,8 +61,8 @@ final class HomeWeatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding {
         let reasonText: String
         if status.source == .fallback {
             reasonText = localizedCopy(
-                "날씨 연동이 아직 준비되지 않아 기본 퀘스트로 진행합니다.",
-                "Weather integration is not ready yet. Running default quests."
+                "실시간 날씨 정보를 불러오지 못해 최근 안전 기준으로 미션을 조정했어요.",
+                "Live weather is unavailable. Missions are adjusted with a conservative safety baseline."
             )
         } else if board.riskLevel == .clear {
             reasonText = localizedCopy(
@@ -86,8 +86,8 @@ final class HomeWeatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding {
         let fallbackNotice: String?
         if status.source == .fallback {
             fallbackNotice = localizedCopy(
-                "연동 전에도 산책/기록/퀘스트는 정상적으로 계속됩니다.",
-                "Walk, logs, and quests continue normally even before weather integration."
+                "연결이 복구되면 자동으로 최신 위험도를 다시 반영합니다.",
+                "When connectivity recovers, the latest risk will be applied automatically."
             )
         } else {
             fallbackNotice = nil

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -1013,6 +1013,10 @@ enum AppFeatureGate {
     ]
 
     static func currentSession() -> AppSessionState {
+        if let identity = DefaultAuthSessionStore.shared.currentIdentity(),
+           identity.userId.isEmpty == false {
+            return .member(userId: identity.userId)
+        }
         guard let id = UserdefaultSetting.shared.getValue()?.id, id.isEmpty == false else {
             return .guest
         }
@@ -1292,7 +1296,29 @@ final class AuthFlowCoordinator: ObservableObject {
     private let guestModeKey = "auth.guest_mode.v1"
     private let entryChoiceCompletedKey = "auth.entry_choice_completed.v1"
     private let guestDataUpgradeService = GuestDataUpgradeService.shared
+    private let authSessionStore: AuthSessionStoreProtocol
+    private let profileStore: ProfileStoring
+    private let petSelectionStore: PetSelectionStoring
+    private let walkSessionMetadataStore: WalkSessionMetadataStore
     private var onAuthenticated: (() -> Void)?
+
+    /// 인증/프로필/선호 스토어 의존성을 주입해 인증 플로우 코디네이터를 초기화합니다.
+    /// - Parameters:
+    ///   - authSessionStore: 로그인 세션(토큰/사용자 식별자) 저장소입니다.
+    ///   - profileStore: 로컬 프로필 스냅샷 저장소입니다.
+    ///   - petSelectionStore: 반려견 선택 상태 저장소입니다.
+    ///   - walkSessionMetadataStore: 산책 메타데이터/선호 설정 저장소입니다.
+    init(
+        authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
+        profileStore: ProfileStoring = ProfileStore.shared,
+        petSelectionStore: PetSelectionStoring = PetSelectionStore.shared,
+        walkSessionMetadataStore: WalkSessionMetadataStore = .shared
+    ) {
+        self.authSessionStore = authSessionStore
+        self.profileStore = profileStore
+        self.petSelectionStore = petSelectionStore
+        self.walkSessionMetadataStore = walkSessionMetadataStore
+    }
 
     var sessionState: AppSessionState {
         AppFeatureGate.currentSession()
@@ -1394,8 +1420,24 @@ final class AuthFlowCoordinator: ObservableObject {
         guestDataUpgradeResult = nil
     }
 
+    /// 현재 로그인 세션과 로컬 프로필 상태를 모두 정리하고 게스트 진입 상태로 전환합니다.
+    func signOut() {
+        authSessionStore.clear()
+        profileStore.removeAll()
+        petSelectionStore.clearSelectionState()
+        walkSessionMetadataStore.clearPreferences()
+        UserDefaults.standard.set(false, forKey: guestModeKey)
+        UserDefaults.standard.set(false, forKey: entryChoiceCompletedKey)
+        pendingUpgradeRequest = nil
+        pendingGuestDataUpgradePrompt = nil
+        guestDataUpgradeInProgress = false
+        guestDataUpgradeResult = nil
+        onAuthenticated = nil
+        refresh()
+    }
+
     func startGuestDataUpgrade(forceRetry: Bool = false) {
-        guard let userId = UserdefaultSetting.shared.getValue()?.id, userId.isEmpty == false else {
+        guard let userId = currentMemberUserId() else {
             return
         }
         pendingGuestDataUpgradePrompt = nil
@@ -1410,7 +1452,7 @@ final class AuthFlowCoordinator: ObservableObject {
     }
 
     func latestGuestDataUpgradeReport() -> GuestDataUpgradeReport? {
-        guard let userId = UserdefaultSetting.shared.getValue()?.id, userId.isEmpty == false else {
+        guard let userId = currentMemberUserId() else {
             return nil
         }
         return guestDataUpgradeService.latestReport(for: userId)
@@ -1422,13 +1464,27 @@ final class AuthFlowCoordinator: ObservableObject {
         shouldShowSignIn = false
         shouldShowEntryChoice = false
         pendingUpgradeRequest = nil
-        if let userId = UserdefaultSetting.shared.getValue()?.id, userId.isEmpty == false {
+        if let userId = currentMemberUserId() {
             pendingGuestDataUpgradePrompt = guestDataUpgradeService.pendingPrompt(for: userId)
             guestDataUpgradeResult = guestDataUpgradeService.latestReport(for: userId)
         }
         let completion = onAuthenticated
         onAuthenticated = nil
         completion?()
+    }
+
+    /// 현재 인증 세션/프로필 스토어에서 사용자 식별자를 조회합니다.
+    /// - Returns: 로그인 사용자 ID가 있으면 반환하고, 없으면 `nil`을 반환합니다.
+    private func currentMemberUserId() -> String? {
+        if let sessionUserId = authSessionStore.currentIdentity()?.userId,
+           sessionUserId.isEmpty == false {
+            return sessionUserId
+        }
+        if let profileUserId = UserdefaultSetting.shared.getValue()?.id,
+           profileUserId.isEmpty == false {
+            return profileUserId
+        }
+        return nil
     }
 }
 

--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -37,55 +37,15 @@ struct RootView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            if self.selectedTab == 0 {
-                NavigationView {
-                    homeView.frame(maxWidth: .infinity,maxHeight: .infinity)
-                        .navigationBarHidden(selectedTab == 0)
-                        .accessibilityIdentifier("screen.home")
-                }
-            }
-            else if self.selectedTab == 1 {
-                NavigationView {
-                    walkListView.frame(maxWidth: .infinity,maxHeight: .infinity)
-                        .navigationBarHidden(selectedTab == 1)
-                        .accessibilityIdentifier("screen.walkList")
-                }
-            }
-            else if self.selectedTab == 2 {
-                NavigationView {
-                    mapView
-                        .environmentObject(loading)
-                        .navigationBarHidden(selectedTab == 2)
-                        .accessibilityIdentifier("screen.map")
-                }
-            }
-            else if self.selectedTab == 3 {
-                NavigationView {
-                    RivalTabView(
-                        onOpenMap: { selectedTab = 2 },
-                        onOpenSettings: { selectedTab = 4 }
-                    )
-                        .frame(maxWidth: .infinity,maxHeight: .infinity)
-                        .navigationBarHidden(selectedTab == 3)
-                        .accessibilityIdentifier("screen.rival")
-                }
-            }
-            else if self.selectedTab == 4 {
-                NavigationView {
-                    notificationCenterView.frame(maxWidth: .infinity,maxHeight: .infinity)
-                        .navigationBarHidden(selectedTab == 4)
-                        .accessibilityIdentifier("screen.settings")
-                }
-            }
+        ZStack(alignment: .bottom) {
+            tabContent
             if tabStatus.isTabAppear {
                 CustomTabBar(selectedTab: $selectedTab)
-                    .frame(maxHeight: .infinity)
-                    .aspectRatio(contentMode: .fit)
+                    .padding(.bottom, 2)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
-        .background(Color.appBackground.ignoresSafeArea())
-        .edgesIgnoringSafeArea(.all)
+        .background(Color.appTabScaffoldBackground.ignoresSafeArea())
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay(content: {
                 if loading.phase == .loading {
@@ -131,6 +91,49 @@ struct RootView: View {
                 .presentationDetents([.medium])
             }
 
+    }
+
+    @ViewBuilder
+    private var tabContent: some View {
+        if selectedTab == 0 {
+            NavigationView {
+                homeView
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .navigationBarHidden(selectedTab == 0)
+                    .accessibilityIdentifier("screen.home")
+            }
+        } else if selectedTab == 1 {
+            NavigationView {
+                walkListView
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .navigationBarHidden(selectedTab == 1)
+                    .accessibilityIdentifier("screen.walkList")
+            }
+        } else if selectedTab == 2 {
+            NavigationView {
+                mapView
+                    .environmentObject(loading)
+                    .navigationBarHidden(selectedTab == 2)
+                    .accessibilityIdentifier("screen.map")
+            }
+        } else if selectedTab == 3 {
+            NavigationView {
+                RivalTabView(
+                    onOpenMap: { selectedTab = 2 },
+                    onOpenSettings: { selectedTab = 4 }
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .navigationBarHidden(selectedTab == 3)
+                .accessibilityIdentifier("screen.rival")
+            }
+        } else if selectedTab == 4 {
+            NavigationView {
+                notificationCenterView
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .navigationBarHidden(selectedTab == 4)
+                    .accessibilityIdentifier("screen.settings")
+            }
+        }
     }
 }
 

--- a/dogArea/Views/HomeView/HomeSubView/TerritoryGoalView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/TerritoryGoalView.swift
@@ -2,12 +2,14 @@ import SwiftUI
 
 struct TerritoryGoalView: View {
     @ObservedObject var viewModel: TerritoryGoalViewModel
+    @ObservedObject private var tabStatus = TabAppear.shared
 
     var body: some View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 18) {
                 headerSection
                 overviewCard
+                insightSection
                 recentSection
                 emptyHintCard
             }
@@ -15,13 +17,56 @@ struct TerritoryGoalView: View {
             .padding(.top, 18)
             .padding(.bottom, 28)
         }
-        .background(Color.appDynamicHex(light: 0xF1F5F9, dark: 0x0F172A).ignoresSafeArea())
+        .background(Color.appTabScaffoldBackground.ignoresSafeArea())
         .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("영역 목표 상세")
         .onAppear {
+            tabStatus.hide()
             viewModel.refresh()
+        }
+        .onDisappear {
+            tabStatus.appear()
         }
         .refreshable {
             viewModel.refresh()
+        }
+    }
+
+    private var insightSection: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("최근 정복")
+                    .font(.appScaledFont(for: .Regular, size: 11, relativeTo: .caption))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                Text("\(viewModel.recentAreas.count)개")
+                    .font(.appScaledFont(for: .SemiBold, size: 26, relativeTo: .title3))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(Color.appDynamicHex(light: 0xFFFFFF, dark: 0x1E293B))
+            .cornerRadius(14)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155), lineWidth: 1)
+            )
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("다음 목표까지")
+                    .font(.appScaledFont(for: .Regular, size: 11, relativeTo: .caption))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                Text(viewModel.remainingAreaText)
+                    .font(.appScaledFont(for: .SemiBold, size: 26, relativeTo: .title3))
+                    .foregroundStyle(Color.appDynamicHex(light: 0xF59E0B, dark: 0xFACC15))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(Color.appDynamicHex(light: 0xFFFFFF, dark: 0x1E293B))
+            .cornerRadius(14)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155), lineWidth: 1)
+            )
         }
     }
 
@@ -44,6 +89,9 @@ struct TerritoryGoalView: View {
                 .padding(.vertical, 6)
                 .background(Color.appDynamicHex(light: 0xFEF3C7, dark: 0x78350F, alpha: 0.3))
                 .cornerRadius(10)
+            Text("비교군/최근 정복 이력/다음 목표까지 남은 면적을 한 번에 확인할 수 있어요.")
+                .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .caption))
+                .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
         }
     }
 

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -68,7 +68,7 @@ struct HomeView: View {
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
-            Color.appDynamicHex(light: 0xF1F5F9, dark: 0x0F172A)
+            Color.appTabScaffoldBackground
                 .ignoresSafeArea()
 
             ScrollView(showsIndicators: false) {
@@ -104,9 +104,14 @@ struct HomeView: View {
                     homeWeeklySnapshotSection
                     seasonMotionCard(summary: viewModel.seasonMotionSummary)
                     if viewModel.indoorMissionBoard.shouldDisplayCard {
-                        Text("데일리 미션 상태")
-                            .font(.appScaledFont(for: .SemiBold, size: 30, relativeTo: .title2))
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("데일리 미션 상태")
+                                .font(.appScaledFont(for: .SemiBold, size: 30, relativeTo: .title2))
+                            Text("오늘 날씨·활동 상태를 반영한 추천 미션 진행 현황입니다.")
+                                .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .caption))
+                                .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         indoorMissionCard(board: viewModel.indoorMissionBoard)
                     }
                     territoryHeaderSection

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -1381,6 +1381,7 @@ private final class IndoorMissionStore {
 
     private enum DefaultsKey {
         static let weatherRiskOverride = "weather.risk.level.v1"
+        static let weatherRiskObservedAt = "weather.risk.observed_at.v1"
         static let actionCounts = "indoor.mission.actionCounts.v1"
         static let completionFlags = "indoor.mission.completed.v1"
         static let exposureHistory = "indoor.mission.exposureHistory.v1"
@@ -2121,6 +2122,16 @@ private final class IndoorMissionStore {
         }
         if let raw = UserDefaults.standard.string(forKey: DefaultsKey.weatherRiskOverride),
            let level = IndoorWeatherRiskLevel(rawValue: raw.lowercased()) {
+            let now = Date().timeIntervalSince1970
+            let observedAt = Double(UserDefaults.standard.string(forKey: DefaultsKey.weatherRiskObservedAt) ?? "") ?? 0
+            if observedAt > 0 {
+                let age = now - observedAt
+                if age <= 7200 {
+                    return (level, .userOverride)
+                }
+                let conservative = level == .clear ? IndoorWeatherRiskLevel.caution : level
+                return (conservative, .fallback)
+            }
             return (level, .userOverride)
         }
         return (.clear, .fallback)

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -29,21 +29,22 @@ struct MapView : View{
     @ObservedObject var tabStatus = TabAppear.shared
     
     var body : some View {
-        ZStack{
-            MapSubView(myAlert: myAlert, viewModel: viewModel)
-            Rectangle()
-                .fill(viewModel.weatherOverlayTintColor)
-                .opacity(viewModel.weatherOverlayOpacity)
-                .ignoresSafeArea()
-                .allowsHitTesting(false)
-                .animation(
-                    .easeInOut(duration: viewModel.weatherOverlayAnimationDuration),
-                    value: viewModel.weatherOverlayRiskLevel
-                )
-            MapAlertSubView(viewModel: viewModel, myAlert: myAlert)
-            
-            VStack {
-                Spacer().frame(height: 50)
+        GeometryReader { proxy in
+            ZStack{
+                MapSubView(myAlert: myAlert, viewModel: viewModel)
+                Rectangle()
+                    .fill(viewModel.weatherOverlayTintColor)
+                    .opacity(viewModel.weatherOverlayOpacity)
+                    .ignoresSafeArea()
+                    .allowsHitTesting(false)
+                    .animation(
+                        .easeInOut(duration: viewModel.weatherOverlayAnimationDuration),
+                        value: viewModel.weatherOverlayRiskLevel
+                    )
+                MapAlertSubView(viewModel: viewModel, myAlert: myAlert)
+
+                VStack {
+                    Spacer().frame(height: max(proxy.safeAreaInsets.top, 0) + 8)
                 HStack {
                     Spacer()
                     Button(action:{
@@ -152,6 +153,7 @@ struct MapView : View{
                         .clipShape(RoundedCornersShape(radius: 20,corners: [.topLeft,.topRight]))
                 }
             }
+        }
         }
         .onAppear {
             viewModel.reloadSelectedPetContext()

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -14,6 +14,169 @@ import WatchConnectivity
 #if canImport(UIKit)
 import UIKit
 #endif
+
+enum WeatherRiskLevelValue: String, CaseIterable {
+    case clear
+    case caution
+    case bad
+    case severe
+}
+
+struct WeatherRiskSnapshot: Equatable {
+    let level: WeatherRiskLevelValue
+    let observedAt: TimeInterval
+}
+
+protocol WeatherRiskProviding {
+    /// 주어진 좌표의 현재 날씨를 조회해 위험도 레벨을 산출합니다.
+    /// - Parameters:
+    ///   - latitude: 조회 대상 위도입니다.
+    ///   - longitude: 조회 대상 경도입니다.
+    /// - Returns: 위험도 레벨과 관측 시각을 담은 스냅샷입니다.
+    func fetchRisk(latitude: Double, longitude: Double) async throws -> WeatherRiskSnapshot
+}
+
+final class OpenMeteoWeatherRiskProvider: WeatherRiskProviding {
+    private struct OpenMeteoResponse: Decodable {
+        struct Current: Decodable {
+            let time: String
+            let temperature2M: Double
+            let precipitation: Double
+            let windSpeed10M: Double
+
+            enum CodingKeys: String, CodingKey {
+                case time
+                case temperature2M = "temperature_2m"
+                case precipitation
+                case windSpeed10M = "wind_speed_10m"
+            }
+        }
+
+        let current: Current
+    }
+
+    private let session: URLSession
+    private let requestTimeout: TimeInterval
+
+    /// Open-Meteo 기반 날씨 위험도 조회기를 생성합니다.
+    /// - Parameters:
+    ///   - session: HTTP 요청에 사용할 URLSession입니다.
+    ///   - requestTimeout: 단건 요청 타임아웃(초)입니다.
+    init(session: URLSession = .shared, requestTimeout: TimeInterval = 2.5) {
+        self.session = session
+        self.requestTimeout = requestTimeout
+    }
+
+    /// 주어진 좌표의 현재 날씨를 조회해 위험도 레벨을 산출합니다.
+    /// - Parameters:
+    ///   - latitude: 조회 대상 위도입니다.
+    ///   - longitude: 조회 대상 경도입니다.
+    /// - Returns: 위험도 레벨과 관측 시각을 담은 스냅샷입니다.
+    func fetchRisk(latitude: Double, longitude: Double) async throws -> WeatherRiskSnapshot {
+        var components = URLComponents(string: "https://api.open-meteo.com/v1/forecast")
+        components?.queryItems = [
+            .init(name: "latitude", value: String(latitude)),
+            .init(name: "longitude", value: String(longitude)),
+            .init(name: "current", value: "temperature_2m,precipitation,wind_speed_10m"),
+            .init(name: "wind_speed_unit", value: "ms"),
+            .init(name: "timezone", value: "auto")
+        ]
+        guard let url = components?.url else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = requestTimeout
+        let (data, _) = try await session.data(for: request)
+        let decoded = try JSONDecoder().decode(OpenMeteoResponse.self, from: data)
+        let observedAt = Self.parseObservedAt(decoded.current.time)
+        let risk = Self.score(
+            precipitationMMPerHour: decoded.current.precipitation,
+            temperatureC: decoded.current.temperature2M,
+            windMps: decoded.current.windSpeed10M
+        )
+        return WeatherRiskSnapshot(level: risk, observedAt: observedAt)
+    }
+
+    /// Open-Meteo 시각 문자열을 epoch seconds로 변환합니다.
+    /// - Parameter value: Open-Meteo `current.time` 문자열입니다.
+    /// - Returns: 파싱된 epoch seconds이며, 실패 시 현재 시각을 반환합니다.
+    private static func parseObservedAt(_ value: String) -> TimeInterval {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+        if let date = isoFormatter.date(from: value) {
+            return date.timeIntervalSince1970
+        }
+        let fallbackFormatter = DateFormatter()
+        fallbackFormatter.locale = Locale(identifier: "en_US_POSIX")
+        fallbackFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        fallbackFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm"
+        if let date = fallbackFormatter.date(from: value) {
+            return date.timeIntervalSince1970
+        }
+        return Date().timeIntervalSince1970
+    }
+
+    /// 강수/기온/풍속 지표를 종합해 최종 날씨 위험도를 계산합니다.
+    /// - Parameters:
+    ///   - precipitationMMPerHour: 시간당 강수량(mm/h)입니다.
+    ///   - temperatureC: 기온(섭씨)입니다.
+    ///   - windMps: 풍속(m/s)입니다.
+    /// - Returns: 지표별 최대 위험도 규칙으로 계산된 최종 위험도입니다.
+    private static func score(
+        precipitationMMPerHour: Double,
+        temperatureC: Double,
+        windMps: Double
+    ) -> WeatherRiskLevelValue {
+        let precipitationRisk = riskForPrecipitation(precipitationMMPerHour)
+        let temperatureRisk = riskForTemperature(temperatureC)
+        let windRisk = riskForWind(windMps)
+        return [precipitationRisk, temperatureRisk, windRisk]
+            .max(by: { $0.severityRank < $1.severityRank }) ?? .clear
+    }
+
+    /// 강수량 임계값 기반 위험도를 계산합니다.
+    /// - Parameter value: 시간당 강수량(mm/h)입니다.
+    /// - Returns: 강수량 기준 위험도입니다.
+    private static func riskForPrecipitation(_ value: Double) -> WeatherRiskLevelValue {
+        if value >= 12 { return .severe }
+        if value >= 6 { return .bad }
+        if value >= 1 { return .caution }
+        return .clear
+    }
+
+    /// 기온 임계값 기반 위험도를 계산합니다.
+    /// - Parameter value: 섭씨 기온입니다.
+    /// - Returns: 기온 기준 위험도입니다.
+    private static func riskForTemperature(_ value: Double) -> WeatherRiskLevelValue {
+        if value >= 33 || value <= -8 { return .severe }
+        if value >= 30 || value <= -3 { return .bad }
+        if value >= 28 || value <= 0 { return .caution }
+        return .clear
+    }
+
+    /// 풍속 임계값 기반 위험도를 계산합니다.
+    /// - Parameter value: 풍속(m/s)입니다.
+    /// - Returns: 풍속 기준 위험도입니다.
+    private static func riskForWind(_ value: Double) -> WeatherRiskLevelValue {
+        if value >= 14 { return .severe }
+        if value >= 10 { return .bad }
+        if value >= 6 { return .caution }
+        return .clear
+    }
+}
+
+private extension WeatherRiskLevelValue {
+    var severityRank: Int {
+        switch self {
+        case .clear: return 0
+        case .caution: return 1
+        case .bad: return 2
+        case .severe: return 3
+        }
+    }
+}
+
 class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSessionDelegate {
     enum WalkEndReason: String {
         case manual = "manual"
@@ -144,6 +307,9 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let nearbyPresenceUserIdKey = "nearby.presenceUserId"
     private let mapMotionReducedKey = "map.motion.reduced"
     private let weatherRiskOverrideKey = "weather.risk.level.v1"
+    private let weatherRiskObservedAtKey = "weather.risk.observed_at.v1"
+    private let weatherRiskCacheTTL: TimeInterval = 7200
+    private let weatherRiskRefreshInterval: TimeInterval = 3600
     private var lastAutoRecordedLocation: CLLocation?
     private var lastAutoRecordedAt: Date = .distantPast
     private let autoRecordMinDistance: CLLocationDistance = 12.0
@@ -179,6 +345,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let userSessionStore: UserSessionStoreProtocol
     private let authSessionStore: AuthSessionStoreProtocol
     private let preferenceStore: MapPreferenceStoreProtocol
+    private let weatherRiskProvider: WeatherRiskProviding
     private let areaCalculationService: MapAreaCalculationServicing
     private let clusterAnnotationService: MapClusterAnnotationServicing
     private let eventCenter: AppEventCenterProtocol
@@ -187,6 +354,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let maxCaptureRipples = 12
     private let trailLifetime: TimeInterval = 5.0
     private let trailLimit = 12
+    private var weatherFetchTask: Task<Void, Never>? = nil
+    private var lastWeatherFetchAttemptAt: Date = .distantPast
 
     private enum WatchIncomingAction: String {
         case startWalk
@@ -273,6 +442,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
         authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
         preferenceStore: MapPreferenceStoreProtocol = DefaultMapPreferenceStore.shared,
+        weatherRiskProvider: WeatherRiskProviding = OpenMeteoWeatherRiskProvider(),
         areaCalculationService: MapAreaCalculationServicing = MapAreaCalculationService(),
         clusterAnnotationService: MapClusterAnnotationServicing = MapClusterAnnotationService(),
         eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared
@@ -281,6 +451,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.userSessionStore = userSessionStore
         self.authSessionStore = authSessionStore
         self.preferenceStore = preferenceStore
+        self.weatherRiskProvider = weatherRiskProvider
         self.areaCalculationService = areaCalculationService
         self.clusterAnnotationService = clusterAnnotationService
         self.eventCenter = eventCenter
@@ -318,12 +489,14 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.refreshSyncOutboxSummary()
         self.flushSyncOutboxIfNeeded(force: true)
         self.refreshWeatherOverlayRisk()
+        self.refreshWeatherRiskFromProviderIfNeeded(location: self.locationManager.location, force: true)
     }
 
     deinit {
         timer?.invalidate()
         nearbyTickTimer?.invalidate()
         syncFlushTask?.cancel()
+        weatherFetchTask?.cancel()
         lifecycleObservers.forEach { eventCenter.removeObserver($0) }
     }
 
@@ -1590,16 +1763,27 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         }
     }
 
-    private func resolveWeatherOverlayRiskFromDefaults() -> (risk: WeatherOverlayRiskLevel, fallback: Bool) {
+    /// 저장된 날씨 위험도 캐시/환경값을 기준으로 현재 지도 오버레이 상태를 계산합니다.
+    /// - Parameter now: 캐시 만료 판단 기준 시각입니다.
+    /// - Returns: 적용할 위험도와 fallback 표시 여부입니다.
+    private func resolveWeatherOverlayRiskFromDefaults(now: Date = Date()) -> (risk: WeatherOverlayRiskLevel, fallback: Bool) {
         if let env = ProcessInfo.processInfo.environment["WEATHER_RISK_LEVEL"],
            let fromEnv = WeatherOverlayRiskLevel(rawValue: env.lowercased()) {
             return (fromEnv, false)
         }
         if let raw = preferenceStore.string(forKey: weatherRiskOverrideKey),
            let fromDefaults = WeatherOverlayRiskLevel(rawValue: raw.lowercased()) {
-            return (fromDefaults, false)
+            guard let observedAt = storedWeatherRiskObservedAt() else {
+                return (fromDefaults, false)
+            }
+            let age = now.timeIntervalSince1970 - observedAt
+            if age <= weatherRiskCacheTTL {
+                return (fromDefaults, false)
+            }
+            let conservativeRisk: WeatherOverlayRiskLevel = fromDefaults == .clear ? .caution : fromDefaults
+            return (conservativeRisk, true)
         }
-        return (.clear, true)
+        return (.caution, true)
     }
 
     func refreshWeatherOverlayRisk() {
@@ -1614,6 +1798,66 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             weatherOverlayRiskLevel = nextRisk
             weatherOverlayOpacity = nextRisk == .clear ? 0.0 : (isMapMotionReduced ? 0.12 : 0.18)
         }
+    }
+
+    /// 현재 위치를 기준으로 날씨 위험도를 비동기로 갱신하고 로컬 캐시에 반영합니다.
+    /// - Parameters:
+    ///   - location: 위험도 조회 기준 위치입니다.
+    ///   - force: `true`이면 주기 제한을 무시하고 즉시 갱신합니다.
+    private func refreshWeatherRiskFromProviderIfNeeded(location: CLLocation?, force: Bool) {
+        guard ProcessInfo.processInfo.environment["WEATHER_RISK_LEVEL"] == nil else { return }
+        guard let location else { return }
+        guard location.horizontalAccuracy >= 0, location.horizontalAccuracy <= 160 else { return }
+        guard weatherFetchTask == nil else { return }
+
+        let now = Date()
+        if force == false,
+           now.timeIntervalSince(lastWeatherFetchAttemptAt) < weatherRiskRefreshInterval {
+            return
+        }
+        lastWeatherFetchAttemptAt = now
+
+        let latitude = location.coordinate.latitude
+        let longitude = location.coordinate.longitude
+
+        weatherFetchTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let snapshot = try await weatherRiskProvider.fetchRisk(
+                    latitude: latitude,
+                    longitude: longitude
+                )
+                await MainActor.run {
+                    self.applyWeatherRiskSnapshot(snapshot)
+                }
+            } catch {
+                await MainActor.run {
+                    self.refreshWeatherOverlayRisk()
+                }
+            }
+            await MainActor.run {
+                self.weatherFetchTask = nil
+            }
+        }
+    }
+
+    /// 날씨 공급자 응답을 저장소와 UI 상태에 반영합니다.
+    /// - Parameter snapshot: 공급자에서 계산된 날씨 위험도 스냅샷입니다.
+    private func applyWeatherRiskSnapshot(_ snapshot: WeatherRiskSnapshot) {
+        let next = WeatherOverlayRiskLevel(rawValue: snapshot.level.rawValue) ?? .clear
+        preferenceStore.set(next.rawValue, forKey: weatherRiskOverrideKey)
+        preferenceStore.set(String(snapshot.observedAt), forKey: weatherRiskObservedAtKey)
+        refreshWeatherOverlayRisk()
+    }
+
+    /// 저장소에 캐시된 날씨 위험도 관측 시각을 조회합니다.
+    /// - Returns: epoch seconds 관측 시각이며, 파싱 실패 시 `nil`을 반환합니다.
+    private func storedWeatherRiskObservedAt() -> TimeInterval? {
+        guard let raw = preferenceStore.string(forKey: weatherRiskObservedAtKey),
+              let value = Double(raw) else {
+            return nil
+        }
+        return value
     }
 
     private func currentPresenceUserId() -> String? {
@@ -1917,6 +2161,7 @@ extension MapViewModel {
             if isWalking {
                 syncWatchContext(force: true)
             }
+            refreshWeatherRiskFromProviderIfNeeded(location: manager.location, force: true)
             
         @unknown default:
             locationManager.requestAlwaysAuthorization()
@@ -1938,6 +2183,7 @@ extension MapViewModel {
             }
             self.nearbyTick()
             self.handleAutoPointRecord(with: location)
+            self.refreshWeatherRiskFromProviderIfNeeded(location: location, force: false)
             self.compactMapMotionArtifacts()
             self.persistActiveWalkSession()
             self.handleAutoEndIfNeeded()

--- a/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
+++ b/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
@@ -12,6 +12,7 @@ struct NotificationCenterView: View {
     @EnvironmentObject var authFlow: AuthFlowCoordinator
     @State private var isProfileEditPresented: Bool = false
     @State private var toastMessage: String? = nil
+    @State private var isLogoutAlertPresented: Bool = false
 
     var body: some View {
         Group {
@@ -20,6 +21,16 @@ struct NotificationCenterView: View {
             } else {
                 guestLockedContent
             }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color.appTabScaffoldBackground.ignoresSafeArea())
+        .alert("로그아웃할까요?", isPresented: $isLogoutAlertPresented) {
+            Button("취소", role: .cancel) { }
+            Button("로그아웃", role: .destructive) {
+                authFlow.signOut()
+            }
+        } message: {
+            Text("현재 기기의 인증 상태를 해제하고 게스트 모드로 전환합니다.")
         }
     }
 
@@ -119,6 +130,13 @@ struct NotificationCenterView: View {
                    }
                    .pickerStyle(.menu)
                }
+               Button("로그아웃") {
+                   isLogoutAlertPresented = true
+               }
+               .accessibilityIdentifier("settings.logout")
+               .buttonStyle(AppFilledButtonStyle(role: .destructive))
+               .padding(.top, 12)
+               .padding(.horizontal, 16)
                Spacer()
            }
            .onAppear {

--- a/dogArea/Views/ProfileSettingView/RivalTabView.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabView.swift
@@ -31,7 +31,7 @@ struct RivalTabView: View {
             }
             .padding(.bottom, 24)
         }
-        .background(Color.appYellowPale.opacity(0.35))
+        .background(Color.appTabScaffoldBackground)
         .accessibilityIdentifier("screen.rival.content")
         .onAppear {
             viewModel.start()

--- a/dogArea/Views/WalkListView/WalkListView.swift
+++ b/dogArea/Views/WalkListView/WalkListView.swift
@@ -89,7 +89,9 @@ struct WalkListView: View {
                 }
             }.refreshable {
                 viewModel.fetchModel()
-            }.onAppear{
+            }
+            .background(Color.appTabScaffoldBackground)
+            .onAppear{
                 tabStatus.appear()
 
                 viewModel.fetchModel()
@@ -99,6 +101,7 @@ struct WalkListView: View {
                 .font(.appFont(for: .ExtraBold, size: 36))
                 .accessibilityIdentifier("screen.walkList.content")
         }
+        .background(Color.appTabScaffoldBackground.ignoresSafeArea())
     }
 
     var guestUpgradeCard: some View {


### PR DESCRIPTION
## Summary
- fix top safe-area overlap and stabilize custom tab-bar layout in RootView
- hide custom tab bar on TerritoryGoalView push and improve destination distinction UI
- add Home daily mission explanatory copy and unify tab scaffold background tone
- add logout action in settings and implement AuthFlowCoordinator.signOut()
- make AppFeatureGate session resolution prefer auth session identity to prevent false guest state
- add Open-Meteo based weather risk fetch/caching in MapViewModel and wire overlay refresh
- update weather fallback copy for clearer runtime behavior

## Validation
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh
- bash scripts/run_design_audit_ui_tests.sh (light + dark)
- bash scripts/ios_pr_check.sh
