### PR TITLE
[Task][Widget][P0] Live Activity + auto-end safety 연동 (#216)

### DIFF
--- a/docs/project-settings-dependency-stability-v1.md
+++ b/docs/project-settings-dependency-stability-v1.md
@@ -9,7 +9,7 @@
 ## 2. 기준 툴체인/타깃
 - Xcode 기준: `LastUpgradeCheck = 1500` (Xcode 15 계열 기준)
 - Swift 언어 버전: `SWIFT_VERSION = 5.0`
-- iOS 최소 버전: `IPHONEOS_DEPLOYMENT_TARGET = 17.0`
+- iOS 최소 버전: `IPHONEOS_DEPLOYMENT_TARGET = 18.0`
 - watchOS 최소 버전: `WATCHOS_DEPLOYMENT_TARGET = 10.2`
 
 ## 3. 공통 빌드 스킴 기준

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -1314,7 +1314,7 @@
 				EXECUTABLE_NAME = dogAreaWidgetExtension;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = dogAreaWidgetExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1339,7 +1339,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.th.dogAreaUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1356,7 +1356,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.th.dogAreaUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1376,7 +1376,7 @@
 				EXECUTABLE_NAME = dogAreaWidgetExtension;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = dogAreaWidgetExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1446,7 +1446,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1504,7 +1504,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -1542,7 +1542,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1585,7 +1585,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/dogArea/Info.plist
+++ b/dogArea/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AUTH_REDIRECT_URL</key>
+	<string>$(AUTH_REDIRECT_URL)</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.th.dogArea.update</string>
@@ -31,16 +33,16 @@
 	<string>산책 완료 카드 이미지를 사진 앱에 저장하기 위해 접근이 필요합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>산책 완료 사진 선택 및 프로필 설정을 위해 접근이 필요합니다.</string>
-	<key>SUPABASE_URL</key>
-	<string>$(SUPABASE_URL)</string>
-	<key>SUPABASE_ANON_KEY</key>
-	<string>$(SUPABASE_ANON_KEY)</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>PROJECT_REF</key>
 	<string>$(PROJECT_REF)</string>
 	<key>STORAGE_BUCKETS</key>
 	<string>$(STORAGE_BUCKETS)</string>
-	<key>AUTH_REDIRECT_URL</key>
-	<string>$(AUTH_REDIRECT_URL)</string>
+	<key>SUPABASE_ANON_KEY</key>
+	<string>$(SUPABASE_ANON_KEY)</string>
+	<key>SUPABASE_URL</key>
+	<string>$(SUPABASE_URL)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>

--- a/dogArea/Source/Domain/Map/Services/MapClusterAnnotationService.swift
+++ b/dogArea/Source/Domain/Map/Services/MapClusterAnnotationService.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 import MapKit
+import UserNotifications
+#if canImport(ActivityKit)
+import ActivityKit
+#endif
 
 protocol MapClusterAnnotationServicing {
     /// 현재 폴리곤 목록과 카메라 거리 기반 설정으로 클러스터 배열을 계산합니다.
@@ -138,5 +142,262 @@ final class MapClusterAnnotationService: MapClusterAnnotationServicing {
     ) -> Double {
         let raw = cameraDistance * distanceRatio
         return min(maxCellMeters, max(minCellMeters, raw))
+    }
+}
+
+enum WalkLiveActivityFallbackReason: String, Equatable {
+    case unsupportedOS = "unsupported_os"
+    case activitiesDisabled = "activities_disabled"
+    case requestFailed = "request_failed"
+}
+
+enum WalkLiveActivityServiceResult: Equatable {
+    case liveActivity
+    case fallback(WalkLiveActivityFallbackReason)
+    case ended
+}
+
+protocol WalkLiveActivityServicing {
+    /// 산책 상태를 Live Activity 또는 fallback 채널로 동기화합니다.
+    /// - Parameter state: 현재 산책 세션 상태입니다.
+    /// - Returns: Live Activity 반영 여부 또는 fallback 전환 결과입니다.
+    func sync(state: WalkLiveActivityState) async -> WalkLiveActivityServiceResult
+
+    /// 진행 중인 Live Activity를 종료 상태로 정리합니다.
+    /// - Parameters:
+    ///   - state: 종료 시점 상태 스냅샷입니다.
+    ///   - dismissImmediately: `true`면 즉시 제거, `false`면 시스템 기본 정책으로 제거합니다.
+    /// - Returns: 종료 처리 결과입니다.
+    func end(state: WalkLiveActivityState, dismissImmediately: Bool) async -> WalkLiveActivityServiceResult
+
+    /// 앱 진입 시 세션 상태와 Live Activity 상태를 정합화합니다.
+    /// - Parameters:
+    ///   - activeSession: 현재 앱에 활성 산책 세션이 존재하는지 여부입니다.
+    ///   - state: 활성 세션이 있을 때 반영할 산책 상태입니다.
+    func reconcile(activeSession: Bool, state: WalkLiveActivityState?) async
+}
+
+actor WalkLiveActivityService: WalkLiveActivityServicing {
+    private let notificationCenter: UNUserNotificationCenter
+    private var lastFallbackNotificationKey: String = ""
+
+    /// Live Activity/알림 fallback 동기화 서비스를 생성합니다.
+    /// - Parameter notificationCenter: fallback 로컬 알림 전송에 사용할 시스템 알림 센터입니다.
+    init(notificationCenter: UNUserNotificationCenter = .current()) {
+        self.notificationCenter = notificationCenter
+    }
+
+    /// 산책 상태를 Live Activity 또는 fallback 채널로 동기화합니다.
+    /// - Parameter state: 현재 산책 세션 상태입니다.
+    /// - Returns: Live Activity 반영 여부 또는 fallback 전환 결과입니다.
+    func sync(state: WalkLiveActivityState) async -> WalkLiveActivityServiceResult {
+        guard state.isWalking else {
+            return await end(state: state, dismissImmediately: false)
+        }
+        guard #available(iOS 16.1, *) else {
+            await postFallbackNotificationIfNeeded(state: state, reason: .unsupportedOS)
+            return .fallback(.unsupportedOS)
+        }
+
+        let authorization = ActivityAuthorizationInfo()
+        guard authorization.areActivitiesEnabled else {
+            await postFallbackNotificationIfNeeded(state: state, reason: .activitiesDisabled)
+            return .fallback(.activitiesDisabled)
+        }
+
+        do {
+            let activity = try await ensureActivity(for: state)
+            let content = ActivityContent(
+                state: state.makeContentState(),
+                staleDate: Date().addingTimeInterval(600)
+            )
+            await activity.update(content)
+            return .liveActivity
+        } catch {
+            await postFallbackNotificationIfNeeded(state: state, reason: .requestFailed)
+            return .fallback(.requestFailed)
+        }
+    }
+
+    /// 진행 중인 Live Activity를 종료 상태로 정리합니다.
+    /// - Parameters:
+    ///   - state: 종료 시점 상태 스냅샷입니다.
+    ///   - dismissImmediately: `true`면 즉시 제거, `false`면 시스템 기본 정책으로 제거합니다.
+    /// - Returns: 종료 처리 결과입니다.
+    func end(state: WalkLiveActivityState, dismissImmediately: Bool = true) async -> WalkLiveActivityServiceResult {
+        guard #available(iOS 16.1, *) else {
+            await postFallbackNotificationIfNeeded(state: state, reason: .unsupportedOS)
+            return .ended
+        }
+        let finalized = finalizedState(from: state)
+        let activities = Activity<WalkLiveActivityAttributes>.activities
+        guard activities.isEmpty == false else {
+            return .ended
+        }
+
+        let content = ActivityContent(
+            state: finalized.makeContentState(),
+            staleDate: nil
+        )
+        for activity in activities {
+            await activity.end(content, dismissalPolicy: dismissImmediately ? .immediate : .default)
+        }
+        return .ended
+    }
+
+    /// 앱 진입 시 세션 상태와 Live Activity 상태를 정합화합니다.
+    /// - Parameters:
+    ///   - activeSession: 현재 앱에 활성 산책 세션이 존재하는지 여부입니다.
+    ///   - state: 활성 세션이 있을 때 반영할 산책 상태입니다.
+    func reconcile(activeSession: Bool, state: WalkLiveActivityState?) async {
+        if activeSession, let state {
+            _ = await sync(state: state)
+            return
+        }
+        _ = await end(state: state ?? defaultEndedState(), dismissImmediately: false)
+    }
+
+    /// 현재 세션에 대응하는 Live Activity를 찾거나 새로 생성합니다.
+    /// - Parameter state: 동기화 대상 산책 상태입니다.
+    /// - Returns: 업데이트 가능한 Live Activity 인스턴스입니다.
+    @available(iOS 16.1, *)
+    private func ensureActivity(for state: WalkLiveActivityState) async throws -> Activity<WalkLiveActivityAttributes> {
+        if let current = matchingActivity(for: state.sessionId) {
+            return current
+        }
+        let attributes = WalkLiveActivityAttributes(
+            sessionId: state.sessionId,
+            startedAt: state.startedAt
+        )
+        let content = ActivityContent(
+            state: state.makeContentState(),
+            staleDate: Date().addingTimeInterval(600)
+        )
+        return try Activity.request(attributes: attributes, content: content, pushType: nil)
+    }
+
+    /// 세션 ID와 일치하는 Live Activity를 조회합니다.
+    /// - Parameter sessionId: 찾을 산책 세션 ID입니다.
+    /// - Returns: 일치 activity가 있으면 해당 인스턴스, 없으면 첫 번째 activity 또는 `nil`입니다.
+    @available(iOS 16.1, *)
+    private func matchingActivity(for sessionId: String) -> Activity<WalkLiveActivityAttributes>? {
+        if let matched = Activity<WalkLiveActivityAttributes>.activities.first(where: { $0.attributes.sessionId == sessionId }) {
+            return matched
+        }
+        return Activity<WalkLiveActivityAttributes>.activities.first
+    }
+
+    /// 종료 이벤트용 상태 스냅샷을 생성합니다.
+    /// - Parameter state: 종료 직전 상태입니다.
+    /// - Returns: 종료 단계(`ended`)가 반영된 상태입니다.
+    private func finalizedState(from state: WalkLiveActivityState) -> WalkLiveActivityState {
+        WalkLiveActivityState(
+            sessionId: state.sessionId,
+            startedAt: state.startedAt,
+            isWalking: false,
+            elapsedSeconds: state.elapsedSeconds,
+            pointCount: state.pointCount,
+            petName: state.petName,
+            autoEndStage: .ended,
+            statusMessage: state.statusMessage,
+            updatedAt: Date().timeIntervalSince1970
+        )
+    }
+
+    /// 세션 정보가 없을 때 orphan 정리용 기본 종료 상태를 생성합니다.
+    /// - Parameter now: 상태 생성 기준 시각입니다.
+    /// - Returns: orphan 정리 시 사용할 기본 종료 상태입니다.
+    private func defaultEndedState(now: Date = Date()) -> WalkLiveActivityState {
+        WalkLiveActivityState(
+            sessionId: "orphan",
+            startedAt: now.timeIntervalSince1970,
+            isWalking: false,
+            elapsedSeconds: 0,
+            pointCount: 0,
+            petName: "반려견",
+            autoEndStage: .ended,
+            statusMessage: "세션 동기화로 정리되었습니다.",
+            updatedAt: now.timeIntervalSince1970
+        )
+    }
+
+    /// fallback 알림 중복 방지를 위한 고유 키를 생성합니다.
+    /// - Parameters:
+    ///   - state: 현재 산책 상태입니다.
+    ///   - reason: fallback 사유입니다.
+    /// - Returns: 상태/사유 조합을 나타내는 키 문자열입니다.
+    private func fallbackNotificationKey(
+        state: WalkLiveActivityState,
+        reason: WalkLiveActivityFallbackReason
+    ) -> String {
+        "\(reason.rawValue)|\(state.sessionId)|\(state.autoEndStage.rawValue)|\(state.isWalking)"
+    }
+
+    /// 필요할 때만 fallback 로컬 알림을 발송합니다.
+    /// - Parameters:
+    ///   - state: 현재 산책 상태입니다.
+    ///   - reason: Live Activity fallback 사유입니다.
+    private func postFallbackNotificationIfNeeded(
+        state: WalkLiveActivityState,
+        reason: WalkLiveActivityFallbackReason
+    ) async {
+        let key = fallbackNotificationKey(state: state, reason: reason)
+        guard key != lastFallbackNotificationKey else { return }
+        lastFallbackNotificationKey = key
+
+        let granted = await ensureNotificationAuthorization()
+        guard granted else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = "산책 상태 업데이트"
+        content.body = state.autoEndStage.fallbackNotificationBody
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: "walk.live.fallback.\(state.autoEndStage.rawValue)",
+            content: content,
+            trigger: UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        )
+        await addNotificationRequest(request)
+    }
+
+    /// 로컬 알림 권한을 확인하고 필요 시 권한 요청을 수행합니다.
+    /// - Returns: 알림 전송이 가능한 권한 상태면 `true`, 아니면 `false`입니다.
+    private func ensureNotificationAuthorization() async -> Bool {
+        let settings = await notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined:
+            return await withCheckedContinuation { continuation in
+                notificationCenter.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+                    continuation.resume(returning: granted)
+                }
+            }
+        case .denied:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    /// 시스템 알림 센터의 현재 권한 설정을 비동기로 조회합니다.
+    /// - Returns: 현재 알림 설정 스냅샷입니다.
+    private func notificationSettings() async -> UNNotificationSettings {
+        await withCheckedContinuation { continuation in
+            notificationCenter.getNotificationSettings { settings in
+                continuation.resume(returning: settings)
+            }
+        }
+    }
+
+    /// 로컬 알림 요청을 시스템 큐에 등록합니다.
+    /// - Parameter request: 등록할 로컬 알림 요청입니다.
+    private func addNotificationRequest(_ request: UNNotificationRequest) async {
+        await withCheckedContinuation { continuation in
+            notificationCenter.add(request) { _ in
+                continuation.resume()
+            }
+        }
     }
 }

