### PR TITLE
fix: tab bar overlap and map state reset on tab switch

### DIFF
--- a/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
+++ b/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
@@ -21,29 +21,33 @@ struct CustomTabBar: View {
     ]
 
     var body: some View {
-        HStack(spacing: 8) {
-            tabItemButton(for: sideItems[0])
-            tabItemButton(for: sideItems[1])
+        ZStack(alignment: .bottom) {
+            HStack(spacing: 8) {
+                tabItemButton(for: sideItems[0])
+                tabItemButton(for: sideItems[1])
 
-            centerMapButton
+                centerMapButton
 
-            tabItemButton(for: sideItems[2])
-            tabItemButton(for: sideItems[3])
+                tabItemButton(for: sideItems[2])
+                tabItemButton(for: sideItems[3])
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            .padding(.bottom, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 26, style: .continuous)
+                    .fill(Color.appDynamicHex(light: 0xFFFFFF, dark: 0x1E293B, alpha: 0.98))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 26, style: .continuous)
+                            .stroke(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155), lineWidth: 1)
+                    )
+                    .shadow(color: Color.black.opacity(0.09), radius: 18, x: 0, y: -6)
+            )
+            .padding(.horizontal, 10)
+            .padding(.bottom, 6)
         }
-        .padding(.horizontal, 12)
-        .padding(.top, 8)
-        .padding(.bottom, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 26, style: .continuous)
-                .fill(Color.appDynamicHex(light: 0xFFFFFF, dark: 0x1E293B, alpha: 0.98))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 26, style: .continuous)
-                        .stroke(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155), lineWidth: 1)
-                )
-                .shadow(color: Color.black.opacity(0.09), radius: 18, x: 0, y: -6)
-        )
-        .padding(.horizontal, 10)
-        .padding(.bottom, 6)
+        .frame(maxWidth: .infinity)
+        .frame(height: Self.reservedContentHeight, alignment: .bottom)
     }
 
     /// 일반 탭 아이템 버튼을 렌더링합니다.

