### PR TITLE
fix: guard rival nearby flow on invalid auth session

### DIFF
--- a/docs/rival-nearby-auth-session-guard-v1.md
+++ b/docs/rival-nearby-auth-session-guard-v1.md
@@ -1,0 +1,33 @@
+# Rival Nearby Auth Session Guard v1
+
+Date: 2026-03-04
+Issue: #277 (`nearby-presence get_hotspots 401 Invalid JWT`)
+
+## Problem Summary
+
+- Rival 탭 폴링(`refreshHotspots`/`refreshLeaderboard`)이 인증 세션 불일치 상태에서도 계속 호출될 수 있었습니다.
+- `currentUserId`가 `identity`만으로 계산되면(토큰 세션 없음) 호출이 반복되며 401 로그가 누적될 수 있습니다.
+
+## Code Guard Added
+
+- `RivalTabViewModel.currentUserId`에서 `authSessionStore.currentTokenSession()` 존재를 필수로 확인합니다.
+- 401/403 감지 시:
+  - 토큰 세션 즉시 삭제 (`clearTokenSession`)
+  - 익명 공유 상태 OFF
+  - 핫스팟/리더보드 데이터 초기화
+  - 사용자 토스트로 재로그인 안내
+
+## Deployment / Env Consistency Check Notes
+
+- `supabase/functions/nearby-presence/index.ts`는 서버 내부에서 `service_role`로 DB 작업을 수행합니다.
+- 본 저장소의 `supabase/config.toml`에는 `nearby-presence` 전용 `verify_jwt` override가 없습니다.
+  - 따라서 배포 환경 기본값(Edge Function JWT 검증 정책)에 따라 Authorization 헤더 유효성에 영향을 받습니다.
+- 운영 점검 시 아래 항목을 확인해야 합니다.
+  - 함수 배포 상태: `nearby-presence` latest 배포 여부
+  - 프로젝트 JWT/키 정책: 앱에서 사용하는 인증 토큰과 함수 JWT 검증 정책 일치 여부
+  - 로그: 401 발생 시 인증 만료/재로그인 플로우로 즉시 수렴하는지
+
+## Verification
+
+- `swift scripts/rival_auth_session_guard_unit_check.swift`
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -161,6 +161,9 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
                 refreshHotspots(force: true)
                 refreshLeaderboard(force: true)
             } catch {
+                if handleAuthFailureIfNeeded(error) {
+                    return
+                }
                 preferenceStore.set(false, forKey: locationSharingKey)
                 locationSharingEnabled = false
                 refreshViewState()
@@ -194,6 +197,9 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
             do {
                 try await nearbyService.setVisibility(userId: userId, enabled: false)
             } catch {
+                if handleAuthFailureIfNeeded(error) {
+                    return
+                }
                 preferenceStore.set(previous, forKey: locationSharingKey)
                 locationSharingEnabled = previous
                 refreshViewState()
@@ -274,6 +280,9 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
                         "retryable": RivalNetworkErrorInterpreter.isConnectivityError(error) ? "true" : "false"
                     ]
                 )
+                if handleAuthFailureIfNeeded(error) {
+                    return
+                }
                 if let supabaseError = error as? SupabaseHTTPError,
                    case .unexpectedStatusCode(404) = supabaseError {
                     hotspots = []
@@ -348,6 +357,9 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
                 lastLeaderboardRefreshAt = Date()
                 applyLeaderboardModerationFilter()
             } catch {
+                if handleAuthFailureIfNeeded(error) {
+                    return
+                }
                 leaderboardState = .errorRetryable
             }
         }
