### PR TITLE
[P4][Ops] 관측 지표/롤아웃/킬스위치 릴리즈 게이트 자동화

### DIFF
--- a/.github/workflows/realtime-ops-gate.yml
+++ b/.github/workflows/realtime-ops-gate.yml
@@ -1,0 +1,37 @@
+name: realtime-ops-gate
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      metrics_file:
+        description: "Path to KPI JSON input"
+        required: false
+        default: "docs/realtime-ops-kpi-sample-pass.json"
+
+jobs:
+  realtime-ops-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5.10"
+
+      - name: Validate Realtime Ops Docs/Workflow
+        run: swift scripts/realtime_ops_rollout_unit_check.swift
+
+      - name: Evaluate Realtime Ops Gate (PR sample)
+        if: github.event_name == 'pull_request'
+        run: swift scripts/realtime_ops_rollout_gate.swift --input docs/realtime-ops-kpi-sample-pass.json
+
+      - name: Evaluate Realtime Ops Gate (manual input)
+        if: github.event_name == 'workflow_dispatch'
+        run: swift scripts/realtime_ops_rollout_gate.swift --input "${{ inputs.metrics_file }}"

--- a/docs/realtime-ops-kpi-sample-pass.json
+++ b/docs/realtime-ops-kpi-sample-pass.json
@@ -1,0 +1,9 @@
+{
+  "stage": "10%",
+  "windowMinutes": 60,
+  "activeSessions": 120,
+  "staleRatio": 0.08,
+  "p95LatencyMs": 210,
+  "errorRate": 0.004,
+  "batteryImpactPercentPerHour": 1.4
+}

--- a/docs/realtime-ops-rollout-killswitch-v1.md
+++ b/docs/realtime-ops-rollout-killswitch-v1.md
@@ -1,0 +1,61 @@
+# Realtime Ops Rollout + Kill Switch v1
+
+## 1. 목적
+실시간 공유 기능 운영 시 필수 KPI, 알람, 단계 롤아웃, 긴급 차단 절차를 단일 문서로 고정한다.
+
+## 2. 핵심 KPI 정의
+| KPI | 정의 | 게이트 임계값 |
+| --- | --- | --- |
+| `active_sessions_5m` | 최근 5분 활성 공유 세션 수 | stage별 최소치 충족 |
+| `stale_ratio_5m` | stale 상태 세션 비율 | `< 0.12` |
+| `p95_latency_ms` | presence 업링크 p95 지연 | `< 350` |
+| `error_rate_5m` | 최근 5분 오류율 | `< 0.01` |
+| `battery_impact_percent_per_hour` | 실시간 공유 ON 기기 배터리 소모율 추정 | `< 2.5` |
+
+### 2.1 stage별 active sessions 최소치
+- `internal`: `>= 20`
+- `10%`: `>= 80`
+- `50%`: `>= 200`
+- `100%`: `>= 400`
+
+## 3. Alert 임계값 및 온콜 런북
+### 3.1 P1 Alert
+- `stale_ratio_5m >= 0.12`
+- `p95_latency_ms >= 350`
+- `error_rate_5m >= 0.01`
+- `battery_impact_percent_per_hour >= 2.5`
+
+### 3.2 온콜 런북 (5분 내 안정화 목표)
+1. `feature_flags.rollout_percent`를 직전 단계로 즉시 롤백한다.
+2. 서버 kill switch(`NEARBY_PRESENCE_ENABLED=false`)를 적용한다.
+3. 클라이언트 kill switch(`ff_nearby_hotspot_v1=false`)를 강제 비활성화한다.
+4. 장애 시각/영향 범위/추정 원인을 incidents 채널에 기록한다.
+5. 30분 내 임시 회복 여부를 재확인하고, 불가 시 `NO-GO`로 고정한다.
+
+## 4. 단계 롤아웃 절차
+1. `internal` -> 내부 QA + 게이트 통과
+2. `10%` -> 24h 관측, KPI 임계값 유지 확인
+3. `50%` -> 24h 관측, KPI 임계값 유지 확인
+4. `100%` -> 24h 관측, 주간 리포트 반영
+
+## 5. Kill Switch 검증 시나리오
+### 5.1 클라이언트 kill switch
+- `ff_nearby_hotspot_v1`를 `false`로 설정 후 앱 재실행
+- 익명 공유 시작 CTA 비노출 또는 차단 메시지 노출 확인
+
+### 5.2 서버 kill switch
+- `NEARBY_PRESENCE_ENABLED=false` 적용
+- 업링크 요청이 즉시 `disabled/not configured` 경로로 전환되는지 확인
+- stale/latency/error KPI가 10분 내 안정화되는지 확인
+
+## 6. 운영 대시보드/주간 리포트
+- 운영 대시보드: `public.view_rollout_kpis_24h` + 실시간 공유 KPI 패널
+- 주간 리포트 템플릿: `docs/realtime-ops-weekly-report-template-v1.md`
+- 자동 게이트 스크립트: `scripts/realtime_ops_rollout_gate.swift`
+- GitHub Actions 게이트: `.github/workflows/realtime-ops-gate.yml`
+
+## 7. 배포 게이트 규칙
+- 배포 전 필수:
+  - `swift scripts/realtime_ops_rollout_gate.swift --input <kpi-json>`
+  - `swift scripts/realtime_ops_rollout_unit_check.swift`
+- 하나라도 실패하면 배포를 중단하고 `NO-GO` 판정한다.

