### PR TITLE
[Task][Widget][P1] 영역 현황 위젯(일/주 타일 + 방어 예정)

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -1,5 +1,8 @@
 import Foundation
 import CoreLocation
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
 
 struct SupabaseRuntimeConfig: Equatable {
     let baseURL: URL
@@ -412,6 +415,30 @@ protocol CaricatureServiceProtocol {
 
 protocol AreaReferenceServiceProtocol {
     func fetchSnapshot() async -> AreaReferenceSnapshot
+}
+
+struct TerritoryWidgetSummaryDTO: Equatable {
+    let todayTileCount: Int
+    let weeklyTileCount: Int
+    let defenseScheduledTileCount: Int
+    let scoreUpdatedAt: TimeInterval?
+    let refreshedAt: TimeInterval
+    let hasData: Bool
+}
+
+protocol TerritoryWidgetSummaryServiceProtocol {
+    /// 위젯용 영역 요약 지표를 서버 RPC에서 조회합니다.
+    /// - Parameter now: 서버 집계 기준 시각입니다.
+    /// - Returns: 오늘/주간/방어 예정 타일과 갱신 시각을 포함한 요약 DTO입니다.
+    func fetchSummary(now: Date) async throws -> TerritoryWidgetSummaryDTO
+}
+
+protocol TerritoryWidgetSnapshotSyncing {
+    /// 서버 요약을 조회해 위젯 공유 스냅샷을 갱신합니다.
+    /// - Parameters:
+    ///   - force: `true`면 TTL을 무시하고 즉시 갱신합니다.
+    ///   - now: TTL/상태 계산 기준 시각입니다.
+    func sync(force: Bool, now: Date) async
 }
 
 struct FeatureControlService: FeatureFlagRemoteServiceProtocol {
@@ -928,6 +955,213 @@ struct RivalLeagueService: RivalLeagueServiceProtocol {
                 isMe: row.isMe
             )
         }
+    }
+}
+
+struct TerritoryWidgetSummaryService: TerritoryWidgetSummaryServiceProtocol {
+    private struct ResponseDTO: Decodable {
+        let todayTileCount: Int?
+        let weeklyTileCount: Int?
+        let defenseScheduledTileCount: Int?
+        let scoreUpdatedAt: String?
+        let refreshedAt: String?
+        let hasData: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case todayTileCount = "today_tile_count"
+            case weeklyTileCount = "weekly_tile_count"
+            case defenseScheduledTileCount = "defense_scheduled_tile_count"
+            case scoreUpdatedAt = "score_updated_at"
+            case refreshedAt = "refreshed_at"
+            case hasData = "has_data"
+        }
+    }
+
+    private let client: SupabaseHTTPClient
+
+    init(client: SupabaseHTTPClient = .live) {
+        self.client = client
+    }
+
+    /// 위젯용 영역 요약 지표를 서버 RPC에서 조회합니다.
+    /// - Parameter now: 서버 집계 기준 시각입니다.
+    /// - Returns: 오늘/주간/방어 예정 타일과 갱신 시각을 포함한 요약 DTO입니다.
+    func fetchSummary(now: Date) async throws -> TerritoryWidgetSummaryDTO {
+        let payload: [String: Any] = [
+            "now_ts": ISO8601DateFormatter().string(from: now)
+        ]
+        let data = try await client.request(
+            .rest(path: "rpc/rpc_get_widget_territory_summary"),
+            method: .post,
+            bodyData: try JSONSerialization.data(withJSONObject: payload)
+        )
+        let decoded = try JSONDecoder().decode(ResponseDTO.self, from: data)
+        let refreshedAt = SupabaseISO8601.parseEpoch(decoded.refreshedAt) ?? now.timeIntervalSince1970
+        let summary = TerritoryWidgetSummaryDTO(
+            todayTileCount: max(0, decoded.todayTileCount ?? 0),
+            weeklyTileCount: max(0, decoded.weeklyTileCount ?? 0),
+            defenseScheduledTileCount: max(0, decoded.defenseScheduledTileCount ?? 0),
+            scoreUpdatedAt: SupabaseISO8601.parseEpoch(decoded.scoreUpdatedAt),
+            refreshedAt: refreshedAt,
+            hasData: decoded.hasData
+                ?? ((decoded.weeklyTileCount ?? 0) > 0 || (decoded.todayTileCount ?? 0) > 0)
+        )
+        return summary
+    }
+}
+
+final class DefaultTerritoryWidgetSnapshotSyncService: TerritoryWidgetSnapshotSyncing {
+    private let summaryService: TerritoryWidgetSummaryServiceProtocol
+    private let snapshotStore: TerritoryWidgetSnapshotStoring
+    private let userSessionStore: UserSessionStoreProtocol
+    private let preferenceStore: UserDefaults
+    private let syncTTL: TimeInterval
+    private let staleGraceInterval: TimeInterval
+
+    /// 영역 위젯 스냅샷 동기화 서비스를 생성합니다.
+    /// - Parameters:
+    ///   - summaryService: 서버 요약 RPC 호출 서비스입니다.
+    ///   - snapshotStore: 앱 그룹 기반 위젯 스냅샷 저장소입니다.
+    ///   - userSessionStore: 현재 로그인 사용자 컨텍스트 조회 저장소입니다.
+    ///   - preferenceStore: 마지막 동기화 메타데이터를 저장할 기본 설정 저장소입니다.
+    ///   - syncTTL: RPC 재조회 최소 간격(초)입니다.
+    ///   - staleGraceInterval: 오프라인 캐시를 허용할 최대 유예 시간(초)입니다.
+    init(
+        summaryService: TerritoryWidgetSummaryServiceProtocol = TerritoryWidgetSummaryService(),
+        snapshotStore: TerritoryWidgetSnapshotStoring = DefaultTerritoryWidgetSnapshotStore.shared,
+        userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
+        preferenceStore: UserDefaults = .standard,
+        syncTTL: TimeInterval = 15 * 60,
+        staleGraceInterval: TimeInterval = 6 * 60 * 60
+    ) {
+        self.summaryService = summaryService
+        self.snapshotStore = snapshotStore
+        self.userSessionStore = userSessionStore
+        self.preferenceStore = preferenceStore
+        self.syncTTL = syncTTL
+        self.staleGraceInterval = staleGraceInterval
+    }
+
+    /// 서버 요약을 조회해 위젯 공유 스냅샷을 갱신합니다.
+    /// - Parameters:
+    ///   - force: `true`면 TTL을 무시하고 즉시 갱신합니다.
+    ///   - now: TTL/상태 계산 기준 시각입니다.
+    func sync(force: Bool, now: Date) async {
+        guard shouldSync(force: force, now: now) else { return }
+
+        guard let user = userSessionStore.currentUserInfo(),
+              user.id.isEmpty == false else {
+            saveGuestSnapshot(now: now)
+            return
+        }
+
+        do {
+            let summary = try await summaryService.fetchSummary(now: now)
+            saveMemberSnapshot(summary: summary, now: now)
+        } catch {
+            saveFailureSnapshot(now: now)
+        }
+    }
+
+    /// TTL과 이전 상태를 기준으로 이번 동기화를 수행할지 판단합니다.
+    /// - Parameters:
+    ///   - force: `true`면 즉시 동기화합니다.
+    ///   - now: 판단 기준 시각입니다.
+    /// - Returns: 동기화가 필요하면 `true`, 스킵 가능하면 `false`입니다.
+    private func shouldSync(force: Bool, now: Date) -> Bool {
+        if force { return true }
+        let snapshot = snapshotStore.load()
+        let age = now.timeIntervalSince1970 - snapshot.updatedAt
+        return age >= syncTTL
+    }
+
+    /// 비회원 상태 스냅샷을 저장합니다.
+    /// - Parameter now: 저장 시각입니다.
+    private func saveGuestSnapshot(now: Date) {
+        let snapshot = TerritoryWidgetSnapshot(
+            status: .guestLocked,
+            message: "로그인 후 오늘/주간 영역 현황을 위젯에서 확인할 수 있어요.",
+            summary: nil,
+            updatedAt: now.timeIntervalSince1970
+        )
+        save(snapshot, now: now)
+    }
+
+    /// 서버 요약 응답을 회원 상태 스냅샷으로 저장합니다.
+    /// - Parameters:
+    ///   - summary: 서버에서 조회한 최신 영역 요약 DTO입니다.
+    ///   - now: 저장 시각입니다.
+    private func saveMemberSnapshot(summary: TerritoryWidgetSummaryDTO, now: Date) {
+        let snapshotStatus: TerritoryWidgetSnapshotStatus = summary.hasData ? .memberReady : .emptyData
+        let snapshotMessage: String = summary.hasData
+            ? "오늘/주간/방어 예정 지표를 표시합니다."
+            : "아직 집계된 타일이 없어요. 첫 산책을 시작해보세요."
+
+        let snapshot = TerritoryWidgetSnapshot(
+            status: snapshotStatus,
+            message: snapshotMessage,
+            summary: TerritoryWidgetSummarySnapshot(
+                todayTileCount: summary.todayTileCount,
+                weeklyTileCount: summary.weeklyTileCount,
+                defenseScheduledTileCount: summary.defenseScheduledTileCount,
+                scoreUpdatedAt: summary.scoreUpdatedAt,
+                refreshedAt: summary.refreshedAt
+            ),
+            updatedAt: now.timeIntervalSince1970
+        )
+        save(snapshot, now: now)
+    }
+
+    /// 서버 조회 실패 시 마지막 성공 스냅샷 기반 상태로 저장합니다.
+    /// - Parameter now: 저장 시각입니다.
+    private func saveFailureSnapshot(now: Date) {
+        let current = snapshotStore.load()
+        let cachedSummary = current.summary
+
+        if let cachedSummary {
+            let cacheAge = now.timeIntervalSince1970 - cachedSummary.refreshedAt
+            let status: TerritoryWidgetSnapshotStatus = cacheAge <= staleGraceInterval ? .offlineCached : .syncDelayed
+            let message: String = cacheAge <= staleGraceInterval
+                ? "오프라인 상태예요. 마지막 성공 스냅샷을 표시 중입니다."
+                : "동기화가 지연되고 있어요. 앱을 열어 최신화해주세요."
+            save(
+                TerritoryWidgetSnapshot(
+                    status: status,
+                    message: message,
+                    summary: cachedSummary,
+                    updatedAt: now.timeIntervalSince1970
+                ),
+                now: now
+            )
+            return
+        }
+
+        save(
+            TerritoryWidgetSnapshot(
+                status: .syncDelayed,
+                message: "데이터를 아직 불러오지 못했어요. 앱을 열어 동기화해주세요.",
+                summary: nil,
+                updatedAt: now.timeIntervalSince1970
+            ),
+            now: now
+        )
+    }
+
+    /// 위젯 스냅샷 저장 후 재로딩을 요청하고 마지막 동기화 시각을 기록합니다.
+    /// - Parameters:
+    ///   - snapshot: 저장할 영역 위젯 스냅샷입니다.
+    ///   - now: 마지막 동기화 시각 기록 기준입니다.
+    private func save(_ snapshot: TerritoryWidgetSnapshot, now: Date) {
+        snapshotStore.save(snapshot)
+        preferenceStore.set(now.timeIntervalSince1970, forKey: "territory.widget.lastSyncAt.v1")
+        reloadTerritoryWidgetTimeline()
+    }
+
+    /// WidgetKit 타임라인을 즉시 재요청해 최신 스냅샷이 반영되도록 합니다.
+    private func reloadTerritoryWidgetTimeline() {
+        #if canImport(WidgetKit)
+        WidgetCenter.shared.reloadTimelines(ofKind: WalkWidgetBridgeContract.territoryWidgetKind)
+        #endif
     }
 }
 

