### PR TITLE
[P2][Auth] 회원가입 입력 검증/중복 이메일 안내 강화

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -2511,12 +2511,12 @@ final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol
 
         let decoded = try? JSONDecoder().decode(SupabaseAuthResponseDTO.self, from: data)
         guard (200..<300).contains(statusCode) else {
+            let description = decoded?.errorDescription ?? decoded?.message ?? decoded?.error ?? "인증에 실패했습니다. (\(statusCode))"
+            if isDuplicateEmailErrorDescription(description) {
+                throw SupabaseAuthError.userAlreadyExists
+            }
             if statusCode == 400 || statusCode == 401 {
                 throw SupabaseAuthError.invalidCredentials
-            }
-            let description = decoded?.errorDescription ?? decoded?.message ?? decoded?.error ?? "인증에 실패했습니다. (\(statusCode))"
-            if description.localizedCaseInsensitiveContains("already") {
-                throw SupabaseAuthError.userAlreadyExists
             }
             throw SupabaseAuthError.requestFailed(description)
         }
@@ -2528,6 +2528,17 @@ final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol
             throw SupabaseAuthError.responseDecodeFailed
         }
         return result
+    }
+
+    /// Auth 실패 응답 설명이 이메일 중복 상황인지 판별합니다.
+    /// - Parameter description: Auth 응답에서 추출한 오류 설명 문자열입니다.
+    /// - Returns: 이메일 중복으로 해석되면 `true`, 아니면 `false`입니다.
+    private func isDuplicateEmailErrorDescription(_ description: String) -> Bool {
+        let lowercased = description.lowercased()
+        return lowercased.contains("already")
+            || lowercased.contains("duplicate")
+            || lowercased.contains("registered")
+            || lowercased.contains("exists")
     }
 }
 

--- a/dogArea/Views/SigningView/SignInView.swift
+++ b/dogArea/Views/SigningView/SignInView.swift
@@ -233,11 +233,13 @@ private struct EmailSignUpSheetView: View {
 
     @State private var email: String
     @State private var password: String = ""
+    @State private var confirmPassword: String = ""
     @State private var loading: Bool = false
     @State private var errorMessage: String? = nil
 
     private let authUseCase: AuthUseCaseProtocol
     private let onOutcome: (AuthUseCaseOutcome) -> Void
+    private let minimumPasswordLength: Int = 8
 
     /// 회원가입 시트의 초기 입력값과 인증 결과 전달 핸들러를 설정합니다.
     /// - Parameters:
@@ -275,6 +277,7 @@ private struct EmailSignUpSheetView: View {
                         .accessibilityIdentifier("signup.email")
 
                     SecureField("비밀번호", text: $password)
+                        .textContentType(.newPassword)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 12)
                         .background(Color.appSurface)
@@ -284,6 +287,18 @@ private struct EmailSignUpSheetView: View {
                         )
                         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         .accessibilityIdentifier("signup.password")
+
+                    SecureField("비밀번호 확인", text: $confirmPassword)
+                        .textContentType(.newPassword)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 12)
+                        .background(Color.appSurface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .stroke(Color.appTextLightGray.opacity(0.7), lineWidth: 1)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .accessibilityIdentifier("signup.passwordConfirm")
 
                     Button("회원가입 계속") {
                         submitSignUp()
@@ -331,9 +346,14 @@ private struct EmailSignUpSheetView: View {
 
         let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let normalizedPassword = password.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedConfirmPassword = confirmPassword.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        guard normalizedEmail.isEmpty == false, normalizedPassword.isEmpty == false else {
-            errorMessage = "이메일과 비밀번호를 모두 입력해주세요."
+        if let validationError = validateSignUpInput(
+            email: normalizedEmail,
+            password: normalizedPassword,
+            confirmPassword: normalizedConfirmPassword
+        ) {
+            errorMessage = validationError
             return
         }
 
@@ -355,5 +375,39 @@ private struct EmailSignUpSheetView: View {
                 }
             }
         }
+    }
+
+    /// 회원가입 입력값을 로컬에서 검증하고 실패 사유를 반환합니다.
+    /// - Parameters:
+    ///   - email: 공백 정리 후 검증할 이메일 문자열입니다.
+    ///   - password: 공백 정리 후 검증할 비밀번호 문자열입니다.
+    ///   - confirmPassword: 비밀번호 확인 입력값입니다.
+    /// - Returns: 검증 실패 시 사용자에게 노출할 메시지이며, 통과하면 `nil`입니다.
+    private func validateSignUpInput(
+        email: String,
+        password: String,
+        confirmPassword: String
+    ) -> String? {
+        guard email.isEmpty == false, password.isEmpty == false, confirmPassword.isEmpty == false else {
+            return "이메일, 비밀번호, 비밀번호 확인을 모두 입력해주세요."
+        }
+        guard isValidEmailFormat(email) else {
+            return "올바른 이메일 형식을 입력해주세요."
+        }
+        guard password.count >= minimumPasswordLength else {
+            return "비밀번호는 \(minimumPasswordLength)자 이상 입력해주세요."
+        }
+        guard password == confirmPassword else {
+            return "비밀번호 확인이 일치하지 않습니다."
+        }
+        return nil
+    }
+
+    /// 이메일 문자열이 기본 형식을 만족하는지 검사합니다.
+    /// - Parameter email: 형식 검증 대상 이메일 문자열입니다.
+    /// - Returns: 기본 이메일 형식을 만족하면 `true`, 아니면 `false`입니다.
+    private func isValidEmailFormat(_ email: String) -> Bool {
+        let pattern = #"^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#
+        return email.range(of: pattern, options: .regularExpression) != nil
     }
 }