--- a/docs/realtime-ops-weekly-report-template-v1.md
+++ b/docs/realtime-ops-weekly-report-template-v1.md
@@ -1,0 +1,36 @@
+# Realtime Ops Weekly Report Template v1
+
+## 1. 기간/버전
+- 기간:
+- 대상 버전:
+- 작성자:
+
+## 2. KPI 요약
+| KPI | 이번 주 | 지난 주 | 임계값 | 판정 |
+| --- | ---: | ---: | ---: | --- |
+| active_sessions_5m |  |  | stage min | PASS/FAIL |
+| stale_ratio_5m |  |  | < 0.12 | PASS/FAIL |
+| p95_latency_ms |  |  | < 350 | PASS/FAIL |
+| error_rate_5m |  |  | < 0.01 | PASS/FAIL |
+| battery_impact_percent_per_hour |  |  | < 2.5 | PASS/FAIL |
+
+## 3. Alert/Incident
+- P0:
+- P1:
+- 주요 원인:
+- 재발 방지 액션:
+
+## 4. 롤아웃 상태
+- 현재 단계: internal / 10% / 50% / 100%
+- 단계 승급 여부: YES / NO
+- 롤백 수행 여부: YES / NO
+
+## 5. Kill Switch 훈련/실적
+- 클라이언트 kill switch 검증 일시:
+- 서버 kill switch 검증 일시:
+- 5분 내 차단 달성 여부: YES / NO
+
+## 6. 다음 주 액션
+1. 
+2. 
+3. 

--- a/docs/release-regression-checklist-v1.md
+++ b/docs/release-regression-checklist-v1.md
@@ -155,6 +155,7 @@
 
 ### 7.4 배포 파이프라인
 - workflow 정의: `PASS | FAIL | BLOCKED`
+- realtime-ops-gate: `PASS | FAIL | BLOCKED`
 - 최근 실행 상태: `PASS | FAIL | BLOCKED`
 - 근거:
 
@@ -169,6 +170,7 @@
 
 ## 8. 배포 전/후 핵심 지표 비교
 - 기준 뷰: `public.view_rollout_kpis_24h`
+- 실시간 게이트 스크립트: `swift scripts/realtime_ops_rollout_gate.swift --input <kpi-json>`
 - 스냅샷 수집 규칙:
   - 배포 직전 24h: `T-24h ~ T0`
   - 배포 후 24h: `T0 ~ T+24h`
@@ -177,6 +179,11 @@
   - `watch_action_loss_rate` (목표: `<= 0.01`)
   - `caricature_success_rate` (목표: `>= 0.90`)
   - `nearby_opt_in_ratio` (관측 지표, 목표 없음)
