### PR TITLE
[Task][Rival][Observability] 라이벌 탭 metric 이벤트 적재

### DIFF
--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -543,6 +543,10 @@ enum AppMetricEvent: String {
     case weatherRiskReevaluated = "weather_risk_reevaluated"
     case syncAuthRefreshSucceeded = "sync_auth_refresh_succeeded"
     case syncAuthRefreshFailed = "sync_auth_refresh_failed"
+    case rivalPrivacyOptInCompleted = "rival_privacy_opt_in_completed"
+    case rivalLeaderboardFetched = "rival_leaderboard_fetched"
+    case rivalHotspotFetchSucceeded = "rival_hotspot_fetch_succeeded"
+    case rivalHotspotFetchFailed = "rival_hotspot_fetch_failed"
 }
 
 final class FeatureFlagStore {

--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -65,6 +65,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
     private let locationManager: CLLocationManager
     private let authSessionStore: AuthSessionStoreProtocol
     private let sessionProvider: () -> AppSessionState
+    private let metricTracker: AppMetricTracker
     private let locationSharingKey = "nearby.locationSharingEnabled.v1"
     private var pollingTimer: Timer? = nil
     private var lastRefreshAt: Date = .distantPast
@@ -79,7 +80,8 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
         moderationStore: RivalModerationStoreProtocol? = nil,
         locationManager: CLLocationManager = CLLocationManager(),
         authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
-        sessionProvider: @escaping () -> AppSessionState = { AppFeatureGate.currentSession() }
+        sessionProvider: @escaping () -> AppSessionState = { AppFeatureGate.currentSession() },
+        metricTracker: AppMetricTracker = .shared
     ) {
         self.nearbyService = nearbyService
         self.rivalLeagueService = rivalLeagueService
@@ -88,6 +90,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
         self.locationManager = locationManager
         self.authSessionStore = authSessionStore
         self.sessionProvider = sessionProvider
+        self.metricTracker = metricTracker
         super.init()
     }
 
@@ -144,6 +147,12 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
                 try await nearbyService.setVisibility(userId: currentUserId ?? "", enabled: true)
                 preferenceStore.set(true, forKey: locationSharingKey)
                 locationSharingEnabled = true
+                metricTracker.track(
+                    .rivalPrivacyOptInCompleted,
+                    userKey: currentUserId,
+                    featureKey: .nearbyHotspotV1,
+                    payload: ["source": "consent_sheet"]
+                )
                 showToast("익명 공유가 시작됐어요")
                 refreshViewState()
                 refreshHotspots(force: true)
@@ -224,6 +233,17 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
                     centerLongitude: coordinate.longitude,
                     radiusKm: 1.0
                 )
+                let maxIntensity = fetched.map(\.intensity).max() ?? 0
+                metricTracker.track(
+                    .rivalHotspotFetchSucceeded,
+                    userKey: userId,
+                    featureKey: .nearbyHotspotV1,
+                    eventValue: Double(fetched.count),
+                    payload: [
+                        "cell_count": "\(fetched.count)",
+                        "max_intensity": String(format: "%.4f", maxIntensity)
+                    ]
+                )
                 hotspots = fetched
                 lastRefreshAt = Date()
                 updateHotspotSummary()
