### PR TITLE
[P2][Home] guest data upgrade retry CTA

### DIFF
--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -201,6 +201,8 @@ struct HomeView: View {
                 }.onChange(of: viewModel.seasonResetTransitionToken) { _, token in
                 guard token != nil else { return }
                 presentSeasonResetTransitionBanner()
+                }.onChange(of: authFlow.guestDataUpgradeResult?.id) { _, _ in
+                viewModel.refreshGuestDataUpgradeReport()
                 }.onChange(of: isLowPowerModeEnabled) { _, enabled in
                 if enabled {
                     seasonShieldRotation = 0
@@ -324,6 +326,14 @@ struct HomeView: View {
                     .font(.appFont(for: .Light, size: 11))
                     .foregroundStyle(report.validationPassed == true ? Color.appGreen : Color.appRed)
             }
+            if report.hasOutstandingWork {
+                Button(authFlow.guestDataUpgradeInProgress ? "재시도 중..." : "이관 재시도") {
+                    triggerGuestDataUpgradeRetry()
+                }
+                .accessibilityIdentifier("home.guestUpgrade.retry")
+                .disabled(authFlow.guestDataUpgradeInProgress)
+                .buttonStyle(AppFilledButtonStyle(role: .secondary, fillsWidth: false))
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(10)
@@ -360,6 +370,13 @@ struct HomeView: View {
         case .unknown:
             return "알 수 없는 동기화 오류가 발생했어요."
         }
+    }
+
+    /// 홈 게스트 데이터 이관 카드의 재시도 CTA를 실행합니다.
+    /// 재시도를 시작한 직후 최신 리포트를 다시 읽어 카드 상태를 갱신합니다.
+    private func triggerGuestDataUpgradeRetry() {
+        authFlow.startGuestDataUpgrade(forceRetry: true)
+        viewModel.refreshGuestDataUpgradeReport()
     }
 
     private var goalTrackerCard: some View {

--- a/scripts/home_guest_upgrade_retry_cta_unit_check.swift
+++ b/scripts/home_guest_upgrade_retry_cta_unit_check.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+
+assertTrue(
+    homeView.contains(".accessibilityIdentifier(\"home.guestUpgrade.retry\")"),
+    "home guest data upgrade card should expose retry CTA accessibility identifier"
+)
+assertTrue(
+    homeView.contains("authFlow.startGuestDataUpgrade(forceRetry: true)"),
+    "home retry CTA should trigger forced guest data upgrade"
+)
+assertTrue(
+    homeView.contains(".onChange(of: authFlow.guestDataUpgradeResult?.id)"),
+    "home view should refresh report when auth flow publishes upgrade result"
+)
+assertTrue(
+    homeView.contains("private func triggerGuestDataUpgradeRetry()"),
+    "home view should isolate retry CTA action handler"
+)
+
+print("PASS: home guest upgrade retry CTA unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -72,6 +72,7 @@ swift scripts/tabbar_safearea_regression_unit_check.swift
 swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/sync_walk_404_policy_unit_check.swift
+swift scripts/home_guest_upgrade_retry_cta_unit_check.swift
 swift scripts/settings_profile_account_actions_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/project_stability_unit_check.swift


### PR DESCRIPTION
## Summary\n- add retry CTA to home guest data upgrade card when outstanding work exists\n- connect CTA to forced guest data upgrade execution path\n- refresh home report when auth flow publishes upgrade result\n- add unit check and include it in ios_pr_check\n\n## Testing\n- swift scripts/home_guest_upgrade_retry_cta_unit_check.swift\n- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh\n\nCloses #279