--- a/dogArea/Source/WidgetBridge/WalkWidgetBridge.swift
+++ b/dogArea/Source/WidgetBridge/WalkWidgetBridge.swift
@@ -4,6 +4,8 @@ import Foundation
 enum WalkWidgetBridgeContract {
     static let appGroupIdentifier = "group.com.th.dogArea.shared"
     static let snapshotStorageKey = "walk.widget.snapshot.v1"
+    static let territorySnapshotStorageKey = "territory.widget.snapshot.v1"
+    static let territoryWidgetKind = "com.th.dogArea.territory-status"
     static let actionRequestStorageKey = "walk.widget.action.request.v1"
     static let deepLinkScheme = "dogarea"
     static let deepLinkHost = "widget"

--- a/dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift
+++ b/dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift
@@ -28,6 +28,44 @@ struct WalkWidgetSnapshot: Codable, Equatable {
     )
 }
 
+enum TerritoryWidgetSnapshotStatus: String, Codable {
+    case memberReady = "member_ready"
+    case guestLocked = "guest_locked"
+    case emptyData = "empty_data"
+    case offlineCached = "offline_cached"
+    case syncDelayed = "sync_delayed"
+}
+
+struct TerritoryWidgetSummarySnapshot: Codable, Equatable {
+    let todayTileCount: Int
+    let weeklyTileCount: Int
+    let defenseScheduledTileCount: Int
+    let scoreUpdatedAt: TimeInterval?
+    let refreshedAt: TimeInterval
+
+    static let zero = TerritoryWidgetSummarySnapshot(
+        todayTileCount: 0,
+        weeklyTileCount: 0,
+        defenseScheduledTileCount: 0,
+        scoreUpdatedAt: nil,
+        refreshedAt: Date().timeIntervalSince1970
+    )
+}
+
+struct TerritoryWidgetSnapshot: Codable, Equatable {
+    let status: TerritoryWidgetSnapshotStatus
+    let message: String
+    let summary: TerritoryWidgetSummarySnapshot?
+    let updatedAt: TimeInterval
+
+    static let initial = TerritoryWidgetSnapshot(
+        status: .guestLocked,
+        message: "로그인 후 내 영역 현황을 위젯에서 빠르게 확인해보세요.",
+        summary: nil,
+        updatedAt: Date().timeIntervalSince1970
+    )
+}
+
 enum WalkLiveActivityAutoEndStage: String, Codable, Equatable, Hashable {
     case active = "active"
     case restCandidate = "rest_candidate"
@@ -151,6 +189,55 @@ final class DefaultWalkWidgetSnapshotStore: WalkWidgetSnapshotStoring {
     func save(_ snapshot: WalkWidgetSnapshot) {
         guard let data = try? encoder.encode(snapshot) else { return }
         storage.set(data, forKey: WalkWidgetBridgeContract.snapshotStorageKey)
+    }
+
+    /// App Group 저장소를 우선 사용하고, 실패 시 표준 저장소를 반환합니다.
+    /// - Returns: 위젯과 앱 간 공유 가능한 UserDefaults 인스턴스입니다.
+    private static func resolveStorage() -> UserDefaults {
+        UserDefaults(suiteName: WalkWidgetBridgeContract.appGroupIdentifier) ?? .standard
+    }
+}
+
+protocol TerritoryWidgetSnapshotStoring {
+    /// 영역 위젯 스냅샷을 조회합니다.
+    /// - Returns: 저장된 스냅샷이 있으면 해당 값, 없으면 기본 스냅샷을 반환합니다.
+    func load() -> TerritoryWidgetSnapshot
+
+    /// 영역 위젯 스냅샷을 저장합니다.
+    /// - Parameter snapshot: 위젯 표시용으로 직렬화할 최신 영역 스냅샷입니다.
+    func save(_ snapshot: TerritoryWidgetSnapshot)
+}
+
+final class DefaultTerritoryWidgetSnapshotStore: TerritoryWidgetSnapshotStoring {
+    static let shared = DefaultTerritoryWidgetSnapshotStore()
+
+    private let storage: UserDefaults
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    /// 영역 위젯 스냅샷 저장소를 초기화합니다.
+    /// - Parameter storage: 스냅샷 직렬화 데이터를 저장할 UserDefaults입니다.
+    init(storage: UserDefaults = DefaultTerritoryWidgetSnapshotStore.resolveStorage()) {
+        self.storage = storage
+    }
+
+    /// 영역 위젯 스냅샷을 조회합니다.
+    /// - Returns: 저장된 스냅샷이 있으면 해당 값, 없으면 기본 스냅샷을 반환합니다.
+    func load() -> TerritoryWidgetSnapshot {
+        guard
+            let data = storage.data(forKey: WalkWidgetBridgeContract.territorySnapshotStorageKey),
+            let decoded = try? decoder.decode(TerritoryWidgetSnapshot.self, from: data)
+        else {
+            return .initial
+        }
+        return decoded
+    }
+
+    /// 영역 위젯 스냅샷을 저장합니다.
+    /// - Parameter snapshot: 위젯 표시용으로 직렬화할 최신 영역 스냅샷입니다.
+    func save(_ snapshot: TerritoryWidgetSnapshot) {
+        guard let data = try? encoder.encode(snapshot) else { return }
+        storage.set(data, forKey: WalkWidgetBridgeContract.territorySnapshotStorageKey)
     }
 
     /// App Group 저장소를 우선 사용하고, 실패 시 표준 저장소를 반환합니다.

--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -20,6 +20,7 @@ struct RootView: View {
     @State private var tabbarHidden = false
     @StateObject var tabStatus = TabAppear.shared
     private let widgetActionStore: WalkWidgetActionRequestStoring = DefaultWalkWidgetActionRequestStore.shared
+    private let territoryWidgetSnapshotSyncService: TerritoryWidgetSnapshotSyncing = DefaultTerritoryWidgetSnapshotSyncService()
     private var homeView: HomeView
     private var walkListView: WalkListView    
     private var mapView: MapView
@@ -96,9 +97,11 @@ struct RootView: View {
             }
             .onAppear {
                 consumePendingWidgetActionIfNeeded()
+                syncTerritoryWidgetSnapshot(force: true)
             }
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                 consumePendingWidgetActionIfNeeded()
+                syncTerritoryWidgetSnapshot(force: false)
             }
             .onOpenURL { url in
                 routeWidgetDeepLinkIfNeeded(url)
@@ -176,6 +179,14 @@ struct RootView: View {
                     "source": route.source
                 ]
             )
+        }
+    }
+
+    /// 앱 생명주기 진입 시 영역 위젯 스냅샷 동기화를 요청합니다.
+    /// - Parameter force: `true`면 TTL을 무시하고 즉시 동기화합니다.
+    private func syncTerritoryWidgetSnapshot(force: Bool) {
+        Task(priority: .utility) {
+            await territoryWidgetSnapshotSyncService.sync(force: force, now: Date())
         }
     }
 }