--- a/dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift
+++ b/dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(ActivityKit)
+import ActivityKit
+#endif
 
 enum WalkWidgetSnapshotStatus: String, Codable {
     case ready = "ready"
@@ -24,6 +27,89 @@ struct WalkWidgetSnapshot: Codable, Equatable {
         updatedAt: Date().timeIntervalSince1970
     )
 }
+
+enum WalkLiveActivityAutoEndStage: String, Codable, Equatable, Hashable {
+    case active = "active"
+    case restCandidate = "rest_candidate"
+    case warning = "warning"
+    case autoEnding = "auto_ending"
+    case ended = "ended"
+
+    var title: String {
+        switch self {
+        case .active:
+            return "정상 기록 중"
+        case .restCandidate:
+            return "휴식 후보 (5분)"
+        case .warning:
+            return "자동 종료 경고 (12분)"
+        case .autoEnding:
+            return "자동 종료 단계 (15분)"
+        case .ended:
+            return "산책 종료"
+        }
+    }
+
+    var fallbackNotificationBody: String {
+        switch self {
+        case .active:
+            return "산책 상태가 정상적으로 기록되고 있어요."
+        case .restCandidate:
+            return "5분 무이동 상태예요. 산책을 이어가면 단계가 해제돼요."
+        case .warning:
+            return "12분 무이동 상태예요. 3분 뒤 자동 종료될 수 있어요."
+        case .autoEnding:
+            return "15분 무이동으로 자동 종료 단계가 적용됐어요."
+        case .ended:
+            return "산책 세션이 종료됐어요."
+        }
+    }
+}
+
+struct WalkLiveActivityState: Equatable {
+    let sessionId: String
+    let startedAt: TimeInterval
+    let isWalking: Bool
+    let elapsedSeconds: Int
+    let pointCount: Int
+    let petName: String
+    let autoEndStage: WalkLiveActivityAutoEndStage
+    let statusMessage: String?
+    let updatedAt: TimeInterval
+}
+
+#if canImport(ActivityKit)
+@available(iOS 16.1, *)
+struct WalkLiveActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        let elapsedSeconds: Int
+        let pointCount: Int
+        let petName: String
+        let autoEndStage: WalkLiveActivityAutoEndStage
+        let statusMessage: String?
+        let updatedAt: TimeInterval
+    }
+
+    let sessionId: String
+    let startedAt: TimeInterval
+}
+
+@available(iOS 16.1, *)
+extension WalkLiveActivityState {
+    /// Live Activity 업데이트에 필요한 ContentState를 생성합니다.
+    /// - Returns: 경과 시간/포인트/자동종료 단계를 포함한 상태 payload입니다.
+    func makeContentState() -> WalkLiveActivityAttributes.ContentState {
+        WalkLiveActivityAttributes.ContentState(
+            elapsedSeconds: elapsedSeconds,
+            pointCount: pointCount,
+            petName: petName,
+            autoEndStage: autoEndStage,
+            statusMessage: statusMessage,
+            updatedAt: updatedAt
+        )
+    }
+}
+#endif
 
 protocol WalkWidgetSnapshotStoring {
     /// 위젯 스냅샷을 조회합니다.
@@ -73,4 +159,3 @@ final class DefaultWalkWidgetSnapshotStore: WalkWidgetSnapshotStoring {
         UserDefaults(suiteName: WalkWidgetBridgeContract.appGroupIdentifier) ?? .standard
     }
 }
