### PR TITLE
feat(auth-metrics): emit refresh success/failure events

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -203,15 +203,18 @@ struct SupabaseHTTPClient {
     private let session: URLSession
     private let configLoader: () -> SupabaseRuntimeConfig?
     private let authSessionStore: AuthSessionStoreProtocol
+    private let metricTracker: AppMetricTracker
 
     init(
         session: URLSession = .shared,
         configLoader: @escaping () -> SupabaseRuntimeConfig? = { SupabaseRuntimeConfig.load() },
-        authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared
+        authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
+        metricTracker: AppMetricTracker = .shared
     ) {
         self.session = session
         self.configLoader = configLoader
         self.authSessionStore = authSessionStore
+        self.metricTracker = metricTracker
     }
 
     func request<T: Encodable>(
@@ -288,16 +291,41 @@ struct SupabaseHTTPClient {
             authSessionStore.persist(refreshed.identity)
             if let tokenSession = refreshed.tokenSession {
                 authSessionStore.persist(tokenSession: tokenSession)
+                metricTracker.track(
+                    .syncAuthRefreshSucceeded,
+                    userKey: refreshed.identity.userId
+                )
                 return tokenSession.accessToken
             }
+            metricTracker.track(
+                .syncAuthRefreshFailed,
+                userKey: refreshed.identity.userId,
+                payload: ["reason": "missing_token_session"]
+            )
             authSessionStore.clearTokenSession()
             return nil
         case .retryableFailure:
+            metricTracker.track(
+                .syncAuthRefreshFailed,
+                userKey: currentIdentityUserId(),
+                payload: ["reason": "retryable_failure"]
+            )
             return nil
         case .terminalFailure:
+            metricTracker.track(
+                .syncAuthRefreshFailed,
+                userKey: currentIdentityUserId(),
+                payload: ["reason": "terminal_failure"]
+            )
             authSessionStore.clearTokenSession()
             return nil
         }
+    }
+
+    /// 현재 저장된 인증 식별자에서 사용자 ID를 조회합니다.
+    /// - Returns: 로컬에 사용자 식별자가 있으면 해당 userId, 없으면 `nil`입니다.
+    private func currentIdentityUserId() -> String? {
+        authSessionStore.currentIdentity()?.userId
     }
 
     /// refresh token으로 새 세션 토큰을 발급받고 사용자 식별 정보를 복원합니다.

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -541,6 +541,8 @@ enum AppMetricEvent: String {
     case weatherFeedbackSubmitted = "weather_feedback_submitted"
     case weatherFeedbackRateLimited = "weather_feedback_rate_limited"
     case weatherRiskReevaluated = "weather_risk_reevaluated"
+    case syncAuthRefreshSucceeded = "sync_auth_refresh_succeeded"
+    case syncAuthRefreshFailed = "sync_auth_refresh_failed"
 }
 
 final class FeatureFlagStore {

--- a/scripts/auth_session_autologin_unit_check.swift
+++ b/scripts/auth_session_autologin_unit_check.swift
@@ -18,6 +18,7 @@ func load(_ relativePath: String) -> String {
 
 let auth = load("dogArea/Source/ProfileRepository.swift")
 let infra = load("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+let defaults = load("dogArea/Source/UserdefaultSetting.swift")
 
 assertTrue(auth.contains("struct AuthTokenSession"), "auth store should define token session model")
 assertTrue(auth.contains("persist(tokenSession:"), "auth session store should persist token sessions")
@@ -30,5 +31,9 @@ assertTrue(infra.contains("authorizationHeaderValue"), "supabase http client sho
 assertTrue(infra.contains("grant_type=refresh_token"), "supabase http client should refresh expired access tokens")
 assertTrue(infra.contains("SupabaseRefreshTokenRequestDTO"), "supabase http client should send refresh token payload")
 assertTrue(infra.contains("authSessionStore.persist(tokenSession:"), "refresh flow should persist rotated token session")
+assertTrue(infra.contains(".syncAuthRefreshSucceeded"), "refresh flow should track syncAuthRefreshSucceeded metric")
+assertTrue(infra.contains(".syncAuthRefreshFailed"), "refresh flow should track syncAuthRefreshFailed metric")
+assertTrue(defaults.contains("case syncAuthRefreshSucceeded = \"sync_auth_refresh_succeeded\""), "metric enum should define sync_auth_refresh_succeeded")
+assertTrue(defaults.contains("case syncAuthRefreshFailed = \"sync_auth_refresh_failed\""), "metric enum should define sync_auth_refresh_failed")
 
 print("PASS: auth session autologin unit checks")


### PR DESCRIPTION
## Summary
- add app metric event keys:
  - `sync_auth_refresh_succeeded`
  - `sync_auth_refresh_failed`
- instrument `SupabaseHTTPClient.validAccessToken` refresh branch to emit:
  - success metric when rotated token is persisted
  - failure metric for retryable/terminal/missing-token-session outcomes
- update `scripts/auth_session_autologin_unit_check.swift` to enforce refresh metric contract

## Validation
- `swift scripts/auth_session_autologin_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

## Links
- Closes #249
- Epic #123
