### PR TITLE
[Task][Settings][UI] 세팅 탭 톤 통일 리디자인

### DIFF
--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -49,14 +49,13 @@ struct RootView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            tabContent
-            if tabStatus.isTabAppear {
-                CustomTabBar(selectedTab: $selectedTab)
-                    .padding(.bottom, 2)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+        tabContent
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                if tabStatus.isTabAppear {
+                    CustomTabBar(selectedTab: $selectedTab)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
-        }
         .background(Color.appTabScaffoldBackground.ignoresSafeArea())
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay(content: {

--- a/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
+++ b/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+
 struct NotificationCenterView: View {
     @StateObject var viewModel = SettingViewModel()
     @EnvironmentObject var loading: LoadingViewModel
@@ -35,175 +36,309 @@ struct NotificationCenterView: View {
     }
 
     private var memberContent: some View {
-        VStack {
-               TitleTextView(title: "사용자 정보", subTitle: "사용자의 정보를 알려드립니다.")
-               HStack {
-                   Spacer()
-                   Button(action: {
-                       isProfileEditPresented = true
-                   }, label: {
-                       Text("프로필 편집")
-                           .font(.appFont(for: .Regular, size: 13))
-                   })
-                   .accessibilityIdentifier("settings.profile.edit")
-                   .buttonStyle(AppFilledButtonStyle(role: .secondary, fillsWidth: false))
-                   .padding(.horizontal, 16)
-               }
-               HStack {
-                   UserProfileImageView()
-                       .environmentObject(viewModel)
-                       .padding(.trailing, 20)
-                   VStack(alignment: .leading) {
-                       Text("\(viewModel.userInfo?.name ?? "산책꾼")")
-                           .font(.appFont(for: .SemiBold, size: 20))
-                       if let season = viewModel.seasonProfileSummary {
-                           Text("Season \(season.rankTier.title)")
-                               .font(.appFont(for: .SemiBold, size: 11))
-                               .padding(.horizontal, 8)
-                               .padding(.vertical, 4)
-                               .background(SeasonProfileFrameStyle.style(for: season.rankTier).fill.opacity(0.2))
-                               .cornerRadius(8)
-                       }
-                       if let profileMessage = viewModel.userInfo?.profileMessage,
-                          profileMessage.isEmpty == false {
-                           Text(profileMessage)
-                               .font(.appFont(for: .Regular, size: 13))
-                               .foregroundStyle(Color.appTextDarkGray)
-                       }
-                       Text("가입 정보: \(viewModel.userInfo?.createdAt.createdAtTimeYYMMDD ?? "")")
-                           .font(.appFont(for: .Light, size: 11))
-                           .foregroundStyle(Color.appTextDarkGray)
-                   }
-                   Spacer()
-               }
-               if let season = viewModel.seasonProfileSummary {
-                   seasonSummaryCard(summary: season)
-                       .padding(.horizontal, 16)
-               }
-               UnderLine()
-               TitleTextView(title: "강아지 정보",type: .MediumTitle, subTitle: "강아지를 소개할게요")
-               if viewModel.pets.isEmpty == false {
-                   ScrollView(.horizontal, showsIndicators: false) {
-                       HStack(spacing: 8) {
-                           ForEach(viewModel.pets, id: \.petId) { pet in
-                               Text(pet.petName)
-                                   .appPill(isActive: viewModel.selectedPetId == pet.petId)
-                                   .onTapGesture {
-                                       viewModel.selectPet(pet.petId)
-                                   }
-                           }
-                       }.padding(.horizontal, 16)
-                   }
-               }
-               HStack {
-                   PetProfileImageView()
-                       .environmentObject(viewModel)
-                       .padding(.trailing, 20)
-                   VStack(alignment: .leading) {
-                       Text("\(viewModel.selectedPet?.petName ?? "강아지")")
-                           .font(.appFont(for: .SemiBold, size: 20))
-                       Text(petDetailsText(viewModel.selectedPet))
-                           .font(.appFont(for: .Regular, size: 12))
-                           .foregroundStyle(Color.appTextDarkGray)
-                       if let status = viewModel.selectedPet?.caricatureStatus {
-                           Text("캐리커처 상태: \(status.rawValue)")
-                               .font(.appFont(for: .Light, size: 11))
-                               .foregroundStyle(Color.appTextDarkGray)
-                       }
-                   }
-                   Spacer()
-               }
-               if viewModel.pets.count > 1 {
-                   HStack {
-                       Text("현재 함께 사는 강아지")
-                           .font(.appFont(for: .Light, size: 12))
-                           .foregroundStyle(Color.appTextDarkGray)
-                       Spacer()
-                   }
-                   Picker("대표 강아지", selection: Binding<String>(
-                    get: { viewModel.selectedPetId.isEmpty == false ? viewModel.selectedPetId : (viewModel.pets.first?.petId ?? "") },
-                    set: { viewModel.selectPet($0) }
-                   )) {
-                       ForEach(viewModel.pets, id: \.id) { pet in
-                           Text(pet.petName).tag(pet.petId)
-                       }
-                   }
-                   .pickerStyle(.menu)
-               }
-               Button("로그아웃") {
-                   isLogoutAlertPresented = true
-               }
-               .accessibilityIdentifier("settings.logout")
-               .buttonStyle(AppFilledButtonStyle(role: .destructive))
-               .padding(.top, 12)
-               .padding(.horizontal, 16)
-               Spacer()
-           }
-           .onAppear {
-               viewModel.reloadUserInfo()
-           }
-           .sheet(isPresented: $isProfileEditPresented) {
-               ProfileFieldEditSheet(viewModel: viewModel) { message in
-                   toastMessage = message
-                   DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
-                       toastMessage = nil
-                   }
-               }
-           }
-           .overlay {
-               if let toastMessage {
-                   SimpleMessageView(message: toastMessage)
-                       .transition(.opacity)
-               }
-           }
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 16) {
+                settingsHeader(
+                    title: "설정",
+                    subtitle: "프로필, 반려견, 계정 상태를 한 번에 관리해요."
+                )
+
+                memberProfileCard
+
+                if let season = viewModel.seasonProfileSummary {
+                    seasonSummaryCard(summary: season)
+                }
+
+                petInfoCard
+
+                accountActionCard
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            .padding(.bottom, 24)
+        }
+        .scrollIndicators(.hidden)
+        .onAppear {
+            viewModel.reloadUserInfo()
+        }
+        .sheet(isPresented: $isProfileEditPresented) {
+            ProfileFieldEditSheet(viewModel: viewModel) { message in
+                toastMessage = message
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                    toastMessage = nil
+                }
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if let toastMessage {
+                SimpleMessageView(message: toastMessage)
+                    .padding(.bottom, 16)
+                    .transition(.opacity)
+            }
+        }
     }
 
     private var guestLockedContent: some View {
-        VStack(spacing: 14) {
-            TitleTextView(title: "사용자 정보", subTitle: "로그인 후 프로필을 관리할 수 있어요.")
-            VStack(alignment: .leading, spacing: 10) {
-                Text("현재는 게스트 모드예요.")
-                    .font(.appFont(for: .SemiBold, size: 16))
-                Text("프로필 편집/반려견 정보 수정/클라우드 동기화는 로그인 후에 사용할 수 있습니다.")
-                    .font(.appFont(for: .Regular, size: 13))
-                    .foregroundStyle(Color.appTextDarkGray)
-                Button("로그인/회원가입 열기") {
-                    _ = authFlow.requestAccess(feature: .cloudSync)
-                }
-                .accessibilityIdentifier("settings.open.signin")
-                .buttonStyle(AppFilledButtonStyle(role: .primary))
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 16) {
+                settingsHeader(
+                    title: "설정",
+                    subtitle: "로그인 후 프로필과 동기화 기능을 사용할 수 있어요."
+                )
+
+                guestSignInCard
+
+                guestFeaturePreviewCard
             }
-            .padding(14)
-            .appCardSurface()
             .padding(.horizontal, 16)
-            Spacer()
+            .padding(.top, 16)
+            .padding(.bottom, 24)
         }
+        .scrollIndicators(.hidden)
     }
 
-    private func seasonSummaryCard(summary: SeasonProfileSummary) -> some View {
+    private var memberProfileCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 14) {
+                UserProfileImageView()
+                    .environmentObject(viewModel)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(viewModel.userInfo?.name ?? "산책꾼")
+                        .font(.appScaledFont(for: .SemiBold, size: 24, relativeTo: .title2))
+                        .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
+
+                    if let season = viewModel.seasonProfileSummary {
+                        Text("Season \(season.rankTier.title)")
+                            .font(.appScaledFont(for: .SemiBold, size: 11, relativeTo: .caption))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(SeasonProfileFrameStyle.style(for: season.rankTier).fill.opacity(0.24))
+                            .cornerRadius(8)
+                    }
+
+                    if let profileMessage = viewModel.userInfo?.profileMessage,
+                       profileMessage.isEmpty == false {
+                        Text(profileMessage)
+                            .font(.appScaledFont(for: .Regular, size: 13, relativeTo: .body))
+                            .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Text("가입 정보: \(viewModel.userInfo?.createdAt.createdAtTimeYYMMDD ?? "-")")
+                        .font(.appScaledFont(for: .Regular, size: 11, relativeTo: .caption))
+                        .foregroundStyle(Color.appDynamicHex(light: 0x94A3B8, dark: 0x64748B))
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            HStack {
+                Spacer()
+                Button(action: {
+                    isProfileEditPresented = true
+                }, label: {
+                    Text("프로필 편집")
+                })
+                .accessibilityIdentifier("settings.profile.edit")
+                .buttonStyle(AppFilledButtonStyle(role: .secondary, fillsWidth: false))
+                .frame(minHeight: 44)
+            }
+        }
+        .appCardSurface()
+    }
+
+    private var petInfoCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("반려견 정보")
+                    .font(.appScaledFont(for: .SemiBold, size: 18, relativeTo: .headline))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
+                Spacer()
+                if viewModel.pets.count > 1 {
+                    Text("총 \(viewModel.pets.count)마리")
+                        .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .caption))
+                        .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                }
+            }
+
+            if viewModel.pets.isEmpty == false {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(viewModel.pets, id: \.petId) { pet in
+                            Button {
+                                viewModel.selectPet(pet.petId)
+                            } label: {
+                                Text(pet.petName)
+                                    .appPill(isActive: viewModel.selectedPetId == pet.petId)
+                            }
+                            .buttonStyle(.plain)
+                            .frame(minHeight: 44)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+
+            HStack(alignment: .center, spacing: 14) {
+                PetProfileImageView()
+                    .environmentObject(viewModel)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(viewModel.selectedPet?.petName ?? "강아지")
+                        .font(.appScaledFont(for: .SemiBold, size: 22, relativeTo: .title3))
+                        .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
+
+                    Text(petDetailsText(viewModel.selectedPet))
+                        .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .body))
+                        .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let status = viewModel.selectedPet?.caricatureStatus {
+                        Text("캐리커처 상태: \(status.rawValue)")
+                            .font(.appScaledFont(for: .Regular, size: 11, relativeTo: .caption))
+                            .foregroundStyle(Color.appDynamicHex(light: 0x94A3B8, dark: 0x64748B))
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            if viewModel.pets.count > 1 {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("대표 반려견 선택")
+                        .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .caption))
+                        .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+
+                    Picker(
+                        "대표 강아지",
+                        selection: Binding<String>(
+                            get: {
+                                viewModel.selectedPetId.isEmpty == false
+                                ? viewModel.selectedPetId
+                                : (viewModel.pets.first?.petId ?? "")
+                            },
+                            set: { viewModel.selectPet($0) }
+                        )
+                    ) {
+                        ForEach(viewModel.pets, id: \.id) { pet in
+                            Text(pet.petName).tag(pet.petId)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
+                .padding(.top, 4)
+            }
+        }
+        .appCardSurface()
+    }
+
+    private var accountActionCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("계정")
+                .font(.appScaledFont(for: .SemiBold, size: 18, relativeTo: .headline))
+                .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
+
+            Text("로그아웃하면 현재 기기 인증 상태가 해제되고 게스트 모드로 전환됩니다.")
+                .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .body))
+                .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("로그아웃") {
+                isLogoutAlertPresented = true
+            }
+            .accessibilityIdentifier("settings.logout")
+            .buttonStyle(AppFilledButtonStyle(role: .destructive))
+            .frame(minHeight: 44)
+        }
+        .appCardSurface()
+    }
+
+    private var guestSignInCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("현재는 게스트 모드예요")
+                .font(.appScaledFont(for: .SemiBold, size: 20, relativeTo: .title3))
+                .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
+
+            Text("프로필 편집, 반려견 정보 관리, 클라우드 동기화는 로그인 후 사용할 수 있습니다.")
+                .font(.appScaledFont(for: .Regular, size: 13, relativeTo: .body))
+                .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("로그인/회원가입 열기") {
+                _ = authFlow.requestAccess(feature: .cloudSync)
+            }
+            .accessibilityIdentifier("settings.open.signin")
+            .buttonStyle(AppFilledButtonStyle(role: .primary))
+            .frame(minHeight: 44)
+        }
+        .appCardSurface()
+    }
+
+    private var guestFeaturePreviewCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("로그인하면 가능한 기능")
+                .font(.appScaledFont(for: .SemiBold, size: 16, relativeTo: .headline))
+                .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("• 반려견 프로필/사진 관리")
+                Text("• 산책 데이터 백업 및 동기화")
+                Text("• 라이벌/시즌 기능 전체 사용")
+            }
+            .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .body))
+            .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+        }
+        .appCardSurface()
+    }
+
+    /// 설정 화면 상단 헤더를 렌더링합니다.
+    /// - Parameters:
+    ///   - title: 헤더의 메인 타이틀 텍스트입니다.
+    ///   - subtitle: 메인 타이틀 하단에 표시할 보조 설명 텍스트입니다.
+    /// - Returns: 설정 화면 톤에 맞춘 헤더 뷰입니다.
+    private func settingsHeader(title: String, subtitle: String) -> some View {
         VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.appScaledFont(for: .SemiBold, size: 34, relativeTo: .largeTitle))
