### PR TITLE
fix: profile save no-op when local userInfo missing

### DIFF
--- a/dogArea/Views/ProfileSettingView/SettingViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/SettingViewModel.swift
@@ -27,7 +27,7 @@ final class SettingViewModel: ObservableObject {
         var errorDescription: String? {
             switch self {
             case .userNotFound:
-                return "사용자 정보를 불러오지 못했습니다."
+                return "사용자 정보를 불러오지 못했습니다. 다시 로그인한 뒤 시도해주세요."
             case .invalidAgeRange:
                 return "나이는 0~30 사이 숫자로 입력해주세요."
             case .invalidDisplayName:
@@ -52,6 +52,7 @@ final class SettingViewModel: ObservableObject {
     private let profileRepository: ProfileRepository
     private let imageRepository: ProfileImageRepository
     private let accountDeletionService: AccountDeletionServiceProtocol
+    private let authSessionStore: AuthSessionStoreProtocol
     private let walkRepository: WalkRepositoryProtocol
     private let featureFlags = FeatureFlagStore.shared
     private let metricTracker = AppMetricTracker.shared
@@ -66,11 +67,13 @@ final class SettingViewModel: ObservableObject {
         profileRepository: ProfileRepository = DefaultProfileRepository.shared,
         imageRepository: ProfileImageRepository = SupabaseProfileImageRepository.shared,
         accountDeletionService: AccountDeletionServiceProtocol = SupabaseAccountDeletionService.shared,
+        authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
         walkRepository: WalkRepositoryProtocol = WalkRepositoryContainer.shared
     ) {
         self.profileRepository = profileRepository
         self.imageRepository = imageRepository
         self.accountDeletionService = accountDeletionService
+        self.authSessionStore = authSessionStore
         self.walkRepository = walkRepository
         bindSelectedPetSync()
         fetchModel()
@@ -164,10 +167,6 @@ final class SettingViewModel: ObservableObject {
         userProfileImage: UIImage?,
         petProfileImage: UIImage?
     ) async -> Result<Void, Error> {
-        guard let current = profileRepository.fetchUserInfo() else {
-            return .failure(ProfileEditValidationError.userNotFound)
-        }
-
         let normalizedProfileName = profileName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard normalizedProfileName.isEmpty == false else {
             return .failure(ProfileEditValidationError.invalidDisplayName)
@@ -183,6 +182,13 @@ final class SettingViewModel: ObservableObject {
             normalizedAgeYears = parsed
         } else {
             return .failure(ProfileEditValidationError.invalidAgeRange)
+        }
+
+        guard let current = currentEditableUserInfo(
+            fallbackDisplayName: normalizedProfileName,
+            fallbackProfileMessage: normalizedProfileMessage
+        ) else {
+            return .failure(ProfileEditValidationError.userNotFound)
         }
 
         var pets = current.pet
@@ -328,6 +334,48 @@ final class SettingViewModel: ObservableObject {
     /// - Returns: 인코딩 성공 시 JPEG 데이터, 실패 시 `nil`입니다.
     private func compressedJPEGData(for image: UIImage) -> Data? {
         image.jpegData(compressionQuality: 0.35)
+    }
+
+    /// 저장 시점에 편집 가능한 사용자 스냅샷을 조회하고, 누락 시 인증 세션 기반으로 최소 스냅샷을 복구합니다.
+    /// - Parameters:
+    ///   - fallbackDisplayName: 로컬 스냅샷이 없을 때 사용할 표시 이름입니다.
+    ///   - fallbackProfileMessage: 로컬 스냅샷이 없을 때 사용할 프로필 메시지입니다.
+    /// - Returns: 저장 가능한 사용자 스냅샷이며, 복구 불가 시 `nil`입니다.
+    private func currentEditableUserInfo(
+        fallbackDisplayName: String,
+        fallbackProfileMessage: String?
+    ) -> UserInfo? {
+        if let current = profileRepository.fetchUserInfo() {
+            return current
+        }
+        reloadUserInfo()
+        if let current = profileRepository.fetchUserInfo() {
+            return current
+        }
+        guard let identity = authSessionStore.currentIdentity(),
+              identity.userId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+            return nil
+        }
+
+        let selectedPetSnapshot = selectedPet ?? profileRepository.selectedPet(from: userInfo)
+        let recoveredPets: [PetInfo]
+        if let selectedPetSnapshot {
+            recoveredPets = [selectedPetSnapshot]
+        } else {
+            recoveredPets = [PetInfo(petName: "강아지", petProfile: nil)]
+        }
+        let recoveredSelectedPetId = selectedPetId.isEmpty == false
+        ? selectedPetId
+        : recoveredPets.first?.petId
+        return UserInfo(
+            id: identity.userId,
+            name: fallbackDisplayName,
+            profile: nil,
+            profileMessage: fallbackProfileMessage,
+            pet: recoveredPets,
+            selectedPetId: recoveredSelectedPetId,
+            createdAt: Date().timeIntervalSince1970
+        )
     }
 
     private func bindSelectedPetSync() {

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -70,6 +70,7 @@ swift scripts/tabbar_safearea_regression_unit_check.swift
 swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/settings_profile_account_actions_unit_check.swift
+swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 
 if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then

--- a/scripts/profile_edit_userinfo_recovery_unit_check.swift
+++ b/scripts/profile_edit_userinfo_recovery_unit_check.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let settingViewModel = load("dogArea/Views/ProfileSettingView/SettingViewModel.swift")
+
+assertTrue(
+    settingViewModel.contains("private let authSessionStore: AuthSessionStoreProtocol"),
+    "setting view model should inject auth session store for user info recovery"
+)
+assertTrue(
+    settingViewModel.contains("authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared"),
+    "setting view model init should provide default auth session store"
+)
+assertTrue(
+    settingViewModel.contains("currentEditableUserInfo("),
+    "setting view model should recover editable user info when local snapshot is missing"
+)
+assertTrue(
+    settingViewModel.contains("guard let identity = authSessionStore.currentIdentity()"),
+    "recovery path should derive user id from current auth identity"
+)
+assertTrue(
+    settingViewModel.contains("return .failure(ProfileEditValidationError.userNotFound)"),
+    "profile save should still fail explicitly when both local and session identity are unavailable"
+)
+
+print("PASS: profile edit userinfo recovery unit checks")


### PR DESCRIPTION
## Summary\n- recover editable user snapshot in profile save path using auth session identity fallback\n- keep explicit user-not-found failure when both local snapshot and auth identity are unavailable\n- add regression unit check script and wire it into ios_pr_check\n\n## Validation\n- PASS: profile edit userinfo recovery unit checks\n- [dogArea] running document/unit checks
PASS: swift stability unit checks
PASS: userdefault store split unit checks
PASS: map motion pack unit checks
PASS: quest motion pack unit checks
PASS: quest stage1 policy unit checks
PASS: quest stage2 engine unit checks
PASS: season motion pack unit checks
PASS: release regression checklist unit checks
PASS: game layer observability qa unit checks
PASS: game layer KPI dashboard unit checks
PASS: fault injection matrix unit checks
PASS: supabase ops hardening unit checks
PASS: rival privacy policy stage1 unit checks
PASS: rival privacy hard guard unit checks
PASS: rival observability metrics unit checks
PASS: rival location services threading unit checks
PASS: rival league matching unit checks
PASS: rival stage2 backend unit checks
PASS: rival stage3 client ux unit checks
PASS: season anti-farming unit checks
PASS: season comeback catchup unit checks
PASS: season stage2 pipeline unit checks
PASS: season stage3 ui integration unit checks
PASS: territory status widget unit checks
PASS: hotspot widget privacy unit checks
PASS: season policy stage1 unit checks
PASS: weather risk policy stage1 unit checks
PASS: weather stage2 engine unit checks
PASS: weather ux stage3 unit checks
PASS: weather feedback loop unit checks
PASS: quest failure buffer unit checks
PASS: pet adaptive quest unit checks
PASS: pet context badge/empty-state unit checks
PASS: area reference DB UI transition unit checks
PASS: walk repository contract checks
All walk-repository backfill checks passed.
PASS: walk session pet canonicalization unit checks
PASS: presentation firebase boundary unit checks
PASS: supabase profile image upload unit checks
PASS: auth session autologin unit checks
[PASS] repository should not contain hardcoded model/service secrets
PASS: security key exposure unit checks
PASS: map/home viewmodel boundary unit checks
PASS: tabbar safe area regression unit checks
PASS: map camera jump fix unit checks
PASS: map area calculation service unit checks
PASS: settings profile/account actions unit checks
PASS: profile edit userinfo recovery unit checks
PASS: project stability unit checks
[dogArea] DOGAREA_SKIP_BUILD=1, skipping xcodebuild\n\nCloses #275