-

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -341,6 +341,9 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private var lastSyncFlushAt: Date = .distantPast
     private var lastSyncSummarySnapshot: SyncOutboxSummary? = nil
     private var lastWidgetSnapshotSyncAt: Date = .distantPast
+    private var lastLiveActivitySyncAt: Date = .distantPast
+    private var liveActivitySyncTask: Task<Void, Never>? = nil
+    private var lastLiveActivityFallbackReason: WalkLiveActivityFallbackReason? = nil
     private var syncFlushTask: Task<Void, Never>? = nil
     private let syncOutbox = SyncOutboxStore.shared
     private let syncTransport = SupabaseSyncOutboxTransport()
@@ -352,6 +355,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let areaCalculationService: MapAreaCalculationServicing
     private let clusterAnnotationService: MapClusterAnnotationServicing
     private let widgetSnapshotStore: WalkWidgetSnapshotStoring
+    private let liveActivityService: WalkLiveActivityServicing
     private let eventCenter: AppEventCenterProtocol
     private var lastCaptureHapticAt: Date = .distantPast
     private var lastWarningHapticAt: Date = .distantPast
@@ -361,6 +365,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private var weatherFetchTask: Task<Void, Never>? = nil
     private var lastWeatherFetchAttemptAt: Date = .distantPast
     private let widgetSnapshotSyncInterval: TimeInterval = 5.0