+  - `active_sessions_5m` (stage 최소치 충족)
+  - `stale_ratio_5m` (목표: `< 0.12`)
+  - `p95_latency_ms` (목표: `< 350`)
+  - `error_rate_5m` (목표: `< 0.01`)
+  - `battery_impact_percent_per_hour` (목표: `< 2.5`)
 - SQL 예시:
 ```sql
 select

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -35,6 +35,8 @@ swift scripts/release_regression_checklist_unit_check.swift
 swift scripts/game_layer_observability_qa_unit_check.swift
 swift scripts/game_layer_kpi_dashboard_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift
+swift scripts/realtime_ops_rollout_unit_check.swift
+swift scripts/realtime_ops_rollout_gate.swift --input docs/realtime-ops-kpi-sample-pass.json
 swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift

--- a/scripts/realtime_ops_rollout_gate.swift
+++ b/scripts/realtime_ops_rollout_gate.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+struct RealtimeOpsGateInput: Decodable {
+    let stage: String
+    let windowMinutes: Int
+    let activeSessions: Int
+    let staleRatio: Double
+    let p95LatencyMs: Double
+    let errorRate: Double
+    let batteryImpactPercentPerHour: Double
+}
+
+enum RealtimeOpsRolloutStage {
+    case internalStage
+    case tenPercent
+    case fiftyPercent
+    case hundredPercent
+}
+
+enum RealtimeOpsGateError: LocalizedError {
+    case invalidArguments
+    case invalidStage(String)
+    case inputReadFailed(String)
+    case inputDecodeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidArguments:
+            return "usage: swift scripts/realtime_ops_rollout_gate.swift --input <json-file>"
+        case .invalidStage(let raw):
+            return "unsupported stage: \(raw). allowed: internal, 10%, 50%, 100%"
+        case .inputReadFailed(let path):
+            return "failed to read input file: \(path)"
+        case .inputDecodeFailed:
+            return "failed to decode KPI input JSON"
+        }
+    }
+}
+
+/// 커맨드라인 인자에서 KPI 입력 파일 경로를 추출합니다.
+/// - Parameter arguments: 실행 시 전달된 전체 인자 배열입니다.
+/// - Returns: `--input` 인자의 파일 경로입니다.
+/// - Throws: 인자 형식이 잘못되었으면 `RealtimeOpsGateError.invalidArguments`를 던집니다.
+func parseInputPath(arguments: [String]) throws -> String {
+    guard let inputIndex = arguments.firstIndex(of: "--input"), arguments.indices.contains(inputIndex + 1) else {
+        throw RealtimeOpsGateError.invalidArguments
+    }
+    return arguments[inputIndex + 1]
+}
+
+/// 지정한 JSON 파일에서 실시간 운영 게이트 입력값을 로드합니다.
+/// - Parameter path: KPI 입력 JSON 파일 경로입니다.
+/// - Returns: 디코딩된 `RealtimeOpsGateInput`입니다.
+/// - Throws: 파일 읽기/디코딩 실패 시 `RealtimeOpsGateError`를 던집니다.
+func loadGateInput(from path: String) throws -> RealtimeOpsGateInput {
+    let fileURL = URL(fileURLWithPath: path)
+    guard let data = try? Data(contentsOf: fileURL) else {
+        throw RealtimeOpsGateError.inputReadFailed(path)
+    }
+    guard let decoded = try? JSONDecoder().decode(RealtimeOpsGateInput.self, from: data) else {
+        throw RealtimeOpsGateError.inputDecodeFailed
+    }
+    return decoded
+}
+
+/// 문자열 stage 값을 롤아웃 단계 열거형으로 변환합니다.
+/// - Parameter rawStage: 입력 JSON의 stage 문자열입니다.
+/// - Returns: 정규화된 `RealtimeOpsRolloutStage`입니다.
+/// - Throws: 허용되지 않은 stage 문자열이면 `RealtimeOpsGateError.invalidStage`를 던집니다.
+func parseStage(_ rawStage: String) throws -> RealtimeOpsRolloutStage {
+    let normalized = rawStage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    switch normalized {
+    case "internal":
+        return .internalStage
+    case "10", "10%":
+        return .tenPercent
+    case "50", "50%":
+        return .fiftyPercent
+    case "100", "100%":
+        return .hundredPercent
+    default:
+        throw RealtimeOpsGateError.invalidStage(rawStage)
+    }
+}
+
+/// 롤아웃 단계별 최소 활성 세션 수 기준을 반환합니다.
+/// - Parameter stage: 현재 롤아웃 단계입니다.
+/// - Returns: 게이트 통과에 필요한 최소 활성 세션 수입니다.
+func minimumActiveSessions(for stage: RealtimeOpsRolloutStage) -> Int {
+    switch stage {
+    case .internalStage: return 20
+    case .tenPercent: return 80
+    case .fiftyPercent: return 200
+    case .hundredPercent: return 400
+    }
+}
+
+/// 게이트 실패 조건을 평가해 실패 사유 목록을 반환합니다.
+/// - Parameter input: KPI 게이트 평가 입력값입니다.
+/// - Returns: 기준 미달 항목의 설명 문자열 배열입니다.
+/// - Throws: stage 파싱이 실패하면 `RealtimeOpsGateError`를 던집니다.
+func evaluateFailures(input: RealtimeOpsGateInput) throws -> [String] {
+    let stage = try parseStage(input.stage)
+    var failures: [String] = []
+
+    let minActiveSessions = minimumActiveSessions(for: stage)
+    if input.activeSessions < minActiveSessions {
+        failures.append("active_sessions_5m \(input.activeSessions) < \(minActiveSessions)")
+    }
+    if input.staleRatio >= 0.12 {
+        failures.append(String(format: "stale_ratio_5m %.4f >= 0.12", input.staleRatio))
+    }
+    if input.p95LatencyMs >= 350 {
+        failures.append(String(format: "p95_latency_ms %.1f >= 350", input.p95LatencyMs))
+    }
+    if input.errorRate >= 0.01 {
+        failures.append(String(format: "error_rate_5m %.4f >= 0.01", input.errorRate))
+    }
+    if input.batteryImpactPercentPerHour >= 2.5 {
+        failures.append(String(format: "battery_impact_percent_per_hour %.2f >= 2.5", input.batteryImpactPercentPerHour))
+    }
+
+    return failures
+}
+
+/// KPI 입력값을 사람이 읽기 쉬운 한 줄 요약으로 렌더링합니다.
+/// - Parameter input: 출력할 KPI 입력값입니다.
+/// - Returns: 로그/리포트용 한 줄 텍스트입니다.
+func summaryLine(for input: RealtimeOpsGateInput) -> String {
+    String(
+        format: "stage=%@ window=%dm active=%d stale=%.4f p95=%.1fms error=%.4f battery=%.2f%%/h",
+        input.stage,
+        input.windowMinutes,
+        input.activeSessions,
+        input.staleRatio,
+        input.p95LatencyMs,
+        input.errorRate,
+        input.batteryImpactPercentPerHour
+    )
+}
+
+do {
+    let inputPath = try parseInputPath(arguments: CommandLine.arguments)
+    let input = try loadGateInput(from: inputPath)
+    let failures = try evaluateFailures(input: input)
+
+    print("Realtime Ops Gate input: \(summaryLine(for: input))")
+
+    if failures.isEmpty {
+        print("PASS: realtime ops rollout gate")
+        exit(0)
+    }
+
+    fputs("FAIL: realtime ops rollout gate\n", stderr)
+    failures.forEach { fputs("- \($0)\n", stderr) }
+    exit(1)
+} catch {
+    fputs("FAIL: \(error.localizedDescription)\n", stderr)
+    exit(2)
+}

--- a/scripts/realtime_ops_rollout_unit_check.swift
+++ b/scripts/realtime_ops_rollout_unit_check.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let opsDoc = load("docs/realtime-ops-rollout-killswitch-v1.md")
+let templateDoc = load("docs/realtime-ops-weekly-report-template-v1.md")
+let workflow = load(".github/workflows/realtime-ops-gate.yml")
+let gateScript = load("scripts/realtime_ops_rollout_gate.swift")
+let prCheck = load("scripts/ios_pr_check.sh")
+let releaseChecklist = load("docs/release-regression-checklist-v1.md")
+
+assertTrue(opsDoc.contains("active_sessions_5m"), "ops doc should define active sessions KPI")
+assertTrue(opsDoc.contains("stale_ratio_5m"), "ops doc should define stale ratio KPI")
+assertTrue(opsDoc.contains("p95_latency_ms"), "ops doc should define p95 latency KPI")
+assertTrue(opsDoc.contains("error_rate_5m"), "ops doc should define error rate KPI")
+assertTrue(opsDoc.contains("battery_impact_percent_per_hour"), "ops doc should define battery impact KPI")
+assertTrue(opsDoc.contains("internal") && opsDoc.contains("10%") && opsDoc.contains("50%") && opsDoc.contains("100%"), "ops doc should define staged rollout percentages")
+assertTrue(opsDoc.contains("ff_nearby_hotspot_v1=false"), "ops doc should define client kill switch")
+assertTrue(opsDoc.contains("NEARBY_PRESENCE_ENABLED=false"), "ops doc should define server kill switch")
+assertTrue(opsDoc.contains("docs/realtime-ops-weekly-report-template-v1.md"), "ops doc should link weekly report template")
+
+assertTrue(templateDoc.contains("KPI 요약"), "weekly template should include KPI summary section")
+assertTrue(templateDoc.contains("Alert/Incident"), "weekly template should include alert incident section")
+assertTrue(templateDoc.contains("Kill Switch"), "weekly template should include kill switch section")
+assertTrue(releaseChecklist.contains("realtime-ops-gate"), "release checklist should reference realtime ops gate workflow")
+assertTrue(releaseChecklist.contains("scripts/realtime_ops_rollout_gate.swift --input <kpi-json>"), "release checklist should include realtime gate script command")
+
+assertTrue(workflow.contains("name: realtime-ops-gate"), "workflow should define realtime ops gate workflow")
+assertTrue(workflow.contains("metrics_file"), "workflow should expose metrics_file input for dispatch")
+assertTrue(workflow.contains("swift scripts/realtime_ops_rollout_unit_check.swift"), "workflow should run realtime ops unit check")
+assertTrue(workflow.contains("swift scripts/realtime_ops_rollout_gate.swift --input"), "workflow should run realtime ops gate script")
+
+assertTrue(gateScript.contains("minimumActiveSessions(for:") , "gate script should define stage-based active session threshold")
+assertTrue(gateScript.contains("input.staleRatio >= 0.12"), "gate script should enforce stale ratio threshold")
+assertTrue(gateScript.contains("input.p95LatencyMs >= 350"), "gate script should enforce p95 latency threshold")
+assertTrue(gateScript.contains("input.errorRate >= 0.01"), "gate script should enforce error rate threshold")
+assertTrue(gateScript.contains("input.batteryImpactPercentPerHour >= 2.5"), "gate script should enforce battery threshold")
+
+assertTrue(prCheck.contains("scripts/realtime_ops_rollout_unit_check.swift"), "ios_pr_check should include realtime ops unit check")
+assertTrue(prCheck.contains("scripts/realtime_ops_rollout_gate.swift --input docs/realtime-ops-kpi-sample-pass.json"), "ios_pr_check should execute realtime ops gate with sample input")
+
+print("PASS: realtime ops rollout unit checks")


### PR DESCRIPTION
## Summary
- add realtime ops rollout + kill switch runbook (`docs/realtime-ops-rollout-killswitch-v1.md`)
- add weekly report template (`docs/realtime-ops-weekly-report-template-v1.md`)
- add KPI sample input (`docs/realtime-ops-kpi-sample-pass.json`)
- add automated gate evaluator (`scripts/realtime_ops_rollout_gate.swift`)
- add regression/unit checker for docs/workflow integration (`scripts/realtime_ops_rollout_unit_check.swift`)
- add CI workflow for realtime ops gate (`.github/workflows/realtime-ops-gate.yml`)
- wire checks into `scripts/ios_pr_check.sh` and release checklist

## Testing
- swift scripts/realtime_ops_rollout_unit_check.swift
- swift scripts/realtime_ops_rollout_gate.swift --input docs/realtime-ops-kpi-sample-pass.json
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #242
