### PR TITLE
[Issue #239] Map live hotspot rendering LOD/cluster/trail UX

### DIFF
--- a/dogArea/Source/Domain/Map/Services/MapClusterAnnotationService.swift
+++ b/dogArea/Source/Domain/Map/Services/MapClusterAnnotationService.swift
@@ -28,12 +28,76 @@ protocol MapClusterAnnotationServicing {
         minCellMeters: Double,
         maxCellMeters: Double
     ) -> [Cluster]
+
+    /// 실시간 핫스팟 렌더링 후보를 뷰포트/캡/LOD 규칙으로 계산합니다.
+    /// - Parameters:
+    ///   - hotspots: 렌더링 원본 핫스팟 목록입니다.
+    ///   - viewportCenter: 현재 지도 중심 좌표입니다. `nil`이면 뷰포트 필터를 건너뜁니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    ///   - maxVisible: 최종 렌더링 최대 개수입니다.
+    ///   - pageMultiplier: 뷰포트 내부 후보 풀 확장 배수입니다.
+    ///   - clusterDistanceThreshold: 클러스터 모드로 전환할 최소 카메라 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 클러스터 셀 크기 비율입니다.
+    ///   - minCellMeters: 셀 크기의 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 크기의 최대값(미터)입니다.
+    /// - Returns: LOD/캡 규칙이 반영된 최종 렌더링 노드 목록입니다.
+    func renderHotspots(
+        hotspots: [NearbyHotspotRenderInput],
+        viewportCenter: CLLocationCoordinate2D?,
+        cameraDistance: Double,
+        maxVisible: Int,
+        pageMultiplier: Int,
+        clusterDistanceThreshold: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> [NearbyHotspotRenderNode]
 }
 
 final class MapClusterAnnotationService: MapClusterAnnotationServicing {
     private struct ClusterBucketKey: Hashable {
         let x: Int
         let y: Int
+    }
+
+    private struct HotspotBucketValue {
+        var memberCount: Int
+        var weightedLatitudeSum: Double
+        var weightedLongitudeSum: Double
+        var activityCountSum: Int
+        var maxIntensity: Double
+        var visualState: NearbyHotspotVisualState
+        var representativeID: String
+
+        /// 버킷에 핫스팟 샘플을 누적 병합합니다.
+        /// - Parameter hotspot: 같은 셀로 분류된 핫스팟 입력입니다.
+        mutating func merge(with hotspot: NearbyHotspotRenderInput) {
+            let weight = max(1.0, Double(hotspot.count))
+            memberCount += 1
+            weightedLatitudeSum += hotspot.centerCoordinate.latitude * weight
+            weightedLongitudeSum += hotspot.centerCoordinate.longitude * weight
+            activityCountSum += max(1, hotspot.count)
+            maxIntensity = max(maxIntensity, hotspot.intensity)
+            visualState = visualState.merged(with: hotspot.visualState)
+        }
+
+        /// 누적 버킷 값을 렌더 노드로 변환합니다.
+        /// - Parameter bucketKey: 버킷 좌표 키입니다.
+        /// - Returns: 지도에 직접 그릴 수 있는 핫스팟 렌더 노드입니다.
+        func asNode(bucketKey: ClusterBucketKey) -> NearbyHotspotRenderNode {
+            let weight = max(1.0, Double(activityCountSum))
+            return NearbyHotspotRenderNode(
+                id: "cluster-\(bucketKey.x)-\(bucketKey.y)-\(representativeID)",
+                centerCoordinate: .init(
+                    latitude: weightedLatitudeSum / weight,
+                    longitude: weightedLongitudeSum / weight
+                ),
+                count: activityCountSum,
+                intensity: maxIntensity,
+                visualState: visualState,
+                isCluster: memberCount > 1
+            )
+        }
     }
 
     /// 현재 폴리곤 목록과 카메라 거리 기반 설정으로 클러스터 배열을 계산합니다.
@@ -59,6 +123,73 @@ final class MapClusterAnnotationService: MapClusterAnnotationServicing {
             minCellMeters: minCellMeters,
             maxCellMeters: maxCellMeters
         )
+    }
+
+    /// 실시간 핫스팟 렌더링 후보를 뷰포트/캡/LOD 규칙으로 계산합니다.
+    /// - Parameters:
+    ///   - hotspots: 렌더링 원본 핫스팟 목록입니다.
+    ///   - viewportCenter: 현재 지도 중심 좌표입니다. `nil`이면 뷰포트 필터를 건너뜁니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    ///   - maxVisible: 최종 렌더링 최대 개수입니다.
+    ///   - pageMultiplier: 뷰포트 내부 후보 풀 확장 배수입니다.
+    ///   - clusterDistanceThreshold: 클러스터 모드로 전환할 최소 카메라 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 클러스터 셀 크기 비율입니다.
+    ///   - minCellMeters: 셀 크기의 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 크기의 최대값(미터)입니다.
+    /// - Returns: LOD/캡 규칙이 반영된 최종 렌더링 노드 목록입니다.
+    func renderHotspots(
+        hotspots: [NearbyHotspotRenderInput],
+        viewportCenter: CLLocationCoordinate2D?,
+        cameraDistance: Double,
+        maxVisible: Int,
+        pageMultiplier: Int,
+        clusterDistanceThreshold: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> [NearbyHotspotRenderNode] {
+        guard hotspots.isEmpty == false else { return [] }
+
+        let visibleCap = max(8, maxVisible)
+        let candidateLimit = max(visibleCap, visibleCap * max(1, pageMultiplier))
+        let viewportRadius = max(240.0, min(10_000.0, cameraDistance * 1.35))
+        let scoped = filterByViewport(
+            hotspots: hotspots,
+            center: viewportCenter,
+            radiusMeters: viewportRadius
+        )
+        let source = scoped.isEmpty ? hotspots : scoped
+        let ranked = rankedHotspots(
+            source,
+            center: viewportCenter
+        )
+        let candidates = Array(ranked.prefix(candidateLimit))
+        guard candidates.isEmpty == false else { return [] }
+
+        let nodes: [NearbyHotspotRenderNode]
+        if cameraDistance >= clusterDistanceThreshold {
+            nodes = clusterHotspots(
+                candidates,
+                cameraDistance: cameraDistance,
+                distanceRatio: distanceRatio,
+                minCellMeters: minCellMeters,
+                maxCellMeters: maxCellMeters
+            )
+        } else {
+            nodes = candidates.map {
+                NearbyHotspotRenderNode(
+                    id: $0.id,
+                    centerCoordinate: $0.centerCoordinate,
+                    count: $0.count,
+                    intensity: $0.intensity,
+                    visualState: $0.visualState,
+                    isCluster: false
+                )
+            }
+        }
+
+        let resorted = rankedRenderNodes(nodes, center: viewportCenter)
+        return Array(resorted.prefix(visibleCap))
     }
 
     /// 폴리곤 중심점을 단일 클러스터로 초기화합니다.
@@ -143,6 +274,204 @@ final class MapClusterAnnotationService: MapClusterAnnotationServicing {
         let raw = cameraDistance * distanceRatio
         return min(maxCellMeters, max(minCellMeters, raw))
     }
+
+    /// 뷰포트 중심/반경 기준으로 핫스팟 목록을 필터링합니다.
+    /// - Parameters:
+    ///   - hotspots: 필터링할 원본 핫스팟 목록입니다.
+    ///   - center: 현재 지도 중심 좌표입니다.
+    ///   - radiusMeters: 뷰포트 반경(미터)입니다.
+    /// - Returns: 뷰포트 반경 안에 포함된 핫스팟 목록입니다.
+    private func filterByViewport(
+        hotspots: [NearbyHotspotRenderInput],
+        center: CLLocationCoordinate2D?,
+        radiusMeters: CLLocationDistance
+    ) -> [NearbyHotspotRenderInput] {
+        guard let center else { return hotspots }
+        return hotspots.filter {
+            greatCircleDistanceMeters(from: center, to: $0.centerCoordinate) <= radiusMeters
+        }
+    }
+
+    /// 핫스팟 목록을 거리/강도/활동 수 기준으로 정렬합니다.
+    /// - Parameters:
+    ///   - hotspots: 정렬할 핫스팟 목록입니다.
+    ///   - center: 현재 지도 중심 좌표입니다.
+    /// - Returns: 렌더 우선순위가 반영된 정렬 결과입니다.
+    private func rankedHotspots(
+        _ hotspots: [NearbyHotspotRenderInput],
+        center: CLLocationCoordinate2D?
+    ) -> [NearbyHotspotRenderInput] {
+        hotspots.sorted { lhs, rhs in
+            if let center {
+                let lhsDistance = greatCircleDistanceMeters(from: center, to: lhs.centerCoordinate)
+                let rhsDistance = greatCircleDistanceMeters(from: center, to: rhs.centerCoordinate)
+                if abs(lhsDistance - rhsDistance) >= 8 {
+                    return lhsDistance < rhsDistance
+                }
+            }
+            if lhs.intensity != rhs.intensity {
+                return lhs.intensity > rhs.intensity
+            }
+            if lhs.count != rhs.count {
+                return lhs.count > rhs.count
+            }
+            return lhs.id < rhs.id
+        }
+    }
+
+    /// 원거리 모드에서 핫스팟을 버킷 단위로 병합합니다.
+    /// - Parameters:
+    ///   - hotspots: 병합 대상 핫스팟 목록입니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 셀 크기 비율입니다.
+    ///   - minCellMeters: 셀 크기의 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 크기의 최대값(미터)입니다.
+    /// - Returns: 버킷 병합 결과 노드 목록입니다.
+    private func clusterHotspots(
+        _ hotspots: [NearbyHotspotRenderInput],
+        cameraDistance: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> [NearbyHotspotRenderNode] {
+        guard hotspots.count > 1 else {
+            return hotspots.map {
+                NearbyHotspotRenderNode(
+                    id: $0.id,
+                    centerCoordinate: $0.centerCoordinate,
+                    count: $0.count,
+                    intensity: $0.intensity,
+                    visualState: $0.visualState,
+                    isCluster: false
+                )
+            }
+        }
+
+        let referenceLatitude = hotspots.map(\.centerCoordinate.latitude).reduce(0.0, +) / Double(hotspots.count)
+        let cellMeters = clusterCellSizeMeters(
+            cameraDistance: cameraDistance,
+            distanceRatio: distanceRatio,
+            minCellMeters: minCellMeters,
+            maxCellMeters: maxCellMeters
+        )
+        let metersPerMapPoint = MKMetersPerMapPointAtLatitude(referenceLatitude)
+        let cellMapPoints = max(1.0, cellMeters / max(0.0001, metersPerMapPoint))
+
+        var buckets: [ClusterBucketKey: HotspotBucketValue] = [:]
+        buckets.reserveCapacity(hotspots.count)
+
+        for hotspot in hotspots {
+            let point = MKMapPoint(hotspot.centerCoordinate)
+            let key = ClusterBucketKey(
+                x: Int(floor(point.x / cellMapPoints)),
+                y: Int(floor(point.y / cellMapPoints))
+            )
+            if var existing = buckets[key] {
+                existing.merge(with: hotspot)
+                buckets[key] = existing
+            } else {
+                let weight = max(1.0, Double(hotspot.count))
+                buckets[key] = HotspotBucketValue(
+                    memberCount: 1,
+                    weightedLatitudeSum: hotspot.centerCoordinate.latitude * weight,
+                    weightedLongitudeSum: hotspot.centerCoordinate.longitude * weight,
+                    activityCountSum: max(1, hotspot.count),
+                    maxIntensity: hotspot.intensity,
+                    visualState: hotspot.visualState,
+                    representativeID: hotspot.id
+                )
+            }
+        }
+
+        return buckets
+            .sorted { lhs, rhs in
+                lhs.value.activityCountSum > rhs.value.activityCountSum
+            }
+            .map { key, value in
+                value.asNode(bucketKey: key)
+            }
+    }
+
+    /// 렌더링 노드를 거리/강도 기준으로 정렬합니다.
+    /// - Parameters:
+    ///   - nodes: 정렬할 렌더링 노드 목록입니다.
+    ///   - center: 현재 지도 중심 좌표입니다.
+    /// - Returns: 정렬된 렌더링 노드 목록입니다.
+    private func rankedRenderNodes(
+        _ nodes: [NearbyHotspotRenderNode],
+        center: CLLocationCoordinate2D?
+    ) -> [NearbyHotspotRenderNode] {
+        nodes.sorted { lhs, rhs in
+            if let center {
+                let lhsDistance = greatCircleDistanceMeters(from: center, to: lhs.centerCoordinate)
+                let rhsDistance = greatCircleDistanceMeters(from: center, to: rhs.centerCoordinate)
+                if abs(lhsDistance - rhsDistance) >= 8 {
+                    return lhsDistance < rhsDistance
+                }
+            }
+            if lhs.intensity != rhs.intensity {
+                return lhs.intensity > rhs.intensity
+            }
+            if lhs.count != rhs.count {
+                return lhs.count > rhs.count
+            }
+            return lhs.id < rhs.id
+        }
+    }
+
+    /// 두 좌표 사이 대권 거리를 미터 단위로 계산합니다.
+    /// - Parameters:
+    ///   - from: 시작 좌표입니다.
+    ///   - to: 도착 좌표입니다.
+    /// - Returns: 두 좌표 사이 거리(미터)입니다.
+    private func greatCircleDistanceMeters(
+        from: CLLocationCoordinate2D,
+        to: CLLocationCoordinate2D
+    ) -> CLLocationDistance {
+        let earthRadius = 6_371_000.0
+        let lat1 = from.latitude * .pi / 180
+        let lon1 = from.longitude * .pi / 180
+        let lat2 = to.latitude * .pi / 180
+        let lon2 = to.longitude * .pi / 180
+        let dLat = lat2 - lat1
+        let dLon = lon2 - lon1
+        let a = sin(dLat / 2) * sin(dLat / 2)
+            + cos(lat1) * cos(lat2) * sin(dLon / 2) * sin(dLon / 2)
+        let c = 2 * atan2(sqrt(a), sqrt(max(0, 1 - a)))
+        return earthRadius * c
+    }
+}
+
+enum NearbyHotspotVisualState: String, Codable, CaseIterable {
+    case normal
+    case stale
+    case lowConfidence
+
+    /// 두 시각 상태를 병합할 때 더 보수적인 상태를 우선합니다.
+    /// - Parameter other: 병합 대상 상태입니다.
+    /// - Returns: stale > lowConfidence > normal 우선순위로 병합된 상태입니다.
+    fileprivate func merged(with other: NearbyHotspotVisualState) -> NearbyHotspotVisualState {
+        if self == .stale || other == .stale { return .stale }
+        if self == .lowConfidence || other == .lowConfidence { return .lowConfidence }
+        return .normal
+    }
+}
+
+struct NearbyHotspotRenderInput: Identifiable {
+    let id: String
+    let centerCoordinate: CLLocationCoordinate2D
+    let count: Int
+    let intensity: Double
+    let visualState: NearbyHotspotVisualState
+}
+
+struct NearbyHotspotRenderNode: Identifiable {
+    let id: String
+    let centerCoordinate: CLLocationCoordinate2D
+    let count: Int
+    let intensity: Double
+    let visualState: NearbyHotspotVisualState
+    let isCluster: Bool
 }
 
 enum WalkLiveActivityFallbackReason: String, Equatable {

--- a/dogArea/Views/MapView/MapSubViews/MapSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapSubView.swift
@@ -68,12 +68,10 @@ struct MapSubView: View {
                 }
             }
             if viewModel.isNearbyHotspotFeatureAvailable && viewModel.nearbyHotspotEnabled {
-                ForEach(viewModel.nearbyHotspots) { spot in
-                    MapCircle(center: spot.centerCoordinate, radius: 100)
-                        .foregroundStyle(
-                            viewModel.nearbyHotspotColor(for: spot.intensity)
-                                .opacity(viewModel.nearbyHotspotOpacity(for: spot.intensity))
-                        )
+                ForEach(viewModel.renderableNearbyHotspotNodes) { hotspot in
+                    Annotation("", coordinate: hotspot.centerCoordinate) {
+                        nearbyHotspotAnnotationView(for: hotspot)
+                    }
                 }
             }
             if let walkArea = viewModel.polygon.polygon{
@@ -182,6 +180,74 @@ struct MapSubView: View {
     private var clusterPulseOpacity: Double {
         guard clusterPulseActive else { return 1.0 }
         return viewModel.isMapMotionReduced ? 0.92 : 0.82
+    }
+
+    /// 핫스팟 렌더 노드를 지도 어노테이션 뷰로 구성합니다.
+    /// - Parameter hotspot: 렌더링할 핫스팟 노드입니다.
+    /// - Returns: 선택 상태/시각 상태가 반영된 어노테이션 뷰입니다.
+    @ViewBuilder
+    private func nearbyHotspotAnnotationView(for hotspot: NearbyHotspotRenderNode) -> some View {
+        let isSelected = viewModel.selectedNearbyHotspotID == hotspot.id
+        let diameter = nearbyHotspotMarkerDiameter(for: hotspot)
+        let fill = viewModel.nearbyHotspotMarkerColor(for: hotspot.intensity, visualState: hotspot.visualState)
+        let border = viewModel.nearbyHotspotMarkerBorderColor(for: hotspot.visualState)
+        let dashPattern = viewModel.nearbyHotspotMarkerDashPattern(for: hotspot.visualState)
+        let opacity = viewModel.nearbyHotspotMarkerOpacity(for: hotspot.intensity, visualState: hotspot.visualState)
+
+        ZStack {
+            if isSelected {
+                Circle()
+                    .stroke(Color.appYellow.opacity(0.95), lineWidth: 2.6)
+                    .frame(width: diameter + 12, height: diameter + 12)
+            }
+
+            Circle()
+                .fill(fill.opacity(opacity))
+                .frame(width: diameter, height: diameter)
+
+            Circle()
+                .stroke(
+                    border,
+                    style: StrokeStyle(
+                        lineWidth: isSelected ? 2.2 : 1.5,
+                        dash: dashPattern
+                    )
+                )
+                .frame(width: diameter, height: diameter)
+
+            if hotspot.isCluster {
+                Text("\(hotspot.count)")
+                    .font(.appFont(for: .SemiBold, size: 12))
+                    .foregroundStyle(Color.appInk)
+                    .minimumScaleFactor(0.7)
+            } else {
+                Image(systemName: "dot.radiowaves.left.and.right")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(Color.appInk.opacity(0.92))
+            }
+        }
+        .frame(
+            minWidth: 44,
+            idealWidth: max(44, diameter),
+            minHeight: 44,
+            idealHeight: max(44, diameter)
+        )
+        .contentShape(Circle())
+        .onTapGesture {
+            viewModel.toggleNearbyHotspotSelection(hotspot)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(viewModel.nearbyHotspotStatusText(for: hotspot))
+    }
+
+    /// 핫스팟 유형에 따라 마커 직경을 계산합니다.
+    /// - Parameter hotspot: 렌더링 대상 핫스팟 노드입니다.
+    /// - Returns: 클러스터 여부/활동 수가 반영된 마커 직경 포인트 값입니다.
+    private func nearbyHotspotMarkerDiameter(for hotspot: NearbyHotspotRenderNode) -> CGFloat {
+        if hotspot.isCluster {
+            return min(58, 42 + CGFloat(min(16, hotspot.count / 3)))
+        }
+        return 40
     }
 
     var mapControls: some View {

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -329,6 +329,9 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         static let clusterCellDistanceRatioKey = "map.lod.cluster.cellDistanceRatio"
         static let clusterCellMinMetersKey = "map.lod.cluster.cellMinMeters"
         static let clusterCellMaxMetersKey = "map.lod.cluster.cellMaxMeters"
+        static let hotspotMaxVisibleKey = "map.hotspot.maxVisible"
+        static let hotspotPageMultiplierKey = "map.hotspot.pageMultiplier"
+        static let hotspotClusterDistanceThresholdKey = "map.hotspot.clusterDistanceThreshold"
 
         static let overlayMaxCameraDistanceDefault = 4_500.0
         static let overlayClusterThresholdDefault = 24
@@ -337,6 +340,9 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         static let clusterCellDistanceRatioDefault = 0.08
         static let clusterCellMinMetersDefault = 80.0
         static let clusterCellMaxMetersDefault = 500.0
+        static let hotspotMaxVisibleDefault = 36
+        static let hotspotPageMultiplierDefault = 3
+        static let hotspotClusterDistanceThresholdDefault = 1_900.0
     }
 
     /// 런치 인자 기반으로 UI 테스트 런타임 여부를 판별합니다.
@@ -384,7 +390,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     @Published var heatmapCells: [HeatmapCellDTO] = []
     @Published var nearbyHotspotEnabled: Bool = true
     @Published var locationSharingEnabled: Bool = false
-    @Published var nearbyHotspots: [NearbyHotspotDTO] = []
+    @Published var nearbyHotspots: [NearbyHotspotDTO] = [] {
+        didSet {
+            refreshRenderableNearbyHotspots()
+        }
+    }
+    @Published private(set) var renderableNearbyHotspotNodes: [NearbyHotspotRenderNode] = []
+    @Published var selectedNearbyHotspotID: String? = nil
     @Published var selectedPetId: String? = nil
     @Published var selectedPetName: String = "강아지"
     @Published var availablePets: [PetInfo] = []
@@ -508,6 +520,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let maxCaptureRipples = 12
     private let trailLifetime: TimeInterval = 5.0
     private let trailLimit = 12
+    private let trailVisibleMaxCameraDistance: Double = 2_600
     private var weatherFetchTask: Task<Void, Never>? = nil
     private var lastWeatherFetchAttemptAt: Date = .distantPast
     private let widgetSnapshotSyncInterval: TimeInterval = 5.0
@@ -1164,7 +1177,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     }
 
     var activeTrailMarkers: [TrailMarker] {
-        guard isWalking else { return [] }
+        guard isWalking, currentCameraDistance <= trailVisibleMaxCameraDistance else { return [] }
         let now = Date().timeIntervalSince1970
         return Array(
             polygon.locations
@@ -1755,7 +1768,10 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     ///   - now: 로그 판정 기준 시각입니다.
     func recordCameraChange(_ camera: MapCamera, now: Date = Date()) {
         let reason = resolveCameraChangeReason(now: now)
-        updateCameraCacheIfNeeded(camera, now: now, force: reason != .manualMove)
+        let didUpdateCache = updateCameraCacheIfNeeded(camera, now: now, force: reason != .manualMove)
+        if didUpdateCache {
+            refreshRenderableNearbyHotspots()
+        }
         guard shouldLogCameraChange(camera, reason: reason) else { return }
         #if DEBUG
         let latitude = String(format: "%.5f", camera.centerCoordinate.latitude)
@@ -1774,17 +1790,18 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     ///   - camera: 이번 이벤트에서 전달된 최신 지도 카메라 상태입니다.
     ///   - now: 캐시 갱신 여부를 판정할 기준 시각입니다.
     ///   - force: 사용자 액션 기반 이동처럼 즉시 반영이 필요한 경우 `true`입니다.
-    private func updateCameraCacheIfNeeded(_ camera: MapCamera, now: Date, force: Bool) {
+    /// - Returns: 카메라 캐시가 실제로 갱신되면 `true`입니다.
+    private func updateCameraCacheIfNeeded(_ camera: MapCamera, now: Date, force: Bool) -> Bool {
         guard camera.centerCoordinate.latitude.isFinite,
               camera.centerCoordinate.longitude.isFinite,
-              camera.distance.isFinite else { return }
+              camera.distance.isFinite else { return false }
 
         if force {
             self.camera = camera
             lastCachedCameraCenter = camera.centerCoordinate
             lastCachedCameraDistance = camera.distance
             lastCachedCameraUpdatedAt = now
-            return
+            return true
         }
 
         guard let lastCenter = lastCachedCameraCenter,
@@ -1793,7 +1810,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             lastCachedCameraCenter = camera.centerCoordinate
             lastCachedCameraDistance = camera.distance
             lastCachedCameraUpdatedAt = now
-            return
+            return true
         }
 
         let centerDelta = greatCircleDistanceMeters(from: lastCenter, to: camera.centerCoordinate)
@@ -1802,13 +1819,14 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         guard centerDelta >= cameraCacheCenterThreshold
                 || distanceDelta >= cameraCacheDistanceThreshold
                 || elapsed >= cameraCacheMinUpdateInterval else {
-            return
+            return false
         }
 
         self.camera = camera
         lastCachedCameraCenter = camera.centerCoordinate
         lastCachedCameraDistance = camera.distance
         lastCachedCameraUpdatedAt = now
+        return true
     }
 
     /// 수동 포인트 추가 후 카메라가 점프했을 때 직전 스냅샷으로 복원합니다.
@@ -1979,6 +1997,27 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         )
     }
 
+    private var hotspotMaxVisible: Int {
+        lodIntValue(
+            key: MapOverlayLODTuning.hotspotMaxVisibleKey,
+            defaultValue: MapOverlayLODTuning.hotspotMaxVisibleDefault
+        )
+    }
+
+    private var hotspotPageMultiplier: Int {
+        lodIntValue(
+            key: MapOverlayLODTuning.hotspotPageMultiplierKey,
+            defaultValue: MapOverlayLODTuning.hotspotPageMultiplierDefault
+        )
+    }
+
+    private var hotspotClusterDistanceThreshold: Double {
+        lodDoubleValue(
+            key: MapOverlayLODTuning.hotspotClusterDistanceThresholdKey,
+            defaultValue: MapOverlayLODTuning.hotspotClusterDistanceThresholdDefault
+        )
+    }
+
     var shouldRenderFullPolygonOverlays: Bool {
         guard showOnlyOne == false else { return true }
         guard currentCameraDistance <= overlayMaxCameraDistance else { return false }
@@ -2080,6 +2119,181 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         case ..<0.8: return 0.50
         default: return 0.60
         }
+    }
+
+    /// 핫스팟 원본 데이터를 시각 상태로 분류합니다.
+    /// - Parameter hotspot: 분류할 원본 핫스팟입니다.
+    /// - Returns: `normal/stale/lowConfidence` 중 렌더링 상태입니다.
+    func nearbyHotspotVisualState(for hotspot: NearbyHotspotDTO) -> NearbyHotspotVisualState {
+        let suppression = (hotspot.suppressionReason ?? "").lowercased()
+        if suppression.contains("stale")
+            || suppression.contains("delay")
+            || (hotspot.delayMinutes ?? 0) > 0 {
+            return .stale
+        }
+        if let required = hotspot.requiredMinSample, hotspot.count < required {
+            return .lowConfidence
+        }
+        if suppression.contains("low_confidence")
+            || suppression.contains("min_sample")
+            || suppression.contains("low") {
+            return .lowConfidence
+        }
+        return .normal
+    }
+
+    /// 뷰포트/LOD/캡 규칙으로 근처 핫스팟 렌더링 노드를 계산합니다.
+    func refreshRenderableNearbyHotspots() {
+        guard isNearbyHotspotFeatureAvailable, nearbyHotspotEnabled else {
+            renderableNearbyHotspotNodes = []
+            selectedNearbyHotspotID = nil
+            return
+        }
+
+        let inputs: [NearbyHotspotRenderInput] = nearbyHotspots.map { hotspot in
+            NearbyHotspotRenderInput(
+                id: hotspot.id,
+                centerCoordinate: hotspot.centerCoordinate,
+                count: max(1, hotspot.count),
+                intensity: hotspot.intensity,
+                visualState: nearbyHotspotVisualState(for: hotspot)
+            )
+        }
+
+        let viewportCenter = resolvedHotspotViewportCenter()
+        let distance = max(180.0, resolvedHotspotViewportDistance())
+        let nodes = clusterAnnotationService.renderHotspots(
+            hotspots: inputs,
+            viewportCenter: viewportCenter,
+            cameraDistance: distance,
+            maxVisible: hotspotMaxVisible,
+            pageMultiplier: hotspotPageMultiplier,
+            clusterDistanceThreshold: hotspotClusterDistanceThreshold,
+            distanceRatio: clusterCellDistanceRatio,
+            minCellMeters: clusterCellMinMeters,
+            maxCellMeters: clusterCellMaxMeters
+        )
+
+        renderableNearbyHotspotNodes = nodes
+        if let selectedNearbyHotspotID,
+           nodes.contains(where: { $0.id == selectedNearbyHotspotID }) == false {
+            self.selectedNearbyHotspotID = nil
+        }
+    }
+
+    /// 핫스팟 렌더링 계산에 사용할 뷰포트 중심 좌표를 해석합니다.
+    /// - Returns: 유효한 중심 좌표가 있으면 반환하고, 없으면 `nil`을 반환합니다.
+    private func resolvedHotspotViewportCenter() -> CLLocationCoordinate2D? {
+        if let cached = lastCachedCameraCenter,
+           cached.latitude.isFinite,
+           cached.longitude.isFinite {
+            return cached
+        }
+        if let current = location?.coordinate,
+           current.latitude.isFinite,
+           current.longitude.isFinite {
+            return current
+        }
+        if camera.centerCoordinate.latitude.isFinite,
+           camera.centerCoordinate.longitude.isFinite {
+            return camera.centerCoordinate
+        }
+        return nil
+    }
+
+    /// 핫스팟 렌더링 계산에 사용할 현재 카메라 거리(미터)를 해석합니다.
+    /// - Returns: 뷰포트 계산에 사용할 거리(미터)입니다.
+    private func resolvedHotspotViewportDistance() -> Double {
+        if let cached = lastCachedCameraDistance, cached.isFinite {
+            return cached
+        }
+        if camera.distance.isFinite, camera.distance > 0 {
+            return camera.distance
+        }
+        return currentCameraDistance
+    }
+
+    /// 핫스팟 시각 상태와 강도에 맞는 마커 채움 색상을 반환합니다.
+    /// - Parameters:
+    ///   - intensity: 핫스팟 강도(0...1)입니다.
+    ///   - visualState: stale/lowConfidence 분류 상태입니다.
+    /// - Returns: 렌더링에 사용할 채움 색상입니다.
+    func nearbyHotspotMarkerColor(for intensity: Double, visualState: NearbyHotspotVisualState) -> Color {
+        switch visualState {
+        case .normal:
+            return nearbyHotspotColor(for: intensity)
+        case .stale:
+            return Color.appTextLightGray
+        case .lowConfidence:
+            return Color.appYellowPale
+        }
+    }
+
+    /// 핫스팟 시각 상태에 맞는 마커 테두리 색상을 반환합니다.
+    /// - Parameter visualState: stale/lowConfidence 분류 상태입니다.
+    /// - Returns: 마커 테두리 색상입니다.
+    func nearbyHotspotMarkerBorderColor(for visualState: NearbyHotspotVisualState) -> Color {
+        switch visualState {
+        case .normal: return Color.appInk.opacity(0.6)
+        case .stale: return Color.appTextDarkGray.opacity(0.55)
+        case .lowConfidence: return Color.appYellow.opacity(0.85)
+        }
+    }
+
+    /// 핫스팟 시각 상태에 맞는 마커 테두리 대시 패턴을 반환합니다.
+    /// - Parameter visualState: stale/lowConfidence 분류 상태입니다.
+    /// - Returns: 실선은 빈 배열, 구분 상태는 점선 배열을 반환합니다.
+    func nearbyHotspotMarkerDashPattern(for visualState: NearbyHotspotVisualState) -> [CGFloat] {
+        switch visualState {
+        case .normal: return []
+        case .stale: return [4, 4]
+        case .lowConfidence: return [2, 3]
+        }
+    }
+
+    /// 핫스팟 시각 상태와 강도에 맞는 마커 투명도를 반환합니다.
+    /// - Parameters:
+    ///   - intensity: 핫스팟 강도(0...1)입니다.
+    ///   - visualState: stale/lowConfidence 분류 상태입니다.
+    /// - Returns: 렌더링에 사용할 마커 불투명도입니다.
+    func nearbyHotspotMarkerOpacity(for intensity: Double, visualState: NearbyHotspotVisualState) -> Double {
+        switch visualState {
+        case .normal:
+            return nearbyHotspotOpacity(for: intensity)
+        case .stale:
+            return 0.26
+        case .lowConfidence:
+            return 0.32
+        }
+    }
+
+    /// 핫스팟 선택 시 노출할 보조 메시지를 생성합니다.
+    /// - Parameter hotspot: 선택된 핫스팟 렌더 노드입니다.
+    /// - Returns: 상단 상태 배너에 표시할 메시지입니다.
+    func nearbyHotspotStatusText(for hotspot: NearbyHotspotRenderNode) -> String {
+        let base = hotspot.isCluster
+            ? "주변 활동 \(hotspot.count)건이 묶인 구역입니다."
+            : "주변 활동 \(hotspot.count)건이 관측된 지점입니다."
+        switch hotspot.visualState {
+        case .normal:
+            return base
+        case .stale:
+            return "\(base) 데이터가 지연되어 최신성과 정확도가 낮을 수 있어요."
+        case .lowConfidence:
+            return "\(base) 표본 수가 적어 참고용으로 확인해주세요."
+        }
+    }
+
+    /// 핫스팟 마커 선택 상태를 토글합니다.
+    /// - Parameter hotspot: 탭된 핫스팟 렌더 노드입니다.
+    func toggleNearbyHotspotSelection(_ hotspot: NearbyHotspotRenderNode) {
+        if selectedNearbyHotspotID == hotspot.id {
+            selectedNearbyHotspotID = nil
+            walkStatusMessage = nil
+            return
+        }
+        selectedNearbyHotspotID = hotspot.id
+        walkStatusMessage = nearbyHotspotStatusText(for: hotspot)
     }
 
     func toggleHeatmapEnabled() {


### PR DESCRIPTION
## Summary
- add hotspot rendering pipeline in `MapClusterAnnotationService` with viewport filtering, paging cap, and distance-based LOD cluster mode
- add MapViewModel hotspot render state (`renderableNearbyHotspotNodes`) and stale/low-confidence visual classification
- hide trail markers at far zoom, refresh render nodes on camera cache updates, and add hotspot selection UX status messaging
- switch `MapSubView` hotspot layer from raw circles to accessible 44pt marker annotations with cluster count and selection affordance

## Validation
- `xcodebuild -scheme dogArea -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug -quiet build CODE_SIGNING_ALLOWED=NO`
- `bash scripts/ios_pr_check.sh`

Closes #239
