### PR TITLE
Fix tab bar overlap on Home/Map and preserve map camera state

### DIFF
--- a/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
+++ b/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
@@ -9,6 +9,8 @@ import Foundation
 import SwiftUI
 
 struct CustomTabBar: View {
+    static let reservedContentHeight: CGFloat = 124
+
     @Binding var selectedTab: Int
 
     private let sideItems: [TabVisualItem] = [

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -120,7 +120,7 @@ struct HomeView: View {
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 12)
-                .padding(.bottom, 106)
+                .padding(.bottom, CustomTabBar.reservedContentHeight + 12)
             }
             .refreshable {
                 viewModel.fetchData()
@@ -246,7 +246,7 @@ struct HomeView: View {
                 .shadow(color: Color.black.opacity(0.12), radius: 12, x: 0, y: 8)
         }
         .padding(.trailing, 20)
-        .padding(.bottom, 86)
+        .padding(.bottom, CustomTabBar.reservedContentHeight - 20)
         .accessibilityLabel("시즌 카드 확장 상태 변경")
     }
 

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -14,8 +14,8 @@ import UIKit
 struct MapView : View{
     @EnvironmentObject var loading: LoadingViewModel
     @EnvironmentObject var authFlow: AuthFlowCoordinator
-    @ObservedObject var myAlert: CustomAlertViewModel = .init()
-    @ObservedObject var viewModel: MapViewModel = .init()
+    @StateObject private var myAlert = CustomAlertViewModel()
+    @StateObject private var viewModel = MapViewModel()
     @State private var isModalPresented = false
     @State private var isWalkingViewPresented = false
     @State private var endWalkingViewPresented = false
@@ -151,6 +151,7 @@ struct MapView : View{
                         .clipShape(RoundedCornersShape(radius: 20,corners: [.topLeft,.topRight]))
                 }
             }
+                .padding(.bottom, CustomTabBar.reservedContentHeight - 8)
         }
         }
         .onAppear {


### PR DESCRIPTION
## Summary
- add shared tab bar reserved height constant and apply it to Home bottom spacing
- move MapView-owned objects to @StateObject to prevent unintended camera/session resets
- lift Map bottom controls above tab bar reserved area so start button is always tappable

## Validation
- bash scripts/ios_pr_check.sh