+    private let liveActivitySyncInterval: TimeInterval = 2.0
 
     private enum WatchIncomingAction: String {
         case startWalk
@@ -451,6 +456,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         areaCalculationService: MapAreaCalculationServicing = MapAreaCalculationService(),
         clusterAnnotationService: MapClusterAnnotationServicing = MapClusterAnnotationService(),
         widgetSnapshotStore: WalkWidgetSnapshotStoring = DefaultWalkWidgetSnapshotStore.shared,
+        liveActivityService: WalkLiveActivityServicing = WalkLiveActivityService(),
         eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared
     ) {
         self.walkRepository = walkRepository
@@ -461,6 +467,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.areaCalculationService = areaCalculationService
         self.clusterAnnotationService = clusterAnnotationService
         self.widgetSnapshotStore = widgetSnapshotStore
+        self.liveActivityService = liveActivityService
         self.eventCenter = eventCenter
         super.init()
         self.locationManager.delegate = self
@@ -499,11 +506,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.refreshWeatherOverlayRisk()
         self.refreshWeatherRiskFromProviderIfNeeded(location: self.locationManager.location, force: true)
         self.syncWalkWidgetSnapshot(force: true)
+        self.syncWalkLiveActivity(force: true)
     }
 
     deinit {
         timer?.invalidate()
         nearbyTickTimer?.invalidate()
+        liveActivitySyncTask?.cancel()
         syncFlushTask?.cancel()
         weatherFetchTask?.cancel()
         lifecycleObservers.forEach { eventCenter.removeObserver($0) }
@@ -622,6 +631,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         }
         self.syncWatchContext(force: true)
         self.syncWalkWidgetSnapshot(force: true)