+                .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
+            Text(subtitle)
+                .font(.appScaledFont(for: .Regular, size: 14, relativeTo: .subheadline))
+                .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+        }
+        .padding(.horizontal, 2)
+    }
+
+    /// 시즌 진행 정보를 요약 카드 형태로 렌더링합니다.
+    /// - Parameter summary: 사용자 시즌 상태(랭크, 점수, 기여도)를 담은 요약 모델입니다.
+    /// - Returns: 시즌 프레임 스타일이 반영된 요약 카드 뷰입니다.
+    private func seasonSummaryCard(summary: SeasonProfileSummary) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
             Text("시즌 진행 현황")
-                .font(.appFont(for: .SemiBold, size: 13))
+                .font(.appScaledFont(for: .SemiBold, size: 16, relativeTo: .headline))
             Text("랭크 \(summary.rankTier.title) · 점수 \(summary.score)pt")
-                .font(.appFont(for: .Regular, size: 12))
+                .font(.appScaledFont(for: .Regular, size: 13, relativeTo: .body))
                 .foregroundStyle(Color.appTextDarkGray)
             Text("주차 \(summary.weekKey) · 기여 \(summary.contributionCount)회")
-                .font(.appFont(for: .Light, size: 11))
+                .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .caption))
                 .foregroundStyle(Color.appTextDarkGray)
             Text("프로필 프레임: \(summary.rankTier.title)")
