### PR TITLE
fix: harden sync-walk 404 fallback and retry policy

### DIFF
--- a/docs/sync-walk-404-fallback-policy-v1.md
+++ b/docs/sync-walk-404-fallback-policy-v1.md
@@ -1,0 +1,43 @@
+# Sync-Walk 404 Fallback Policy v1
+
+Date: 2026-03-04  
+Issue: #278 (`sync-walk` function 404)
+
+## Problem
+
+- 일부 환경에서 `functions/v1/sync-walk` 호출이 404로 응답했습니다.
+- 기존 정책은 `not_configured`를 retryable로 분류해, 동기화 큐가 같은 실패를 반복할 수 있었습니다.
+
+## Client Policy Updates
+
+1. Function route fallback
+- primary route: `sync-walk`
+- legacy route fallback: `sync_walk` (primary가 404일 때 1회 재시도)
+
+2. 404 retry policy hardening
+- `sync-walk` 404는 `permanent(.notConfigured)`로 처리
+- 함수 비가용 쿨다운(10분) 동안 재호출을 차단해 요청 폭주를 방지
+
+3. Outbox drain behavior
+- `notConfigured` 영구실패는 현재 flush 사이클에서 다음 stage까지 연속 처리
+- 결과적으로 pending이 장시간 남아 반복 재시도되는 상태를 줄임
+
+4. User-facing fallback copy
+- 지도 동기화 상태: `서버 기능 미배포(404)`
+- 홈 이관 카드: `동기화 서버 기능이 아직 준비되지 않았어요(404).`
+
+## Ops Checklist
+
+- Supabase Edge Function 배포 확인
+  - canonical: `sync-walk`
+  - legacy fallback 필요 시 `sync_walk` 라우트 여부 확인
+- 프로젝트 함수 JWT/환경변수 정책 점검
+  - `SUPABASE_URL`
+  - `SUPABASE_ANON_KEY`
+  - 함수별 secret(`SUPABASE_SERVICE_ROLE_KEY`)
+- 배포 후 앱에서 404가 사라지면 fallback은 자동으로 성공 라우트에 수렴
+
+## Validation
+
+- `swift scripts/sync_walk_404_policy_unit_check.swift`
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -794,15 +794,31 @@ struct SupabaseSyncOutboxTransport: WalkSyncServiceProtocol {
         }
     }
 
-    private let client: SupabaseHTTPClient
+    private enum SyncWalkFunctionRoute {
+        static let primary = "sync-walk"
+        static let legacy = "sync_walk"
+    }
 