+        self.syncWalkLiveActivity(force: true)
     }
 
     func startWalkNow() {
@@ -645,6 +655,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         }
         syncWatchContext(force: true)
         syncWalkWidgetSnapshot(force: true)
+        syncWalkLiveActivity(force: true)
     }
 
     func toggleWalkStartCountdown() {
@@ -950,6 +961,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         syncWatchContext(force: true)
         walkStatusMessage = "위치 권한이 해제되어 산책을 안전 일시중지했습니다."
         setRuntimeGuardStatus("권한 강등 감지로 세션 일시중지")
+        syncWalkWidgetSnapshot(force: true, statusOverride: .locationDenied, messageOverride: walkStatusMessage)
+        syncWalkLiveActivity(force: true)
     }
 
     private func prepareRecoverableSessionIfNeeded() {
@@ -1072,6 +1085,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         walkStatusMessage = autoRecovered ? "산책 세션을 자동 복구했습니다." : "이전 산책 세션을 복구했습니다."
         setRuntimeGuardStatus("세션 복구 완료")
         syncWatchContext(force: true)
+        syncWalkWidgetSnapshot(force: true)
+        syncWalkLiveActivity(force: true)
     }
 
     func discardRecoverableWalkSession() {
@@ -1085,6 +1100,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         recoverableWalkSummaryText = ""
         recoverableWalkEstimateText = ""
         clearActiveWalkSession()
+        syncWalkWidgetSnapshot(force: true)
+        syncWalkLiveActivity(force: true)
     }
 
     func finalizeRecoverableWalkSessionEstimated() {
@@ -1178,6 +1195,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             )
             applyPolygonList(updated)
             clearActiveWalkSession()
+            syncWalkWidgetSnapshot(force: true)
+            syncWalkLiveActivity(force: true)
         } else {
             walkStatusMessage = "미종료 산책 종료 저장에 실패했습니다."
             metricTracker.track(
@@ -1264,12 +1283,14 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             didNotifyInactivityWarning = true
             walkStatusMessage = "12분 무이동: 3분 후 자동 종료 예정입니다."
             triggerWarningHapticIfNeeded()
+            syncWalkLiveActivity(force: true)
             return
         }
 
         if inactivity >= restCandidateInterval, didNotifyRestCandidate == false {
             didNotifyRestCandidate = true
             walkStatusMessage = "5분 무이동: 휴식 상태로 감지했습니다."
+            syncWalkLiveActivity(force: true)
         }
     }
 
@@ -1283,6 +1304,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             self?.flushSyncOutboxIfNeeded(force: true)
             self?.syncVisibilitySettingIfNeeded()
             self?.refreshWeatherOverlayRisk()
+            self?.syncWalkLiveActivity(force: true)
         }
         let willResign = eventCenter.addObserver(
             forName: UIApplication.willResignActiveNotification,
@@ -1334,6 +1356,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         }
         persistActiveWalkSession(force: true)
         syncWatchContext(force: true)
