### PR TITLE
[Task][Home][Gamification] 누적 영역 명소 달성 배지 팝업 + 알림

### DIFF
--- a/dogArea/Source/Domain/Home/Services/HomeQuestReminderSupport.swift
+++ b/dogArea/Source/Domain/Home/Services/HomeQuestReminderSupport.swift
@@ -133,3 +133,411 @@ final class LocalQuestReminderScheduler: QuestReminderScheduling {
         }
     }
 }
+/// 영역 목표 달성 시점에 홈에서 표시할 마일스톤 이벤트 모델입니다.
+struct AreaMilestoneEvent: Identifiable, Codable, Equatable {
+    let milestoneId: String
+    let landmarkName: String
+    let thresholdArea: Double
+    let achievedAt: TimeInterval
+    let source: String
+
+    var id: String { milestoneId }
+}
+
+/// 마일스톤 달성 판정에 사용하는 비교군 임계값 모델입니다.
+struct AreaMilestoneCandidate: Equatable {
+    let landmarkName: String
+    let thresholdArea: Double
+}
+
+/// 영역 마일스톤 중복 발급을 제어하는 저장소 인터페이스입니다.
+protocol AreaMilestoneLedgerStoring {
+    /// 특정 사용자 범위의 baseline 시드 여부를 반환합니다.
+    /// - Parameter ownerScope: 사용자 범위를 구분하는 키입니다.
+    /// - Returns: baseline이 이미 시드되었으면 `true`입니다.
+    func hasSeededBaseline(for ownerScope: String) -> Bool
+
+    /// 특정 사용자 범위에 baseline 시드 완료 상태를 기록합니다.
+    /// - Parameter ownerScope: 사용자 범위를 구분하는 키입니다.
+    func markSeededBaseline(for ownerScope: String)
+
+    /// 지정 마일스톤이 이미 달성 처리되었는지 반환합니다.
+    /// - Parameters:
+    ///   - milestoneId: 조회할 마일스톤 식별자입니다.
+    ///   - ownerScope: 사용자 범위를 구분하는 키입니다.
+    /// - Returns: 이미 달성 처리된 마일스톤이면 `true`입니다.
+    func hasAchievedMilestone(_ milestoneId: String, ownerScope: String) -> Bool
+
+    /// 마일스톤 달성 이벤트를 영속 저장합니다.
+    /// - Parameters:
+    ///   - event: 저장할 마일스톤 달성 이벤트입니다.
+    ///   - ownerScope: 사용자 범위를 구분하는 키입니다.
+    func markAchieved(_ event: AreaMilestoneEvent, ownerScope: String)
+}
+
+/// `UserDefaults` 기반 영역 마일스톤 발급 이력 저장소 구현입니다.
+final class DefaultAreaMilestoneLedgerStore: AreaMilestoneLedgerStoring {
+    private let defaults: UserDefaults
+    private let achievedLedgerKey = "area.milestone.achieved.v1"
+    private let seededOwnerKey = "area.milestone.seeded.v1"
+
+    /// 저장소를 초기화합니다.
+    /// - Parameter defaults: 영속 저장에 사용할 `UserDefaults` 인스턴스입니다.
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// 특정 사용자 범위의 baseline 시드 여부를 반환합니다.
+    /// - Parameter ownerScope: 사용자 범위를 구분하는 키입니다.
+    /// - Returns: baseline이 이미 시드되었으면 `true`입니다.
+    func hasSeededBaseline(for ownerScope: String) -> Bool {
+        seededOwnerScopes().contains(ownerScope)
+    }
+
+    /// 특정 사용자 범위에 baseline 시드 완료 상태를 기록합니다.
+    /// - Parameter ownerScope: 사용자 범위를 구분하는 키입니다.
+    func markSeededBaseline(for ownerScope: String) {
+        var seeded = seededOwnerScopes()
+        seeded.insert(ownerScope)
+        defaults.set(Array(seeded), forKey: seededOwnerKey)
+    }
+
+    /// 지정 마일스톤이 이미 달성 처리되었는지 반환합니다.
+    /// - Parameters:
+    ///   - milestoneId: 조회할 마일스톤 식별자입니다.
+    ///   - ownerScope: 사용자 범위를 구분하는 키입니다.
+    /// - Returns: 이미 달성 처리된 마일스톤이면 `true`입니다.
+    func hasAchievedMilestone(_ milestoneId: String, ownerScope: String) -> Bool {
+        achievedLedger()[scopedMilestoneLedgerKey(ownerScope: ownerScope, milestoneId: milestoneId)] != nil
+    }
+
+    /// 마일스톤 달성 이벤트를 영속 저장합니다.
+    /// - Parameters:
+    ///   - event: 저장할 마일스톤 달성 이벤트입니다.
+    ///   - ownerScope: 사용자 범위를 구분하는 키입니다.
+    func markAchieved(_ event: AreaMilestoneEvent, ownerScope: String) {
+        var ledger = achievedLedger()
+        let key = scopedMilestoneLedgerKey(ownerScope: ownerScope, milestoneId: event.milestoneId)
+        guard ledger[key] == nil else { return }
+        ledger[key] = event
+        persistLedger(ledger)
+    }
+
+    /// 사용자별 시드 완료 집합을 반환합니다.
+    /// - Returns: baseline 시드 완료된 사용자 범위 키 집합입니다.
+    private func seededOwnerScopes() -> Set<String> {
+        let values = defaults.array(forKey: seededOwnerKey) as? [String] ?? []
+        return Set(values)
+    }
+
+    /// 저장된 마일스톤 발급 원장을 로드합니다.
+    /// - Returns: 사용자 범위 포함 키를 기준으로 한 이벤트 원장입니다.
+    private func achievedLedger() -> [String: AreaMilestoneEvent] {
+        guard let data = defaults.data(forKey: achievedLedgerKey) else { return [:] }
+        let decoder = JSONDecoder()
+        return (try? decoder.decode([String: AreaMilestoneEvent].self, from: data)) ?? [:]
+    }
+
+    /// 원장을 `UserDefaults`에 저장합니다.
+    /// - Parameter ledger: 저장할 마일스톤 원장입니다.
+    private func persistLedger(_ ledger: [String: AreaMilestoneEvent]) {
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(ledger) else { return }
+        defaults.set(data, forKey: achievedLedgerKey)
+    }
+
+    /// 사용자 범위와 마일스톤 ID를 조합한 저장 키를 생성합니다.
+    /// - Parameters:
+    ///   - ownerScope: 사용자 범위를 구분하는 키입니다.
+    ///   - milestoneId: 마일스톤 식별자입니다.
+    /// - Returns: 사용자 범위가 포함된 저장 키입니다.
+    private func scopedMilestoneLedgerKey(ownerScope: String, milestoneId: String) -> String {
+        "\(ownerScope)|\(milestoneId)"
+    }
+}
+
+/// 현재 누적 영역과 비교군을 기준으로 새 마일스톤 돌파를 감지합니다.
+protocol AreaMilestoneDetecting {
+    /// 새로 돌파된 마일스톤 이벤트를 계산합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역(㎡)입니다.
+    ///   - ownerUserId: 현재 로그인 사용자 ID입니다.
+    ///   - candidates: 비교 대상 마일스톤 영역 목록입니다.
+    ///   - source: 마일스톤 기준 출처 라벨입니다.
+    ///   - achievedAt: 달성 시각입니다.
+    /// - Returns: 이번 계산에서 새로 돌파된 마일스톤 이벤트 목록입니다.
+    func detectNewMilestones(
+        currentArea: Double,
+        ownerUserId: String?,
+        candidates: [AreaMilestoneCandidate],
+        source: String,
+        achievedAt: Date
+    ) -> [AreaMilestoneEvent]
+}
+
+/// 영역 비교군 기반 마일스톤 달성 감지기입니다.
+final class AreaMilestoneDetector: AreaMilestoneDetecting {
+    private let ledgerStore: AreaMilestoneLedgerStoring
+
+    /// 감지기를 초기화합니다.
+    /// - Parameter ledgerStore: 중복 발급 방지 원장을 담당하는 저장소입니다.
+    init(ledgerStore: AreaMilestoneLedgerStoring = DefaultAreaMilestoneLedgerStore()) {
+        self.ledgerStore = ledgerStore
+    }
+
+    /// 새로 돌파된 마일스톤 이벤트를 계산합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역(㎡)입니다.
+    ///   - ownerUserId: 현재 로그인 사용자 ID입니다.
+    ///   - candidates: 비교 대상 마일스톤 영역 목록입니다.
+    ///   - source: 마일스톤 기준 출처 라벨입니다.
+    ///   - achievedAt: 달성 시각입니다.
+    /// - Returns: 이번 계산에서 새로 돌파된 마일스톤 이벤트 목록입니다.
+    func detectNewMilestones(
+        currentArea: Double,
+        ownerUserId: String?,
+        candidates: [AreaMilestoneCandidate],
+        source: String,
+        achievedAt: Date = Date()
+    ) -> [AreaMilestoneEvent] {
+        let ownerScope = ownerScopeKey(from: ownerUserId)
+        let sortedCandidates = normalizedCandidates(candidates)
+        guard sortedCandidates.isEmpty == false else { return [] }
+
+        if ledgerStore.hasSeededBaseline(for: ownerScope) == false {
+            seedBaselineIfNeeded(
+                currentArea: currentArea,
+                ownerScope: ownerScope,
+                candidates: sortedCandidates,
+                source: source,
+                achievedAt: achievedAt
+            )
+            ledgerStore.markSeededBaseline(for: ownerScope)
+            return []
+        }
+
+        var events: [AreaMilestoneEvent] = []
+        for candidate in sortedCandidates where candidate.thresholdArea <= currentArea {
+            let milestoneId = milestoneIdentifier(ownerScope: ownerScope, candidate: candidate)
+            guard ledgerStore.hasAchievedMilestone(milestoneId, ownerScope: ownerScope) == false else {
+                continue
+            }
+            let event = AreaMilestoneEvent(
+                milestoneId: milestoneId,
+                landmarkName: candidate.landmarkName,
+                thresholdArea: candidate.thresholdArea,
+                achievedAt: achievedAt.timeIntervalSince1970,
+                source: source
+            )
+            ledgerStore.markAchieved(event, ownerScope: ownerScope)
+            events.append(event)
+        }
+        return events
+    }
+
+    /// 감지 첫 실행 시 현재 누적 영역 이하 마일스톤을 baseline으로 선반영합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역(㎡)입니다.
+    ///   - ownerScope: 사용자 범위를 구분하는 키입니다.
+    ///   - candidates: 정렬된 마일스톤 후보 목록입니다.
+    ///   - source: 마일스톤 기준 출처 라벨입니다.
+    ///   - achievedAt: baseline 저장 기준 시각입니다.
+    private func seedBaselineIfNeeded(
+        currentArea: Double,
+        ownerScope: String,
+        candidates: [AreaMilestoneCandidate],
+        source: String,
+        achievedAt: Date
+    ) {
+        for candidate in candidates where candidate.thresholdArea <= currentArea {
+            let event = AreaMilestoneEvent(
+                milestoneId: milestoneIdentifier(ownerScope: ownerScope, candidate: candidate),
+                landmarkName: candidate.landmarkName,
+                thresholdArea: candidate.thresholdArea,
+                achievedAt: achievedAt.timeIntervalSince1970,
+                source: source
+            )
+            ledgerStore.markAchieved(event, ownerScope: ownerScope)
+        }
+    }
+
+    /// 입력 후보를 정렬/중복 제거한 마일스톤 목록으로 정규화합니다.
+    /// - Parameter candidates: 원본 후보 목록입니다.
+    /// - Returns: 면적 오름차순 기준 정렬된 후보 목록입니다.
+    private func normalizedCandidates(_ candidates: [AreaMilestoneCandidate]) -> [AreaMilestoneCandidate] {
+        let unique = Dictionary(
+            candidates.map { (candidateKey(for: $0), $0) },
+            uniquingKeysWith: { lhs, rhs in
+                lhs.thresholdArea <= rhs.thresholdArea ? lhs : rhs
+            }
+        )
+        return unique.values.sorted { lhs, rhs in
+            if lhs.thresholdArea == rhs.thresholdArea {
+                return lhs.landmarkName < rhs.landmarkName
+            }
+            return lhs.thresholdArea < rhs.thresholdArea
+        }
+    }
+
+    /// 사용자 ID를 마일스톤 원장 범위 키로 변환합니다.
+    /// - Parameter userId: 현재 사용자 ID입니다.
+    /// - Returns: 원장 분리에 사용할 사용자 범위 키입니다.
+    private func ownerScopeKey(from userId: String?) -> String {
+        let trimmed = (userId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "guest" : trimmed
+    }
+
+    /// 마일스톤 후보를 안정적인 고유 키 문자열로 변환합니다.
+    /// - Parameter candidate: 키를 생성할 마일스톤 후보입니다.
+    /// - Returns: 이름/면적 기반의 정규화된 키 문자열입니다.
+    private func candidateKey(for candidate: AreaMilestoneCandidate) -> String {
+        "\(normalizedIdentifierFragment(candidate.landmarkName))|\(Int(candidate.thresholdArea.rounded()))"
+    }
+
+    /// 사용자 범위를 포함한 마일스톤 ID를 생성합니다.
+    /// - Parameters:
+    ///   - ownerScope: 사용자 범위를 구분하는 키입니다.
+    ///   - candidate: 마일스톤 후보입니다.
+    /// - Returns: 사용자 범위와 임계값이 반영된 마일스톤 ID입니다.
+    private func milestoneIdentifier(ownerScope: String, candidate: AreaMilestoneCandidate) -> String {
+        let normalizedName = normalizedIdentifierFragment(candidate.landmarkName)
+        let threshold = Int(candidate.thresholdArea.rounded())
+        return "\(ownerScope).\(normalizedName).\(threshold)"
+    }
+
+    /// 식별자에 사용할 문자열 조각을 소문자/밑줄 형식으로 정규화합니다.
+    /// - Parameter value: 정규화할 원본 문자열입니다.
+    /// - Returns: 공백/특수문자가 제거된 식별자 문자열입니다.
+    private func normalizedIdentifierFragment(_ value: String) -> String {
+        let lowered = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "\\s+", with: "_", options: .regularExpression)
+            .replacingOccurrences(of: "[^a-z0-9가-힣_]+", with: "", options: .regularExpression)
+        return lowered.isEmpty ? "milestone" : lowered
+    }
+}
+
+/// 앱이 비활성 상태일 때 마일스톤 달성 로컬 알림 fallback을 스케줄합니다.
+protocol AreaMilestoneNotificationScheduling {
+    /// 필요 시 마일스톤 로컬 알림을 예약합니다.
+    /// - Parameters:
+    ///   - event: 알림 대상으로 예약할 마일스톤 이벤트입니다.
+    ///   - appIsActive: 앱이 현재 포그라운드 활성 상태인지 여부입니다.
+    ///   - now: 일일 상한 계산 기준 시각입니다.
+    func scheduleFallbackNotificationIfNeeded(
+        for event: AreaMilestoneEvent,
+        appIsActive: Bool,
+        now: Date
+    ) async
+}
+
+/// `UNUserNotificationCenter` 기반 마일스톤 알림 fallback 스케줄러입니다.
+final class LocalAreaMilestoneNotificationScheduler: AreaMilestoneNotificationScheduling {
+    private let center: UNUserNotificationCenter
+    private let defaults: UserDefaults
+    private let dailyCountPrefix = "home.area.milestone.notification.daily.v1"
+    private let dailyLimit = 3
+    private static let dayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyyMMdd"
+        return formatter
+    }()
+
+    /// 스케줄러를 초기화합니다.
+    /// - Parameters:
+    ///   - center: 알림 예약에 사용할 시스템 알림 센터입니다.
+    ///   - defaults: 일일 발급 상한 카운트를 저장할 `UserDefaults`입니다.
+    init(
+        center: UNUserNotificationCenter = .current(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.center = center
+        self.defaults = defaults
+    }
+
+    /// 필요 시 마일스톤 로컬 알림을 예약합니다.
+    /// - Parameters:
+    ///   - event: 알림 대상으로 예약할 마일스톤 이벤트입니다.
+    ///   - appIsActive: 앱이 현재 포그라운드 활성 상태인지 여부입니다.
+    ///   - now: 일일 상한 계산 기준 시각입니다.
+    func scheduleFallbackNotificationIfNeeded(
+        for event: AreaMilestoneEvent,
+        appIsActive: Bool,
+        now: Date = Date()
+    ) async {
+        guard appIsActive == false else { return }
+        guard todayNotificationCount(at: now) < dailyLimit else { return }
+        let isAuthorized = await ensureAuthorization()
+        guard isAuthorized else { return }
+
+        let identifier = "home.area.milestone.\(event.milestoneId)"
+        let content = UNMutableNotificationContent()
+        content.title = "영역 배지 획득"
+        content.body = "\(event.landmarkName) 목표를 달성했어요! 홈에서 새 배지를 확인해보세요."
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: identifier,
+            content: content,
+            trigger: UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        )
+
+        let scheduled = await withCheckedContinuation { continuation in
+            center.add(request) { error in
+                continuation.resume(returning: error == nil)
+            }
+        }
+
+        if scheduled {
+            incrementTodayNotificationCount(at: now)
+        }
+    }
+
+    /// 현재 시각 기준 일일 알림 발급 횟수를 반환합니다.
+    /// - Parameter date: 조회 기준 시각입니다.
+    /// - Returns: 해당 일자의 누적 알림 발급 횟수입니다.
+    private func todayNotificationCount(at date: Date) -> Int {
+        defaults.integer(forKey: dailyCountKey(for: date))
+    }
+
+    /// 현재 시각 기준 일일 알림 발급 횟수를 1 증가시킵니다.
+    /// - Parameter date: 카운트 증가 기준 시각입니다.
+    private func incrementTodayNotificationCount(at date: Date) {
+        let key = dailyCountKey(for: date)
+        defaults.set(todayNotificationCount(at: date) + 1, forKey: key)
+    }
+
+    /// 시각을 일일 발급 카운트 저장 키로 변환합니다.
+    /// - Parameter date: 변환할 기준 시각입니다.
+    /// - Returns: 날짜 기준 카운트 키 문자열입니다.
+    private func dailyCountKey(for date: Date) -> String {
+        "\(dailyCountPrefix).\(Self.dayFormatter.string(from: date))"
+    }
+
+    /// 알림 권한 상태를 확인하고 필요 시 시스템 권한 요청을 진행합니다.
+    /// - Returns: 알림 발급이 가능한 상태면 `true`입니다.
+    private func ensureAuthorization() async -> Bool {
+        let settings = await withCheckedContinuation { continuation in
+            center.getNotificationSettings { settings in
+                continuation.resume(returning: settings)
+            }
+        }
+
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined:
+            return await withCheckedContinuation { continuation in
+                center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+                    continuation.resume(returning: granted)
+                }
+            }
+        case .denied:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+}

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -54,6 +54,7 @@ struct HomeView: View {
     @State private var seasonResultRevealContribution: Bool = false
     @State private var seasonResultRevealShield: Bool = false
     @State private var seasonResetBannerVisible: Bool = false
+    @State private var areaMilestonePop: Bool = false
     @State private var questWidgetTab: QuestWidgetTab = .daily
     @State private var homeScrollOffsetY: CGFloat = 0
     @State private var isSeasonDetailPresented: Bool = false
@@ -205,6 +206,9 @@ struct HomeView: View {
                 }.onChange(of: viewModel.seasonResetTransitionToken) { _, token in
                 guard token != nil else { return }
                 presentSeasonResetTransitionBanner()
+                }.onChange(of: viewModel.areaMilestonePresentation) { _, event in
+                guard event != nil else { return }
+                presentAreaMilestoneOverlay()
                 }.onChange(of: authFlow.guestDataUpgradeResult?.id) { _, _ in
                 viewModel.refreshGuestDataUpgradeReport()
                 }.onChange(of: isLowPowerModeEnabled) { _, enabled in
@@ -228,6 +232,13 @@ struct HomeView: View {
                 if let seasonResultModal {
                     seasonResultOverlay(payload: seasonResultModal)
                         .zIndex(11)
+                }
+                if let milestoneEvent = viewModel.areaMilestonePresentation {
+                    HomeAreaMilestoneBadgeOverlayView(
+                        event: milestoneEvent,
+                        isVisible: areaMilestonePop
+                    )
+                    .zIndex(12)
                 }
                 if seasonResetBannerVisible {
                     seasonResetTransitionBanner
@@ -1118,6 +1129,38 @@ struct HomeView: View {
         }
     }
 
+    /// 영역 마일스톤 배지 오버레이를 표시하고 자동 종료 타이머를 시작합니다.
+    private func presentAreaMilestoneOverlay() {
+        AppHapticFeedback.questCompleted()
+        areaMilestonePop = false
+        if isQuestMotionReduced {
+            areaMilestonePop = true
+        } else {
+            withAnimation(.spring(response: 0.28, dampingFraction: 0.76)) {
+                areaMilestonePop = true
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
+            dismissAreaMilestoneOverlay()
+        }
+    }
+
+    /// 영역 마일스톤 배지 오버레이를 닫고 ViewModel 큐의 다음 이벤트를 진행합니다.
+    private func dismissAreaMilestoneOverlay() {
+        if isQuestMotionReduced {
+            areaMilestonePop = false
+            viewModel.clearAreaMilestonePresentation()
+            return
+        }
+        withAnimation(.easeOut(duration: 0.2)) {
+            areaMilestonePop = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            viewModel.clearAreaMilestonePresentation()
+        }
+    }
+
     private func presentQuestCompletionModal(_ payload: QuestCompletionPresentation) {
         questCompletionModal = payload
         questCompletionPop = false
@@ -1505,6 +1548,67 @@ struct HomeView: View {
             }
         }
         .accessibilityIdentifier("home.quest.row.\(mission.id)")
+    }
+}
+
+private struct HomeAreaMilestoneBadgeOverlayView: View {
+    let event: AreaMilestoneEvent
+    let isVisible: Bool
+
+    /// 목표 임계값을 사용자 표시용 문자열로 변환합니다.
+    private var thresholdText: String {
+        event.thresholdArea.calculatedAreaString
+    }
+
+    var body: some View {
+        VStack {
+            Spacer().frame(height: 116)
+
+            VStack(spacing: 10) {
+                Image(systemName: "rosette")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(Color.appYellow)
+                    .accessibilityHidden(true)
+
+                Text("영역 달성 배지 획득")
+                    .font(.appScaledFont(for: .SemiBold, size: 18, relativeTo: .headline))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xE2E8F0))
+                    .multilineTextAlignment(.center)
+
+                Text(event.landmarkName)
+                    .font(.appScaledFont(for: .SemiBold, size: 20, relativeTo: .title3))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x92400E, dark: 0xFDE68A))
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.85)
+
+                Text("누적 \(thresholdText) 돌파")
+                    .font(.appScaledFont(for: .Regular, size: 13, relativeTo: .subheadline))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+            }
+            .padding(.horizontal, 22)
+            .padding(.vertical, 18)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(Color.appDynamicHex(light: 0xFFFFFF, dark: 0x1E293B))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.appDynamicHex(light: 0xFDE68A, dark: 0x92400E), lineWidth: 1)
+            )
+            .scaleEffect(isVisible ? 1.0 : 0.9)
+            .opacity(isVisible ? 1.0 : 0.0)
+
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.opacity(isVisible ? 0.2 : 0))
+        .allowsHitTesting(false)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(event.landmarkName) 영역 달성 배지를 획득했습니다. 누적 \(thresholdText) 돌파")
     }
 }
 

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -8,6 +8,9 @@
 import Foundation
 import SwiftUI
 import Combine
