### PR TITLE
fix: auth onboarding branch/session consistency

### DIFF
--- a/dogArea/Source/ProfileRepository.swift
+++ b/dogArea/Source/ProfileRepository.swift
@@ -190,16 +190,13 @@ protocol AuthUseCaseProtocol {
 
 final class DefaultAuthUseCase: AuthUseCaseProtocol {
     private let authRepository: AuthRepositoryProtocol
-    private let profileRepository: ProfileRepository
     private let sessionStore: AuthSessionStoreProtocol
 
     init(
         authRepository: AuthRepositoryProtocol = DefaultAuthRepository(),
-        profileRepository: ProfileRepository = DefaultProfileRepository.shared,
         sessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared
     ) {
         self.authRepository = authRepository
-        self.profileRepository = profileRepository
         self.sessionStore = sessionStore
     }
 
@@ -211,8 +208,13 @@ final class DefaultAuthUseCase: AuthUseCaseProtocol {
             sessionStore.persist(tokenSession: tokenSession)
         }
 
-        let localProfileId = profileRepository.fetchUserInfo()?.id
-        let requiresOnboarding = localProfileId != result.credential.identity.userId
+        let requiresOnboarding: Bool
+        switch request {
+        case .emailSignUp:
+            requiresOnboarding = true
+        case .emailSignIn, .apple:
+            requiresOnboarding = false
+        }
         return AuthUseCaseOutcome(
             identity: result.credential.identity,
             displayNameHint: result.displayNameHint,

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -1022,14 +1022,14 @@ enum AppFeatureGate {
     ]
 
     static func currentSession() -> AppSessionState {
-        if let identity = DefaultAuthSessionStore.shared.currentIdentity(),
-           identity.userId.isEmpty == false {
-            return .member(userId: identity.userId)
-        }
-        guard let id = UserdefaultSetting.shared.getValue()?.id, id.isEmpty == false else {
+        guard let identity = DefaultAuthSessionStore.shared.currentIdentity(),
+              identity.userId.isEmpty == false else {
             return .guest
         }
-        return .member(userId: id)
+        guard DefaultAuthSessionStore.shared.currentTokenSession() != nil else {
+            return .guest
+        }
+        return .member(userId: identity.userId)
     }
 
     static func decision(for capability: FeatureCapability, session: AppSessionState) -> FeatureGateDecision {
@@ -1485,15 +1485,14 @@ final class AuthFlowCoordinator: ObservableObject {
     /// 현재 인증 세션/프로필 스토어에서 사용자 식별자를 조회합니다.
     /// - Returns: 로그인 사용자 ID가 있으면 반환하고, 없으면 `nil`을 반환합니다.
     private func currentMemberUserId() -> String? {
-        if let sessionUserId = authSessionStore.currentIdentity()?.userId,
-           sessionUserId.isEmpty == false {
-            return sessionUserId
+        guard let sessionUserId = authSessionStore.currentIdentity()?.userId,
+              sessionUserId.isEmpty == false else {
+            return nil
         }
-        if let profileUserId = UserdefaultSetting.shared.getValue()?.id,
-           profileUserId.isEmpty == false {
-            return profileUserId
+        guard authSessionStore.currentTokenSession() != nil else {
+            return nil
         }
-        return nil
+        return sessionUserId
     }
 }
 

--- a/dogArea/Views/SigningView/SignInView.swift
+++ b/dogArea/Views/SigningView/SignInView.swift
@@ -32,7 +32,6 @@ struct SignInView: View {
         onAuthenticated: @escaping () -> Void = {},
         onDismiss: @escaping () -> Void = {},
         authService: AppleCredentialAuthServiceProtocol = DeviceAppleCredentialAuthService.shared,
-        profileRepository: ProfileRepository = DefaultProfileRepository.shared,
         authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
         isAppleSignInTemporarilyDisabled: Bool = true,
         authUseCase: AuthUseCaseProtocol? = nil
@@ -43,7 +42,6 @@ struct SignInView: View {
         self.isAppleSignInTemporarilyDisabled = isAppleSignInTemporarilyDisabled
         self.authUseCase = authUseCase ?? DefaultAuthUseCase(
             authRepository: DefaultAuthRepository(credentialService: authService),
-            profileRepository: profileRepository,
             sessionStore: authSessionStore
         )
     }

--- a/scripts/auth_onboarding_session_consistency_unit_check.swift
+++ b/scripts/auth_onboarding_session_consistency_unit_check.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let authSource = load("dogArea/Source/ProfileRepository.swift")
+let sessionSource = load("dogArea/Source/UserdefaultSetting.swift")
+
+assertTrue(
+    authSource.contains("switch request"),
+    "auth use case should branch onboarding decision by request type"
+)
+assertTrue(
+    authSource.contains("case .emailSignUp:"),
+    "email signup should be the explicit onboarding entry path"
+)
+assertTrue(
+    authSource.contains("case .emailSignIn, .apple:"),
+    "email login and apple login should not force onboarding by local profile mismatch"
+)
+assertTrue(
+    sessionSource.contains("guard DefaultAuthSessionStore.shared.currentTokenSession() != nil else"),
+    "feature gate session should require token session to treat user as member"
+)
+assertTrue(
+    sessionSource.contains("guard authSessionStore.currentTokenSession() != nil else"),
+    "auth flow member user id resolution should require token session"
+)
+
+print("PASS: auth onboarding/session consistency unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -64,6 +64,7 @@ swift scripts/walk_session_pet_canonicalization_unit_check.swift
 swift scripts/presentation_firebase_boundary_unit_check.swift
 swift scripts/supabase_profile_image_upload_unit_check.swift
 swift scripts/auth_session_autologin_unit_check.swift
+swift scripts/auth_onboarding_session_consistency_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/tabbar_safearea_regression_unit_check.swift


### PR DESCRIPTION
## Summary\n- change auth onboarding decision to be request-type based (signup only), removing local profile mismatch dependency\n- make session/member gating token-backed to avoid stale logged-in state when auth session is invalid\n- add regression unit check and wire it into ios_pr_check\n\n## Validation\n- PASS: auth onboarding/session consistency unit checks\n- [dogArea] running document/unit checks
PASS: swift stability unit checks
PASS: userdefault store split unit checks
PASS: map motion pack unit checks
PASS: quest motion pack unit checks
PASS: quest stage1 policy unit checks
PASS: quest stage2 engine unit checks
PASS: season motion pack unit checks
PASS: release regression checklist unit checks
PASS: game layer observability qa unit checks
PASS: game layer KPI dashboard unit checks
PASS: fault injection matrix unit checks
PASS: supabase ops hardening unit checks
PASS: rival privacy policy stage1 unit checks
PASS: rival privacy hard guard unit checks
PASS: rival observability metrics unit checks
PASS: rival location services threading unit checks
PASS: rival league matching unit checks
PASS: rival stage2 backend unit checks
PASS: rival stage3 client ux unit checks
PASS: season anti-farming unit checks
PASS: season comeback catchup unit checks
PASS: season stage2 pipeline unit checks
PASS: season stage3 ui integration unit checks
PASS: territory status widget unit checks
PASS: hotspot widget privacy unit checks
PASS: season policy stage1 unit checks
PASS: weather risk policy stage1 unit checks
PASS: weather stage2 engine unit checks
PASS: weather ux stage3 unit checks
PASS: weather feedback loop unit checks
PASS: quest failure buffer unit checks
PASS: pet adaptive quest unit checks
PASS: pet context badge/empty-state unit checks
PASS: area reference DB UI transition unit checks
PASS: walk repository contract checks
All walk-repository backfill checks passed.
PASS: walk session pet canonicalization unit checks
PASS: presentation firebase boundary unit checks
PASS: supabase profile image upload unit checks
PASS: auth session autologin unit checks
PASS: auth onboarding/session consistency unit checks
[PASS] repository should not contain hardcoded model/service secrets
PASS: security key exposure unit checks
PASS: map/home viewmodel boundary unit checks
PASS: tabbar safe area regression unit checks
PASS: map camera jump fix unit checks
PASS: map area calculation service unit checks
PASS: settings profile/account actions unit checks
PASS: profile edit userinfo recovery unit checks
PASS: project stability unit checks
[dogArea] DOGAREA_SKIP_BUILD=1, skipping xcodebuild\n\nCloses #276