### PR TITLE
[Bug][Map][UX] 영역 추가 카메라 축척 점프 제거 (#232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - Cycle #206 결과 보고서(2026-03-03): `docs/cycle-206-game-layer-observability-qa-report-2026-03-03.md`
 - Cycle #214 결과 보고서(2026-03-03): `docs/cycle-214-widget-epic-closure-report-2026-03-03.md`
 - Cycle #218 결과 보고서(2026-03-03): `docs/cycle-218-hotspot-widget-privacy-report-2026-03-03.md`
+- Cycle #232 결과 보고서(2026-03-03): `docs/cycle-232-map-camera-jump-fix-report-2026-03-03.md`
 - Cycle #147 결과 보고서(2026-02-27): `docs/cycle-147-pet-adaptive-quest-report-2026-02-27.md`
 - Cycle #145 결과 보고서(2026-02-27): `docs/cycle-145-season-catchup-buff-report-2026-02-27.md`
 - Cycle #124 결과 보고서(2026-02-27): `docs/cycle-124-season-policy-report-2026-02-27.md`

--- a/docs/cycle-232-map-camera-jump-fix-report-2026-03-03.md
+++ b/docs/cycle-232-map-camera-jump-fix-report-2026-03-03.md
@@ -1,0 +1,51 @@
+# Cycle #232 지도 카메라 축척 점프 수정 리포트 (2026-03-03)
+
+- 이슈: #232 `[Bug][Map][UX] 영역 추가 시 카메라 축척 점프 제거(줌/중심 고정)`
+- 브랜치: `codex/issue-232-camera-jump-fix`
+- 목적: 포인트 추가 시 지도 카메라가 임의로 추적 모드로 전환되어 축척/중심이 점프하는 문제를 제거한다.
+
+## 1. 변경 요약
+
+1. `+` 포인트 추가 버튼에서 `setTrackingMode()` 호출 제거
+2. 내 위치 버튼에서만 추적 모드 전환하도록 역할 분리
+3. 포인트 추가 전 카메라 스냅샷 저장 + 추가 후 점프 감지 시 복원
+4. 지도 카메라 변경 원인 로깅 추가(수동 이동/내 위치 버튼/시스템 fallback)
+
+## 2. 파일 변경
+
+- `dogArea/Views/MapView/MapView.swift`
+  - 내 위치 버튼 액션을 `handleLocationButtonTap()`으로 변경
+  - `+` 버튼에서 카메라 스냅샷 준비 후 포인트 추가 알림 호출
+  - `onMapCameraChange`에서 카메라 변경 이벤트를 ViewModel 로깅 경로로 전달
+- `dogArea/Views/MapView/MapViewModel.swift`
+  - `CameraChangeReason` 분기 추가
+  - `recordCameraChange`, `handleLocationButtonTap`, `preparePointAddCameraSnapshot`, `addLocationPreservingCamera` 구현
+  - `setTrackingMode`/`setRegion`에 reason 전달 경로 추가
+- `dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift`
+  - 포인트 확정 액션을 `addLocationPreservingCamera()`로 교체
+- `scripts/map_camera_jump_fix_unit_check.swift`
+  - 회귀 방지 정적 검증 스크립트 추가
+- `scripts/ios_pr_check.sh`
+  - 신규 체크 스크립트를 기본 PR 검증에 연결
+
+## 3. 수용 기준 매핑
+
+1. 포인트 추가 직후 카메라 급격 점프 제거
+- `+` 버튼에서 추적 모드 전환 제거 + 카메라 복원 경로 추가로 충족
+
+2. 포인트 추가 시 축척/중심 유지
+- 포인트 추가 전 카메라 스냅샷 저장 후 편차 발생 시 즉시 복원
+
+3. `내 위치 보기`에서만 추적 모드 복귀
+- 버튼 액션을 전용 핸들러로 분리해 추적 모드 전환 지점을 단일화
+
+4. 연속 추가 상황 회귀 방지
+- `map_camera_jump_fix_unit_check` 추가 + `ios_pr_check` 편입
+
+## 4. 검증
+
+1. `swift scripts/map_camera_jump_fix_unit_check.swift`
+2. `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
+3. `bash scripts/ios_pr_check.sh`
+
+참고: 사용자 요청에 따라 디자인 스크린샷 테스트(`run_design_audit_ui_tests.sh`)는 실행하지 않았다.

--- a/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
@@ -18,7 +18,7 @@ struct MapAlertSubView: View {
         ca = CustomAlert(presentAlert: $myAlert.isAlert,
                          alertModel: myAlert.alertType.model,
                          leftButtonAction: {
-          viewModel.addLocation()
+          viewModel.addLocationPreservingCamera()
         },rightButtonAction: {
 //            print("right")
         })

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -97,9 +97,8 @@ struct MapView : View{
                 
                 if viewModel.isWalking {
                     HStack {
-                        if isCameraSeeingSomewhere,
-                           let loc = viewModel.location{
-                            Button(action: {viewModel.setRegion(loc,distance: 2000)}, label: {Text("내 위치 보기")})
+                        if isCameraSeeingSomewhere, viewModel.location != nil {
+                            Button(action: { viewModel.handleLocationButtonTap() }, label: {Text("내 위치 보기")})
                                 .buttonStyle(.borderedProminent)
                                 .padding(.leading)
                         }
@@ -108,9 +107,8 @@ struct MapView : View{
                     }
                 } else {
                     HStack {
-                        if isCameraSeeingSomewhere,
-                           let loc = viewModel.location{
-                            Button(action: {viewModel.setRegion(loc,distance: 2000)}, label: {Text("내 위치 보기")})
+                        if isCameraSeeingSomewhere, viewModel.location != nil {
+                            Button(action: { viewModel.handleLocationButtonTap() }, label: {Text("내 위치 보기")})
                                 .buttonStyle(.borderedProminent)
                                 .padding(.leading)
                         }
@@ -250,13 +248,16 @@ struct MapView : View{
             WalkListDetailView(model: model)
         })
         .onMapCameraChange{ context in
+            viewModel.recordCameraChange(context.camera)
             if let loc = viewModel.location {
                 self.isCameraSeeingSomewhere =  context.camera.centerCoordinate.clLocation.distance(from: loc) > 300
-                if !viewModel.showOnlyOne {
-                    if Int(context.camera.distance) != Int(self.distance) {
-                        self.distance = context.camera.distance
-                        viewModel.updateAnnotations(cameraDistance: context.camera.distance)
-                    }
+            } else {
+                self.isCameraSeeingSomewhere = false
+            }
+            if !viewModel.showOnlyOne {
+                if Int(context.camera.distance) != Int(self.distance) {
+                    self.distance = context.camera.distance
+                    viewModel.updateAnnotations(cameraDistance: context.camera.distance)
                 }
             }
         }
@@ -460,7 +461,7 @@ struct MapView : View{
                     .cornerRadius(6)
             }
             Button {
-                viewModel.setTrackingMode()
+                viewModel.preparePointAddCameraSnapshot()
                 myAlert.alertType = .addPoint
                 myAlert.callAlert(type: .addPoint)
             } label: {

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -196,6 +196,12 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         }
     }
 
+    enum CameraChangeReason: String {
+        case manualMove = "manual_move"
+        case locationButton = "location_button"
+        case systemFallback = "system_fallback"
+    }
+
     private struct ActiveWalkPointSnapshot: Codable {
         let latitude: Double
         let longitude: Double
@@ -213,6 +219,11 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         let lastMovementAt: TimeInterval?
         let points: [ActiveWalkPointSnapshot]
         let savedAt: TimeInterval
+    }
+
+    private struct CameraSnapshot {
+        let centerCoordinate: CLLocationCoordinate2D
+        let distance: Double
     }
 
     private enum MapOverlayLODTuning {
@@ -338,6 +349,15 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private var pendingRecoverableSession: ActiveWalkSessionSnapshot?
     private var lifecycleObservers: [NSObjectProtocol] = []
     private var lastAcceptedWalkLocation: CLLocation?
+    private var pendingCameraChangeReason: CameraChangeReason?
+    private var pendingCameraReasonSetAt: Date = .distantPast
+    private let pendingCameraReasonTTL: TimeInterval = 2.0
+    private var lastLoggedCameraCenter: CLLocationCoordinate2D?
+    private var lastLoggedCameraDistance: Double?
+    private var lastLoggedCameraReason: CameraChangeReason?
+    private let cameraLogCenterThreshold: CLLocationDistance = 40.0
+    private let cameraLogDistanceThreshold: Double = 120.0
+    private var pendingPointAddCameraSnapshot: CameraSnapshot?
     private var lastSyncFlushAt: Date = .distantPast
     private var lastSyncSummarySnapshot: SyncOutboxSummary? = nil
     private var lastWidgetSnapshotSyncAt: Date = .distantPast
@@ -554,6 +574,20 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     func addLocation(){
         guard let location = self.location else { return }
         appendWalkPoint(from: location, recordedAt: Date(), source: .manual)
+    }
+
+    /// 수동 포인트 추가 전에 현재 카메라 중심/거리 상태를 저장합니다.
+    func preparePointAddCameraSnapshot() {
+        pendingPointAddCameraSnapshot = CameraSnapshot(
+            centerCoordinate: camera.centerCoordinate,
+            distance: max(120.0, camera.distance)
+        )
+    }
+
+    /// 수동 포인트를 추가한 뒤 필요 시 저장된 카메라 상태를 복원합니다.
+    func addLocationPreservingCamera() {
+        addLocation()
+        restorePointAddCameraSnapshotIfNeeded()
     }
     func removeLocation(_ locationID : UUID){
         if polygon.locations.firstIndex(where:{ $0.id == locationID}) != nil {
@@ -1403,17 +1437,115 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
 
         appendWalkPoint(from: location, recordedAt: now, source: .auto)
     }
-    func setTrackingMode() {
+    /// 지도 카메라를 내 위치 추적 모드로 전환합니다.
+    /// - Parameter reason: 추적 전환을 유발한 원인입니다. 전달 시 카메라 변경 로그 원인으로 사용됩니다.
+    func setTrackingMode(reason: CameraChangeReason? = nil) {
+        if let reason {
+            markPendingCameraChangeReason(reason)
+        }
         guard let location = self.location else {
-            withAnimation(.easeInOut(duration: 0.3)){ [weak self] in
-                self?.cameraPosition = MapCameraPosition.userLocation(followsHeading: true, fallback: .automatic)
+            markPendingCameraChangeReason(.systemFallback)
+            withAnimation(.easeInOut(duration: 0.3)) { [weak self] in
+                self?.cameraPosition = MapCameraPosition.userLocation(
+                    followsHeading: true,
+                    fallback: .automatic
+                )
             }
-            return }
-        withAnimation(.easeInOut(duration: 0.3)){ [weak self] in
-            self?.cameraPosition = MapCameraPosition.userLocation(followsHeading: true, fallback: MapCameraPosition.camera(.init(centerCoordinate: location.coordinate, distance: 2000)))
+            return
+        }
+        withAnimation(.easeInOut(duration: 0.3)) { [weak self] in
+            self?.cameraPosition = MapCameraPosition.userLocation(
+                followsHeading: true,
+                fallback: MapCameraPosition.camera(.init(centerCoordinate: location.coordinate, distance: 2000))
+            )
+        }
+    }
+
+    /// 사용자의 `내 위치 보기` 요청을 지도 추적 모드 전환으로 처리합니다.
+    func handleLocationButtonTap() {
+        setTrackingMode(reason: .locationButton)
+    }
+
+    /// 지도 카메라 변경 이벤트를 기록하고 원인별 디버그 로그를 남깁니다.
+    /// - Parameters:
+    ///   - camera: 현재 지도 카메라 상태입니다.
+    ///   - now: 로그 판정 기준 시각입니다.
+    func recordCameraChange(_ camera: MapCamera, now: Date = Date()) {
+        self.camera = camera
+        let reason = resolveCameraChangeReason(now: now)
+        guard shouldLogCameraChange(camera, reason: reason) else { return }
+        #if DEBUG
+        let latitude = String(format: "%.5f", camera.centerCoordinate.latitude)
+        let longitude = String(format: "%.5f", camera.centerCoordinate.longitude)
+        print(
+            "map camera change: reason=\(reason.rawValue) distance=\(Int(camera.distance)) center=(\(latitude),\(longitude))"
+        )
+        #endif
+        lastLoggedCameraCenter = camera.centerCoordinate
+        lastLoggedCameraDistance = camera.distance
+        lastLoggedCameraReason = reason
+    }
+
+    /// 수동 포인트 추가 후 카메라가 점프했을 때 직전 스냅샷으로 복원합니다.
+    private func restorePointAddCameraSnapshotIfNeeded() {
+        guard let snapshot = pendingPointAddCameraSnapshot else { return }
+        defer { pendingPointAddCameraSnapshot = nil }
+
+        let currentCenter = CLLocation(
+            latitude: camera.centerCoordinate.latitude,
+            longitude: camera.centerCoordinate.longitude
+        )
+        let preservedCenter = CLLocation(
+            latitude: snapshot.centerCoordinate.latitude,
+            longitude: snapshot.centerCoordinate.longitude
+        )
+        let centerDelta = currentCenter.distance(from: preservedCenter)
+        let distanceDelta = abs(camera.distance - snapshot.distance)
+        guard centerDelta > 15 || distanceDelta > 15 else { return }
+
+        setRegion(snapshot.centerCoordinate, distance: snapshot.distance, reason: .systemFallback)
+    }
+
+    /// 다음 카메라 변경 이벤트에 적용할 원인을 저장합니다.
+    /// - Parameter reason: 카메라 변경 원인입니다.
+    private func markPendingCameraChangeReason(_ reason: CameraChangeReason) {
+        pendingCameraChangeReason = reason
+        pendingCameraReasonSetAt = Date()
+    }
+
+    /// 저장된 카메라 변경 원인을 해석해 반환합니다.
+    /// - Parameter now: 원인 유효 시간 판정 기준 시각입니다.
+    /// - Returns: 저장된 원인이 유효하면 해당 값, 아니면 `.manualMove`입니다.
+    private func resolveCameraChangeReason(now: Date) -> CameraChangeReason {
+        guard let reason = pendingCameraChangeReason else { return .manualMove }
+        defer { pendingCameraChangeReason = nil }
+        if now.timeIntervalSince(pendingCameraReasonSetAt) > pendingCameraReasonTTL {
+            return .manualMove
+        }
+        return reason
+    }
+
+    /// 카메라 로그를 남길지 여부를 이전 로그 상태와 비교해 판단합니다.
+    /// - Parameters:
+    ///   - camera: 현재 지도 카메라 상태입니다.
+    ///   - reason: 이번 변경 원인입니다.
+    /// - Returns: 임계치를 넘는 변경이거나 원인이 바뀌었으면 `true`입니다.
+    private func shouldLogCameraChange(_ camera: MapCamera, reason: CameraChangeReason) -> Bool {
+        guard let lastCenter = lastLoggedCameraCenter,
+              let lastDistance = lastLoggedCameraDistance,
+              let lastReason = lastLoggedCameraReason else {
+            return true
         }
 
+        if lastReason != reason { return true }
+
+        let previous = CLLocation(latitude: lastCenter.latitude, longitude: lastCenter.longitude)
+        let current = CLLocation(latitude: camera.centerCoordinate.latitude, longitude: camera.centerCoordinate.longitude)
+        let centerDelta = current.distance(from: previous)
+        let distanceDelta = abs(camera.distance - lastDistance)
+        return centerDelta >= cameraLogCenterThreshold || distanceDelta >= cameraLogDistanceThreshold
     }
+
     private func forceQuit() {
         endWalk(reason: .autoTimeout)
         walkStatusMessage = "최대 산책 시간 도달로 자동 종료했습니다."
@@ -2437,25 +2569,34 @@ extension MapViewModel {
         }
     }
 
-    func setRegion(_ location : CLLocation?, distance: Double = 2000){
+    /// 위치 객체를 기준으로 지도의 중심/축척을 설정합니다.
+    /// - Parameters:
+    ///   - location: 중심으로 이동할 위치 객체입니다.
+    ///   - distance: 카메라 거리(미터)입니다.
+    ///   - reason: 카메라 변경 원인 로그에 사용할 선택값입니다.
+    func setRegion(_ location : CLLocation?, distance: Double = 2000, reason: CameraChangeReason? = nil){
         guard let coordinate=location?.coordinate else {return}
+        if let reason {
+            markPendingCameraChangeReason(reason)
+        }
         withAnimation(.easeInOut(duration: 0.3)){
             cameraPosition = MapCameraPosition.camera(.init(centerCoordinate: coordinate, distance: distance))
         }
     }
-    func setRegion(_ coordination : CLLocationCoordinate2D?, distance: Double = 2000){
+    /// 좌표를 기준으로 지도의 중심/축척을 설정합니다.
+    /// - Parameters:
+    ///   - coordination: 중심으로 이동할 좌표입니다.
+    ///   - distance: 카메라 거리(미터)입니다.
+    ///   - reason: 카메라 변경 원인 로그에 사용할 선택값입니다.
+    func setRegion(_ coordination : CLLocationCoordinate2D?, distance: Double = 2000, reason: CameraChangeReason? = nil){
         guard let coordinate=coordination else {return}
+        if let reason {
+            markPendingCameraChangeReason(reason)
+        }
         withAnimation(.easeInOut(duration: 0.3)){
             cameraPosition = MapCameraPosition.camera(.init(centerCoordinate: coordinate, distance: distance))
         }
     }
-    private func seeCurrentLocation(){
-        guard let location = self.location else {
-            cameraPosition = MapCameraPosition.userLocation(followsHeading: true, fallback: .automatic)
-            return }
-        cameraPosition = MapCameraPosition.userLocation(followsHeading: true, fallback: MapCameraPosition.camera(.init(centerCoordinate: location.coordinate, distance: 2000)))
-    }
-
 }
 //MARK: - 클러스터링 관련 내용
 extension MapViewModel {

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -62,6 +62,7 @@ swift scripts/presentation_firebase_boundary_unit_check.swift
 swift scripts/supabase_profile_image_upload_unit_check.swift
 swift scripts/auth_session_autologin_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
+swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 

--- a/scripts/map_camera_jump_fix_unit_check.swift
+++ b/scripts/map_camera_jump_fix_unit_check.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let mapView = load("dogArea/Views/MapView/MapView.swift")
+let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
+let mapAlertSubView = load("dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift")
+
+assertTrue(mapView.contains("viewModel.preparePointAddCameraSnapshot()"), "MapView add-point action should prepare camera snapshot")
+assertTrue(!mapView.contains("viewModel.setTrackingMode()\n                myAlert.alertType = .addPoint"), "MapView add-point action should not switch tracking mode directly")
+assertTrue(mapView.contains("viewModel.handleLocationButtonTap()"), "MapView current-location button should delegate to tracking handler")
+assertTrue(mapView.contains("viewModel.recordCameraChange(context.camera)"), "MapView should forward camera change events for reason logging")
+
+assertTrue(mapAlertSubView.contains("viewModel.addLocationPreservingCamera()"), "MapAlertSubView should preserve camera while adding point")
+
+assertTrue(mapViewModel.contains("enum CameraChangeReason"), "MapViewModel should define camera change reason enum")
+assertTrue(mapViewModel.contains("case manualMove = \"manual_move\""), "MapViewModel should log manual move reason")
+assertTrue(mapViewModel.contains("case locationButton = \"location_button\""), "MapViewModel should log location button reason")
+assertTrue(mapViewModel.contains("case systemFallback = \"system_fallback\""), "MapViewModel should log system fallback reason")
+assertTrue(mapViewModel.contains("func handleLocationButtonTap()"), "MapViewModel should expose current-location handler")
+assertTrue(mapViewModel.contains("func recordCameraChange(_ camera: MapCamera"), "MapViewModel should expose camera logging entrypoint")
+assertTrue(mapViewModel.contains("map camera change: reason="), "MapViewModel should print camera change reason log")
+assertTrue(mapViewModel.contains("func addLocationPreservingCamera()"), "MapViewModel should support point-add with camera preservation")
+assertTrue(mapViewModel.contains("func setTrackingMode(reason: CameraChangeReason? = nil)"), "MapViewModel setTrackingMode should accept explicit reason")
+assertTrue(mapViewModel.contains("func setRegion(_ location : CLLocation?, distance: Double = 2000, reason: CameraChangeReason? = nil)"), "MapViewModel location setRegion should accept reason")
+
+print("PASS: map camera jump fix unit checks")


### PR DESCRIPTION
## 요약
- `+` 포인트 추가 액션에서 추적 모드 전환을 제거해 카메라 점프를 차단했습니다.
- 내 위치 버튼에서만 추적 모드 전환이 일어나도록 역할을 분리했습니다.
- 포인트 추가 전 카메라 스냅샷을 저장하고, 추가 직후 점프가 감지되면 중심/거리 복원을 수행합니다.
- 카메라 변경 원인 로그(수동 이동/내 위치 버튼/시스템 fallback)를 추가했습니다.

## 변경 파일
- `dogArea/Views/MapView/MapView.swift`
- `dogArea/Views/MapView/MapViewModel.swift`
- `dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift`
- `scripts/map_camera_jump_fix_unit_check.swift`
- `scripts/ios_pr_check.sh`
- `docs/cycle-232-map-camera-jump-fix-report-2026-03-03.md`
- `README.md`

## 검증
- `swift scripts/map_camera_jump_fix_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
- `bash scripts/ios_pr_check.sh` (`BUILD SUCCEEDED`)

## 비고
- 사용자 요청에 따라 디자인 스크린샷 테스트(`run_design_audit_ui_tests.sh`)는 실행하지 않았습니다.

Closes #232
