### PR TITLE
Fix widget extension CFBundleVersion mismatch

### DIFF
--- a/dogAreaWidgetExtension/Info.plist
+++ b/dogAreaWidgetExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>14</string>
 	<key>MinimumOSVersion</key>
 	<string>18.0</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
## Summary\n- set widget extension CFBundleVersion to 14 in Info.plist to match parent app version\n- remove app-extension bundle version mismatch warning during embedded binary validation\n\n## Validation\n- xcodebuild -project dogArea.xcodeproj -scheme "dogAreaWatch Watch App" -configuration Debug -destination 'generic/platform=watchOS Simulator' CODE_SIGNING_ALLOWED=NO build\n- confirmed warning "The CFBundleVersion of an app extension ... must match ..." no longer appears