### PR TITLE
[Task][Widget][P1] 퀘스트/라이벌 진행 위젯(+보상 진입)

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -401,6 +401,54 @@ protocol RivalLeagueServiceProtocol {
     func fetchLeaderboard(period: RivalLeaderboardPeriod, topN: Int) async throws -> [RivalLeaderboardEntryDTO]
 }
 
+struct QuestRivalWidgetSummaryDTO: Equatable {
+    let questInstanceId: String?
+    let questTitle: String
+    let questProgressValue: Double
+    let questTargetValue: Double
+    let questProgressRatio: Double
+    let questClaimable: Bool
+    let questRewardPoint: Int
+    let rivalRank: Int?
+    let rivalRankDelta: Int
+    let rivalLeague: String
+    let refreshedAt: TimeInterval
+    let hasData: Bool
+}
+
+struct QuestRewardClaimDTO: Equatable {
+    let questInstanceId: String
+    let claimStatus: String
+    let alreadyClaimed: Bool
+    let rewardPoints: Int
+    let claimedAt: TimeInterval?
+}
+
+protocol QuestRivalWidgetSummaryServiceProtocol {
+    /// 위젯용 퀘스트/라이벌 결합 요약 지표를 조회합니다.
+    /// - Parameter now: 서버 집계 기준 시각입니다.
+    /// - Returns: 퀘스트 진행률, 보상 가능 여부, 라이벌 순위를 포함한 요약 DTO입니다.
+    func fetchSummary(now: Date) async throws -> QuestRivalWidgetSummaryDTO
+}
+
+protocol QuestRivalWidgetSnapshotSyncing {
+    /// 서버 요약을 조회해 퀘스트/라이벌 위젯 공유 스냅샷을 갱신합니다.
+    /// - Parameters:
+    ///   - force: `true`면 TTL을 무시하고 즉시 갱신합니다.
+    ///   - now: TTL/상태 계산 기준 시각입니다.
+    func sync(force: Bool, now: Date) async
+}
+
+protocol QuestRewardClaimServiceProtocol {
+    /// 퀘스트 보상 수령을 서버 RPC로 요청합니다.
+    /// - Parameters:
+    ///   - questInstanceId: 보상을 수령할 퀘스트 인스턴스 식별자입니다.
+    ///   - requestId: 멱등 처리를 위한 요청 식별자입니다.
+    ///   - now: 서버 처리 기준 시각입니다.
+    /// - Returns: 수령 상태/중복 여부/보상 포인트를 포함한 응답 DTO입니다.
+    func claimReward(questInstanceId: String, requestId: String, now: Date) async throws -> QuestRewardClaimDTO
+}
+
 protocol CaricatureServiceProtocol {
     func requestCaricature(
         petId: String,
@@ -994,6 +1042,541 @@ struct RivalLeagueService: RivalLeagueServiceProtocol {
                 isMe: row.isMe
             )
         }
+    }
+}
+
+struct QuestRewardClaimService: QuestRewardClaimServiceProtocol {
+    private struct ClaimEnvelopeDTO: Decodable {
+        let claim: ResponseRowDTO?
+    }
+
+    private struct ResponseRowDTO: Decodable {
+        let questInstanceId: String?
+        let claimStatus: String?
+        let alreadyClaimed: Bool?
+        let rewardPoints: Int?
+        let claimedAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case questInstanceId = "quest_instance_id"
+            case claimStatus = "claim_status"
+            case alreadyClaimed = "already_claimed"
+            case rewardPoints = "reward_points"
+            case claimedAt = "claimed_at"
+        }
+    }
+
+    private let client: SupabaseHTTPClient
+
+    /// 퀘스트 보상 수령 서비스 인스턴스를 생성합니다.
+    /// - Parameter client: Supabase 요청을 수행하는 HTTP 클라이언트입니다.
+    init(client: SupabaseHTTPClient = .live) {
+        self.client = client
+    }
+
+    /// 퀘스트 보상 수령을 서버 함수로 요청합니다.
+    /// - Parameters:
+    ///   - questInstanceId: 보상을 수령할 퀘스트 인스턴스 식별자입니다.
+    ///   - requestId: 멱등 처리를 위한 요청 식별자입니다.
+    ///   - now: 서버 처리 기준 시각입니다.
+    /// - Returns: 수령 상태/중복 여부/보상 포인트를 포함한 응답 DTO입니다.
+    func claimReward(questInstanceId: String, requestId: String, now: Date) async throws -> QuestRewardClaimDTO {
+        guard let canonicalQuestId = questInstanceId.canonicalUUIDString else {
+            throw SupabaseHTTPError.invalidBody
+        }
+        let normalizedRequestId = requestId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? UUID().uuidString.lowercased()
+            : requestId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let payload: [String: Any] = [
+            "action": "claim_reward",
+            "target_instance_id": canonicalQuestId,
+            "request_id": normalizedRequestId,
+            "now_ts": ISO8601DateFormatter().string(from: now)
+        ]
+        let data = try await client.request(
+            .function(name: "quest-engine"),
+            method: .post,
+            bodyData: try JSONSerialization.data(withJSONObject: payload)
+        )
+        let envelope = try JSONDecoder().decode(ClaimEnvelopeDTO.self, from: data)
+        guard let claim = envelope.claim else {
+            throw SupabaseHTTPError.invalidResponse
+        }
+        return QuestRewardClaimDTO(
+            questInstanceId: claim.questInstanceId ?? canonicalQuestId,
+            claimStatus: claim.claimStatus ?? "unknown",
+            alreadyClaimed: claim.alreadyClaimed ?? false,
+            rewardPoints: max(0, claim.rewardPoints ?? 0),
+            claimedAt: SupabaseISO8601.parseEpoch(claim.claimedAt)
+        )
+    }
+}
+
+struct QuestRivalWidgetSummaryService: QuestRivalWidgetSummaryServiceProtocol {
+    private struct ResponseDTO: Decodable {
+        let questInstanceId: String?
+        let questTitle: String?
+        let questProgressValue: Double?
+        let questTargetValue: Double?
+        let questClaimable: Bool?
+        let questRewardPoint: Int?
+        let rivalRank: Int?
+        let rivalLeague: String?
+        let refreshedAt: String?
+        let hasData: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case questInstanceId = "quest_instance_id"
+            case questTitle = "quest_title"
+            case questProgressValue = "quest_progress_value"
+            case questTargetValue = "quest_target_value"
+            case questClaimable = "quest_claimable"
+            case questRewardPoint = "quest_reward_point"
+            case rivalRank = "rival_rank"
+            case rivalLeague = "rival_league"
+            case refreshedAt = "refreshed_at"
+            case hasData = "has_data"
+        }
+    }
+
+    private struct QuestFallbackRowDTO: Decodable {
+        let id: String?
+        let titleSnapshot: String?
+        let targetValueSnapshot: Double?
+        let progressValue: Double?
+        let status: String?
+        let rewardPointsSnapshot: Int?
+        let claimedAt: String?
+        let expiresAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case titleSnapshot = "title_snapshot"
+            case targetValueSnapshot = "target_value_snapshot"
+            case progressValue = "progress_value"
+            case status
+            case rewardPointsSnapshot = "reward_points_snapshot"
+            case claimedAt = "claimed_at"
+            case expiresAt = "expires_at"
+        }
+    }
+
+    private struct RivalFallbackRowDTO: Decodable {
+        let rankPosition: Int?
+        let effectiveLeague: String?
+        let isMe: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case rankPosition = "rank_position"
+            case effectiveLeague = "effective_league"
+            case isMe = "is_me"
+        }
+    }
+
+    private struct QuestFallbackSummary {
+        let instanceId: String?
+        let title: String
+        let progressValue: Double
+        let targetValue: Double
+        let claimable: Bool
+        let rewardPoint: Int
+    }
+
+    private struct RivalFallbackSummary {
+        let rank: Int?
+        let league: String
+    }
+
+    private let client: SupabaseHTTPClient
+
+    /// 퀘스트/라이벌 위젯 요약 서비스 인스턴스를 생성합니다.
+    /// - Parameter client: Supabase 요청을 수행하는 HTTP 클라이언트입니다.
+    init(client: SupabaseHTTPClient = .live) {
+        self.client = client
+    }
+
+    /// 위젯용 퀘스트/라이벌 결합 요약 지표를 조회합니다.
+    /// - Parameter now: 서버 집계 기준 시각입니다.
+    /// - Returns: 퀘스트 진행률, 보상 가능 여부, 라이벌 순위를 포함한 요약 DTO입니다.
+    func fetchSummary(now: Date) async throws -> QuestRivalWidgetSummaryDTO {
+        do {
+            return try await fetchFromSummaryRPC(now: now)
+        } catch {
+            return try await fetchFromFallback(now: now)
+        }
+    }
+
+    /// 전용 요약 RPC 응답을 조회해 위젯 DTO로 변환합니다.
+    /// - Parameter now: 서버 집계 기준 시각입니다.
+    /// - Returns: 서버 결합 집계 응답을 정규화한 위젯 요약 DTO입니다.
+    private func fetchFromSummaryRPC(now: Date) async throws -> QuestRivalWidgetSummaryDTO {
+        let payload: [String: Any] = [
+            "now_ts": ISO8601DateFormatter().string(from: now)
+        ]
+        let data = try await client.request(
+            .rest(path: "rpc/rpc_get_widget_quest_rival_summary"),
+            method: .post,
+            bodyData: try JSONSerialization.data(withJSONObject: payload)
+        )
+        let decoded = try decodeSummaryResponse(data: data)
+        let questTarget = max(1.0, decoded.questTargetValue ?? 1.0)
+        let questProgress = max(0.0, decoded.questProgressValue ?? 0.0)
+        let questRatio = min(1.0, max(0.0, questProgress / questTarget))
+        let questTitle = (decoded.questTitle ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedTitle = questTitle.isEmpty ? "오늘의 퀘스트를 준비 중입니다." : questTitle
+        let refreshedAt = SupabaseISO8601.parseEpoch(decoded.refreshedAt) ?? now.timeIntervalSince1970
+        return QuestRivalWidgetSummaryDTO(
+            questInstanceId: decoded.questInstanceId?.canonicalUUIDString,
+            questTitle: resolvedTitle,
+            questProgressValue: questProgress,
+            questTargetValue: questTarget,
+            questProgressRatio: questRatio,
+            questClaimable: decoded.questClaimable ?? false,
+            questRewardPoint: max(0, decoded.questRewardPoint ?? 0),
+            rivalRank: decoded.rivalRank,
+            rivalRankDelta: 0,
+            rivalLeague: decoded.rivalLeague ?? "onboarding",
+            refreshedAt: refreshedAt,
+            hasData: decoded.hasData
+                ?? (decoded.questInstanceId != nil || decoded.rivalRank != nil)
+        )
+    }
+
+    /// 요약 RPC 실패 시 기존 테이블/RPC를 조합해 fallback 요약을 생성합니다.
+    /// - Parameter now: 서버 집계 기준 시각입니다.
+    /// - Returns: 퀘스트/라이벌 fallback 조합 결과 DTO입니다.
+    private func fetchFromFallback(now: Date) async throws -> QuestRivalWidgetSummaryDTO {
+        async let questSummary = fetchQuestFallback(now: now)
+        async let rivalSummary = fetchRivalFallback(now: now)
+        let quest = try await questSummary
+        let rival = try await rivalSummary
+
+        let questTarget = max(1.0, quest.targetValue)
+        let questProgress = max(0.0, quest.progressValue)
+        let questRatio = min(1.0, max(0.0, questProgress / questTarget))
+        let hasData = quest.instanceId != nil || rival.rank != nil
+
+        return QuestRivalWidgetSummaryDTO(
+            questInstanceId: quest.instanceId,
+            questTitle: quest.title,
+            questProgressValue: questProgress,
+            questTargetValue: questTarget,
+            questProgressRatio: questRatio,
+            questClaimable: quest.claimable,
+            questRewardPoint: quest.rewardPoint,
+            rivalRank: rival.rank,
+            rivalRankDelta: 0,
+            rivalLeague: rival.league,
+            refreshedAt: now.timeIntervalSince1970,
+            hasData: hasData
+        )
+    }
+
+    /// RPC 응답이 객체/배열 어느 형태든 단일 요약 객체로 파싱합니다.
+    /// - Parameter data: RPC 원시 응답 데이터입니다.
+    /// - Returns: 단일 요약 응답 DTO입니다.
+    private func decodeSummaryResponse(data: Data) throws -> ResponseDTO {
+        let decoder = JSONDecoder()
+        if let object = try? decoder.decode(ResponseDTO.self, from: data) {
+            return object
+        }
+        if let rows = try? decoder.decode([ResponseDTO].self, from: data),
+           let first = rows.first {
+            return first
+        }
+        throw SupabaseHTTPError.invalidResponse
+    }
+
+    /// 퀘스트 인스턴스 목록에서 위젯 표시용 대표 퀘스트를 추출합니다.
+    /// - Parameter now: 만료 판정 기준 시각입니다.
+    /// - Returns: 위젯 표시용 퀘스트 fallback 요약입니다.
+    private func fetchQuestFallback(now: Date) async throws -> QuestFallbackSummary {
+        let query = "select=id,title_snapshot,target_value_snapshot,progress_value,status,reward_points_snapshot,claimed_at,expires_at&status=in.(active,completed,claimed)&order=updated_at.desc&limit=30"
+        let data = try await client.request(
+            .rest(path: "quest_instances", query: query),
+            method: .get,
+            body: Optional<String>.none
+        )
+        let rows = try JSONDecoder().decode([QuestFallbackRowDTO].self, from: data)
+        let nowEpoch = now.timeIntervalSince1970
+        let validRows = rows.filter { row in
+            guard let expiresAt = SupabaseISO8601.parseEpoch(row.expiresAt) else { return true }
+            return expiresAt >= nowEpoch
+        }
+        let selected = selectQuestRow(from: validRows) ?? validRows.first
+        guard let selected else {
+            return QuestFallbackSummary(
+                instanceId: nil,
+                title: "오늘의 퀘스트를 준비 중입니다.",
+                progressValue: 0,
+                targetValue: 1,
+                claimable: false,
+                rewardPoint: 0
+            )
+        }
+        let status = (selected.status ?? "").lowercased()
+        let target = max(1.0, selected.targetValueSnapshot ?? 1.0)
+        let progress = max(0.0, selected.progressValue ?? 0.0)
+        let claimable = status == "completed" && selected.claimedAt == nil
+        return QuestFallbackSummary(
+            instanceId: selected.id?.canonicalUUIDString,
+            title: (selected.titleSnapshot ?? "").isEmpty
+                ? "오늘의 퀘스트를 준비 중입니다."
+                : (selected.titleSnapshot ?? ""),
+            progressValue: progress,
+            targetValue: target,
+            claimable: claimable,
+            rewardPoint: max(0, selected.rewardPointsSnapshot ?? 0)
+        )
+    }
+
+    /// 퀘스트 행 목록에서 보상 가능 퀘스트를 우선 선택합니다.
+    /// - Parameter rows: 서버에서 조회한 퀘스트 인스턴스 행 목록입니다.
+    /// - Returns: 위젯 카드에 우선 노출할 퀘스트 행입니다.
+    private func selectQuestRow(from rows: [QuestFallbackRowDTO]) -> QuestFallbackRowDTO? {
+        if let claimable = rows.first(where: { row in
+            ((row.status ?? "").lowercased() == "completed") && row.claimedAt == nil
+        }) {
+            return claimable
+        }
+        if let active = rows.first(where: { row in
+            (row.status ?? "").lowercased() == "active"
+        }) {
+            return active
+        }
+        return rows.first
+    }
+
+    /// 라이벌 리더보드에서 현재 사용자의 순위/리그를 fallback 요약으로 추출합니다.
+    /// - Parameter now: 집계 기준 시각입니다.
+    /// - Returns: 순위와 리그를 담은 fallback 요약입니다.
+    private func fetchRivalFallback(now: Date) async throws -> RivalFallbackSummary {
+        let payload: [String: Any] = [
+            "period_type": RivalLeaderboardPeriod.week.rawValue,
+            "top_n": 50,
+            "now_ts": ISO8601DateFormatter().string(from: now)
+        ]
+        let data = try await client.request(
+            .rest(path: "rpc/rpc_get_rival_leaderboard"),
+            method: .post,
+            bodyData: try JSONSerialization.data(withJSONObject: payload)
+        )
+        let rows = try JSONDecoder().decode([RivalFallbackRowDTO].self, from: data)
+        if let me = rows.first(where: { $0.isMe == true }) {
+            return RivalFallbackSummary(
+                rank: me.rankPosition,
+                league: me.effectiveLeague ?? "onboarding"
+            )
+        }
+        return RivalFallbackSummary(rank: nil, league: "onboarding")
+    }
+}
+
+final class DefaultQuestRivalWidgetSnapshotSyncService: QuestRivalWidgetSnapshotSyncing {
+    private let summaryService: QuestRivalWidgetSummaryServiceProtocol
+    private let snapshotStore: QuestRivalWidgetSnapshotStoring
+    private let userSessionStore: UserSessionStoreProtocol
+    private let preferenceStore: UserDefaults
+    private let syncTTL: TimeInterval
+    private let staleGraceInterval: TimeInterval
+    private let lastSyncKey = "quest.rival.widget.lastSyncAt.v1"
+    private let contextKeyStorageKey = "quest.rival.widget.context.v1"
+
+    /// 퀘스트/라이벌 위젯 스냅샷 동기화 서비스를 생성합니다.
+    /// - Parameters:
+    ///   - summaryService: 서버 요약 RPC 호출 서비스입니다.
+    ///   - snapshotStore: 앱 그룹 기반 위젯 스냅샷 저장소입니다.
+    ///   - userSessionStore: 현재 로그인 사용자/반려견 컨텍스트 조회 저장소입니다.
+    ///   - preferenceStore: 마지막 동기화 메타데이터를 저장할 기본 설정 저장소입니다.
+    ///   - syncTTL: RPC 재조회 최소 간격(초)입니다.
+    ///   - staleGraceInterval: 오프라인 캐시를 허용할 최대 유예 시간(초)입니다.
+    init(
+        summaryService: QuestRivalWidgetSummaryServiceProtocol = QuestRivalWidgetSummaryService(),
+        snapshotStore: QuestRivalWidgetSnapshotStoring = DefaultQuestRivalWidgetSnapshotStore.shared,
+        userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
+        preferenceStore: UserDefaults = .standard,
+        syncTTL: TimeInterval = 10 * 60,
+        staleGraceInterval: TimeInterval = 3 * 60 * 60
+    ) {
+        self.summaryService = summaryService
+        self.snapshotStore = snapshotStore
+        self.userSessionStore = userSessionStore
+        self.preferenceStore = preferenceStore
+        self.syncTTL = syncTTL
+        self.staleGraceInterval = staleGraceInterval
+    }
+
+    /// 서버 요약을 조회해 퀘스트/라이벌 위젯 공유 스냅샷을 갱신합니다.
+    /// - Parameters:
+    ///   - force: `true`면 TTL을 무시하고 즉시 갱신합니다.
+    ///   - now: TTL/상태 계산 기준 시각입니다.
+    func sync(force: Bool, now: Date) async {
+        let contextKey = resolveContextKey()
+        guard shouldSync(force: force, now: now, contextKey: contextKey) else { return }
+
+        guard let user = userSessionStore.currentUserInfo(),
+              user.id.isEmpty == false else {
+            saveGuestSnapshot(now: now)
+            return
+        }
+
+        do {
+            let summary = try await summaryService.fetchSummary(now: now)
+            saveMemberSnapshot(summary: summary, contextKey: contextKey, now: now)
+        } catch {
+            saveFailureSnapshot(contextKey: contextKey, now: now)
+        }
+    }
+
+    /// TTL/컨텍스트 변화를 기준으로 이번 동기화를 수행할지 판단합니다.
+    /// - Parameters:
+    ///   - force: `true`면 즉시 동기화합니다.
+    ///   - now: 판단 기준 시각입니다.
+    ///   - contextKey: 현재 로그인 사용자/반려견 컨텍스트 키입니다.
+    /// - Returns: 동기화가 필요하면 `true`, 스킵 가능하면 `false`입니다.
+    private func shouldSync(force: Bool, now: Date, contextKey: String) -> Bool {
+        if force { return true }
+        let snapshot = snapshotStore.load()
+        if snapshot.contextKey != contextKey {
+            return true
+        }
+        let age = now.timeIntervalSince1970 - snapshot.updatedAt
+        return age >= syncTTL
+    }
+
+    /// 현재 사용자/선택 반려견 조합으로 컨텍스트 식별 키를 생성합니다.
+    /// - Returns: 다계정/다견 전환 감지를 위한 컨텍스트 키 문자열입니다.
+    private func resolveContextKey() -> String {
+        guard let user = userSessionStore.currentUserInfo(),
+              user.id.isEmpty == false else {
+            return "guest"
+        }
+        let selectedPet = userSessionStore.selectedPet(from: user)
+        let petId = selectedPet?.petId.lowercased() ?? "none"
+        return "\(user.id.lowercased())|\(petId)"
+    }
+
+    /// 비회원 상태 스냅샷을 저장합니다.
+    /// - Parameter now: 저장 시각입니다.
+    private func saveGuestSnapshot(now: Date) {
+        save(
+            QuestRivalWidgetSnapshot(
+                status: .guestLocked,
+                message: "로그인 후 퀘스트 진행률과 라이벌 순위를 위젯에서 확인할 수 있어요.",
+                summary: nil,
+                contextKey: "guest",
+                updatedAt: now.timeIntervalSince1970
+            ),
+            now: now
+        )
+    }
+
+    /// 서버 요약 응답을 회원 상태 스냅샷으로 저장합니다.
+    /// - Parameters:
+    ///   - summary: 서버에서 조회한 최신 퀘스트/라이벌 요약 DTO입니다.
+    ///   - contextKey: 사용자/반려견 컨텍스트 키입니다.
+    ///   - now: 저장 시각입니다.
+    private func saveMemberSnapshot(summary: QuestRivalWidgetSummaryDTO, contextKey: String, now: Date) {
+        let status: QuestRivalWidgetSnapshotStatus = summary.hasData ? .memberReady : .emptyData
+        let rankDelta = resolveRankDelta(currentRank: summary.rivalRank, contextKey: contextKey)
+        let snapshot = QuestRivalWidgetSnapshot(
+            status: status,
+            message: summary.hasData
+                ? "퀘스트 진행률과 라이벌 순위를 최신 기준으로 표시합니다."
+                : "표시할 퀘스트/라이벌 데이터가 아직 없습니다.",
+            summary: QuestRivalWidgetSummarySnapshot(
+                questInstanceId: summary.questInstanceId,
+                questTitle: summary.questTitle,
+                questProgressValue: summary.questProgressValue,
+                questTargetValue: summary.questTargetValue,
+                questProgressRatio: summary.questProgressRatio,
+                questClaimable: summary.questClaimable,
+                questRewardPoint: summary.questRewardPoint,
+                rivalRank: summary.rivalRank,
+                rivalRankDelta: rankDelta,
+                rivalLeague: summary.rivalLeague,
+                refreshedAt: summary.refreshedAt
+            ),
+            contextKey: contextKey,
+            updatedAt: now.timeIntervalSince1970
+        )
+        save(snapshot, now: now)
+    }
+
+    /// 서버 조회 실패 시 마지막 성공 스냅샷 기반 상태로 저장합니다.
+    /// - Parameters:
+    ///   - contextKey: 사용자/반려견 컨텍스트 키입니다.
+    ///   - now: 저장 시각입니다.
+    private func saveFailureSnapshot(contextKey: String, now: Date) {
+        let current = snapshotStore.load()
+        guard current.contextKey == contextKey,
+              let cachedSummary = current.summary else {
+            save(
+                QuestRivalWidgetSnapshot(
+                    status: .syncDelayed,
+                    message: "위젯 요약 동기화가 지연되고 있어요. 앱을 열어 최신화해주세요.",
+                    summary: nil,
+                    contextKey: contextKey,
+                    updatedAt: now.timeIntervalSince1970
+                ),
+                now: now
+            )
+            return
+        }
+
+        let cacheAge = now.timeIntervalSince1970 - cachedSummary.refreshedAt
+        let status: QuestRivalWidgetSnapshotStatus = cacheAge <= staleGraceInterval ? .offlineCached : .syncDelayed
+        let message: String = cacheAge <= staleGraceInterval
+            ? "오프라인 상태예요. 마지막 성공 스냅샷을 표시 중입니다."
+            : "동기화가 지연되고 있어요. 앱을 열어 최신화해주세요."
+        save(
+            QuestRivalWidgetSnapshot(
+                status: status,
+                message: message,
+                summary: cachedSummary,
+                contextKey: contextKey,
+                updatedAt: now.timeIntervalSince1970
+            ),
+            now: now
+        )
+    }
+
+    /// 현재 랭크와 이전 저장 랭크를 비교해 순위 변화량을 계산합니다.
+    /// - Parameters:
+    ///   - currentRank: 이번 동기화에서 조회한 현재 랭크입니다.
+    ///   - contextKey: 사용자/반려견 컨텍스트 키입니다.
+    /// - Returns: 이전 랭크 대비 상승(+)/하락(-) 변화량입니다.
+    private func resolveRankDelta(currentRank: Int?, contextKey: String) -> Int {
+        let storageKey = "quest.rival.widget.lastRank.v1.\(contextKey)"
+        defer {
+            if let currentRank {
+                preferenceStore.set(currentRank, forKey: storageKey)
+            } else {
+                preferenceStore.removeObject(forKey: storageKey)
+            }
+        }
+        guard let currentRank else { return 0 }
+        guard preferenceStore.object(forKey: storageKey) != nil else { return 0 }
+        let previousRank = preferenceStore.integer(forKey: storageKey)
+        return previousRank - currentRank
+    }
+
+    /// 위젯 스냅샷 저장 후 재로딩을 요청하고 마지막 동기화 시각을 기록합니다.
+    /// - Parameters:
+    ///   - snapshot: 저장할 퀘스트/라이벌 위젯 스냅샷입니다.
+    ///   - now: 마지막 동기화 시각 기록 기준입니다.
+    private func save(_ snapshot: QuestRivalWidgetSnapshot, now: Date) {
+        snapshotStore.save(snapshot)
+        preferenceStore.set(now.timeIntervalSince1970, forKey: lastSyncKey)
+        preferenceStore.set(snapshot.contextKey, forKey: contextKeyStorageKey)
+        reloadQuestRivalWidgetTimeline()
+    }
+
+    /// WidgetKit 타임라인을 즉시 재요청해 최신 스냅샷이 반영되도록 합니다.
+    private func reloadQuestRivalWidgetTimeline() {
+        #if canImport(WidgetKit)
+        WidgetCenter.shared.reloadTimelines(ofKind: WalkWidgetBridgeContract.questRivalWidgetKind)
+        #endif
     }
 }
 

--- a/dogArea/Source/WidgetBridge/WalkWidgetBridge.swift
+++ b/dogArea/Source/WidgetBridge/WalkWidgetBridge.swift
@@ -8,6 +8,8 @@ enum WalkWidgetBridgeContract {
     static let territoryWidgetKind = "com.th.dogArea.territory-status"
     static let hotspotSnapshotStorageKey = "hotspot.widget.snapshot.v1"
     static let hotspotWidgetKind = "com.th.dogArea.hotspot-status"
+    static let questRivalSnapshotStorageKey = "quest.rival.widget.snapshot.v1"
+    static let questRivalWidgetKind = "com.th.dogArea.quest-rival-status"
     static let actionRequestStorageKey = "walk.widget.action.request.v1"
     static let deepLinkScheme = "dogarea"
     static let deepLinkHost = "widget"
@@ -15,11 +17,14 @@ enum WalkWidgetBridgeContract {
     static let deepLinkActionQueryName = "action"
     static let deepLinkActionIdQueryName = "action_id"
     static let deepLinkSourceQueryName = "source"
+    static let deepLinkContextQueryName = "context_id"
 }
 
 enum WalkWidgetActionKind: String, Codable, CaseIterable {
     case startWalk = "start_walk"
     case endWalk = "end_walk"
+    case claimQuestReward = "claim_quest_reward"
+    case openRivalTab = "open_rival_tab"
 
     var deepLinkValue: String {
         rawValue
@@ -30,6 +35,7 @@ struct WalkWidgetActionRoute: Equatable {
     let kind: WalkWidgetActionKind
     let actionId: String
     let source: String
+    let contextId: String?
 
     /// 위젯 액션 라우트를 앱 딥링크 URL로 직렬화합니다.
     /// - Returns: 앱 라우팅에 사용할 `dogarea://widget/walk?...` URL입니다.
@@ -38,7 +44,7 @@ struct WalkWidgetActionRoute: Equatable {
         components.scheme = WalkWidgetBridgeContract.deepLinkScheme
         components.host = WalkWidgetBridgeContract.deepLinkHost
         components.path = WalkWidgetBridgeContract.deepLinkPath
-        components.queryItems = [
+        var queryItems: [URLQueryItem] = [
             URLQueryItem(
                 name: WalkWidgetBridgeContract.deepLinkActionQueryName,
                 value: kind.deepLinkValue
@@ -52,6 +58,16 @@ struct WalkWidgetActionRoute: Equatable {
                 value: source
             )
         ]
+        if let contextId,
+           contextId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            queryItems.append(
+                URLQueryItem(
+                    name: WalkWidgetBridgeContract.deepLinkContextQueryName,
+                    value: contextId
+                )
+            )
+        }
+        components.queryItems = queryItems
         return components.url
     }
 
@@ -82,7 +98,9 @@ struct WalkWidgetActionRoute: Equatable {
             .flatMap { $0.isEmpty ? nil : $0 } ?? UUID().uuidString.lowercased()
         let source = queryByName[WalkWidgetBridgeContract.deepLinkSourceQueryName]
             .flatMap { $0.isEmpty ? nil : $0 } ?? "widget"
-        return .init(kind: kind, actionId: actionId, source: source)
+        let contextId = queryByName[WalkWidgetBridgeContract.deepLinkContextQueryName]
+            .flatMap { $0.isEmpty ? nil : $0 }
+        return .init(kind: kind, actionId: actionId, source: source, contextId: contextId)
     }
 }
 
@@ -90,12 +108,13 @@ struct WalkWidgetActionRequest: Codable, Equatable {
     let kind: WalkWidgetActionKind
     let actionId: String
     let source: String
+    let contextId: String?
     let requestedAt: TimeInterval
 
     /// 저장 요청 모델을 화면 라우팅 모델로 변환합니다.
     /// - Returns: 앱 내부 액션 적용용 라우트입니다.
     func asRoute() -> WalkWidgetActionRoute {
-        .init(kind: kind, actionId: actionId, source: source)
+        .init(kind: kind, actionId: actionId, source: source, contextId: contextId)
     }
 }
 

--- a/dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift
+++ b/dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift
@@ -120,6 +120,61 @@ struct HotspotWidgetSnapshot: Codable, Equatable {
     )
 }
 
+enum QuestRivalWidgetSnapshotStatus: String, Codable {
+    case memberReady = "member_ready"
+    case guestLocked = "guest_locked"
+    case emptyData = "empty_data"
+    case offlineCached = "offline_cached"
+    case syncDelayed = "sync_delayed"
+    case claimInFlight = "claim_in_flight"
+    case claimFailed = "claim_failed"
+    case claimSucceeded = "claim_succeeded"
+}
+
+struct QuestRivalWidgetSummarySnapshot: Codable, Equatable {
+    let questInstanceId: String?
+    let questTitle: String
+    let questProgressValue: Double
+    let questTargetValue: Double
+    let questProgressRatio: Double
+    let questClaimable: Bool
+    let questRewardPoint: Int
+    let rivalRank: Int?
+    let rivalRankDelta: Int
+    let rivalLeague: String
+    let refreshedAt: TimeInterval
+
+    static let zero = QuestRivalWidgetSummarySnapshot(
+        questInstanceId: nil,
+        questTitle: "오늘의 퀘스트를 준비 중입니다.",
+        questProgressValue: 0,
+        questTargetValue: 1,
+        questProgressRatio: 0,
+        questClaimable: false,
+        questRewardPoint: 0,
+        rivalRank: nil,
+        rivalRankDelta: 0,
+        rivalLeague: "onboarding",
+        refreshedAt: Date().timeIntervalSince1970
+    )
+}
+
+struct QuestRivalWidgetSnapshot: Codable, Equatable {
+    let status: QuestRivalWidgetSnapshotStatus
+    let message: String
+    let summary: QuestRivalWidgetSummarySnapshot?
+    let contextKey: String
+    let updatedAt: TimeInterval
+
+    static let initial = QuestRivalWidgetSnapshot(
+        status: .guestLocked,
+        message: "로그인 후 퀘스트 진행률과 라이벌 지표를 위젯에서 확인할 수 있어요.",
+        summary: nil,
+        contextKey: "guest",
+        updatedAt: Date().timeIntervalSince1970
+    )
+}
+
 enum WalkLiveActivityAutoEndStage: String, Codable, Equatable, Hashable {
     case active = "active"
     case restCandidate = "rest_candidate"
@@ -341,6 +396,55 @@ final class DefaultHotspotWidgetSnapshotStore: HotspotWidgetSnapshotStoring {
     func save(_ snapshot: HotspotWidgetSnapshot) {
         guard let data = try? encoder.encode(snapshot) else { return }
         storage.set(data, forKey: WalkWidgetBridgeContract.hotspotSnapshotStorageKey)
+    }
+
+    /// App Group 저장소를 우선 사용하고, 실패 시 표준 저장소를 반환합니다.
+    /// - Returns: 위젯과 앱 간 공유 가능한 UserDefaults 인스턴스입니다.
+    private static func resolveStorage() -> UserDefaults {
+        UserDefaults(suiteName: WalkWidgetBridgeContract.appGroupIdentifier) ?? .standard
+    }
+}
+
+protocol QuestRivalWidgetSnapshotStoring {
+    /// 퀘스트/라이벌 위젯 스냅샷을 조회합니다.
+    /// - Returns: 저장된 스냅샷이 있으면 해당 값, 없으면 기본 스냅샷을 반환합니다.
+    func load() -> QuestRivalWidgetSnapshot
+
+    /// 퀘스트/라이벌 위젯 스냅샷을 저장합니다.
+    /// - Parameter snapshot: 위젯 표시용으로 직렬화할 최신 퀘스트/라이벌 스냅샷입니다.
+    func save(_ snapshot: QuestRivalWidgetSnapshot)
+}
+
+final class DefaultQuestRivalWidgetSnapshotStore: QuestRivalWidgetSnapshotStoring {
+    static let shared = DefaultQuestRivalWidgetSnapshotStore()
+
+    private let storage: UserDefaults
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    /// 퀘스트/라이벌 위젯 스냅샷 저장소를 초기화합니다.
+    /// - Parameter storage: 스냅샷 직렬화 데이터를 저장할 UserDefaults입니다.
+    init(storage: UserDefaults = DefaultQuestRivalWidgetSnapshotStore.resolveStorage()) {
+        self.storage = storage
+    }
+
+    /// 퀘스트/라이벌 위젯 스냅샷을 조회합니다.
+    /// - Returns: 저장된 스냅샷이 있으면 해당 값, 없으면 기본 스냅샷을 반환합니다.
+    func load() -> QuestRivalWidgetSnapshot {
+        guard
+            let data = storage.data(forKey: WalkWidgetBridgeContract.questRivalSnapshotStorageKey),
+            let decoded = try? decoder.decode(QuestRivalWidgetSnapshot.self, from: data)
+        else {
+            return .initial
+        }
+        return decoded
+    }
+
+    /// 퀘스트/라이벌 위젯 스냅샷을 저장합니다.
+    /// - Parameter snapshot: 위젯 표시용으로 직렬화할 최신 퀘스트/라이벌 스냅샷입니다.
+    func save(_ snapshot: QuestRivalWidgetSnapshot) {
+        guard let data = try? encoder.encode(snapshot) else { return }
+        storage.set(data, forKey: WalkWidgetBridgeContract.questRivalSnapshotStorageKey)
     }
 
     /// App Group 저장소를 우선 사용하고, 실패 시 표준 저장소를 반환합니다.

--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 #if canImport(UIKit)
 import UIKit
 #endif
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
 
 struct RootView: View {
     @Environment(\.managedObjectContext) private var viewContext
@@ -22,6 +25,9 @@ struct RootView: View {
     private let widgetActionStore: WalkWidgetActionRequestStoring = DefaultWalkWidgetActionRequestStore.shared
     private let territoryWidgetSnapshotSyncService: TerritoryWidgetSnapshotSyncing = DefaultTerritoryWidgetSnapshotSyncService()
     private let hotspotWidgetSnapshotSyncService: HotspotWidgetSnapshotSyncing = DefaultHotspotWidgetSnapshotSyncService()
+    private let questRivalWidgetSnapshotSyncService: QuestRivalWidgetSnapshotSyncing = DefaultQuestRivalWidgetSnapshotSyncService()
+    private let questRewardClaimService: QuestRewardClaimServiceProtocol = QuestRewardClaimService()
+    private let questRivalSnapshotStore: QuestRivalWidgetSnapshotStoring = DefaultQuestRivalWidgetSnapshotStore.shared
     private var homeView: HomeView
     private var walkListView: WalkListView    
     private var mapView: MapView
@@ -100,11 +106,18 @@ struct RootView: View {
                 consumePendingWidgetActionIfNeeded()
                 syncTerritoryWidgetSnapshot(force: true)
                 syncHotspotWidgetSnapshot(force: true)
+                syncQuestRivalWidgetSnapshot(force: true)
             }
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                 consumePendingWidgetActionIfNeeded()
                 syncTerritoryWidgetSnapshot(force: false)
                 syncHotspotWidgetSnapshot(force: false)
+                syncQuestRivalWidgetSnapshot(force: false)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UserdefaultSetting.selectedPetDidChangeNotification)) { _ in
+                syncTerritoryWidgetSnapshot(force: true)
+                syncHotspotWidgetSnapshot(force: true)
+                syncQuestRivalWidgetSnapshot(force: true)
             }
             .onOpenURL { url in
                 routeWidgetDeepLinkIfNeeded(url)
@@ -168,9 +181,23 @@ struct RootView: View {
         dispatchWidgetAction(request.asRoute())
     }
 
-    /// 위젯 액션 라우트를 지도 탭으로 전달합니다.
-    /// - Parameter route: 지도 화면에서 처리할 위젯 액션 라우트입니다.
+    /// 위젯 액션 라우트를 종류에 맞는 탭/서비스로 전달합니다.
+    /// - Parameter route: 앱 내부에서 처리할 위젯 액션 라우트입니다.
     private func dispatchWidgetAction(_ route: WalkWidgetActionRoute) {
+        switch route.kind {
+        case .startWalk, .endWalk:
+            dispatchWalkWidgetAction(route)
+        case .openRivalTab:
+            selectedTab = 3
+        case .claimQuestReward:
+            selectedTab = 0
+            handleQuestRewardClaimFromWidget(route)
+        }
+    }
+
+    /// 산책 관련 위젯 액션을 지도 탭으로 전달합니다.
+    /// - Parameter route: 지도 화면에서 처리할 위젯 액션 라우트입니다.
+    private func dispatchWalkWidgetAction(_ route: WalkWidgetActionRoute) {
         selectedTab = 2
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             NotificationCenter.default.post(
@@ -179,10 +206,87 @@ struct RootView: View {
                 userInfo: [
                     "kind": route.kind.rawValue,
                     "actionId": route.actionId,
-                    "source": route.source
+                    "source": route.source,
+                    "contextId": route.contextId as Any
                 ]
             )
         }
+    }
+
+    /// 위젯 보상 수령 액션을 멱등 요청으로 처리하고 스냅샷 상태를 갱신합니다.
+    /// - Parameter route: 보상 수령 대상 퀘스트 식별자를 포함한 액션 라우트입니다.
+    private func handleQuestRewardClaimFromWidget(_ route: WalkWidgetActionRoute) {
+        let snapshot = questRivalSnapshotStore.load()
+        let targetQuestId = route.contextId ?? snapshot.summary?.questInstanceId
+        guard let questInstanceId = targetQuestId?.canonicalUUIDString else {
+            syncQuestRivalWidgetSnapshot(force: true)
+            return
+        }
+
+        let inFlight = QuestRivalWidgetSnapshot(
+            status: .claimInFlight,
+            message: "보상 수령 요청을 처리 중입니다.",
+            summary: snapshot.summary,
+            contextKey: snapshot.contextKey,
+            updatedAt: Date().timeIntervalSince1970
+        )
+        saveQuestRivalWidgetSnapshot(inFlight)
+
+        Task(priority: .userInitiated) {
+            do {
+                let claim = try await questRewardClaimService.claimReward(
+                    questInstanceId: questInstanceId,
+                    requestId: route.actionId,
+                    now: Date()
+                )
+                let latest = questRivalSnapshotStore.load()
+                let updatedSummary = latest.summary.map { summary in
+                    QuestRivalWidgetSummarySnapshot(
+                        questInstanceId: summary.questInstanceId,
+                        questTitle: summary.questTitle,
+                        questProgressValue: summary.questProgressValue,
+                        questTargetValue: summary.questTargetValue,
+                        questProgressRatio: summary.questProgressRatio,
+                        questClaimable: false,
+                        questRewardPoint: claim.rewardPoints,
+                        rivalRank: summary.rivalRank,
+                        rivalRankDelta: summary.rivalRankDelta,
+                        rivalLeague: summary.rivalLeague,
+                        refreshedAt: Date().timeIntervalSince1970
+                    )
+                }
+                let successSnapshot = QuestRivalWidgetSnapshot(
+                    status: .claimSucceeded,
+                    message: claim.alreadyClaimed
+                        ? "이미 수령 처리된 보상입니다."
+                        : "보상 \(claim.rewardPoints)pt 수령 완료!",
+                    summary: updatedSummary,
+                    contextKey: latest.contextKey,
+                    updatedAt: Date().timeIntervalSince1970
+                )
+                saveQuestRivalWidgetSnapshot(successSnapshot)
+            } catch {
+                let latest = questRivalSnapshotStore.load()
+                let failedSnapshot = QuestRivalWidgetSnapshot(
+                    status: .claimFailed,
+                    message: "보상 수령에 실패했어요. 앱에서 다시 시도해주세요.",
+                    summary: latest.summary,
+                    contextKey: latest.contextKey,
+                    updatedAt: Date().timeIntervalSince1970
+                )
+                saveQuestRivalWidgetSnapshot(failedSnapshot)
+            }
+            await questRivalWidgetSnapshotSyncService.sync(force: true, now: Date())
+        }
+    }
+
+    /// 퀘스트/라이벌 스냅샷을 저장하고 WidgetKit 타임라인을 즉시 재요청합니다.
+    /// - Parameter snapshot: 저장할 퀘스트/라이벌 위젯 스냅샷입니다.
+    private func saveQuestRivalWidgetSnapshot(_ snapshot: QuestRivalWidgetSnapshot) {
+        questRivalSnapshotStore.save(snapshot)
+        #if canImport(WidgetKit)
+        WidgetCenter.shared.reloadTimelines(ofKind: WalkWidgetBridgeContract.questRivalWidgetKind)
+        #endif
     }
 
     /// 앱 생명주기 진입 시 영역 위젯 스냅샷 동기화를 요청합니다.
@@ -198,6 +302,14 @@ struct RootView: View {
     private func syncHotspotWidgetSnapshot(force: Bool) {
         Task(priority: .utility) {
             await hotspotWidgetSnapshotSyncService.sync(force: force, now: Date())
+        }
+    }
+
+    /// 앱 생명주기 진입 시 퀘스트/라이벌 위젯 스냅샷 동기화를 요청합니다.
+    /// - Parameter force: `true`면 TTL을 무시하고 즉시 동기화합니다.
+    private func syncQuestRivalWidgetSnapshot(force: Bool) {
+        Task(priority: .utility) {
+            await questRivalWidgetSnapshotSyncService.sync(force: force, now: Date())
         }
     }
 }

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -216,7 +216,12 @@ struct MapView : View{
                 let actionId = notification.userInfo?["actionId"] as? String
             else { return }
             let source = (notification.userInfo?["source"] as? String) ?? "widget"
-            let route = WalkWidgetActionRoute(kind: kind, actionId: actionId, source: source)
+            let route = WalkWidgetActionRoute(
+                kind: kind,
+                actionId: actionId,
+                source: source,
+                contextId: notification.userInfo?["contextId"] as? String
+            )
             viewModel.applyWidgetWalkAction(route)
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -1995,6 +1995,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             )
             syncWalkWidgetSnapshot(force: true)
             syncWalkLiveActivity(force: true)
+
+        case .claimQuestReward, .openRivalTab:
+            metricTracker.track(
+                .widgetActionRejected,
+                userKey: currentMetricUserId(),
+                payload: ["action": route.kind.rawValue, "reason": "unsupported_on_map"]
+            )
         }
     }
 

--- a/dogAreaWidgetExtension/WalkControlIntents.swift
+++ b/dogAreaWidgetExtension/WalkControlIntents.swift
@@ -19,6 +19,7 @@ struct StartWalkIntent: AppIntent {
             kind: kind,
             actionId: UUID().uuidString.lowercased(),
             source: "widget_intent",
+            contextId: nil,
             requestedAt: Date().timeIntervalSince1970
         )
         DefaultWalkWidgetActionRequestStore.shared.setPending(route)
@@ -57,6 +58,7 @@ struct EndWalkIntent: AppIntent {
             kind: kind,
             actionId: UUID().uuidString.lowercased(),
             source: "widget_intent",
+            contextId: nil,
             requestedAt: Date().timeIntervalSince1970
         )
         DefaultWalkWidgetActionRequestStore.shared.setPending(route)
@@ -73,6 +75,61 @@ struct EndWalkIntent: AppIntent {
                 updatedAt: Date().timeIntervalSince1970
             )
         )
+        return .result()
+    }
+}
+
+struct ClaimQuestRewardIntent: AppIntent {
+    static var title: LocalizedStringResource = "퀘스트 보상 받기"
+    static var openAppWhenRun: Bool = true
+
+    /// 위젯에서 퀘스트 보상 수령 액션을 앱 공유 저장소에 기록합니다.
+    /// - Returns: 앱 실행 후 소비할 요청을 기록한 인텐트 결과입니다.
+    func perform() async throws -> some IntentResult {
+        let snapshotStore = DefaultQuestRivalWidgetSnapshotStore.shared
+        let current = snapshotStore.load()
+        let questInstanceId = current.summary?.questInstanceId
+        let route = WalkWidgetActionRequest(
+            kind: .claimQuestReward,
+            actionId: UUID().uuidString.lowercased(),
+            source: "widget_intent",
+            contextId: questInstanceId,
+            requestedAt: Date().timeIntervalSince1970
+        )
+        DefaultWalkWidgetActionRequestStore.shared.setPending(route)
+
+        let status: QuestRivalWidgetSnapshotStatus = questInstanceId == nil ? .emptyData : .claimInFlight
+        let message: String = questInstanceId == nil
+            ? "수령 가능한 보상을 찾지 못했어요."
+            : "앱에서 보상 수령을 처리 중입니다."
+        snapshotStore.save(
+            QuestRivalWidgetSnapshot(
+                status: status,
+                message: message,
+                summary: current.summary,
+                contextKey: current.contextKey,
+                updatedAt: Date().timeIntervalSince1970
+            )
+        )
+        return .result()
+    }
+}
+
+struct OpenRivalTabIntent: AppIntent {
+    static var title: LocalizedStringResource = "라이벌 열기"
+    static var openAppWhenRun: Bool = true
+
+    /// 위젯에서 라이벌 탭 열기 액션을 앱 공유 저장소에 기록합니다.
+    /// - Returns: 앱 실행 후 소비할 요청을 기록한 인텐트 결과입니다.
+    func perform() async throws -> some IntentResult {
+        let route = WalkWidgetActionRequest(
+            kind: .openRivalTab,
+            actionId: UUID().uuidString.lowercased(),
+            source: "widget_intent",
+            contextId: nil,
+            requestedAt: Date().timeIntervalSince1970
+        )
+        DefaultWalkWidgetActionRequestStore.shared.setPending(route)
         return .result()
     }
 }

--- a/dogAreaWidgetExtension/WalkControlWidget.swift
+++ b/dogAreaWidgetExtension/WalkControlWidget.swift
@@ -633,6 +633,305 @@ struct HotspotStatusWidget: Widget {
     }
 }
 
+struct QuestRivalStatusTimelineEntry: TimelineEntry {
+    let date: Date
+    let snapshot: QuestRivalWidgetSnapshot
+}
+
+struct QuestRivalStatusTimelineProvider: TimelineProvider {
+    private let snapshotStore: QuestRivalWidgetSnapshotStoring
+
+    /// 퀘스트/라이벌 위젯 타임라인 제공자를 생성합니다.
+    /// - Parameter snapshotStore: 앱과 공유하는 퀘스트/라이벌 스냅샷 저장소입니다.
+    init(snapshotStore: QuestRivalWidgetSnapshotStoring = DefaultQuestRivalWidgetSnapshotStore.shared) {
+        self.snapshotStore = snapshotStore
+    }
+
+    /// 위젯 갤러리 플레이스홀더 엔트리를 반환합니다.
+    /// - Parameter context: 위젯 미리보기 컨텍스트입니다.
+    /// - Returns: 기본 퀘스트/라이벌 스냅샷을 포함한 엔트리입니다.
+    func placeholder(in context: Context) -> QuestRivalStatusTimelineEntry {
+        .init(date: Date(), snapshot: .initial)
+    }
+
+    /// 시스템 스냅샷 요청에 현재 저장된 퀘스트/라이벌 스냅샷을 전달합니다.
+    /// - Parameters:
+    ///   - context: 스냅샷 요청 컨텍스트입니다.
+    ///   - completion: 생성한 엔트리를 전달하는 콜백입니다.
+    func getSnapshot(in context: Context, completion: @escaping (QuestRivalStatusTimelineEntry) -> Void) {
+        completion(.init(date: Date(), snapshot: snapshotStore.load()))
+    }
+
+    /// 현재 공유 저장소 기준 타임라인을 생성합니다.
+    /// - Parameters:
+    ///   - context: 타임라인 생성 컨텍스트입니다.
+    ///   - completion: 생성된 타임라인을 전달하는 콜백입니다.
+    func getTimeline(in context: Context, completion: @escaping (Timeline<QuestRivalStatusTimelineEntry>) -> Void) {
+        let now = Date()
+        let entry = QuestRivalStatusTimelineEntry(date: now, snapshot: snapshotStore.load())
+        completion(Timeline(entries: [entry], policy: .after(now.addingTimeInterval(10 * 60))))
+    }
+}
+
+struct QuestRivalStatusWidgetEntryView: View {
+    @Environment(\.widgetFamily) private var family
+
+    let entry: QuestRivalStatusTimelineEntry
+
+    var body: some View {
+        Group {
+            switch entry.snapshot.status {
+            case .guestLocked:
+                guestContent
+            case .emptyData:
+                emptyContent
+            case .memberReady, .offlineCached, .syncDelayed, .claimInFlight, .claimFailed, .claimSucceeded:
+                dataContent
+            }
+        }
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+
+    private var guestContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            badge(title: "비회원", color: .orange.opacity(0.2))
+            Text("퀘스트/라이벌 위젯")
+                .font(.headline)
+            Text("로그인 후 오늘의 퀘스트 진행률과 라이벌 순위를 빠르게 확인할 수 있어요.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+            Spacer(minLength: 2)
+            Text("앱에서 로그인")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.orange)
+        }
+    }
+
+    private var emptyContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            badge(title: "준비 중", color: .blue.opacity(0.18))
+            Text("퀘스트 데이터를 준비 중입니다")
+                .font(.headline)
+                .lineLimit(2)
+            Text(entry.snapshot.message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+            Spacer(minLength: 2)
+            Button(intent: OpenRivalTabIntent()) {
+                Label("라이벌 열기", systemImage: "person.3.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private var dataContent: some View {
+        let summary = entry.snapshot.summary ?? .zero
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                badge(title: statusBadgeTitle, color: statusBadgeColor)
+                Spacer(minLength: 0)
+                Text(updatedAtText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if family == .systemSmall {
+                smallBody(summary: summary)
+            } else {
+                mediumBody(summary: summary)
+            }
+
+            Text(entry.snapshot.message)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+    }
+
+    /// 소형 위젯 본문을 렌더링합니다.
+    /// - Parameter summary: 퀘스트/라이벌 요약 스냅샷입니다.
+    /// - Returns: 퀘스트 진행과 라이벌 순위를 담은 소형 본문 뷰입니다.
+    private func smallBody(summary: QuestRivalWidgetSummarySnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(summary.questTitle)
+                .font(.caption)
+                .lineLimit(2)
+            ProgressView(value: summary.questProgressRatio)
+                .tint(.orange)
+            HStack {
+                Text(questProgressText(summary))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 6)
+                Text(rivalRankText(summary))
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            if summary.questClaimable, summary.questInstanceId != nil {
+                Button(intent: ClaimQuestRewardIntent()) {
+                    Label("보상 받기", systemImage: "gift.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.orange)
+            } else {
+                Button(intent: OpenRivalTabIntent()) {
+                    Label("라이벌", systemImage: "person.3.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+
+    /// 중형 위젯 본문을 렌더링합니다.
+    /// - Parameter summary: 퀘스트/라이벌 요약 스냅샷입니다.
+    /// - Returns: 퀘스트 진행 메트릭과 액션 버튼을 담은 중형 본문 뷰입니다.
+    private func mediumBody(summary: QuestRivalWidgetSummarySnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("오늘의 퀘스트")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(summary.questTitle)
+                        .font(.headline)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 8)
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("라이벌")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(rivalRankText(summary))
+                        .font(.headline)
+                }
+            }
+            ProgressView(value: summary.questProgressRatio)
+                .tint(.orange)
+            HStack {
+                Text(questProgressText(summary))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                if summary.rivalRankDelta != 0 {
+                    Text("변화 \(summary.rivalRankDelta > 0 ? "+" : "")\(summary.rivalRankDelta)")
+                        .font(.caption2)
+                        .foregroundStyle(summary.rivalRankDelta > 0 ? .green : .orange)
+                }
+            }
+            HStack(spacing: 8) {
+                Button(intent: ClaimQuestRewardIntent()) {
+                    Label("보상 받기", systemImage: "gift.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.orange)
+                .disabled(summary.questClaimable == false || summary.questInstanceId == nil)
+
+                Button(intent: OpenRivalTabIntent()) {
+                    Label("라이벌", systemImage: "person.3.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+
+    /// 퀘스트 진행값을 `현재/목표` 문자열로 변환합니다.
+    /// - Parameter summary: 퀘스트 진행 요약을 포함한 스냅샷입니다.
+    /// - Returns: 위젯 표시용 진행값 문자열입니다.
+    private func questProgressText(_ summary: QuestRivalWidgetSummarySnapshot) -> String {
+        let current = Int(summary.questProgressValue.rounded(.down))
+        let target = max(1, Int(summary.questTargetValue.rounded(.up)))
+        return "진행 \(current)/\(target)"
+    }
+
+    /// 라이벌 순위 텍스트를 생성합니다.
+    /// - Parameter summary: 라이벌 요약을 포함한 스냅샷입니다.
+    /// - Returns: 위젯 표시용 순위 문자열입니다.
+    private func rivalRankText(_ summary: QuestRivalWidgetSummarySnapshot) -> String {
+        guard let rank = summary.rivalRank else { return "순위 - (\(summary.rivalLeague))" }
+        return "#\(rank) (\(summary.rivalLeague))"
+    }
+
+    private var updatedAtText: String {
+        if let refreshedAt = entry.snapshot.summary?.refreshedAt {
+            return "업데이트 \(TerritoryStatusWidgetEntryView.formattedTime(timestamp: refreshedAt))"
+        }
+        return "업데이트 -"
+    }
+
+    private var statusBadgeTitle: String {
+        switch entry.snapshot.status {
+        case .memberReady:
+            return "실시간"
+        case .offlineCached:
+            return "오프라인"
+        case .syncDelayed:
+            return "지연"
+        case .claimInFlight:
+            return "수령 중"
+        case .claimFailed:
+            return "수령 실패"
+        case .claimSucceeded:
+            return "수령 완료"
+        case .guestLocked:
+            return "비회원"
+        case .emptyData:
+            return "준비 중"
+        }
+    }
+
+    private var statusBadgeColor: Color {
+        switch entry.snapshot.status {
+        case .memberReady, .claimSucceeded:
+            return .green.opacity(0.20)
+        case .offlineCached:
+            return .orange.opacity(0.20)
+        case .syncDelayed, .claimFailed:
+            return .red.opacity(0.18)
+        case .claimInFlight:
+            return .blue.opacity(0.18)
+        case .guestLocked:
+            return .orange.opacity(0.20)
+        case .emptyData:
+            return .blue.opacity(0.18)
+        }
+    }
+
+    /// 상태 배지를 렌더링합니다.
+    /// - Parameters:
+    ///   - title: 배지에 표시할 상태 텍스트입니다.
+    ///   - color: 배지 배경 색상입니다.
+    /// - Returns: 캡슐 형태의 상태 배지 뷰입니다.
+    private func badge(title: String, color: Color) -> some View {
+        Text(title)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color)
+            .clipShape(Capsule())
+    }
+}
+
+struct QuestRivalStatusWidget: Widget {
+    private let kind = WalkWidgetBridgeContract.questRivalWidgetKind
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: QuestRivalStatusTimelineProvider()) { entry in
+            QuestRivalStatusWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("퀘스트/라이벌 상태")
+        .description("오늘의 퀘스트 진행률과 보상, 라이벌 순위를 빠르게 확인합니다.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
 #if canImport(ActivityKit)
 @available(iOSApplicationExtension 16.1, *)
 private struct WalkLiveActivityView: View {
@@ -642,7 +941,8 @@ private struct WalkLiveActivityView: View {
         WalkWidgetActionRoute(
             kind: .endWalk,
             actionId: "live.end.\(Int(Date().timeIntervalSince1970))",
-            source: "live_activity"
+            source: "live_activity",
+            contextId: nil
         ).makeURL()
     }
 
@@ -650,7 +950,8 @@ private struct WalkLiveActivityView: View {
         WalkWidgetActionRoute(
             kind: .startWalk,
             actionId: "live.open.\(Int(Date().timeIntervalSince1970))",
-            source: "live_activity"
+            source: "live_activity",
+            contextId: nil
         ).makeURL()
     }
 

--- a/dogAreaWidgetExtension/WalkControlWidgetBundle.swift
+++ b/dogAreaWidgetExtension/WalkControlWidgetBundle.swift
@@ -8,6 +8,7 @@ struct WalkControlWidgetBundle: WidgetBundle {
         WalkControlWidget()
         TerritoryStatusWidget()
         HotspotStatusWidget()
+        QuestRivalStatusWidget()
         if #available(iOSApplicationExtension 16.1, *) {
             WalkLiveActivityWidget()
         }

--- a/supabase/migrations/20260303203000_widget_quest_rival_summary_rpc.sql
+++ b/supabase/migrations/20260303203000_widget_quest_rival_summary_rpc.sql
@@ -1,0 +1,78 @@
+-- #219 widget quest/rival combined summary rpc
+
+create or replace function public.rpc_get_widget_quest_rival_summary(
+  in_now_ts timestamptz default now()
+)
+returns table (
+  quest_instance_id uuid,
+  quest_title text,
+  quest_progress_value double precision,
+  quest_target_value double precision,
+  quest_claimable boolean,
+  quest_reward_point integer,
+  rival_rank integer,
+  rival_league text,
+  refreshed_at timestamptz,
+  has_data boolean
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  requester_uid uuid;
+  quest_row record;
+  rival_row record;
+begin
+  requester_uid := auth.uid();
+  if requester_uid is null then
+    return;
+  end if;
+
+  select
+    qi.id,
+    qi.title_snapshot,
+    qi.progress_value,
+    qi.target_value_snapshot,
+    (qi.status = 'completed' and qi.claimed_at is null) as claimable,
+    qi.reward_points_snapshot
+  into quest_row
+  from public.quest_instances qi
+  where qi.owner_user_id = requester_uid
+    and qi.status in ('active', 'completed', 'claimed')
+    and qi.expires_at >= in_now_ts - interval '1 day'
+  order by
+    case
+      when qi.status = 'completed' and qi.claimed_at is null then 0
+      when qi.status = 'active' then 1
+      when qi.status = 'claimed' then 2
+      else 3
+    end,
+    qi.updated_at desc
+  limit 1;
+
+  select
+    r.rank_position,
+    r.effective_league
+  into rival_row
+  from public.rpc_get_rival_leaderboard('week', 50, in_now_ts) r
+  where r.is_me = true
+  limit 1;
+
+  return query
+  select
+    quest_row.id::uuid,
+    coalesce(quest_row.title_snapshot::text, '오늘의 퀘스트를 준비 중입니다.'),
+    coalesce(quest_row.progress_value::double precision, 0::double precision),
+    greatest(coalesce(quest_row.target_value_snapshot::double precision, 1::double precision), 1::double precision),
+    coalesce(quest_row.claimable::boolean, false),
+    greatest(coalesce(quest_row.reward_points_snapshot::integer, 0), 0),
+    rival_row.rank_position::integer,
+    coalesce(rival_row.effective_league::text, 'onboarding'),
+    in_now_ts,
+    (quest_row.id is not null or rival_row.rank_position is not null);
+end;
+$$;
+
+revoke all on function public.rpc_get_widget_quest_rival_summary(timestamptz) from public;
+grant execute on function public.rpc_get_widget_quest_rival_summary(timestamptz) to authenticated, service_role;


### PR DESCRIPTION
## Summary
- add Quest/Rival widget snapshot domain and app-group store with new widget kind
- add Quest/Rival widget UI and interactive intents (claim reward, open rival tab)
- extend widget bridge action routing with context_id and new action kinds
- add root routing for claim/open-rival with idempotent claim handling via quest-engine
- add Supabase infrastructure services for quest-rival summary sync (server-first + fallback)
- add migration for rpc_get_widget_quest_rival_summary
- sync widget snapshots on app active and pet-context change

## Test
- xcodebuild -project dogArea.xcodeproj -scheme dogAreaWidgetExtension -configuration Debug -destination generic/platform=iOS Simulator CODE_SIGNING_ALLOWED=NO -derivedDataPath build/DerivedDataCodex build -quiet
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh
- bash scripts/run_design_audit_ui_tests.sh (started, interrupted due long simulator package rebuild in this environment)

## Issue
- closes #219