### PR TITLE
Handle nearby hotspot 404 without log spam

### DIFF
--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -1705,6 +1705,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
                     self.nearbyHotspots = hotspots
                 }
             } catch {
+                if let supabaseError = error as? SupabaseHTTPError,
+                   case .unexpectedStatusCode(404) = supabaseError {
+                    await MainActor.run {
+                        self.nearbyHotspots = []
+                    }
+                    return
+                }
                 print("nearby hotspot fetch failed: \(error.localizedDescription)")
             }
         }

--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -233,7 +233,12 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
                     screenState = .ready
                 }
             } catch {
-                if RivalNetworkErrorInterpreter.isConnectivityError(error) {
+                if let supabaseError = error as? SupabaseHTTPError,
+                   case .unexpectedStatusCode(404) = supabaseError {
+                    hotspots = []
+                    updateHotspotSummary()
+                    screenState = .empty
+                } else if RivalNetworkErrorInterpreter.isConnectivityError(error) {
                     screenState = hotspots.isEmpty ? .offlineEmpty : .offlineCached
                 } else {
                     screenState = .errorRetryable


### PR DESCRIPTION
## Summary\n- treat nearby hotspot 404 as an expected empty result in map polling\n- avoid repeated console spam for expected 404 responses\n- align rival hotspot screen state for the same 404 case (empty state)\n\n## Testing\n- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh