### PR TITLE
feat(metrics): add game-layer KPI 7d dashboard view

### DIFF
--- a/docs/game-layer-observability-qa-v1.md
+++ b/docs/game-layer-observability-qa-v1.md
@@ -55,6 +55,19 @@
 - `weather_feedback_submitted` 24h 급감(평균 대비 50% 이하): 피드백 파이프라인 경보(P2)
 - `sync_auth_refresh_failure_rate_24h > 0.03`: 인증 세션 경보(P1)
 
+### 4.3 단일 조회 뷰(운영/QA 공통)
+- `public.view_game_layer_kpis_7d`
+- 집계 기간:
+  - `quest_*`, `season_*`, `rival_*`, `weather_*` 지표는 최근 7일
+  - `sync_auth_refresh_failure_rate_24h`는 최근 24시간
+- 산식:
+  - `quest_completion_rate_7d = quest_reward_claimed / quest_progress_applied`
+  - `quest_claim_duplicate_rate_7d = quest_claim_duplicate_blocked / (quest_reward_claimed + quest_claim_duplicate_blocked)`
+  - `season_participation_rate_7d = season_participated_users / game_layer_active_users`
+  - `rival_opt_in_rate_7d = rival_opt_in_users / rival_touched_users`
+  - `weather_replacement_acceptance_rate_7d = weather_replacement_applied / (weather_replacement_applied + weather_shield_consumed)`
+  - `sync_auth_refresh_failure_rate_24h = sync_auth_refresh_failed / (sync_auth_refresh_failed + sync_auth_refresh_succeeded)`
+
 ## 5. QA 시나리오 게이트
 ### 5.1 공통 E2E
 1. 로그인(이메일) 후 앱 재실행 시 자동 로그인 유지 확인
@@ -71,7 +84,7 @@
 ## 6. 운영 런북 연결
 - 마이그레이션/운영 SQL: `docs/supabase-migration.md`
 - 릴리즈 회귀 게이트: `docs/release-regression-checklist-v1.md`
-- 에픽 추적: `#123`, 실행 태스크: `#206`
+- 에픽 추적: `#123`, 실행 태스크: `#206`, `#247`
 
 ## 7. 변경 관리
 - 본 문서 변경 시 `scripts/game_layer_observability_qa_unit_check.swift`를 함께 갱신한다.

--- a/docs/supabase-schema-v1.md
+++ b/docs/supabase-schema-v1.md
@@ -278,6 +278,18 @@ erDiagram
 - 운영 관측:
   - `view_season_batch_status_14d`
 
+### 4.12 게임 레이어 KPI 대시보드(7d/24h)
+- `view_game_layer_kpis_7d`
+  - 최근 7일 KPI:
+    - `quest_completion_rate_7d`
+    - `quest_claim_duplicate_rate_7d`
+    - `season_participation_rate_7d`
+    - `rival_opt_in_rate_7d`
+    - `weather_replacement_acceptance_rate_7d`
+  - 최근 24시간 KPI:
+    - `sync_auth_refresh_failure_rate_24h`
+  - 운영/QA에서 단일 뷰 조회로 릴리즈 게이트 지표를 확인
+
 ## 5. RLS 정책 원칙
 - 사용자 데이터는 `auth.uid()` 소유 범위로만 접근
 - `area_references`는 읽기 공개(`anon`, `authenticated`)
@@ -314,6 +326,8 @@ erDiagram
   - `select`: 소유자
   - write: 서비스 경로(RPC/service role)
 - `view_weather_feedback_kpis_7d`
+  - `select`: 공개(운영 관측용)
+- `view_game_layer_kpis_7d`
   - `select`: 공개(운영 관측용)
 - `weather_replacement_runtime_policies`, `weather_replacement_mappings`
   - `select`: 공개(정책/매핑 조회)