-    init(client: SupabaseHTTPClient = .live) {
+    private static let syncWalkFunctionUnavailableUntilKey = "sync.walk.function.unavailable.until.v1"
+    private static let syncWalkFunctionUnavailableCooldownSeconds: TimeInterval = 10 * 60
+
+    private let client: SupabaseHTTPClient
+    private let availabilityStore: UserDefaults
+
+    init(
+        client: SupabaseHTTPClient = .live,
+        availabilityStore: UserDefaults = .standard
+    ) {
         self.client = client
+        self.availabilityStore = availabilityStore
     }
 
     func send(item: SyncOutboxItem) async -> SyncOutboxSendResult {
         guard AppFeatureGate.isAllowed(.cloudSync, session: AppFeatureGate.currentSession()) else {
             return .retryable(.unauthorized)
+        }
+        guard isSyncWalkFunctionTemporarilyUnavailable() == false else {
+            return .permanent(.notConfigured)
         }
 
         let body: [String: Any] = [
@@ -814,17 +830,17 @@ struct SupabaseSyncOutboxTransport: WalkSyncServiceProtocol {
         ]
 
         do {
-            let data = try await client.request(
-                .function(name: "sync-walk"),
-                method: .post,
+            let data = try await requestSyncWalkFunction(
                 bodyData: try JSONSerialization.data(withJSONObject: body)
             )
+            clearSyncWalkFunctionUnavailableMarker()
             persistSeasonCatchupBuffSnapshotIfNeeded(item: item, data: data)
             return .success
         } catch let error as SupabaseHTTPError {
             switch error {
             case .notConfigured:
-                return .retryable(.notConfigured)
+                markSyncWalkFunctionTemporarilyUnavailable()
+                return .permanent(.notConfigured)
             case .unexpectedStatusCode(let statusCode):
                 switch statusCode {
                 case 401, 403:
@@ -834,7 +850,8 @@ struct SupabaseSyncOutboxTransport: WalkSyncServiceProtocol {
                 case 429, 500..<600:
                     return .retryable(.serverError)
                 case 404:
-                    return .retryable(.notConfigured)
+                    markSyncWalkFunctionTemporarilyUnavailable()
+                    return .permanent(.notConfigured)
                 case 400, 422:
                     return .permanent(.schemaMismatch)
                 case 507:
@@ -863,6 +880,9 @@ struct SupabaseSyncOutboxTransport: WalkSyncServiceProtocol {
         guard AppFeatureGate.isAllowed(.cloudSync, session: AppFeatureGate.currentSession()) else {
             return nil
         }
+        guard isSyncWalkFunctionTemporarilyUnavailable() == false else {
+            return nil
+        }
         let normalized = sessionIds
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
             .filter { $0.isEmpty == false }
@@ -875,11 +895,21 @@ struct SupabaseSyncOutboxTransport: WalkSyncServiceProtocol {
             "session_ids": normalized
         ]
 
-        guard let data = try? await client.request(
-            .function(name: "sync-walk"),
-            method: .post,
-            bodyData: try JSONSerialization.data(withJSONObject: body)
-        ) else {
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
+            return nil
+        }
+        let data: Data
+        do {
+            data = try await requestSyncWalkFunction(bodyData: bodyData)
+            clearSyncWalkFunctionUnavailableMarker()
+        } catch let error as SupabaseHTTPError {
+            if case .notConfigured = error {
+                markSyncWalkFunctionTemporarilyUnavailable()
+            } else if case .unexpectedStatusCode(404) = error {
+                markSyncWalkFunctionTemporarilyUnavailable()
+            }
+            return nil
+        } catch {
             return nil
         }
 
@@ -894,6 +924,48 @@ struct SupabaseSyncOutboxTransport: WalkSyncServiceProtocol {
             totalAreaM2: summary.totalAreaM2,
             totalDurationSec: summary.totalDurationSec
         )
+    }
+
+    /// `sync-walk` 함수 호출을 수행하고 404 발생 시 legacy 라우트(`sync_walk`)로 한 번 더 시도합니다.
+    /// - Parameter bodyData: 함수 요청 본문(JSON) 데이터입니다.
+    /// - Returns: 함수 응답 데이터입니다.
+    private func requestSyncWalkFunction(bodyData: Data) async throws -> Data {
+        do {
+            return try await client.request(
+                .function(name: SyncWalkFunctionRoute.primary),
+                method: .post,
+                bodyData: bodyData
+            )
+        } catch let error as SupabaseHTTPError {
+            guard case .unexpectedStatusCode(404) = error else {
+                throw error
+            }
+            return try await client.request(
+                .function(name: SyncWalkFunctionRoute.legacy),
+                method: .post,
+                bodyData: bodyData
+            )
+        }
+    }
+
+    /// `sync-walk` 함수 404 감지 이후 쿨다운 중인지 확인합니다.
+    /// - Parameter now: 쿨다운 만료 판정 기준 시각입니다.
+    /// - Returns: 쿨다운이 남아 있으면 `true`입니다.
+    private func isSyncWalkFunctionTemporarilyUnavailable(now: Date = Date()) -> Bool {
+        let until = availabilityStore.double(forKey: Self.syncWalkFunctionUnavailableUntilKey)
+        return until > now.timeIntervalSince1970
+    }
+
+    /// `sync-walk` 함수 404 발생 시 재시도 폭주를 방지하기 위해 쿨다운 마커를 기록합니다.
+    /// - Parameter now: 쿨다운 만료시각 계산 기준 시각입니다.
+    private func markSyncWalkFunctionTemporarilyUnavailable(now: Date = Date()) {
+        let until = now.timeIntervalSince1970 + Self.syncWalkFunctionUnavailableCooldownSeconds
+        availabilityStore.set(until, forKey: Self.syncWalkFunctionUnavailableUntilKey)
+    }
+
+    /// `sync-walk` 호출 성공 시 비가용 쿨다운 마커를 제거합니다.
+    private func clearSyncWalkFunctionUnavailableMarker() {
+        availabilityStore.removeObject(forKey: Self.syncWalkFunctionUnavailableUntilKey)
     }
 
     private func persistSeasonCatchupBuffSnapshotIfNeeded(item: SyncOutboxItem, data: Data) {

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -911,6 +911,9 @@ final class SyncOutboxStore {
                     item.lastErrorCode = code
                     item.updatedAt = currentNow
                 }
+                if code == .notConfigured {
+                    continue
+                }
                 return summary()
             }
         }

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -312,6 +312,13 @@ struct HomeView: View {
             )
             .font(.appFont(for: .Light, size: 11))
             .foregroundStyle(Color.appTextDarkGray)
+            if report.hasOutstandingWork,
+               let rawError = report.lastErrorCode,
+               rawError.isEmpty == false {
+                Text("최근 오류: \(guestDataUpgradeErrorMessage(rawValue: rawError))")
+                    .font(.appFont(for: .Light, size: 11))
+                    .foregroundStyle(Color.appRed)
+            }
             if let validationText {
                 Text(validationText)
                     .font(.appFont(for: .Light, size: 11))
@@ -326,6 +333,33 @@ struct HomeView: View {
             RoundedRectangle(cornerRadius: 10)
                 .stroke(report.hasOutstandingWork ? Color.appRed : Color.appGreen, lineWidth: 0.4)
         )
+    }
+
+    /// 게스트 데이터 이관 리포트의 아웃박스 오류 코드를 사용자 노출 문구로 변환합니다.
+    /// - Parameter rawValue: `SyncOutboxErrorCode` raw 문자열입니다.
+    /// - Returns: 이관 상태 카드에 표시할 오류 설명입니다.
+    private func guestDataUpgradeErrorMessage(rawValue: String) -> String {
+        guard let code = SyncOutboxErrorCode(rawValue: rawValue) else {
+            return rawValue
+        }
+        switch code {
+        case .notConfigured:
+            return "동기화 서버 기능이 아직 준비되지 않았어요(404)."
+        case .offline:
+            return "네트워크 오프라인 상태예요."
+        case .tokenExpired, .unauthorized:
+            return "인증 세션이 만료됐어요. 다시 로그인해주세요."
+        case .serverError:
+            return "서버가 일시적으로 불안정해요."
+        case .schemaMismatch:
+            return "앱/서버 스키마 버전 확인이 필요해요."
+        case .storageQuota:
+            return "서버 저장소 한도를 초과했어요."
+        case .conflict:
+            return "동기화 데이터 충돌이 발생했어요."
+        case .unknown:
+            return "알 수 없는 동기화 오류가 발생했어요."
+        }
     }
 
     private var goalTrackerCard: some View {

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -842,7 +842,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     var syncOutboxStatusText: String {
         if syncOutboxPermanentFailureCount > 0 {
             if syncOutboxLastErrorCodeText.isEmpty == false {
-                return "동기화 영구실패 \(syncOutboxPermanentFailureCount)건 (\(syncOutboxLastErrorCodeText))"
+                return "동기화 영구실패 \(syncOutboxPermanentFailureCount)건 (\(syncOutboxErrorDescription(rawValue: syncOutboxLastErrorCodeText)))"
             }
             return "동기화 영구실패 \(syncOutboxPermanentFailureCount)건"
         }
@@ -884,6 +884,33 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             syncRecoveryToastMessage = "온라인 복구: 대기 중 기록 동기화를 완료했어요."
         }
         lastSyncSummarySnapshot = summary
+    }
+
+    /// 동기화 오류 코드를 사용자에게 읽기 쉬운 상태 문구로 변환합니다.
+    /// - Parameter rawValue: `SyncOutboxErrorCode`의 raw 문자열입니다.
+    /// - Returns: 상태 표시용 오류 문구입니다.
+    private func syncOutboxErrorDescription(rawValue: String) -> String {
+        guard let code = SyncOutboxErrorCode(rawValue: rawValue) else {
+            return rawValue
+        }
+        switch code {
+        case .notConfigured:
+            return "서버 기능 미배포(404)"
+        case .offline:
+            return "오프라인"
+        case .tokenExpired, .unauthorized:
+            return "인증 만료"
+        case .serverError:
+            return "서버 오류"
+        case .schemaMismatch:
+            return "스키마 불일치"
+        case .storageQuota:
+            return "저장소 한도"
+        case .conflict:
+            return "충돌"
+        case .unknown:
+            return "알 수 없음"
+        }
     }
 
     private func enqueueSyncOutbox(for polygon: Polygon, hasImage: Bool) {

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -71,6 +71,7 @@ swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/tabbar_safearea_regression_unit_check.swift
 swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
+swift scripts/sync_walk_404_policy_unit_check.swift
 swift scripts/settings_profile_account_actions_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/project_stability_unit_check.swift

--- a/scripts/sync_walk_404_policy_unit_check.swift
+++ b/scripts/sync_walk_404_policy_unit_check.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let infra = load("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+let syncStore = load("dogArea/Source/UserdefaultSetting.swift")
+let mapVM = load("dogArea/Views/MapView/MapViewModel.swift")
+let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+
+assertTrue(
+    infra.contains("private enum SyncWalkFunctionRoute"),
+    "sync-walk transport should define primary/legacy route fallback"
+)
+assertTrue(
+    infra.contains("SyncWalkFunctionRoute.legacy"),
+    "sync-walk transport should attempt legacy function route on 404"
+)
+assertTrue(
+    infra.contains("guard isSyncWalkFunctionTemporarilyUnavailable() == false else"),
+    "sync-walk transport should short-circuit while function unavailability cooldown is active"
+)
+assertTrue(
+    infra.contains("case 404:\n                    markSyncWalkFunctionTemporarilyUnavailable()\n                    return .permanent(.notConfigured)"),
+    "sync-walk 404 should be treated as permanent notConfigured to prevent endless retries"
+)
+assertTrue(
+    syncStore.contains("if code == .notConfigured {\n                    continue\n                }"),
+    "outbox flush should continue draining queued stages after notConfigured permanent failure"
+)
+assertTrue(
+    mapVM.contains("서버 기능 미배포(404)"),
+    "map sync status should expose user-facing 404 fallback message"
+)
+assertTrue(
+    homeView.contains("동기화 서버 기능이 아직 준비되지 않았어요(404)."),
+    "home migration card should expose user-facing 404 fallback message"
+)
+
+print("PASS: sync-walk 404 policy unit checks")


### PR DESCRIPTION
## Summary
- add sync-walk route fallback (primary `sync-walk` -> legacy `sync_walk` on 404)
- treat sync-walk 404/notConfigured as permanent notConfigured and add cooldown marker to prevent repeated retry spam
- continue draining outbox stages for notConfigured permanent failures in same flush cycle
- add user-facing fallback copy for sync 404 in map/home surfaces
- document sync-walk 404 policy and ops checklist

## Validation
- `swift scripts/sync_walk_404_policy_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

## Docs
- `docs/sync-walk-404-fallback-policy-v1.md`

Closes #278
