### PR TITLE
[Task][UI][Regression] RootView 하단 탭바 safe area 회귀 체크 추가

### DIFF
--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -65,6 +65,7 @@ swift scripts/supabase_profile_image_upload_unit_check.swift
 swift scripts/auth_session_autologin_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
+swift scripts/tabbar_safearea_regression_unit_check.swift
 swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/project_stability_unit_check.swift

--- a/scripts/tabbar_safearea_regression_unit_check.swift
+++ b/scripts/tabbar_safearea_regression_unit_check.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// 조건이 거짓이면 표준 에러에 메시지를 출력하고 즉시 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 불리언 조건입니다.
+///   - message: 실패 시 출력할 오류 메시지입니다.
+/// - Returns: 없음. 실패 조건이면 프로세스를 종료합니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 UTF-8 텍스트 파일을 로드합니다.
+/// - Parameter relativePath: 저장소 루트에서 시작하는 파일 상대 경로입니다.
+/// - Returns: 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let rootView = load("dogArea/Views/GlobalViews/BaseView/RootView.swift")
+
+assertTrue(
+    rootView.contains(".safeAreaInset(edge: .bottom, spacing: 0)"),
+    "RootView should reserve bottom safe area for CustomTabBar"
+)
+assertTrue(
+    rootView.contains("CustomTabBar(selectedTab: $selectedTab)"),
+    "RootView should render CustomTabBar inside bottom safe area inset"
+)
+assertTrue(
+    !rootView.contains("ZStack(alignment: .bottom)"),
+    "RootView should avoid bottom overlay ZStack that can cover content"
+)
+assertTrue(
+    !rootView.contains(".padding(.bottom, 2)"),
+    "RootView should avoid manual bottom offset that reintroduces overlap risk"
+)
+
+print("PASS: tabbar safe area regression unit checks")


### PR DESCRIPTION
## Summary
- add `scripts/tabbar_safearea_regression_unit_check.swift` to guard RootView bottom tab bar layout contract
- assert `safeAreaInset(edge: .bottom)` + CustomTabBar placement and reject bottom overlay regressions
- wire the check into `scripts/ios_pr_check.sh`

## Validation
- `swift scripts/tabbar_safearea_regression_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #255
Epic #123