+#if canImport(UIKit)
+import UIKit
+#endif
 
 enum QuestMotionEventType: String, Equatable {
     case progress
@@ -151,6 +154,7 @@ final class HomeViewModel: ObservableObject {
     @Published var seasonResetTransitionToken: UUID? = nil
     @Published var seasonRemainingTimeText: String = "-"
     @Published var lastSeasonResultPresentation: SeasonResultPresentation? = nil
+    @Published var areaMilestonePresentation: AreaMilestoneEvent? = nil
 
     private var allPolygons: [Polygon] = []
     private var cancellables: Set<AnyCancellable> = []
@@ -165,10 +169,13 @@ final class HomeViewModel: ObservableObject {
     private let eventCenter: AppEventCenterProtocol
     private let weeklyStatisticsService: HomeWeeklyStatisticsServicing
     private let weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding
+    private let areaMilestoneDetector: AreaMilestoneDetecting
+    private let areaMilestoneNotificationScheduler: AreaMilestoneNotificationScheduling
     private let seasonMotionStore = SeasonMotionStore()
     private let questReminderScheduler: QuestReminderScheduling
     private let questReminderPreferenceStore = QuestReminderPreferenceStore()
     private var featuredGoalAreas: [AreaMeter] = []
+    private var areaMilestoneQueue: [AreaMilestoneEvent] = []
     private var areaReferenceTask: Task<Void, Never>? = nil
     private static let questReminderHour = 20
     private static let questReminderMinute = 0
@@ -234,7 +241,9 @@ final class HomeViewModel: ObservableObject {
         userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
         eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared,
         weeklyStatisticsService: HomeWeeklyStatisticsServicing = HomeWeeklyStatisticsService(),
-        weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding = HomeWeatherMissionStatusBuilder()
+        weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding = HomeWeatherMissionStatusBuilder(),
+        areaMilestoneDetector: AreaMilestoneDetecting = AreaMilestoneDetector(),
+        areaMilestoneNotificationScheduler: AreaMilestoneNotificationScheduling = LocalAreaMilestoneNotificationScheduler()
     ) {
         self.areaReferenceRepository = areaReferenceRepository
         self.walkRepository = walkRepository
@@ -242,6 +251,8 @@ final class HomeViewModel: ObservableObject {
         self.eventCenter = eventCenter
         self.weeklyStatisticsService = weeklyStatisticsService
         self.weatherMissionStatusBuilder = weatherMissionStatusBuilder
+        self.areaMilestoneDetector = areaMilestoneDetector
+        self.areaMilestoneNotificationScheduler = areaMilestoneNotificationScheduler
         self.questReminderScheduler = LocalQuestReminderScheduler()
         self.questReminderEnabled = false
         self.questReminderEnabled = questReminderPreferenceStore.isEnabled
@@ -286,6 +297,7 @@ final class HomeViewModel: ObservableObject {
                 self.areaReferenceSourceLabel = snapshot.source == .remote ? "DB 비교군" : "로컬 비교군 (Fallback)"
                 self.updateCurrentMeter()
                 self.refreshAreaList()
+                self.evaluateAreaMilestones()
             }
         }
     }
@@ -337,6 +349,12 @@ final class HomeViewModel: ObservableObject {
 
     func clearSeasonResetTransitionToken() {
         seasonResetTransitionToken = nil
+    }
+
+    /// 현재 표시 중인 영역 마일스톤 배지 팝업을 해제하고 다음 큐를 표시합니다.
+    func clearAreaMilestonePresentation() {
+        areaMilestonePresentation = nil
+        presentNextAreaMilestoneIfNeeded()
     }
 
     /// 퀘스트 리마인드 토글 상태를 저장하고 로컬 알림 스케줄을 반영합니다.
@@ -533,6 +551,7 @@ final class HomeViewModel: ObservableObject {
         myArea = .init("\(selectedPetNameWithYi)의 영역", totalArea)
         boundarySplitContribution = makeDayBoundarySplitContribution(reference: Date())
         refreshIndoorMissions()
+        evaluateAreaMilestones()
         if shouldUpdateMeter {
             updateCurrentMeter()
         }
@@ -615,6 +634,83 @@ final class HomeViewModel: ObservableObject {
                 }
             }
         }
+    }
+
+    /// 현재 누적 영역을 기준으로 새로 달성한 영역 마일스톤을 감지하고 UI/알림 큐에 반영합니다.
+    /// - Parameter now: 마일스톤 달성 시각 계산 기준입니다.
+    private func evaluateAreaMilestones(now: Date = Date()) {
+        guard let ownerUserId = userInfo?.id, ownerUserId.isEmpty == false else { return }
+        let candidates = milestoneCandidates()
+        guard candidates.isEmpty == false else { return }
+
+        let events = areaMilestoneDetector.detectNewMilestones(
+            currentArea: myArea.area,
+            ownerUserId: ownerUserId,
+            candidates: candidates,
+            source: areaReferenceSourceLabel,
+            achievedAt: now
+        )
+        guard events.isEmpty == false else { return }
+
+        enqueueAreaMilestones(events)
+
+        let appIsActive = isApplicationActive()
+        for event in events {
+            Task { [areaMilestoneNotificationScheduler] in
+                await areaMilestoneNotificationScheduler.scheduleFallbackNotificationIfNeeded(
+                    for: event,
+                    appIsActive: appIsActive,
+                    now: now
+                )
+            }
+        }
+    }
+
+    /// 마일스톤 감지에 사용할 비교군 후보를 계산합니다.
+    /// - Returns: featured 우선 정책이 적용된 마일스톤 후보 목록입니다.
+    private func milestoneCandidates() -> [AreaMilestoneCandidate] {
+        let sourceAreas: [AreaMeter]
+        if featuredGoalAreas.isEmpty {
+            sourceAreas = Array(krAreas.areas.suffix(10))
+        } else {
+            sourceAreas = featuredGoalAreas
+        }
+        return sourceAreas.map { area in
+            AreaMilestoneCandidate(
+                landmarkName: area.areaName,
+                thresholdArea: area.area
+            )
+        }
+    }
+
+    /// 새 마일스톤 이벤트를 큐에 누적하고 즉시 표시 가능한 경우 팝업을 노출합니다.
+    /// - Parameter events: 이번 계산에서 새로 달성한 마일스톤 이벤트 목록입니다.
+    private func enqueueAreaMilestones(_ events: [AreaMilestoneEvent]) {
+        let ordered = events.sorted { lhs, rhs in
+            if lhs.thresholdArea == rhs.thresholdArea {
+                return lhs.landmarkName < rhs.landmarkName
+            }
+            return lhs.thresholdArea < rhs.thresholdArea
+        }
+        areaMilestoneQueue.append(contentsOf: ordered)
+        presentNextAreaMilestoneIfNeeded()
+    }
+
+    /// 표시 중인 배지가 없으면 큐의 첫 이벤트를 현재 프레젠테이션 상태로 승격합니다.
+    private func presentNextAreaMilestoneIfNeeded() {
+        guard areaMilestonePresentation == nil else { return }
+        guard areaMilestoneQueue.isEmpty == false else { return }
+        areaMilestonePresentation = areaMilestoneQueue.removeFirst()
+    }
+
+    /// 앱 포그라운드 활성 상태 여부를 반환합니다.
+    /// - Returns: 포그라운드 활성 상태면 `true`, 아니면 `false`입니다.
+    private func isApplicationActive() -> Bool {
+        #if canImport(UIKit)
+        return UIApplication.shared.applicationState == .active
+        #else
+        return true
+        #endif
     }
 
     func walkedDates() -> [Date] {

--- a/scripts/home_area_milestone_feedback_unit_check.swift
+++ b/scripts/home_area_milestone_feedback_unit_check.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let support = load("dogArea/Source/Domain/Home/Services/HomeQuestReminderSupport.swift")
+let homeViewModel = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+
+assertTrue(
+    support.contains("struct AreaMilestoneEvent: Identifiable, Codable, Equatable"),
+    "area milestone event model should be defined"
+)
+assertTrue(
+    support.contains("area.milestone.achieved.v1") && support.contains("area.milestone.seeded.v1"),
+    "area milestone dedupe ledger keys should be defined"
+)
+assertTrue(
+    support.contains("home.area.milestone.notification.daily.v1") && support.contains("private let dailyLimit = 3"),
+    "area milestone local notification scheduler should enforce daily fallback limit"
+)
+
+assertTrue(
+    homeViewModel.contains("@Published var areaMilestonePresentation: AreaMilestoneEvent? = nil"),
+    "home view model should expose area milestone presentation state"
+)
+assertTrue(
+    homeViewModel.contains("areaMilestoneDetector.detectNewMilestones"),
+    "home view model should evaluate area milestone crossing events"
+)
+assertTrue(
+    homeViewModel.contains("func clearAreaMilestonePresentation()"),
+    "home view model should clear milestone overlay and continue queue"
+)
+
+assertTrue(
+    homeView.contains("HomeAreaMilestoneBadgeOverlayView") &&
+    homeView.contains("onChange(of: viewModel.areaMilestonePresentation)"),
+    "home view should present milestone badge overlay on milestone events"
+)
+assertTrue(
+    homeView.contains("struct HomeAreaMilestoneBadgeOverlayView"),
+    "home milestone overlay view should be implemented"
+)
+
+print("PASS: home area milestone feedback unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -78,6 +78,7 @@ swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/sync_walk_404_policy_unit_check.swift
 swift scripts/home_guest_upgrade_retry_cta_unit_check.swift
 swift scripts/home_weather_status_card_restore_unit_check.swift
+swift scripts/home_area_milestone_feedback_unit_check.swift
 swift scripts/settings_profile_account_actions_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/project_stability_unit_check.swift


### PR DESCRIPTION
## Summary
- 홈 누적 영역 기준 마일스톤 감지 로직을 프로토콜 기반으로 추가했습니다.
- 새 마일스톤 달성 시 홈에 배지 오버레이를 순차 표시하도록 HomeView/HomeViewModel을 연동했습니다.
- 앱 비활성 상태에서는 일일 3회 상한의 로컬 fallback 알림을 예약하도록 추가했습니다.
- `ios_pr_check`에 마일스톤 회귀 스크립트를 포함했습니다.

## Test
- `bash scripts/ios_pr_check.sh`
- `bash scripts/run_design_audit_ui_tests.sh`

Closes #233
