### PR TITLE
[Task][Rival][Perf] 메인스레드 locationServicesEnabled 호출 제거

### DIFF
--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -102,8 +102,11 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
     func start() {
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
-        if CLLocationManager.locationServicesEnabled() {
+        switch locationManager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
             locationManager.startUpdatingLocation()
+        default:
+            locationManager.stopUpdatingLocation()
         }
         loadModerationPreferences()
         refreshSessionContext()
@@ -536,6 +539,12 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
     /// 위치 권한이 바뀌면 화면 상태를 즉시 재계산합니다.
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         updatePermissionState()
+        switch manager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            manager.startUpdatingLocation()
+        default:
+            manager.stopUpdatingLocation()
+        }
         refreshViewState()
         refreshHotspots(force: true)
         refreshLeaderboard(force: true)

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -39,6 +39,7 @@ swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift
 swift scripts/rival_observability_metrics_unit_check.swift
+swift scripts/rival_location_services_threading_unit_check.swift
 swift scripts/rival_league_matching_unit_check.swift
 swift scripts/rival_stage2_backend_unit_check.swift
 swift scripts/rival_stage3_client_ux_unit_check.swift

--- a/scripts/rival_location_services_threading_unit_check.swift
+++ b/scripts/rival_location_services_threading_unit_check.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// 조건이 거짓이면 표준 에러로 메시지를 출력하고 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 불리언 조건입니다.
+///   - message: 실패 시 출력할 오류 메시지입니다.
+/// - Returns: 없음. 실패 시 즉시 종료합니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로 파일을 UTF-8 문자열로 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 상대 경로입니다.
+/// - Returns: 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let viewModel = load("dogArea/Views/ProfileSettingView/RivalTabViewModel.swift")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(!viewModel.contains("CLLocationManager.locationServicesEnabled()"), "RivalTabViewModel should avoid locationServicesEnabled on main thread")
+assertTrue(viewModel.contains("func start()"), "RivalTabViewModel should define start()")
+assertTrue(viewModel.contains("switch locationManager.authorizationStatus"), "start() should branch by authorizationStatus")
+assertTrue(viewModel.contains("func locationManagerDidChangeAuthorization(_ manager: CLLocationManager)"), "RivalTabViewModel should handle authorization callback")
+assertTrue(viewModel.contains("manager.startUpdatingLocation()"), "authorization callback should start location updates when authorized")
+assertTrue(viewModel.contains("manager.stopUpdatingLocation()"), "authorization callback should stop location updates when unauthorized")
+assertTrue(prCheck.contains("scripts/rival_location_services_threading_unit_check.swift"), "ios_pr_check should include rival location threading check")
+
+print("PASS: rival location services threading unit checks")


### PR DESCRIPTION
## Summary
- remove `CLLocationManager.locationServicesEnabled()` call from `RivalTabViewModel.start()` to avoid main-thread responsiveness risk
- start/stop location updates by `authorizationStatus` in both `start()` and `locationManagerDidChangeAuthorization`
- add `scripts/rival_location_services_threading_unit_check.swift` and wire into `ios_pr_check` for regression guard

## Validation
- `swift scripts/rival_location_services_threading_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #257
Epic #123