+        syncWalkWidgetSnapshot()
+        syncWalkLiveActivity()
         compactMapMotionArtifacts(now: recordedAt)
         eventCenter.post(
             name: .walkPointRecordedForQuest,
@@ -1949,6 +1973,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
                 payload: ["action": route.kind.rawValue, "source": route.source]
             )
             syncWalkWidgetSnapshot(force: true)
+            syncWalkLiveActivity(force: true)
 
         case .endWalk:
             guard isWalking else {
@@ -1969,6 +1994,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
                 payload: ["action": route.kind.rawValue, "source": route.source]
             )
             syncWalkWidgetSnapshot(force: true)
+            syncWalkLiveActivity(force: true)
         }
     }
 
@@ -2015,6 +2041,82 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         lastWidgetSnapshotSyncAt = now
     }
 
+    /// 현재 자동 종료 정책 기준으로 Live Activity 단계 값을 계산합니다.
+    /// - Parameter now: 단계 계산 기준 시각입니다.
+    /// - Returns: 무이동 정책(5/12/15분)에 매핑된 단계 값입니다.
+    private func currentAutoEndStage(now: Date = Date()) -> WalkLiveActivityAutoEndStage {
+        guard isWalking else { return .ended }
+        let baseline = lastMovementAt ?? lastPointEventAt ?? startTime
+        let inactivity = max(0, now.timeIntervalSince(baseline))
+        if inactivity >= inactivityFinalizeInterval { return .autoEnding }
+        if inactivity >= inactivityWarningInterval { return .warning }
+        if inactivity >= restCandidateInterval { return .restCandidate }
+        return .active
+    }
+
+    /// 현재 ViewModel 상태를 Live Activity 서비스용 상태 모델로 변환합니다.
+    /// - Parameter now: 상태 스냅샷 기준 시각입니다.
+    /// - Returns: 세션 식별자/경과시간/포인트/자동종료 단계를 포함한 상태입니다.
+    private func makeWalkLiveActivityState(now: Date = Date()) -> WalkLiveActivityState {
+        WalkLiveActivityState(
+            sessionId: polygon.id.uuidString.lowercased(),
+            startedAt: startTime.timeIntervalSince1970,
+            isWalking: isWalking,
+            elapsedSeconds: Int(max(0, time.rounded(.down))),
+            pointCount: polygon.locations.count,
+            petName: currentWalkingPetName,
+            autoEndStage: currentAutoEndStage(now: now),
+            statusMessage: walkStatusMessage,
+            updatedAt: now.timeIntervalSince1970
+        )
+    }
+
+    /// Live Activity/대체 알림 상태를 주기적으로 동기화합니다.
+    /// - Parameter force: `true`면 최소 간격 제한 없이 즉시 동기화합니다.
+    private func syncWalkLiveActivity(force: Bool = false) {
+        let now = Date()
+        if force == false, now.timeIntervalSince(lastLiveActivitySyncAt) < liveActivitySyncInterval {
+            return
+        }
+        guard liveActivitySyncTask == nil else { return }
+        let state = makeWalkLiveActivityState(now: now)
+        lastLiveActivitySyncAt = now
+
+        liveActivitySyncTask = Task { [weak self] in
+            guard let self else { return }
+            let result: WalkLiveActivityServiceResult
+            if state.isWalking {
+                result = await liveActivityService.sync(state: state)
+            } else {
+                result = await liveActivityService.end(state: state, dismissImmediately: false)
+            }
+            await MainActor.run {
+                self.applyWalkLiveActivityResult(result)
+                self.liveActivitySyncTask = nil
+            }
+        }
+    }
+
+    /// Live Activity 동기화 결과를 배너 메시지 상태에 반영합니다.
+    /// - Parameter result: Live Activity 서비스 처리 결과입니다.
+    private func applyWalkLiveActivityResult(_ result: WalkLiveActivityServiceResult) {
+        switch result {
+        case .liveActivity, .ended:
+            lastLiveActivityFallbackReason = nil
+        case let .fallback(reason):
+            guard lastLiveActivityFallbackReason != reason else { return }
+            lastLiveActivityFallbackReason = reason
+            switch reason {
+            case .unsupportedOS:
+                walkStatusMessage = "Live Activity 미지원 환경이라 일반 알림으로 대체합니다."
+            case .activitiesDisabled:
+                walkStatusMessage = "Live Activity가 비활성화되어 일반 알림 + 앱 배너로 안내합니다."
+            case .requestFailed:
+                walkStatusMessage = "Live Activity 생성에 실패해 일반 알림으로 대체했습니다."
+            }
+        }
+    }
+
     func reloadSelectedPetContext() {
         let userInfo = userSessionStore.currentUserInfo()
         self.availablePets = userInfo?.pet ?? []
@@ -2025,6 +2127,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             self.currentWalkingPetName = self.selectedPetName
         }
         syncWalkWidgetSnapshot(force: true)