@@ -439,6 +451,9 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
     }
 
     private var currentUserId: String? {
+        guard authSessionStore.currentTokenSession() != nil else {
+            return nil
+        }
         if let authUserId = authSessionStore.currentIdentity()?.userId,
            let canonical = authUserId.canonicalUUIDString {
             return canonical
@@ -534,6 +549,37 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
     /// 신고/차단/숨김 이력을 로컬 JSON 로그에 누적합니다.
     private func appendModerationLog(action: String, aliasCode: String, reason: String?) {
         moderationStore.appendLog(action: action, aliasCode: aliasCode, reason: reason)
+    }
+
+    /// Supabase 응답이 인증 실패(401/403)인지 판정합니다.
+    /// - Parameter error: 판정할 원본 오류입니다.
+    /// - Returns: 인증 실패 계열이면 `true`, 아니면 `false`입니다.
+    private func isAuthFailure(_ error: Error) -> Bool {
+        guard let supabaseError = error as? SupabaseHTTPError,
+              case .unexpectedStatusCode(let statusCode) = supabaseError else {
+            return false
+        }
+        return statusCode == 401 || statusCode == 403
+    }
+
+    /// 인증 실패를 감지하면 세션/공유 상태를 정리하고 재로그인 안내 UX로 전환합니다.
+    /// - Parameter error: 네트워크 요청에서 발생한 원본 오류입니다.
+    /// - Returns: 인증 실패를 처리해 호출 측이 추가 처리를 중단해야 하면 `true`입니다.
+    @discardableResult
+    private func handleAuthFailureIfNeeded(_ error: Error) -> Bool {
+        guard isAuthFailure(error) else {
+            return false
+        }
+        authSessionStore.clearTokenSession()
+        preferenceStore.set(false, forKey: locationSharingKey)
+        locationSharingEnabled = false
+        hotspots = []
+        updateHotspotSummary()
+        leaderboardEntries = []
+        latestRawLeaderboardEntries = []
+        refreshViewState()
+        showToast("인증 세션이 만료됐어요. 다시 로그인 후 시도해주세요.")
+        return true
     }
 
     /// 위치 권한이 바뀌면 화면 상태를 즉시 재계산합니다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -43,6 +43,7 @@ swift scripts/rival_location_services_threading_unit_check.swift
 swift scripts/rival_league_matching_unit_check.swift
 swift scripts/rival_stage2_backend_unit_check.swift
 swift scripts/rival_stage3_client_ux_unit_check.swift
+swift scripts/rival_auth_session_guard_unit_check.swift
 swift scripts/season_anti_farming_unit_check.swift
 swift scripts/season_comeback_catchup_unit_check.swift
 swift scripts/season_stage2_pipeline_unit_check.swift

--- a/scripts/rival_auth_session_guard_unit_check.swift
+++ b/scripts/rival_auth_session_guard_unit_check.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let rivalViewModel = load("dogArea/Views/ProfileSettingView/RivalTabViewModel.swift")
+
+assertTrue(
+    rivalViewModel.contains("guard authSessionStore.currentTokenSession() != nil else"),
+    "rival tab should require token session before treating user as authenticated"
+)
+assertTrue(
+    rivalViewModel.contains("private func isAuthFailure(_ error: Error) -> Bool"),
+    "rival tab should classify auth failure status codes explicitly"
+)
+assertTrue(
+    rivalViewModel.contains("authSessionStore.clearTokenSession()"),
+    "rival tab should clear stale token session on auth failure"
+)
+assertTrue(
+    rivalViewModel.contains("인증 세션이 만료됐어요. 다시 로그인 후 시도해주세요."),
+    "rival tab should expose explicit re-login guidance on auth failure"
+)
+
+print("PASS: rival auth session guard unit checks")


### PR DESCRIPTION
## Summary
- require token-backed auth session before treating rival user context as authenticated
- on nearby/leaderboard auth failures(401/403), clear token session and transition UX to explicit re-login guidance
- add regression unit check for rival auth guard and wire it into ios_pr_check
- document nearby function auth/deployment consistency checks

## Validation
- `swift scripts/rival_auth_session_guard_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

## Docs
- `docs/rival-nearby-auth-session-guard-v1.md`

Closes #277