--- a/scripts/game_layer_kpi_dashboard_unit_check.swift
+++ b/scripts/game_layer_kpi_dashboard_unit_check.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// 조건이 거짓일 때 stderr 출력 후 실패 코드로 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 불리언 조건입니다.
+///   - message: 실패 시 출력할 메시지입니다.
+/// - Returns: 없음. 실패 시 프로세스를 종료합니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 상대 경로의 UTF-8 텍스트를 로드합니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: 파일 문자열 본문입니다.
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+struct GameLayerKPIInput {
+    let questProgressApplied: Double
+    let questRewardClaimed: Double
+    let questClaimDuplicateBlocked: Double
+    let seasonParticipatedUsers: Double
+    let gameLayerActiveUsers: Double
+    let rivalOptInUsers: Double
+    let rivalTouchedUsers: Double
+    let weatherReplacementApplied: Double
+    let weatherReplacementOffer: Double
+    let syncAuthRefreshFailed: Double
+    let syncAuthRefreshTotal: Double
+}
+
+/// 게임 레이어 KPI 비율을 산출합니다.
+/// - Parameter input: KPI 집계 입력값입니다.
+/// - Returns: KPI 비율 튜플입니다.
+func computeRates(_ input: GameLayerKPIInput) -> (
+    questCompletion: Double?,
+    questDuplicate: Double?,
+    seasonParticipation: Double?,
+    rivalOptIn: Double?,
+    weatherAcceptance: Double?,
+    syncAuthRefreshFailure: Double?
+) {
+    let questCompletion = input.questProgressApplied == 0
+        ? nil
+        : input.questRewardClaimed / input.questProgressApplied
+
+    let questClaimTotal = input.questRewardClaimed + input.questClaimDuplicateBlocked
+    let questDuplicate = questClaimTotal == 0
+        ? nil
+        : input.questClaimDuplicateBlocked / questClaimTotal
+
+    let seasonParticipation = input.gameLayerActiveUsers == 0
+        ? nil
+        : input.seasonParticipatedUsers / input.gameLayerActiveUsers
+
+    let rivalOptIn = input.rivalTouchedUsers == 0
+        ? nil
+        : input.rivalOptInUsers / input.rivalTouchedUsers
+
+    let weatherAcceptance = input.weatherReplacementOffer == 0
+        ? nil
+        : input.weatherReplacementApplied / input.weatherReplacementOffer
+
+    let syncAuthRefreshFailure = input.syncAuthRefreshTotal == 0
+        ? nil
+        : input.syncAuthRefreshFailed / input.syncAuthRefreshTotal
+
+    return (
+        questCompletion,
+        questDuplicate,
+        seasonParticipation,
+        rivalOptIn,
+        weatherAcceptance,
+        syncAuthRefreshFailure
+    )
+}
+
+let migration = load("supabase/migrations/20260303194000_game_layer_kpi_dashboard_view.sql")
+let observabilitySpec = load("docs/game-layer-observability-qa-v1.md")
+let schemaSpec = load("docs/supabase-schema-v1.md")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(migration.contains("create or replace view public.view_game_layer_kpis_7d"), "migration should create view_game_layer_kpis_7d")
+assertTrue(migration.contains("quest_completion_rate_7d"), "migration should expose quest completion KPI")
+assertTrue(migration.contains("quest_claim_duplicate_rate_7d"), "migration should expose quest duplicate KPI")
+assertTrue(migration.contains("season_participation_rate_7d"), "migration should expose season participation KPI")
+assertTrue(migration.contains("rival_opt_in_rate_7d"), "migration should expose rival opt-in KPI")
+assertTrue(migration.contains("weather_replacement_acceptance_rate_7d"), "migration should expose weather acceptance KPI")
+assertTrue(migration.contains("sync_auth_refresh_failure_rate_24h"), "migration should expose sync auth refresh KPI")
+assertTrue(migration.contains("grant select on public.view_game_layer_kpis_7d to anon, authenticated;"), "migration should grant select on KPI view")
+
+assertTrue(observabilitySpec.contains("view_game_layer_kpis_7d"), "observability spec should reference KPI dashboard view")
+assertTrue(observabilitySpec.contains("weather_replacement_acceptance_rate_7d"), "observability spec should describe weather acceptance KPI")
+assertTrue(schemaSpec.contains("view_game_layer_kpis_7d"), "schema spec should include KPI dashboard view")
+assertTrue(prCheck.contains("scripts/game_layer_kpi_dashboard_unit_check.swift"), "ios_pr_check should include KPI dashboard unit check")
+
+let rates = computeRates(.init(
+    questProgressApplied: 120,
+    questRewardClaimed: 48,
+    questClaimDuplicateBlocked: 2,
+    seasonParticipatedUsers: 36,
+    gameLayerActiveUsers: 100,
+    rivalOptInUsers: 26,
+    rivalTouchedUsers: 100,
+    weatherReplacementApplied: 44,
+    weatherReplacementOffer: 100,
+    syncAuthRefreshFailed: 1,
+    syncAuthRefreshTotal: 200
+))
+
+assertTrue(abs((rates.questCompletion ?? 0) - 0.4) < 0.0001, "quest completion rate formula")
+assertTrue(abs((rates.questDuplicate ?? 0) - 0.04) < 0.0001, "quest duplicate rate formula")
+assertTrue(abs((rates.seasonParticipation ?? 0) - 0.36) < 0.0001, "season participation rate formula")
+assertTrue(abs((rates.rivalOptIn ?? 0) - 0.26) < 0.0001, "rival opt-in rate formula")
+assertTrue(abs((rates.weatherAcceptance ?? 0) - 0.44) < 0.0001, "weather acceptance rate formula")
+assertTrue(abs((rates.syncAuthRefreshFailure ?? 0) - 0.005) < 0.0001, "sync auth refresh failure rate formula")
+
+print("PASS: game layer KPI dashboard unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -33,6 +33,7 @@ swift scripts/quest_stage2_engine_unit_check.swift
 swift scripts/season_motion_pack_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift
 swift scripts/game_layer_observability_qa_unit_check.swift
+swift scripts/game_layer_kpi_dashboard_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift
 swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift

--- a/supabase/migrations/20260303194000_game_layer_kpi_dashboard_view.sql
+++ b/supabase/migrations/20260303194000_game_layer_kpi_dashboard_view.sql
@@ -1,0 +1,97 @@
+-- #247 game-layer 7d KPI dashboard view
+
+create or replace view public.view_game_layer_kpis_7d as
+with metrics_7d as (
+  select
+    event_name,
+    coalesce(nullif(user_key, ''), nullif(app_instance_id, '')) as actor_key
+  from public.app_metric_events
+  where created_at >= now() - interval '7 days'
+),
+metrics_24h as (
+  select event_name
+  from public.app_metric_events
+  where created_at >= now() - interval '24 hours'
+),
+agg_7d as (
+  select
+    count(*) filter (where event_name = 'quest_progress_applied')::double precision as quest_progress_applied_count,
+    count(*) filter (where event_name = 'quest_reward_claimed')::double precision as quest_reward_claimed_count,
+    count(*) filter (where event_name = 'quest_claim_duplicate_blocked')::double precision as quest_claim_duplicate_blocked_count,
+    count(distinct actor_key) filter (
+      where actor_key is not null and event_name = 'season_score_applied'
+    )::double precision as season_participated_users,
+    count(distinct actor_key) filter (
+      where actor_key is not null and event_name in (
+        'walk_save_success',
+        'quest_progress_applied',
+        'season_score_applied',
+        'rival_leaderboard_fetched',
+        'weather_replacement_applied'
+      )
+    )::double precision as game_layer_active_users,
+    count(distinct actor_key) filter (
+      where actor_key is not null and event_name = 'rival_privacy_opt_in_completed'
+    )::double precision as rival_opt_in_users,
+    count(distinct actor_key) filter (
+      where actor_key is not null and event_name in (
+        'rival_privacy_opt_in_completed',
+        'rival_leaderboard_fetched',
+        'rival_privacy_guard_blocked'
+      )
+    )::double precision as rival_touched_users,
+    count(*) filter (where event_name = 'weather_replacement_applied')::double precision as weather_replacement_applied_count,
+    count(*) filter (
+      where event_name in ('weather_replacement_applied', 'weather_shield_consumed')
+    )::double precision as weather_replacement_offer_count
+  from metrics_7d
+),
+agg_24h as (
+  select
+    count(*) filter (where event_name = 'sync_auth_refresh_failed')::double precision as sync_auth_refresh_failed_count,
+    count(*) filter (
+      where event_name in ('sync_auth_refresh_failed', 'sync_auth_refresh_succeeded')
+    )::double precision as sync_auth_refresh_total_count
+  from metrics_24h
+)
+select
+  now() as calculated_at,
+  case
+    when quest_progress_applied_count = 0 then null
+    else quest_reward_claimed_count / nullif(quest_progress_applied_count, 0)
+  end as quest_completion_rate_7d,
+  case
+    when (quest_reward_claimed_count + quest_claim_duplicate_blocked_count) = 0 then null
+    else quest_claim_duplicate_blocked_count / nullif((quest_reward_claimed_count + quest_claim_duplicate_blocked_count), 0)
+  end as quest_claim_duplicate_rate_7d,
+  case
+    when game_layer_active_users = 0 then null
+    else season_participated_users / nullif(game_layer_active_users, 0)
+  end as season_participation_rate_7d,
+  case
+    when rival_touched_users = 0 then null
+    else rival_opt_in_users / nullif(rival_touched_users, 0)
+  end as rival_opt_in_rate_7d,
+  case
+    when weather_replacement_offer_count = 0 then null
+    else weather_replacement_applied_count / nullif(weather_replacement_offer_count, 0)
+  end as weather_replacement_acceptance_rate_7d,
+  case
+    when sync_auth_refresh_total_count = 0 then null
+    else sync_auth_refresh_failed_count / nullif(sync_auth_refresh_total_count, 0)
+  end as sync_auth_refresh_failure_rate_24h,
+  quest_progress_applied_count::bigint as quest_progress_applied_count,
+  quest_reward_claimed_count::bigint as quest_reward_claimed_count,
+  quest_claim_duplicate_blocked_count::bigint as quest_claim_duplicate_blocked_count,
+  season_participated_users::bigint as season_participated_users,
+  game_layer_active_users::bigint as game_layer_active_users,
+  rival_opt_in_users::bigint as rival_opt_in_users,
+  rival_touched_users::bigint as rival_touched_users,
+  weather_replacement_applied_count::bigint as weather_replacement_applied_count,
+  weather_replacement_offer_count::bigint as weather_replacement_offer_count,
+  sync_auth_refresh_failed_count::bigint as sync_auth_refresh_failed_count,
+  sync_auth_refresh_total_count::bigint as sync_auth_refresh_total_count
+from agg_7d
+cross join agg_24h;
+
+grant select on public.view_game_layer_kpis_7d to anon, authenticated;


### PR DESCRIPTION
## Summary
- add Supabase migration `20260303194000_game_layer_kpi_dashboard_view.sql`
  - introduces `public.view_game_layer_kpis_7d`
  - exposes 7d/24h KPI columns for game-layer release gates
- document single-source KPI view and formulas in:
  - `docs/game-layer-observability-qa-v1.md`
  - `docs/supabase-schema-v1.md`
- add `scripts/game_layer_kpi_dashboard_unit_check.swift`
- wire the new check into `scripts/ios_pr_check.sh`

## Validation
- `swift scripts/game_layer_kpi_dashboard_unit_check.swift`
- `swift scripts/game_layer_observability_qa_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

## Links
- Closes #247
- Epic #123
