### PR TITLE
Harden caricature edge flow and watch session delegate

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -580,6 +580,8 @@ struct FeatureControlService: FeatureFlagRemoteServiceProtocol {
 
 struct CaricatureEdgeClient: CaricatureServiceProtocol {
     static let schemaVersion = "2026-02-26.v1"
+    private static let functionUnavailableUntilKey = "caricature.edge.unavailable.until.v1"
+    private static let functionUnavailableCooldownSeconds: TimeInterval = 10 * 60
 
     struct ResponseDTO: Decodable {
         let version: String?
@@ -607,6 +609,7 @@ struct CaricatureEdgeClient: CaricatureServiceProtocol {
 
     enum RequestError: LocalizedError {
         case notConfigured
+        case functionUnavailable(cooldownMinutes: Int)
         case invalidResponse
         case requestFailed(code: Int, message: String)
 
@@ -614,6 +617,8 @@ struct CaricatureEdgeClient: CaricatureServiceProtocol {
             switch self {
             case .notConfigured:
                 return "Supabase 설정이 누락되어 캐리커처 요청을 보낼 수 없습니다."
+            case .functionUnavailable(let cooldownMinutes):
+                return "캐리커처 서버 기능이 아직 배포되지 않았습니다. 약 \(cooldownMinutes)분 후 다시 시도해주세요."
             case .invalidResponse:
                 return "캐리커처 응답을 해석할 수 없습니다."
             case .requestFailed(_, let message):
@@ -623,11 +628,26 @@ struct CaricatureEdgeClient: CaricatureServiceProtocol {
     }
 
     private let client: SupabaseHTTPClient
+    private let availabilityStore: UserDefaults
 
-    init(client: SupabaseHTTPClient = .live) {
+    init(
+        client: SupabaseHTTPClient = .live,
+        availabilityStore: UserDefaults = .standard
+    ) {
         self.client = client
+        self.availabilityStore = availabilityStore
     }
 
+    /// 캐리커처 Edge Function 요청을 전송하고 결과를 반환합니다.
+    /// - Parameters:
+    ///   - petId: 생성 대상 반려견 UUID 문자열입니다.
+    ///   - userId: 요청 사용자 UUID 문자열입니다.
+    ///   - sourceImagePath: Storage 버킷 기준 소스 이미지 경로입니다.
+    ///   - sourceImageURL: 외부/공개 소스 이미지 URL입니다.
+    ///   - style: 요청할 캐리커처 스타일 키입니다.
+    ///   - providerHint: 우선 시도할 공급자 힌트(`auto/gemini/openai`)입니다.
+    ///   - requestId: 멱등/관측용 요청 식별자(UUID)입니다.
+    /// - Returns: 서버가 반환한 작업/결과 메타데이터입니다.
     func requestCaricature(
         petId: String,
         userId: String?,
@@ -637,6 +657,12 @@ struct CaricatureEdgeClient: CaricatureServiceProtocol {
         providerHint: String = "auto",
         requestId: String
     ) async throws -> ResponseDTO {
+        guard isFunctionTemporarilyUnavailable() == false else {
+            throw RequestError.functionUnavailable(
+                cooldownMinutes: Int(Self.functionUnavailableCooldownSeconds / 60)
+            )
+        }
+
         let payload = RequestDTO(
             version: Self.schemaVersion,
             petId: petId,
@@ -657,17 +683,45 @@ struct CaricatureEdgeClient: CaricatureServiceProtocol {
             guard let decoded = try? JSONDecoder().decode(ResponseDTO.self, from: data) else {
                 throw RequestError.invalidResponse
             }
+            clearFunctionUnavailableMarker()
             return decoded
         } catch let error as SupabaseHTTPError {
             switch error {
             case .notConfigured:
                 throw RequestError.notConfigured
             case .unexpectedStatusCode(let code):
+                if code == 404 {
+                    markFunctionTemporarilyUnavailable()
+                    throw RequestError.functionUnavailable(
+                        cooldownMinutes: Int(Self.functionUnavailableCooldownSeconds / 60)
+                    )
+                }
                 throw RequestError.requestFailed(code: code, message: "캐리커처 생성 실패(\(code)).")
             default:
                 throw RequestError.invalidResponse
             }
         }
+    }
+
+    /// 최근 404로 인해 캐리커처 함수가 일시 비활성 상태인지 확인합니다.
+    /// - Parameter now: 쿨다운 만료 판정 기준 시각입니다.
+    /// - Returns: 현재 시각 기준 쿨다운이 남아 있으면 `true`를 반환합니다.
+    private func isFunctionTemporarilyUnavailable(now: Date = Date()) -> Bool {
+        let until = availabilityStore.double(forKey: Self.functionUnavailableUntilKey)
+        return until > now.timeIntervalSince1970
+    }
+
+    /// 캐리커처 함수 404 감지 시 재시도 폭주를 막기 위해 쿨다운을 기록합니다.
+    /// - Parameter now: 쿨다운 만료시각 계산 기준 시각입니다.
+    private func markFunctionTemporarilyUnavailable(now: Date = Date()) {
+        let until = now.timeIntervalSince1970 + Self.functionUnavailableCooldownSeconds
+        availabilityStore.set(until, forKey: Self.functionUnavailableUntilKey)
+    }
+
+    /// 캐리커처 요청이 성공하면 함수 비가용 쿨다운 마커를 제거합니다.
+    /// - Returns: 없음.
+    private func clearFunctionUnavailableMarker() {
+        availabilityStore.removeObject(forKey: Self.functionUnavailableUntilKey)
     }
 }
 

--- a/dogAreaWatch Watch App/ContentsViewModel.swift
+++ b/dogAreaWatch Watch App/ContentsViewModel.swift
@@ -203,4 +203,20 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
         applyContext(applicationContext)
     }
+
+    #if os(iOS)
+    /// iOS 쪽 세션이 비활성 상태로 전환될 때 도달 가능 상태를 갱신합니다.
+    /// - Parameter session: 상태 전환이 발생한 WatchConnectivity 세션입니다.
+    func sessionDidBecomeInactive(_ session: WCSession) {
+        DispatchQueue.main.async { [weak self] in
+            self?.isReachable = session.isReachable
+        }
+    }
+
+    /// iOS 쪽 세션 비활성 이후 재활성화를 트리거합니다.
+    /// - Parameter session: 비활성화된 WatchConnectivity 세션입니다.
+    func sessionDidDeactivate(_ session: WCSession) {
+        session.activate()
+    }
+    #endif
 }

--- a/scripts/caricature_proxy_unit_check.swift
+++ b/scripts/caricature_proxy_unit_check.swift
@@ -37,6 +37,9 @@ Check.assertTrue(functionReadme.contains("Request Schema"), "README should defin
 Check.assertTrue(functionReadme.contains("Error Codes"), "README should define error codes")
 
 Check.assertTrue(supabaseInfrastructure.contains("struct CaricatureEdgeClient"), "app should use shared caricature edge client")
+Check.assertTrue(supabaseInfrastructure.contains("case functionUnavailable"), "edge client should classify function unavailable")
+Check.assertTrue(supabaseInfrastructure.contains("caricature.edge.unavailable.until.v1"), "edge client should persist temporary unavailable marker")
+Check.assertTrue(supabaseInfrastructure.contains("캐리커처 서버 기능이 아직 배포되지 않았습니다"), "edge client should expose user-friendly unavailable message")
 Check.assertTrue(imageVM.contains("CaricatureEdgeClient"), "image generator vm should call edge client")
 Check.assertTrue(imageVM.contains("retryLastRequest"), "image generator vm should support retry")
 Check.assertTrue(imageVM.contains("AppFeatureGate.isAllowed(.aiGeneration"), "image vm should enforce ai feature gate")

--- a/supabase/functions/caricature/index.ts
+++ b/supabase/functions/caricature/index.ts
@@ -132,7 +132,7 @@ const callGemini = async (
   const key = Deno.env.get("GEMINI_API_KEY") ?? Deno.env.get("GEMINI_KEY");
   if (!key) throw new Error("gemini key missing");
   const endpoint =
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent?key=${key}`;
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp-image-generation:generateContent?key=${key}`;
   const payload = {
     contents: [
       {


### PR DESCRIPTION
## Summary\n- add caricature function-unavailable handling with cooldown to reduce repeated 404 retries\n- improve user-facing error message for unavailable edge function\n- update caricature edge function Gemini model endpoint to current image generation model\n- add iOS-only WCSessionDelegate inactive/deactivate handlers in watch view model and guard with conditional compile\n- extend caricature proxy unit checks for unavailable-flow regression\n\n## Validation\n- swift scripts/caricature_proxy_unit_check.swift\n- swift scripts/caricature_pipeline_unit_check.swift\n- swift scripts/watch_reliability_unit_check.swift\n- swift scripts/watch_remote_contract_unit_check.swift\n- xcodebuild -project dogArea.xcodeproj -target dogAreaWidgetExtension -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build