--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -22,22 +22,16 @@ struct RootView: View {
     @State private var selectedTab = RootView.initialSelectedTabForRuntime()
     @State private var tabbarHidden = false
     @StateObject var tabStatus = TabAppear.shared
+    @StateObject private var mapViewModel = MapViewModel()
     private let widgetActionStore: WalkWidgetActionRequestStoring = DefaultWalkWidgetActionRequestStore.shared
     private let territoryWidgetSnapshotSyncService: TerritoryWidgetSnapshotSyncing = DefaultTerritoryWidgetSnapshotSyncService()
     private let hotspotWidgetSnapshotSyncService: HotspotWidgetSnapshotSyncing = DefaultHotspotWidgetSnapshotSyncService()
     private let questRivalWidgetSnapshotSyncService: QuestRivalWidgetSnapshotSyncing = DefaultQuestRivalWidgetSnapshotSyncService()
     private let questRewardClaimService: QuestRewardClaimServiceProtocol = QuestRewardClaimService()
     private let questRivalSnapshotStore: QuestRivalWidgetSnapshotStoring = DefaultQuestRivalWidgetSnapshotStore.shared
-    private var homeView: HomeView
-    private var walkListView: WalkListView    
-    private var mapView: MapView
-    private var notificationCenterView: NotificationCenterView
-    init() {
-        self.homeView = HomeView()
-        self.walkListView = WalkListView()
-        self.mapView = MapView()
-        self.notificationCenterView = NotificationCenterView()
-    }
+    private var homeView = HomeView()
+    private var walkListView = WalkListView()
+    private var notificationCenterView = NotificationCenterView()
 
     /// UI 테스트 디자인 감사 모드에서는 기본 진입 탭을 홈으로 고정해 초기 렌더링 안정성을 높입니다.
     private static func initialSelectedTabForRuntime() -> Int {
@@ -142,7 +136,7 @@ struct RootView: View {
             }
         } else if selectedTab == 2 {
             NavigationView {
-                mapView
+                MapView(viewModel: mapViewModel)
                     .environmentObject(loading)
                     .navigationBarHidden(selectedTab == 2)
                     .accessibilityIdentifier("screen.map")

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -128,7 +128,7 @@ struct HomeView: View {
                     recentConqueredCard
                 }
                 .padding(.horizontal, 16)
-                .padding(.top, 12)
+                .padding(.top, 20)
                 .padding(.bottom, CustomTabBar.reservedContentHeight + 12)
             }
             .refreshable {

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -15,7 +15,7 @@ struct MapView : View{
     @EnvironmentObject var loading: LoadingViewModel
     @EnvironmentObject var authFlow: AuthFlowCoordinator
     @StateObject private var myAlert = CustomAlertViewModel()
-    @StateObject private var viewModel = MapViewModel()
+    @ObservedObject var viewModel: MapViewModel
     @State private var isModalPresented = false
     @State private var isWalkingViewPresented = false
     @State private var endWalkingViewPresented = false
@@ -29,6 +29,12 @@ struct MapView : View{
     @State private var pendingUndoPointID: UUID? = nil
     @State private var addPointUndoDismissTask: Task<Void, Never>? = nil
     @ObservedObject var tabStatus = TabAppear.shared
+
+    /// 지도 화면에 사용할 상태 객체를 주입해 탭 전환 후에도 카메라/산책 상태를 유지합니다.
+    /// - Parameter viewModel: 지도 상태를 보유하는 `MapViewModel`입니다.
+    init(viewModel: MapViewModel = MapViewModel()) {
+        self._viewModel = ObservedObject(wrappedValue: viewModel)
+    }
     
     var body : some View {
         GeometryReader { proxy in
@@ -153,7 +159,7 @@ struct MapView : View{
                         .clipShape(RoundedCornersShape(radius: 20,corners: [.topLeft,.topRight]))
                 }
             }
-                .padding(.bottom, CustomTabBar.reservedContentHeight - 8)
+                .padding(.bottom, CustomTabBar.reservedContentHeight + 8)
         }
         }
         .onAppear {

--- a/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
+++ b/dogArea/Views/ProfileSettingView/NotificationCenterView.swift
@@ -54,8 +54,8 @@ struct NotificationCenterView: View {
                 accountActionCard
             }
             .padding(.horizontal, 16)
-            .padding(.top, 16)
-            .padding(.bottom, 24)
+            .padding(.top, 24)
+            .padding(.bottom, CustomTabBar.reservedContentHeight + 20)
         }
         .scrollIndicators(.hidden)
         .onAppear {
@@ -91,8 +91,8 @@ struct NotificationCenterView: View {
                 guestFeaturePreviewCard
             }
             .padding(.horizontal, 16)
-            .padding(.top, 16)
-            .padding(.bottom, 24)
+            .padding(.top, 24)
+            .padding(.bottom, CustomTabBar.reservedContentHeight + 20)
         }
         .scrollIndicators(.hidden)
     }

--- a/dogArea/Views/ProfileSettingView/RivalTabView.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabView.swift
@@ -29,8 +29,10 @@ struct RivalTabView: View {
                 safetyInfoCard
                 footerButtons
             }
-            .padding(.bottom, 24)
+            .padding(.top, 8)
+            .padding(.bottom, CustomTabBar.reservedContentHeight + 20)
         }
+        .scrollIndicators(.hidden)
         .background(Color.appTabScaffoldBackground)
         .accessibilityIdentifier("screen.rival.content")
         .onAppear {

--- a/dogArea/Views/WalkListView/WalkListView.swift
+++ b/dogArea/Views/WalkListView/WalkListView.swift
@@ -87,6 +87,8 @@ struct WalkListView: View {
                     }
                     
                 }
+                .padding(.top, 8)
+                .padding(.bottom, CustomTabBar.reservedContentHeight + 12)
             }.refreshable {
                 viewModel.fetchModel()
             }


### PR DESCRIPTION
## Summary
- reserve fixed bottom safe-area height for custom tab bar to prevent content overlap
- add consistent bottom spacing in rival/settings/walk-list tab scroll content
- increase map bottom clearance for start/controls visibility
- inject `MapViewModel` from `RootView` so map camera/session state survives tab switches
- slightly increase home top spacing to avoid status bar crowding

## Validation
- `swift scripts/tabbar_safearea_regression_unit_check.swift`
- `swift scripts/map_camera_jump_fix_unit_check.swift`
- attempted: `bash scripts/ios_pr_check.sh` (build DB lock occurred due concurrent xcodebuild from earlier session)