--- a/dogAreaWidgetExtension/WalkControlWidget.swift
+++ b/dogAreaWidgetExtension/WalkControlWidget.swift
@@ -118,6 +118,253 @@ struct WalkControlWidget: Widget {
     }
 }
 
+struct TerritoryStatusTimelineEntry: TimelineEntry {
+    let date: Date
+    let snapshot: TerritoryWidgetSnapshot
+}
+
+struct TerritoryStatusTimelineProvider: TimelineProvider {
+    private let snapshotStore: TerritoryWidgetSnapshotStoring
+
+    /// 영역 현황 위젯 타임라인 제공자를 생성합니다.
+    /// - Parameter snapshotStore: 앱과 공유하는 영역 위젯 스냅샷 저장소입니다.
+    init(snapshotStore: TerritoryWidgetSnapshotStoring = DefaultTerritoryWidgetSnapshotStore.shared) {
+        self.snapshotStore = snapshotStore
+    }
+
+    /// 위젯 갤러리 플레이스홀더 엔트리를 반환합니다.
+    /// - Parameter context: 위젯 미리보기 컨텍스트입니다.
+    /// - Returns: 기본 영역 스냅샷을 포함한 엔트리입니다.
+    func placeholder(in context: Context) -> TerritoryStatusTimelineEntry {
+        .init(date: Date(), snapshot: .initial)
+    }
+
+    /// 시스템 스냅샷 요청에 현재 저장된 영역 스냅샷을 전달합니다.
+    /// - Parameters:
+    ///   - context: 스냅샷 요청 컨텍스트입니다.
+    ///   - completion: 생성한 엔트리를 전달하는 콜백입니다.
+    func getSnapshot(in context: Context, completion: @escaping (TerritoryStatusTimelineEntry) -> Void) {
+        completion(.init(date: Date(), snapshot: snapshotStore.load()))
+    }
+
+    /// 현재 공유 저장소 기준 타임라인을 생성합니다.
+    /// - Parameters:
+    ///   - context: 타임라인 생성 컨텍스트입니다.
+    ///   - completion: 생성된 타임라인을 전달하는 콜백입니다.
+    func getTimeline(in context: Context, completion: @escaping (Timeline<TerritoryStatusTimelineEntry>) -> Void) {
+        let now = Date()
+        let entry = TerritoryStatusTimelineEntry(date: now, snapshot: snapshotStore.load())
+        completion(Timeline(entries: [entry], policy: .after(now.addingTimeInterval(15 * 60))))
+    }
+}
+
+struct TerritoryStatusWidgetEntryView: View {
+    @Environment(\.widgetFamily) private var family
+
+    let entry: TerritoryStatusTimelineEntry
+
+    var body: some View {
+        Group {
+            switch entry.snapshot.status {
+            case .guestLocked:
+                guestContent
+            case .emptyData:
+                emptyContent
+            case .memberReady, .offlineCached, .syncDelayed:
+                dataContent
+            }
+        }
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+
+    private var guestContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            badge(title: "비회원", color: .orange.opacity(0.2))
+            Text("영역 현황")
+                .font(.headline)
+            Text("로그인 후 오늘/주간 지표와 방어 예정 타일을 위젯에서 볼 수 있어요.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+            Spacer(minLength: 2)
+            Text("앱에서 로그인")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.orange)
+        }
+    }
+
+    private var emptyContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            badge(title: "초기 안내", color: .blue.opacity(0.18))
+            Text("첫 타일 점령을 시작해보세요")
+                .font(.headline)
+                .lineLimit(2)
+            Text(entry.snapshot.message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+            Spacer(minLength: 2)
+            Text(updatedAtText)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var dataContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                badge(title: statusBadgeText, color: statusBadgeColor)
+                Spacer(minLength: 0)
+                Text(updatedAtText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if family == .systemSmall {
+                smallMetricContent
+            } else {
+                mediumMetricContent
+            }
+
+            if entry.snapshot.status != .memberReady {
+                Text(entry.snapshot.message)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    private var smallMetricContent: some View {
+        let summary = entry.snapshot.summary ?? .zero
+        return VStack(alignment: .leading, spacing: 6) {
+            Text("주간 타일")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("\(summary.weeklyTileCount)")
+                .font(.system(size: 30, weight: .bold, design: .rounded))
+                .monospacedDigit()
+            Text("오늘 \(summary.todayTileCount) · 방어 \(summary.defenseScheduledTileCount)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private var mediumMetricContent: some View {
+        let summary = entry.snapshot.summary ?? .zero
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("영역 현황")
+                .font(.headline)
+
+            HStack(spacing: 8) {
+                metricTile(title: "오늘", value: summary.todayTileCount, tint: .green)
+                metricTile(title: "주간", value: summary.weeklyTileCount, tint: .blue)
+                metricTile(title: "방어 예정", value: summary.defenseScheduledTileCount, tint: .orange)
+            }
+        }
+    }
+
+    /// 중형 위젯에서 개별 지표 타일을 렌더링합니다.
+    /// - Parameters:
+    ///   - title: 타일 상단에 표시할 지표 이름입니다.
+    ///   - value: 강조 표시할 지표 값입니다.
+    ///   - tint: 지표 강조 색상입니다.
+    /// - Returns: 타이틀/숫자/배경 강조가 적용된 지표 타일 뷰입니다.
+    private func metricTile(title: String, value: Int, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("\(value)")
+                .font(.title3.weight(.bold))
+                .monospacedDigit()
+                .foregroundStyle(tint)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 9)
+        .background(tint.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var updatedAtText: String {
+        if let refreshedAt = entry.snapshot.summary?.refreshedAt {
+            return "업데이트 \(Self.formattedTime(timestamp: refreshedAt))"
+        }
+        return "업데이트 -"
+    }
+
+    private var statusBadgeText: String {
+        switch entry.snapshot.status {
+        case .memberReady:
+            return "실시간"
+        case .offlineCached:
+            return "오프라인"
+        case .syncDelayed:
+            return "지연"
+        case .guestLocked:
+            return "비회원"
+        case .emptyData:
+            return "초기 안내"
+        }
+    }
+
+    private var statusBadgeColor: Color {
+        switch entry.snapshot.status {
+        case .memberReady:
+            return .green.opacity(0.2)
+        case .offlineCached:
+            return .orange.opacity(0.2)
+        case .syncDelayed:
+            return .red.opacity(0.18)
+        case .guestLocked:
+            return .orange.opacity(0.2)
+        case .emptyData:
+            return .blue.opacity(0.18)
+        }
+    }
+
+    /// 상태 배지를 렌더링합니다.
+    /// - Parameters:
+    ///   - title: 배지에 표시할 상태 텍스트입니다.
+    ///   - color: 배지 배경 색상입니다.
+    /// - Returns: 캡슐 형태의 상태 배지 뷰입니다.
+    private func badge(title: String, color: Color) -> some View {
+        Text(title)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color)
+            .clipShape(Capsule())
+    }
+
+    /// 유닉스 타임스탬프를 위젯 표시용 `HH:mm` 문자열로 변환합니다.
+    /// - Parameter timestamp: 변환할 유닉스 초 단위 타임스탬프입니다.
+    /// - Returns: 사용자 로캘 기준의 시:분 문자열입니다.
+    fileprivate static func formattedTime(timestamp: TimeInterval) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.autoupdatingCurrent
+        formatter.setLocalizedDateFormatFromTemplate("HHmm")
+        return formatter.string(from: Date(timeIntervalSince1970: timestamp))
+    }
+}
+
+struct TerritoryStatusWidget: Widget {
+    private let kind = WalkWidgetBridgeContract.territoryWidgetKind
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: TerritoryStatusTimelineProvider()) { entry in
+            TerritoryStatusWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("영역 현황")
+        .description("오늘/주간 점령 지표와 방어 예정 타일을 빠르게 확인합니다.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
 #if canImport(ActivityKit)
 @available(iOSApplicationExtension 16.1, *)
 private struct WalkLiveActivityView: View {

--- a/dogAreaWidgetExtension/WalkControlWidgetBundle.swift
+++ b/dogAreaWidgetExtension/WalkControlWidgetBundle.swift
@@ -6,6 +6,7 @@ struct WalkControlWidgetBundle: WidgetBundle {
     @WidgetBundleBuilder
     var body: some Widget {
         WalkControlWidget()
+        TerritoryStatusWidget()
         if #available(iOSApplicationExtension 16.1, *) {
             WalkLiveActivityWidget()
         }

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -44,6 +44,7 @@ swift scripts/season_anti_farming_unit_check.swift
 swift scripts/season_comeback_catchup_unit_check.swift
 swift scripts/season_stage2_pipeline_unit_check.swift
 swift scripts/season_stage3_ui_unit_check.swift
+swift scripts/territory_status_widget_unit_check.swift
 swift scripts/season_policy_stage1_unit_check.swift
 swift scripts/weather_risk_policy_stage1_unit_check.swift
 swift scripts/weather_stage2_engine_unit_check.swift

--- a/scripts/territory_status_widget_unit_check.swift
+++ b/scripts/territory_status_widget_unit_check.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let migration = load("supabase/migrations/20260303190000_territory_widget_summary_rpc.sql")
+let infra = load("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+let bridge = load("dogArea/Source/WidgetBridge/WalkWidgetBridge.swift")
+let snapshotStore = load("dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift")
+let widget = load("dogAreaWidgetExtension/WalkControlWidget.swift")
+let bundle = load("dogAreaWidgetExtension/WalkControlWidgetBundle.swift")
+
+assertTrue(migration.contains("create or replace function public.rpc_get_widget_territory_summary"), "migration should create territory widget summary rpc")
+assertTrue(migration.contains("defense_scheduled_tile_count"), "migration should return defense scheduled tile count")
+assertTrue(migration.contains("tile_events"), "migration should use tile_events for today metric")
+assertTrue(migration.contains("season_tile_scores"), "migration should use season_tile_scores for defense metric")
+assertTrue(migration.contains("grant execute on function public.rpc_get_widget_territory_summary"), "migration should grant execute on widget summary rpc")
+
+assertTrue(infra.contains("protocol TerritoryWidgetSummaryServiceProtocol"), "infra should define territory widget summary service protocol")
+assertTrue(infra.contains("struct TerritoryWidgetSummaryService"), "infra should include territory widget summary service")
+assertTrue(infra.contains("rpc/rpc_get_widget_territory_summary"), "infra should call territory widget summary rpc")
+assertTrue(infra.contains("DefaultTerritoryWidgetSnapshotSyncService"), "infra should include territory widget snapshot sync service")
+
+assertTrue(bridge.contains("territorySnapshotStorageKey"), "widget bridge contract should define territory snapshot key")
+assertTrue(bridge.contains("territoryWidgetKind"), "widget bridge contract should define territory widget kind")
+
+assertTrue(snapshotStore.contains("enum TerritoryWidgetSnapshotStatus"), "snapshot store should define territory widget status enum")
+assertTrue(snapshotStore.contains("struct TerritoryWidgetSummarySnapshot"), "snapshot store should define territory summary snapshot")
+assertTrue(snapshotStore.contains("final class DefaultTerritoryWidgetSnapshotStore"), "snapshot store should include territory snapshot storage implementation")
+
+assertTrue(widget.contains("struct TerritoryStatusTimelineProvider"), "widget extension should provide territory timeline provider")
+assertTrue(widget.contains("struct TerritoryStatusWidget"), "widget extension should define territory widget")
+assertTrue(widget.contains("supportedFamilies([.systemSmall, .systemMedium])"), "territory widget should support small and medium families")
+assertTrue(bundle.contains("TerritoryStatusWidget()"), "widget bundle should register territory status widget")
+
+print("PASS: territory status widget unit checks")

--- a/supabase/migrations/20260303190000_territory_widget_summary_rpc.sql
+++ b/supabase/migrations/20260303190000_territory_widget_summary_rpc.sql
@@ -1,0 +1,92 @@
+-- #217 territory status widget summary RPC (today/weekly/defense due)
+
+create or replace function public.rpc_get_widget_territory_summary(
+  now_ts timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  requester_uid uuid := auth.uid();
+  run_row public.season_runs%rowtype;
+  utc_today date := (now_ts at time zone 'utc')::date;
+  today_tile_count integer := 0;
+  weekly_tile_count integer := 0;
+  defense_scheduled_tile_count integer := 0;
+  score_updated_at timestamptz := null;
+begin
+  if requester_uid is null then
+    return jsonb_build_object(
+      'today_tile_count', null,
+      'weekly_tile_count', null,
+      'defense_scheduled_tile_count', null,
+      'score_updated_at', null,
+      'refreshed_at', now_ts,
+      'has_data', false
+    );
+  end if;
+
+  select *
+  into run_row
+  from public.season_runs sr
+  order by
+    case sr.status
+      when 'active' then 1
+      when 'settling' then 2
+      else 3
+    end,
+    sr.week_start desc
+  limit 1;
+
+  if run_row.id is null then
+    return jsonb_build_object(
+      'today_tile_count', 0,
+      'weekly_tile_count', 0,
+      'defense_scheduled_tile_count', 0,
+      'score_updated_at', null,
+      'refreshed_at', now_ts,
+      'has_data', false
+    );
+  end if;
+
+  select coalesce(count(distinct te.tile_id), 0)::integer
+  into today_tile_count
+  from public.tile_events te
+  where te.season_id = run_row.id
+    and te.owner_user_id = requester_uid
+    and te.event_day = utc_today
+    and te.event_kind = 'capture';
+
+  select
+    coalesce(sus.active_tile_count, 0)::integer,
+    sus.score_updated_at
+  into weekly_tile_count, score_updated_at
+  from public.season_user_scores sus
+  where sus.season_id = run_row.id
+    and sus.owner_user_id = requester_uid
+  limit 1;
+
+  select coalesce(count(*), 0)::integer
+  into defense_scheduled_tile_count
+  from public.season_tile_scores sts
+  where sts.season_id = run_row.id
+    and sts.owner_user_id = requester_uid
+    and sts.effective_score > 0
+    and sts.last_contribution_at is not null
+    and (sts.last_contribution_at + make_interval(hours => run_row.decay_grace_hours)) > now_ts
+    and (sts.last_contribution_at + make_interval(hours => run_row.decay_grace_hours)) <= (now_ts + interval '24 hours');
+
+  return jsonb_build_object(
+    'today_tile_count', coalesce(today_tile_count, 0),
+    'weekly_tile_count', coalesce(weekly_tile_count, 0),
+    'defense_scheduled_tile_count', coalesce(defense_scheduled_tile_count, 0),
+    'score_updated_at', score_updated_at,
+    'refreshed_at', now_ts,
+    'has_data', (coalesce(today_tile_count, 0) > 0 or coalesce(weekly_tile_count, 0) > 0)
+  );
+end;
+$$;
+
+grant execute on function public.rpc_get_widget_territory_summary(timestamptz) to authenticated, service_role;


### PR DESCRIPTION
## 작업 내용
- 영역 위젯 전용 DTO/스냅샷/상태 모델 및 App Group 저장소 추가
- 서버 요약 경로 `rpc_get_widget_territory_summary` 추가(오늘/주간/방어예정/갱신시각)
- iOS infra에 요약 RPC 서비스 + TTL/오프라인/지연 정책 기반 스냅샷 동기화 서비스 추가
- RootView 생명주기 진입 시 영역 위젯 스냅샷 동기화 연결
- WidgetExtension에 TerritoryStatusWidget(small/medium) 추가
  - 회원: 지표 + 상태 배지 + 갱신 시각
  - 비회원: 수치 차단 + 로그인 CTA
  - 데이터 없음/오프라인/지연 문구 정책 반영
- 정적 회귀 체크 추가
  - `scripts/territory_status_widget_unit_check.swift`
  - `scripts/ios_pr_check.sh`에 포함

## 테스트
- `swift scripts/territory_status_widget_unit_check.swift`
- `bash scripts/ios_pr_check.sh`
- `DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/run_design_audit_ui_tests.sh`

## 이슈
- closes #217