-                .font(.appFont(for: .Light, size: 11))
+                .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .caption))
                 .foregroundStyle(Color.appTextDarkGray)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(10)
+        .padding(14)
         .background(SeasonProfileFrameStyle.style(for: summary.rankTier).fill.opacity(0.2))
-        .cornerRadius(10)
+        .cornerRadius(14)
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(SeasonProfileFrameStyle.style(for: summary.rankTier).stroke, lineWidth: 0.8)
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(SeasonProfileFrameStyle.style(for: summary.rankTier).stroke, lineWidth: 1)
         )
     }
 
+    /// 반려견 상세 요약 텍스트를 생성합니다.
+    /// - Parameter pet: 화면에 표시할 반려견 정보 모델입니다.
+    /// - Returns: 견종, 나이, 성별이 결합된 단일 줄 설명 텍스트입니다.
     private func petDetailsText(_ pet: PetInfo?) -> String {
         guard let pet else { return "견종(선택)/나이/성별 미입력" }
         let breed = pet.breed.flatMap { $0.isEmpty ? nil : $0 } ?? "견종(선택) 미입력"
@@ -214,7 +349,7 @@ struct NotificationCenterView: View {
 }
 
 #Preview {
-  NotificationCenterView()
+    NotificationCenterView()
 }
 
 /*


### PR DESCRIPTION
## Summary
- redesign `NotificationCenterView` with sectioned card layout aligned to Home/Rival visual language
- preserve existing settings data/auth logic: profile edit, pet selection, season summary, guest lock, logout
- apply dynamic type fonts and ensure primary actions maintain 44pt touch target intent
- switch global custom tab bar placement to `safeAreaInset(.bottom)` to prevent bottom content overlap

## Validation
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #253
Epic #123