### PR TITLE
[P2][Home] 홈 날씨 상태 카드 미노출 회귀 복구

### DIFF
--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -140,6 +140,10 @@ struct HomeView: View {
                                     .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
+                            weatherMissionStatusCard(summary: viewModel.weatherMissionStatusSummary)
+                            if let shieldSummary = viewModel.weatherShieldDailySummary {
+                                weatherShieldSummaryCard(summary: shieldSummary)
+                            }
                             indoorMissionCard(board: viewModel.indoorMissionBoard)
                         }
                         territoryHeaderSection

--- a/scripts/home_weather_status_card_restore_unit_check.swift
+++ b/scripts/home_weather_status_card_restore_unit_check.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+
+assertTrue(
+    homeView.contains("weatherMissionStatusCard(summary: viewModel.weatherMissionStatusSummary)"),
+    "home daily mission section should render weather mission status card"
+)
+assertTrue(
+    homeView.contains("if let shieldSummary = viewModel.weatherShieldDailySummary") && homeView.contains("weatherShieldSummaryCard(summary: shieldSummary)"),
+    "home daily mission section should render weather shield summary card when available"
+)
+
+print("PASS: home weather status card restore unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -75,6 +75,7 @@ swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/sync_walk_404_policy_unit_check.swift
 swift scripts/home_guest_upgrade_retry_cta_unit_check.swift
+swift scripts/home_weather_status_card_restore_unit_check.swift
 swift scripts/settings_profile_account_actions_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/project_stability_unit_check.swift


### PR DESCRIPTION
## Summary
- 홈 데일리 미션 섹션 상단에 날씨 상태 카드 렌더 호출 복원
- 날씨 보호 요약 카드(옵션) 렌더 호출 복원
- 회귀 방지 유닛 체크(home_weather_status_card_restore_unit_check) 추가 및 ios_pr_check 연결

## Testing
- swift scripts/home_weather_status_card_restore_unit_check.swift
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #280