+        syncWalkLiveActivity(force: true)
     }
 
     var hasSelectedPet: Bool {
@@ -2253,6 +2356,7 @@ extension MapViewModel {
             self.persistActiveWalkSession()
             self.syncWatchContext()
             self.syncWalkWidgetSnapshot()
+            self.syncWalkLiveActivity()
             if self.time >= self.walkAutoTimeoutInterval {
                 self.forceQuit()
                 return
@@ -2284,19 +2388,23 @@ extension MapViewModel {
         case .notDetermined:
             locationManager.requestAlwaysAuthorization()
             syncWalkWidgetSnapshot(force: true)
+            syncWalkLiveActivity(force: true)
         case .restricted, .denied:
             pauseWalkForAuthorizationDowngrade()
             syncWalkWidgetSnapshot(force: true, statusOverride: .locationDenied)
+            syncWalkLiveActivity(force: true)
         case .authorizedAlways, .authorizedWhenInUse:
             if isWalking {
                 syncWatchContext(force: true)
             }
             refreshWeatherRiskFromProviderIfNeeded(location: manager.location, force: true)
             syncWalkWidgetSnapshot(force: true)
+            syncWalkLiveActivity(force: true)
             
         @unknown default:
             locationManager.requestAlwaysAuthorization()
             syncWalkWidgetSnapshot(force: true, statusOverride: .error, messageOverride: "위치 권한 상태를 확인해주세요.")
+            syncWalkLiveActivity(force: true)
         }
     }
     func locationManager(_ manager: CLLocationManager, didStartMonitoringFor region: CLRegion) {

--- a/dogAreaWidgetExtension/Info.plist
+++ b/dogAreaWidgetExtension/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>
-	<string>17.0</string>
+	<string>18.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/dogAreaWidgetExtension/WalkControlWidget.swift
+++ b/dogAreaWidgetExtension/WalkControlWidget.swift
@@ -1,5 +1,8 @@
 import WidgetKit
 import SwiftUI
+#if canImport(ActivityKit)
+import ActivityKit
+#endif
 
 struct WalkControlTimelineEntry: TimelineEntry {
     let date: Date
@@ -57,7 +60,7 @@ struct WalkControlWidgetEntryView: View {
             HStack(spacing: 6) {
                 Image(systemName: "clock")
                     .foregroundStyle(.secondary)
-                Text(formattedElapsed(entry.snapshot.elapsedSeconds))
+                Text(Self.formattedElapsed(entry.snapshot.elapsedSeconds))
                     .font(.system(.body, design: .rounded).monospacedDigit())
             }
 
@@ -93,7 +96,7 @@ struct WalkControlWidgetEntryView: View {
     /// 경과 시간을 `HH:MM:SS` 형식으로 변환합니다.
     /// - Parameter elapsedSeconds: 경과 시간(초)입니다.
     /// - Returns: 위젯 표시용 시간 문자열입니다.
-    private func formattedElapsed(_ elapsedSeconds: Int) -> String {
+    fileprivate static func formattedElapsed(_ elapsedSeconds: Int) -> String {
         let total = max(0, elapsedSeconds)
         let hours = total / 3600
         let minutes = (total % 3600) / 60
@@ -114,6 +117,126 @@ struct WalkControlWidget: Widget {
         .supportedFamilies([.systemSmall, .systemMedium])
     }
 }
+
+#if canImport(ActivityKit)
+@available(iOSApplicationExtension 16.1, *)
+private struct WalkLiveActivityView: View {
+    let context: ActivityViewContext<WalkLiveActivityAttributes>
+
+    private var endRouteURL: URL? {
+        WalkWidgetActionRoute(
+            kind: .endWalk,
+            actionId: "live.end.\(Int(Date().timeIntervalSince1970))",
+            source: "live_activity"
+        ).makeURL()
+    }
+
+    private var openRouteURL: URL? {
+        WalkWidgetActionRoute(
+            kind: .startWalk,
+            actionId: "live.open.\(Int(Date().timeIntervalSince1970))",
+            source: "live_activity"
+        ).makeURL()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(context.state.petName)
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                Text(context.state.autoEndStage.title)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            HStack(spacing: 10) {
+                Label(Self.formattedElapsed(context.state.elapsedSeconds), systemImage: "clock")
+                    .font(.system(.body, design: .rounded).monospacedDigit())
+                Label("포인트 \(context.state.pointCount)", systemImage: "mappin.and.ellipse")
+                    .font(.subheadline)
+            }
+            if let message = context.state.statusMessage,
+               message.isEmpty == false {
+                Text(message)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+            HStack(spacing: 8) {
+                if #available(iOSApplicationExtension 17.0, *) {
+                    Button(intent: EndWalkIntent()) {
+                        Label("종료", systemImage: "stop.fill")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.red)
+                } else if let endRouteURL {
+                    Link(destination: endRouteURL) {
+                        Label("종료", systemImage: "stop.fill")
+                            .font(.caption)
+                    }
+                }
+
+                if let openRouteURL {
+                    Link(destination: openRouteURL) {
+                        Label("앱 열기", systemImage: "arrow.up.right.square")
+                            .font(.caption)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .activityBackgroundTint(Color(.systemBackground))
+        .activitySystemActionForegroundColor(.primary)
+    }
+
+    /// 경과 시간을 `HH:MM:SS` 형식 문자열로 변환합니다.
+    /// - Parameter elapsedSeconds: 경과 시간(초)입니다.
+    /// - Returns: Live Activity 표시용 시간 문자열입니다.
+    fileprivate static func formattedElapsed(_ elapsedSeconds: Int) -> String {
+        let total = max(0, elapsedSeconds)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let seconds = total % 60
+        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+}
+
+@available(iOSApplicationExtension 16.1, *)
+struct WalkLiveActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: WalkLiveActivityAttributes.self) { context in
+            WalkLiveActivityView(context: context)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Text(context.state.petName)
+                        .font(.caption)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(context.state.autoEndStage.title)
+                        .font(.caption2)
+                        .lineLimit(1)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(WalkLiveActivityView.formattedElapsed(context.state.elapsedSeconds))
+                        .font(.system(.headline, design: .rounded).monospacedDigit())
+                }
+            } compactLeading: {
+                Text("🐾")
+            } compactTrailing: {
+                Text("\(context.state.pointCount)")
+            } minimal: {
+                Image(systemName: "figure.walk")
+            }
+            .keylineTint(.orange)
+        }
+    }
+}
+#endif
 
 #Preview(as: .systemSmall) {
     WalkControlWidget()

--- a/dogAreaWidgetExtension/WalkControlWidgetBundle.swift
+++ b/dogAreaWidgetExtension/WalkControlWidgetBundle.swift
@@ -3,7 +3,11 @@ import SwiftUI
 
 @main
 struct WalkControlWidgetBundle: WidgetBundle {
+    @WidgetBundleBuilder
     var body: some Widget {
         WalkControlWidget()
+        if #available(iOSApplicationExtension 16.1, *) {
+            WalkLiveActivityWidget()
+        }
     }
 }

--- a/scripts/project_stability_unit_check.swift
+++ b/scripts/project_stability_unit_check.swift
@@ -22,7 +22,7 @@ let script = load("scripts/ios_pr_check.sh")
 let doc = load("docs/project-settings-dependency-stability-v1.md")
 let readme = load("README.md")
 
-assertTrue(pbxproj.contains("IPHONEOS_DEPLOYMENT_TARGET = 17.0;"), "project should pin iOS deployment target 17.0")
+assertTrue(pbxproj.contains("IPHONEOS_DEPLOYMENT_TARGET = 18.0;"), "project should pin iOS deployment target 18.0")
 assertTrue(pbxproj.contains("WATCHOS_DEPLOYMENT_TARGET = 10.2;"), "project should pin watchOS deployment target 10.2")
 assertTrue(pbxproj.contains("SWIFT_VERSION = 5.0;"), "project should pin Swift version 5.0")
 assertTrue(pbxproj.contains("path = dogAreaSplash.json;"), "project should use repo-relative splash animation path")


### PR DESCRIPTION
## 작업 내용
- ActivityKit 기반 WalkLiveActivityAttributes/상태 모델 추가
- WalkLiveActivityService(프로토콜 + actor)로 Live Activity 생성/업데이트/종료 수명주기 통합
- MapViewModel 산책 시작/종료/자동종료/복구/권한변경 이벤트를 Live Activity 상태 전이에 연결
- 무이동 5/12/15분 정책 단계를 Live Activity 텍스트로 반영
- 잠금화면 액션(종료/앱 열기) 및 iOS 버전 분기(17+ 인터랙티브 버튼, 하위는 링크) 반영
- Live Activity 비활성/실패 fallback 경로(일반 알림 + 앱 배너 메시지) 반영
- 앱/위젯 iOS 배포 타깃 18.0 상향 + 안정성 문서/체크 스크립트 기준 동기화

## 검증
- xcodebuild -project dogArea.xcodeproj -scheme dogAreaWidgetExtension -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build
- bash scripts/ios_pr_check.sh
- bash scripts/run_design_audit_ui_tests.sh

## 이슈
- closes #216
