### PR TITLE
Map UX: one-tap add point + 3s undo + long-press mode

### DIFF
--- a/dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift
+++ b/dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift
@@ -9,7 +9,6 @@ import Foundation
 enum AlertActionType{
     case custom(AlertModel , () -> () , () -> ())
     case customThreeButton(AlertModel, () -> (), () -> (), () -> ())
-    case addPoint
     case logOut
     case annotationSelected(Location)
     case deletePolygon(UUID)
@@ -19,8 +18,6 @@ enum AlertActionType{
             return model
         case .customThreeButton(let model, _, _, _):
             return model
-        case .addPoint:
-            return AlertModel(title: "영역 표시", message: "영역을 표시하겠습니까?", configure: .defaultType)
         case .logOut:
             return AlertModel(title: "계정 오류", message: "로그아웃 되었습니다.", configure: .oneButton(buttonMsg: "로그인 하기"))
         case .annotationSelected(let location):

--- a/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
@@ -14,14 +14,6 @@ struct MapAlertSubView: View {
     if myAlert.isAlert {
       var ca : CustomAlert
       switch myAlert.alertType {
-      case .addPoint :
-        ca = CustomAlert(presentAlert: $myAlert.isAlert,
-                         alertModel: myAlert.alertType.model,
-                         leftButtonAction: {
-          viewModel.addLocationPreservingCamera()
-        },rightButtonAction: {
-//            print("right")
-        })
       case .annotationSelected(_) :
         ca = CustomAlert(presentAlert: $myAlert.isAlert,
                          alertModel: myAlert.alertType.model,

--- a/dogArea/Views/MapView/MapSubViews/MapSettingView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapSettingView.swift
@@ -99,6 +99,12 @@ struct MapSettingView: View {
                 viewModel.toggleWalkPointRecordMode()
             }
             toggleChip(
+                title: viewModel.isAddPointLongPressModeEnabled ? "영역 추가: 길게 0.4s" : "영역 추가: 1탭+Undo",
+                isActive: viewModel.isAddPointLongPressModeEnabled
+            ) {
+                viewModel.toggleAddPointLongPressMode()
+            }
+            toggleChip(
                 title: "모션 축소",
                 isActive: viewModel.isMapMotionReduced
             ) {

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -26,6 +26,8 @@ struct MapView : View{
     @State private var activeBanner: MapTopBannerCandidate? = nil
     @State private var bannerSuppressedUntil: [MapTopBannerKind: Date] = [:]
     @State private var bannerAutoDismissTask: Task<Void, Never>? = nil
+    @State private var pendingUndoPointID: UUID? = nil
+    @State private var addPointUndoDismissTask: Task<Void, Never>? = nil
     @ObservedObject var tabStatus = TabAppear.shared
     
     var body : some View {
@@ -229,6 +231,7 @@ struct MapView : View{
         }
         .onDisappear {
             bannerAutoDismissTask?.cancel()
+            clearPendingAddPointUndo()
         }
         .sheet(isPresented: $isModalPresented){
             MapSettingView(viewModel: self.viewModel, myAlert: self.myAlert)
@@ -287,7 +290,31 @@ struct MapView : View{
                         .cornerRadius(10)
                         .padding(.top, 12)
                 }
+
+                if pendingUndoPointID != nil {
+                    HStack(spacing: 10) {
+                        Text("포인트를 추가했어요")
+                            .font(.appFont(for: .SemiBold, size: 13))
+                            .foregroundStyle(Color.black)
+                        Spacer()
+                        Button("실행 취소") {
+                            undoLastAddedPoint()
+                        }
+                        .font(.appFont(for: .SemiBold, size: 12))
+                        .foregroundStyle(Color.appInk)
+                        .padding(.horizontal, 10)
+                        .frame(minHeight: 44)
+                        .background(Color.white.opacity(0.9))
+                        .cornerRadius(8)
+                        .accessibilityLabel("포인트 추가 실행 취소")
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(Color.appYellowPale)
+                    .cornerRadius(10)
+                }
             }
+            .padding(.horizontal, 12)
         }
     }
 
@@ -461,10 +488,21 @@ struct MapView : View{
                     .background(Color.appGreen)
                     .cornerRadius(6)
             }
+            if viewModel.isAddPointLongPressModeEnabled {
+                Text("길게 0.4s")
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .foregroundStyle(Color.appTextDarkGray)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.white.opacity(0.9))
+                    .cornerRadius(6)
+            }
             Button {
-                viewModel.preparePointAddCameraSnapshot()
-                myAlert.alertType = .addPoint
-                myAlert.callAlert(type: .addPoint)
+                guard viewModel.isAddPointLongPressModeEnabled == false else {
+                    viewModel.walkStatusMessage = "길게 눌러 포인트를 추가하세요."
+                    return
+                }
+                handleAddPointRequest()
             } label: {
                 ZStack {
                     Circle()
@@ -477,7 +515,49 @@ struct MapView : View{
                 }
             }
             .buttonStyle(.plain)
+            .simultaneousGesture(
+                LongPressGesture(minimumDuration: 0.4)
+                    .onEnded { _ in
+                        guard viewModel.isAddPointLongPressModeEnabled else { return }
+                        handleAddPointRequest()
+                    }
+            )
+            .accessibilityLabel(viewModel.isAddPointLongPressModeEnabled ? "길게 눌러 영역 추가" : "영역 추가")
+            .accessibilityHint("추가 후 3초 안에 실행 취소할 수 있습니다")
         }
+    }
+
+    /// 영역 추가 버튼 요청을 처리하고 3초 Undo 토스트를 예약합니다.
+    private func handleAddPointRequest() {
+        viewModel.preparePointAddCameraSnapshot()
+        guard let addedPointID = viewModel.addLocationPreservingCamera() else { return }
+        scheduleAddPointUndo(for: addedPointID)
+    }
+
+    /// 방금 추가된 포인트에 대해 3초 실행 취소 윈도우를 시작합니다.
+    /// - Parameter pointID: 실행 취소 대상으로 추적할 포인트 UUID입니다.
+    private func scheduleAddPointUndo(for pointID: UUID) {
+        addPointUndoDismissTask?.cancel()
+        pendingUndoPointID = pointID
+        addPointUndoDismissTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard pendingUndoPointID == pointID else { return }
+            clearPendingAddPointUndo()
+        }
+    }
+
+    /// 활성화된 포인트 추가 Undo 요청을 실행합니다.
+    private func undoLastAddedPoint() {
+        guard let pointID = pendingUndoPointID else { return }
+        guard viewModel.undoAddedPoint(pointID) else { return }
+        clearPendingAddPointUndo()
+    }
+
+    /// 현재 표시 중인 포인트 추가 Undo 상태를 정리합니다.
+    private func clearPendingAddPointUndo() {
+        addPointUndoDismissTask?.cancel()
+        addPointUndoDismissTask = nil
+        pendingUndoPointID = nil
     }
 
     /// 상태 메시지에 위치 권한 안내가 포함되어 설정 이동 버튼을 노출해야 하는지 판단합니다.

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -298,6 +298,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     @Published private(set) var weatherOverlayStatusText: String = "날씨 상태 정상"
     @Published private(set) var weatherOverlayFallbackActive: Bool = false
     @Published var mapMotionReduced: Bool = false
+    @Published var isAddPointLongPressModeEnabled: Bool = false
     private let watchSession = WCSession.isSupported() ? WCSession.default : nil
     private let featureFlags = FeatureFlagStore.shared
     private let metricTracker = AppMetricTracker.shared
@@ -322,6 +323,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let nearbyHotspotEnabledKey = "nearby.hotspotEnabled"
     private let nearbyPresenceUserIdKey = "nearby.presenceUserId"
     private let mapMotionReducedKey = "map.motion.reduced"
+    private let addPointLongPressModeKey = "map.addPoint.longPressModeEnabled"
     private let weatherRiskOverrideKey = "weather.risk.level.v1"
     private let weatherRiskObservedAtKey = "weather.risk.observed_at.v1"
     private let weatherRiskCacheTTL: TimeInterval = 7200
@@ -506,12 +508,14 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         let storedNearbyHotspotEnabled = preferenceStore.bool(forKey: nearbyHotspotEnabledKey, default: true)
         let storedLocationSharingEnabled = preferenceStore.bool(forKey: locationSharingKey, default: false)
         let storedMotionReduced = preferenceStore.bool(forKey: mapMotionReducedKey, default: false)
+        let storedAddPointLongPressMode = preferenceStore.bool(forKey: addPointLongPressModeKey, default: false)
 
         self.heatmapEnabled = featureFlags.isEnabled(.heatmapV1) ? storedHeatmapEnabled : false
         let nearbyFeatureOn = featureFlags.isEnabled(.nearbyHotspotV1)
         self.nearbyHotspotEnabled = nearbyFeatureOn ? storedNearbyHotspotEnabled : false
         self.locationSharingEnabled = nearbyFeatureOn ? storedLocationSharingEnabled : false
         self.mapMotionReduced = storedMotionReduced
+        self.isAddPointLongPressModeEnabled = storedAddPointLongPressMode
         self.walkStartCountdownEnabled = userSessionStore.walkStartCountdownEnabled()
         self.walkAutoEndPolicyEnabled = true
         self.walkPointRecordMode = WalkPointRecordMode(
@@ -574,9 +578,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             }
         }
     }
-    func addLocation(){
-        guard let location = self.location else { return }
-        appendWalkPoint(from: location, recordedAt: Date(), source: .manual)
+    /// 현재 위치를 수동 포인트로 즉시 추가합니다.
+    /// - Returns: 포인트가 추가되면 생성된 포인트 UUID, 위치 정보가 없으면 `nil`입니다.
+    @discardableResult
+    func addLocation() -> UUID? {
+        guard let location = self.location else { return nil }
+        let appendedPoint = appendWalkPoint(from: location, recordedAt: Date(), source: .manual)
+        return appendedPoint.id
     }
 
     /// 수동 포인트 추가 전에 현재 카메라 중심/거리 상태를 저장합니다.
@@ -588,9 +596,53 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     }
 
     /// 수동 포인트를 추가한 뒤 필요 시 저장된 카메라 상태를 복원합니다.
-    func addLocationPreservingCamera() {
-        addLocation()
+    /// - Returns: 포인트가 추가되면 생성된 포인트 UUID, 추가하지 못하면 `nil`입니다.
+    @discardableResult
+    func addLocationPreservingCamera() -> UUID? {
+        let addedPointId = addLocation()
         restorePointAddCameraSnapshotIfNeeded()
+        return addedPointId
+    }
+
+    /// 지정한 포인트 UUID를 현재 세션에서 롤백합니다.
+    /// - Parameter pointID: 실행 취소할 포인트 UUID입니다.
+    /// - Returns: 실제로 포인트가 롤백되면 `true`, 대상이 없으면 `false`입니다.
+    @discardableResult
+    func undoAddedPoint(_ pointID: UUID) -> Bool {
+        guard let targetIndex = polygon.locations.firstIndex(where: { $0.id == pointID }) else {
+            return false
+        }
+        polygon.locations.remove(at: targetIndex)
+
+        if polygon.locations.count > 2 {
+            polygon.makePolygon(walkArea: calculateArea(), walkTime: time)
+        } else {
+            polygon.polygon = nil
+            polygon.walkingArea = calculateArea(points: polygon.locations)
+            polygon.walkingTime = time
+        }
+
+        if let lastPoint = polygon.locations.last {
+            let lastPointDate = Date(timeIntervalSince1970: lastPoint.createdAt)
+            lastAutoRecordedLocation = CLLocation(
+                latitude: lastPoint.coordinate.latitude,
+                longitude: lastPoint.coordinate.longitude
+            )
+            lastAutoRecordedAt = lastPointDate
+            lastPointEventAt = lastPointDate
+            movementAnchorLocation = lastAutoRecordedLocation
+        } else {
+            lastAutoRecordedLocation = nil
+            lastAutoRecordedAt = .distantPast
+            lastPointEventAt = nil
+            movementAnchorLocation = nil
+        }
+
+        persistActiveWalkSession(force: true)
+        syncWatchContext(force: true)
+        syncWalkWidgetSnapshot(force: true)
+        syncWalkLiveActivity(force: true)
+        return true
     }
     func removeLocation(_ locationID : UUID){
         if polygon.locations.firstIndex(where:{ $0.id == locationID}) != nil {
@@ -704,6 +756,12 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         walkPointRecordMode = walkPointRecordMode == .manual ? .auto : .manual
         userSessionStore.setWalkPointRecordModeRawValue(walkPointRecordMode.rawValue)
         resetAutoPointRecordState()
+    }
+
+    /// 영역 추가 버튼 입력 방식을 1탭 모드와 길게 누르기 모드 사이에서 전환합니다.
+    func toggleAddPointLongPressMode() {
+        isAddPointLongPressModeEnabled.toggle()
+        preferenceStore.set(isAddPointLongPressModeEnabled, forKey: addPointLongPressModeKey)
     }
 
     var isAutoPointRecordMode: Bool {
@@ -1380,8 +1438,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         #endif
     }
 
-    private func appendWalkPoint(from location: CLLocation, recordedAt: Date, source: PointAppendSource) {
-        polygon.addPoint(.init(coordinate: location.coordinate))
+    private func appendWalkPoint(from location: CLLocation, recordedAt: Date, source: PointAppendSource) -> Location {
+        let appendedPoint = Location(
+            coordinate: location.coordinate,
+            id: UUID(),
+            createdAt: recordedAt.timeIntervalSince1970
+        )
+        polygon.addPoint(appendedPoint)
         pushCaptureRipple(at: location.coordinate, source: source)
         lastAutoRecordedLocation = location
         lastAutoRecordedAt = recordedAt
@@ -1404,6 +1467,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
                 "recordedAt": recordedAt.timeIntervalSince1970
             ]
         )
+        return appendedPoint
     }
 
     private func resetAutoPointRecordState() {

--- a/scripts/map_camera_jump_fix_unit_check.swift
+++ b/scripts/map_camera_jump_fix_unit_check.swift
@@ -18,14 +18,12 @@ func load(_ relativePath: String) -> String {
 
 let mapView = load("dogArea/Views/MapView/MapView.swift")
 let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
-let mapAlertSubView = load("dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift")
 
 assertTrue(mapView.contains("viewModel.preparePointAddCameraSnapshot()"), "MapView add-point action should prepare camera snapshot")
 assertTrue(!mapView.contains("viewModel.setTrackingMode()\n                myAlert.alertType = .addPoint"), "MapView add-point action should not switch tracking mode directly")
 assertTrue(mapView.contains("viewModel.handleLocationButtonTap()"), "MapView current-location button should delegate to tracking handler")
 assertTrue(mapView.contains("viewModel.recordCameraChange(context.camera)"), "MapView should forward camera change events for reason logging")
-
-assertTrue(mapAlertSubView.contains("viewModel.addLocationPreservingCamera()"), "MapAlertSubView should preserve camera while adding point")
+assertTrue(mapView.contains("handleAddPointRequest()"), "MapView add-point action should use one-tap request handler")
 
 assertTrue(mapViewModel.contains("enum CameraChangeReason"), "MapViewModel should define camera change reason enum")
 assertTrue(mapViewModel.contains("case manualMove = \"manual_move\""), "MapViewModel should log manual move reason")


### PR DESCRIPTION
## Summary
- switch add-point flow to optimistic one-tap add (remove add-point confirm alert path)
- add top 3-second undo toast for newly added point rollback
- add map setting toggle: short-tap mode vs long-press(0.4s) mode
- keep camera-preserving point add path in MapViewModel and update regression check script

## Validation
- bash scripts/ios_pr_check.sh (PASS)

Fixes #231