@@ -233,6 +253,24 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
                     screenState = .ready
                 }
             } catch {
+                let metricErrorCode: String
+                if let supabaseError = error as? SupabaseHTTPError,
+                   case .unexpectedStatusCode(let statusCode) = supabaseError {
+                    metricErrorCode = "http_\(statusCode)"
+                } else if error is URLError {
+                    metricErrorCode = "network"
+                } else {
+                    metricErrorCode = "unknown"
+                }
+                metricTracker.track(
+                    .rivalHotspotFetchFailed,
+                    userKey: userId,
+                    featureKey: .nearbyHotspotV1,
+                    payload: [
+                        "error_code": metricErrorCode,
+                        "retryable": RivalNetworkErrorInterpreter.isConnectivityError(error) ? "true" : "false"
+                    ]
+                )
                 if let supabaseError = error as? SupabaseHTTPError,
                    case .unexpectedStatusCode(404) = supabaseError {
                     hotspots = []
@@ -293,6 +331,16 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
             defer { isLeaderboardRefreshing = false }
             do {
                 let rows = try await rivalLeagueService.fetchLeaderboard(period: leaderboardPeriod, topN: 20)
+                metricTracker.track(
+                    .rivalLeaderboardFetched,
+                    userKey: currentUserId,
+                    featureKey: .nearbyHotspotV1,
+                    eventValue: Double(rows.count),
+                    payload: [
+                        "period": leaderboardPeriod.rawValue,
+                        "row_count": "\(rows.count)"
+                    ]
+                )
                 latestRawLeaderboardEntries = rows
                 lastLeaderboardRefreshAt = Date()
                 applyLeaderboardModerationFilter()

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -38,6 +38,7 @@ swift scripts/fault_injection_matrix_unit_check.swift
 swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift
+swift scripts/rival_observability_metrics_unit_check.swift
 swift scripts/rival_league_matching_unit_check.swift
 swift scripts/rival_stage2_backend_unit_check.swift
 swift scripts/rival_stage3_client_ux_unit_check.swift

--- a/scripts/rival_observability_metrics_unit_check.swift
+++ b/scripts/rival_observability_metrics_unit_check.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// 조건이 거짓이면 stderr 출력 후 실패 코드로 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 불리언 조건입니다.
+///   - message: 실패 시 출력할 메시지입니다.
+/// - Returns: 없음. 실패 시 프로세스를 종료합니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 상대 경로의 파일을 UTF-8 문자열로 로드합니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: 파일 문자열 본문입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let defaults = load("dogArea/Source/UserdefaultSetting.swift")
+let rivalViewModel = load("dogArea/Views/ProfileSettingView/RivalTabViewModel.swift")
+let rivalSpec = load("docs/rival-tab-ux-usecase-spec-v1.md")
+let gameLayerSpec = load("docs/game-layer-observability-qa-v1.md")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(defaults.contains("case rivalPrivacyOptInCompleted = \"rival_privacy_opt_in_completed\""), "metric enum should define rival_privacy_opt_in_completed")
+assertTrue(defaults.contains("case rivalLeaderboardFetched = \"rival_leaderboard_fetched\""), "metric enum should define rival_leaderboard_fetched")
+assertTrue(defaults.contains("case rivalHotspotFetchSucceeded = \"rival_hotspot_fetch_succeeded\""), "metric enum should define rival_hotspot_fetch_succeeded")
+assertTrue(defaults.contains("case rivalHotspotFetchFailed = \"rival_hotspot_fetch_failed\""), "metric enum should define rival_hotspot_fetch_failed")
+
+assertTrue(rivalViewModel.contains("private let metricTracker: AppMetricTracker"), "rival view model should keep metric tracker dependency")
+assertTrue(rivalViewModel.contains(".rivalPrivacyOptInCompleted"), "consent success should emit rival_privacy_opt_in_completed")
+assertTrue(rivalViewModel.contains(".rivalHotspotFetchSucceeded"), "hotspot success should emit rival_hotspot_fetch_succeeded")
+assertTrue(rivalViewModel.contains(".rivalHotspotFetchFailed"), "hotspot failure should emit rival_hotspot_fetch_failed")
+assertTrue(rivalViewModel.contains(".rivalLeaderboardFetched"), "leaderboard fetch should emit rival_leaderboard_fetched")
+
+assertTrue(rivalSpec.contains("rival_privacy_opt_in_completed"), "rival ux spec should include opt-in completed event")
+assertTrue(rivalSpec.contains("rival_hotspot_fetch_succeeded"), "rival ux spec should include hotspot success event")
+assertTrue(rivalSpec.contains("rival_hotspot_fetch_failed"), "rival ux spec should include hotspot failure event")
+assertTrue(gameLayerSpec.contains("rival_privacy_opt_in_completed"), "game-layer spec should include rival privacy opt-in event")
+assertTrue(gameLayerSpec.contains("rival_leaderboard_fetched"), "game-layer spec should include rival leaderboard fetched event")
+
+assertTrue(prCheck.contains("scripts/rival_observability_metrics_unit_check.swift"), "ios_pr_check should include rival observability metrics check")
+
+print("PASS: rival observability metrics unit checks")


### PR DESCRIPTION
## Summary
- add rival observability metric event keys to `AppMetricEvent`
- track consent completion, hotspot fetch success/failure, and leaderboard fetch in `RivalTabViewModel`
- add `scripts/rival_observability_metrics_unit_check.swift` and wire it into `ios_pr_check`

## Validation
- `swift scripts/rival_observability_metrics_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #251
Epic #123