--- a/scripts/auth_signup_validation_unit_check.swift
+++ b/scripts/auth_signup_validation_unit_check.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let signInView = load("dogArea/Views/SigningView/SignInView.swift")
+let infra = load("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+
+assertTrue(
+    signInView.contains("@State private var confirmPassword: String = \"\""),
+    "signup sheet should keep password confirmation state"
+)
+assertTrue(
+    signInView.contains("SecureField(\"비밀번호 확인\", text: $confirmPassword)"),
+    "signup sheet should render confirm password input field"
+)
+assertTrue(
+    signInView.contains(".accessibilityIdentifier(\"signup.passwordConfirm\")"),
+    "signup confirm password input should expose accessibility identifier"
+)
+assertTrue(
+    signInView.contains("private func validateSignUpInput(") && signInView.contains("password == confirmPassword"),
+    "signup should validate password confirmation match before request"
+)
+assertTrue(
+    signInView.contains("private func isValidEmailFormat(_ email: String) -> Bool"),
+    "signup should include email format validator"
+)
+assertTrue(
+    signInView.contains("if let validationError = validateSignUpInput("),
+    "signup submit should fail fast on local validation error"
+)
+
+assertTrue(
+    infra.contains("if isDuplicateEmailErrorDescription(description)"),
+    "auth error mapping should prioritize duplicate-email detection"
+)
+assertTrue(
+    infra.contains("private func isDuplicateEmailErrorDescription(_ description: String) -> Bool"),
+    "supabase auth service should define duplicate-email detector helper"
+)
+
+print("PASS: auth signup validation unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -67,6 +67,7 @@ swift scripts/supabase_profile_image_upload_unit_check.swift
 swift scripts/auth_session_autologin_unit_check.swift
 swift scripts/auth_onboarding_session_consistency_unit_check.swift
 swift scripts/auth_signup_entry_ux_unit_check.swift
+swift scripts/auth_signup_validation_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/tabbar_safearea_regression_unit_check.swift


### PR DESCRIPTION
## Summary
- 회원가입 시트에 비밀번호 확인 입력 필드 추가
- 로컬 입력 검증 추가: 필수값, 이메일 형식, 최소 비밀번호 길이, 비밀번호 일치
- Supabase Auth 실패 응답에서 중복 이메일 판단을 우선 적용하도록 에러 매핑 보정
- 전용 회귀 체크(auth_signup_validation_unit_check) 추가 및 ios_pr_check 연결

## Testing
- swift scripts/auth_signup_validation_unit_check.swift
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #288
