### PR TITLE
[P3][Supabase] Live Presence schema/RPC/TTL/RLS contract (#237)

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -456,10 +456,80 @@ protocol WalkSyncServiceProtocol: SyncOutboxTransporting {
 
 protocol ProfileSyncServiceProtocol: ProfileSyncOutboxTransporting {}
 
+struct WalkLivePresenceDTO: Identifiable, Equatable {
+    let ownerUserId: String
+    let sessionId: String
+    let coordinate: CLLocationCoordinate2D
+    let speedMetersPerSecond: Double?
+    let sequence: Int
+    let idempotencyKey: String
+    let updatedAtEpoch: TimeInterval
+    let expiresAtEpoch: TimeInterval
+    let privacyMode: String?
+    let writeApplied: Bool?
+
+    var id: String { ownerUserId }
+
+    /// 두 라이브 프레즌스 DTO가 동일 사용자 상태를 의미하는지 비교합니다.
+    /// - Parameters:
+    ///   - lhs: 좌측 비교 대상 DTO입니다.
+    ///   - rhs: 우측 비교 대상 DTO입니다.
+    /// - Returns: 핵심 식별자/좌표/상태 필드가 모두 같으면 `true`를 반환합니다.
+    static func == (lhs: WalkLivePresenceDTO, rhs: WalkLivePresenceDTO) -> Bool {
+        lhs.ownerUserId == rhs.ownerUserId &&
+        lhs.sessionId == rhs.sessionId &&
+        lhs.coordinate.latitude == rhs.coordinate.latitude &&
+        lhs.coordinate.longitude == rhs.coordinate.longitude &&
+        lhs.speedMetersPerSecond == rhs.speedMetersPerSecond &&
+        lhs.sequence == rhs.sequence &&
+        lhs.idempotencyKey == rhs.idempotencyKey &&
+        lhs.updatedAtEpoch == rhs.updatedAtEpoch &&
+        lhs.expiresAtEpoch == rhs.expiresAtEpoch &&
+        lhs.privacyMode == rhs.privacyMode &&
+        lhs.writeApplied == rhs.writeApplied
+    }
+}
+
 protocol NearbyPresenceServiceProtocol {
     func setVisibility(userId: String, enabled: Bool) async throws
     func upsertPresence(userId: String, latitude: Double, longitude: Double) async throws
     func getHotspots(userId: String?, centerLatitude: Double, centerLongitude: Double, radiusKm: Double) async throws -> [NearbyHotspotDTO]
+    /// 실시간 위치 표시용 원시 presence 레코드를 멱등 업서트합니다.
+    /// - Parameters:
+    ///   - userId: presence 소유 사용자 UUID 문자열입니다.
+    ///   - sessionId: 현재 산책 세션 UUID 문자열입니다. `nil`이면 서버가 사용자 ID를 대체 세션으로 사용합니다.
+    ///   - latitude: 업서트할 위도 값입니다.
+    ///   - longitude: 업서트할 경도 값입니다.
+    ///   - speedMetersPerSecond: 현재 이동 속도(m/s)입니다.
+    ///   - sequence: last-write-wins 비교용 단조 증가 시퀀스입니다.
+    ///   - idempotencyKey: 재전송 중복 제거를 위한 멱등 키입니다.
+    /// - Returns: 서버에 반영된 최신 라이브 프레즌스 행입니다. visibility OFF 등으로 저장이 생략되면 `nil`입니다.
+    func upsertLivePresence(
+        userId: String,
+        sessionId: String?,
+        latitude: Double,
+        longitude: Double,
+        speedMetersPerSecond: Double?,
+        sequence: Int?,
+        idempotencyKey: String?
+    ) async throws -> WalkLivePresenceDTO?
+    /// 지정한 viewport 범위의 실시간 프레즌스 목록을 조회합니다.
+    /// - Parameters:
+    ///   - minLatitude: 조회 최소 위도 경계입니다.
+    ///   - maxLatitude: 조회 최대 위도 경계입니다.
+    ///   - minLongitude: 조회 최소 경도 경계입니다.
+    ///   - maxLongitude: 조회 최대 경도 경계입니다.
+    ///   - maxRows: 최대 반환 row 수입니다.
+    ///   - privacyMode: 조회 프라이버시 모드(`public`/`private`/`all`)입니다.
+    /// - Returns: viewport 범위와 프라이버시 필터가 적용된 실시간 프레즌스 목록입니다.
+    func getLivePresence(
+        minLatitude: Double,
+        maxLatitude: Double,
+        minLongitude: Double,
+        maxLongitude: Double,
+        maxRows: Int,
+        privacyMode: String
+    ) async throws -> [WalkLivePresenceDTO]
 }
 
 enum RivalLeaderboardPeriod: String, CaseIterable {
@@ -1168,6 +1238,28 @@ struct NearbyPresenceService: NearbyPresenceServiceProtocol {
         let hotspots: [ResponseHotspotDTO]
     }
 
+    private struct ResponseLivePresenceDTO: Decodable {
+        let owner_user_id: String
+        let session_id: String
+        let lat_rounded: Double
+        let lng_rounded: Double
+        let speed_mps: Double?
+        let sequence: Int
+        let idempotency_key: String
+        let updated_at: String?
+        let expires_at: String?
+        let privacy_mode: String?
+        let write_applied: Bool?
+    }
+
+    private struct LivePresenceUpsertEnvelope: Decodable {
+        let live_presence: ResponseLivePresenceDTO?
+    }
+
+    private struct LivePresenceEnvelope: Decodable {
+        let presence: [ResponseLivePresenceDTO]
+    }
+
     private let client: SupabaseHTTPClient
 
     init(client: SupabaseHTTPClient = .live) {
@@ -1199,6 +1291,94 @@ struct NearbyPresenceService: NearbyPresenceServiceProtocol {
             method: .post,
             bodyData: try JSONSerialization.data(withJSONObject: body)
         )
+    }
+
+    /// 실시간 위치 표시용 원시 presence 레코드를 멱등 업서트합니다.
+    /// - Parameters:
+    ///   - userId: presence 소유 사용자 UUID 문자열입니다.
+    ///   - sessionId: 현재 산책 세션 UUID 문자열입니다. `nil`이면 서버 기본값을 사용합니다.
+    ///   - latitude: 업서트할 위도 값입니다.
+    ///   - longitude: 업서트할 경도 값입니다.
+    ///   - speedMetersPerSecond: 이동 속도(m/s)입니다.
+    ///   - sequence: last-write-wins 비교용 시퀀스입니다.
+    ///   - idempotencyKey: 재전송 중복 제거용 멱등 키입니다.
+    /// - Returns: 서버가 반영한 최신 라이브 presence 행입니다. 공유 OFF로 생략되면 `nil`입니다.
+    func upsertLivePresence(
+        userId: String,
+        sessionId: String?,
+        latitude: Double,
+        longitude: Double,
+        speedMetersPerSecond: Double?,
+        sequence: Int?,
+        idempotencyKey: String?
+    ) async throws -> WalkLivePresenceDTO? {
+        var payload: [String: Any] = [
+            "action": "upsert_live_presence",
+            "userId": userId,
+            "lat": latitude,
+            "lng": longitude
+        ]
+        if let sessionId, sessionId.isEmpty == false {
+            payload["sessionId"] = sessionId
+        }
+        if let speedMetersPerSecond {
+            payload["speedMps"] = speedMetersPerSecond
+        }
+        if let sequence {
+            payload["sequence"] = sequence
+        }
+        if let idempotencyKey, idempotencyKey.isEmpty == false {
+            payload["idempotencyKey"] = idempotencyKey
+        }
+
+        let data = try await client.request(
+            .function(name: "nearby-presence"),
+            method: .post,
+            bodyData: try JSONSerialization.data(withJSONObject: payload)
+        )
+
+        let decoded = try JSONDecoder().decode(LivePresenceUpsertEnvelope.self, from: data)
+        guard let row = decoded.live_presence else {
+            return nil
+        }
+        return Self.makeLivePresenceDTO(from: row)
+    }
+
+    /// 지정한 viewport 범위의 실시간 presence 목록을 조회합니다.
+    /// - Parameters:
+    ///   - minLatitude: 조회 최소 위도 경계입니다.
+    ///   - maxLatitude: 조회 최대 위도 경계입니다.
+    ///   - minLongitude: 조회 최소 경도 경계입니다.
+    ///   - maxLongitude: 조회 최대 경도 경계입니다.
+    ///   - maxRows: 조회 최대 반환 row 수입니다.
+    ///   - privacyMode: 조회 프라이버시 모드(`public`/`private`/`all`)입니다.
+    /// - Returns: 만료/프라이버시 필터가 적용된 실시간 presence 목록입니다.
+    func getLivePresence(
+        minLatitude: Double,
+        maxLatitude: Double,
+        minLongitude: Double,
+        maxLongitude: Double,
+        maxRows: Int = 200,
+        privacyMode: String = "public"
+    ) async throws -> [WalkLivePresenceDTO] {
+        let payload: [String: Any] = [
+            "action": "get_live_presence",
+            "minLat": minLatitude,
+            "maxLat": maxLatitude,
+            "minLng": minLongitude,
+            "maxLng": maxLongitude,
+            "maxRows": maxRows,
+            "privacyMode": privacyMode
+        ]
+
+        let data = try await client.request(
+            .function(name: "nearby-presence"),
+            method: .post,
+            bodyData: try JSONSerialization.data(withJSONObject: payload)
+        )
+
+        let decoded = try JSONDecoder().decode(LivePresenceEnvelope.self, from: data)
+        return decoded.presence.map(Self.makeLivePresenceDTO)
     }
 
     func getHotspots(
@@ -1236,6 +1416,24 @@ struct NearbyPresenceService: NearbyPresenceServiceProtocol {
                 requiredMinSample: $0.required_min_sample
             )
         }
+    }
+
+    /// Edge Function 응답 행을 앱 도메인용 라이브 프레즌스 DTO로 변환합니다.
+    /// - Parameter row: `rpc_get_walk_live_presence` 또는 `rpc_upsert_walk_live_presence` 응답 행입니다.
+    /// - Returns: UI/도메인 계층에서 바로 사용할 수 있는 라이브 프레즌스 DTO입니다.
+    private static func makeLivePresenceDTO(from row: ResponseLivePresenceDTO) -> WalkLivePresenceDTO {
+        WalkLivePresenceDTO(
+            ownerUserId: row.owner_user_id,
+            sessionId: row.session_id,
+            coordinate: CLLocationCoordinate2D(latitude: row.lat_rounded, longitude: row.lng_rounded),
+            speedMetersPerSecond: row.speed_mps,
+            sequence: row.sequence,
+            idempotencyKey: row.idempotency_key,
+            updatedAtEpoch: SupabaseISO8601.parseEpoch(row.updated_at) ?? 0,
+            expiresAtEpoch: SupabaseISO8601.parseEpoch(row.expires_at) ?? 0,
+            privacyMode: row.privacy_mode,
+            writeApplied: row.write_applied
+        )
     }
 }
 

--- a/supabase/functions/nearby-presence/index.ts
+++ b/supabase/functions/nearby-presence/index.ts
@@ -1,6 +1,11 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
 
-type Action = "set_visibility" | "upsert_presence" | "get_hotspots";
+type Action =
+  | "set_visibility"
+  | "upsert_presence"
+  | "get_hotspots"
+  | "upsert_live_presence"
+  | "get_live_presence";
 
 type RequestDTO = {
   action: Action;
@@ -8,9 +13,21 @@ type RequestDTO = {
   enabled?: boolean;
   lat?: number;
   lng?: number;
+  speedMps?: number;
+  sequence?: number;
+  idempotencyKey?: string;
+  updatedAt?: string;
+  ttlSeconds?: number;
+  sessionId?: string;
   centerLat?: number;
   centerLng?: number;
   radiusKm?: number;
+  minLat?: number;
+  maxLat?: number;
+  minLng?: number;
+  maxLng?: number;
+  maxRows?: number;
+  privacyMode?: "public" | "private" | "all";
 };
 
 type ResponseHotspotDTO = {
@@ -26,6 +43,21 @@ type ResponseHotspotDTO = {
   required_min_sample?: number;
 };
 
+type ResponseLivePresenceDTO = {
+  owner_user_id: string;
+  session_id: string;
+  lat_rounded: number;
+  lng_rounded: number;
+  geohash7: string;
+  speed_mps?: number | null;
+  sequence: number;
+  idempotency_key: string;
+  updated_at: string;
+  expires_at: string;
+  write_applied?: boolean;
+  privacy_mode?: string;
+};
+
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
     status,
@@ -39,6 +71,30 @@ const asUUIDOrNull = (value: unknown): string | null => {
   const normalized = value.trim().toLowerCase();
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
   return uuidPattern.test(normalized) ? normalized : null;
+};
+
+const asFiniteNumberOrNull = (value: unknown): number | null => {
+  if (typeof value !== "number") return null;
+  return Number.isFinite(value) ? value : null;
+};
+
+const asISO8601OrNull = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return null;
+  return new Date(parsed).toISOString();
+};
+
+const asPositiveIntegerOrNull = (value: unknown): number | null => {
+  if (typeof value !== "number" || Number.isFinite(value) === false) return null;
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : null;
+};
+
+const asNonEmptyTextOrNull = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
 };
 
 const geohashEncode = (lat: number, lng: number, precision = 7): string => {
@@ -79,6 +135,55 @@ const geohashEncode = (lat: number, lng: number, precision = 7): string => {
     }
   }
   return hash;
+};
+
+const upsertLivePresence = async (
+  client: ReturnType<typeof createClient>,
+  payload: {
+    userId: string;
+    sessionId?: string;
+    latitude: number;
+    longitude: number;
+    speedMps?: number;
+    sequence?: number;
+    idempotencyKey?: string;
+    updatedAt?: string;
+    ttlSeconds?: number;
+  },
+) => {
+  const latRounded = roundCoord(payload.latitude);
+  const lngRounded = roundCoord(payload.longitude);
+  const normalizedSessionId = asUUIDOrNull(payload.sessionId) ?? payload.userId;
+  const normalizedSequence = asPositiveIntegerOrNull(payload.sequence) ?? 0;
+  const normalizedIdempotencyKey = asNonEmptyTextOrNull(payload.idempotencyKey) ??
+    `${payload.userId}:${normalizedSequence}:${Date.now()}`;
+  const normalizedUpdatedAt = asISO8601OrNull(payload.updatedAt) ?? new Date().toISOString();
+  const normalizedTtlSeconds = Math.min(
+    90,
+    Math.max(60, asPositiveIntegerOrNull(payload.ttlSeconds) ?? 90),
+  );
+  const geohash7 = geohashEncode(latRounded, lngRounded, 7);
+
+  const { data, error } = await client.rpc("rpc_upsert_walk_live_presence", {
+    in_owner_user_id: payload.userId,
+    in_session_id: normalizedSessionId,
+    in_lat_rounded: latRounded,
+    in_lng_rounded: lngRounded,
+    in_geohash7: geohash7,
+    in_speed_mps: asFiniteNumberOrNull(payload.speedMps),
+    in_sequence: normalizedSequence,
+    in_idempotency_key: normalizedIdempotencyKey,
+    in_updated_at: normalizedUpdatedAt,
+    in_ttl_seconds: normalizedTtlSeconds,
+  });
+
+  const rows = ((data ?? []) as ResponseLivePresenceDTO[]);
+  const first = rows.length > 0 ? rows[0] : null;
+  return {
+    geohash7,
+    row: first,
+    error,
+  };
 };
 
 Deno.serve(async (req) => {
@@ -144,7 +249,63 @@ Deno.serve(async (req) => {
       updated_at: new Date().toISOString(),
     });
     if (error) return json({ error: error.message }, 500);
-    return json({ ok: true, geohash7 });
+
+    const livePresenceResult = await upsertLivePresence(client, {
+      userId,
+      sessionId: body.sessionId,
+      latitude: latRounded,
+      longitude: lngRounded,
+      speedMps: body.speedMps,
+      sequence: body.sequence,
+      idempotencyKey: body.idempotencyKey,
+      updatedAt: body.updatedAt,
+      ttlSeconds: body.ttlSeconds,
+    });
+    if (livePresenceResult.error) return json({ error: livePresenceResult.error.message }, 500);
+
+    return json({
+      ok: true,
+      geohash7,
+      live_presence: livePresenceResult.row,
+    });
+  }
+
+  if (body.action === "upsert_live_presence") {
+    const userId = asUUIDOrNull(body.userId);
+    if (!userId || typeof body.lat !== "number" || typeof body.lng !== "number") {
+      return json({ error: "INVALID_PAYLOAD" }, 400);
+    }
+
+    const { data: visibility, error: visibilityError } = await client
+      .from("user_visibility_settings")
+      .select("location_sharing_enabled")
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    if (visibilityError) return json({ error: visibilityError.message }, 500);
+    if (!visibility?.location_sharing_enabled) {
+      return json({ ok: true, skipped: "location_sharing_disabled" });
+    }
+
+    const livePresenceResult = await upsertLivePresence(client, {
+      userId,
+      sessionId: body.sessionId,
+      latitude: body.lat,
+      longitude: body.lng,
+      speedMps: body.speedMps,
+      sequence: body.sequence,
+      idempotencyKey: body.idempotencyKey,
+      updatedAt: body.updatedAt,
+      ttlSeconds: body.ttlSeconds,
+    });
+
+    if (livePresenceResult.error) return json({ error: livePresenceResult.error.message }, 500);
+
+    return json({
+      ok: true,
+      geohash7: livePresenceResult.geohash7,
+      live_presence: livePresenceResult.row,
+    });
   }
 
   if (body.action === "get_hotspots") {
@@ -197,6 +358,36 @@ Deno.serve(async (req) => {
     }
 
     return json({ hotspots });
+  }
+
+  if (body.action === "get_live_presence") {
+    if (
+      typeof body.minLat !== "number" ||
+      typeof body.maxLat !== "number" ||
+      typeof body.minLng !== "number" ||
+      typeof body.maxLng !== "number"
+    ) {
+      return json({ error: "INVALID_PAYLOAD" }, 400);
+    }
+
+    const maxRows = Math.max(1, Math.min(asPositiveIntegerOrNull(body.maxRows) ?? 200, 1000));
+    const normalizedPrivacyMode = body.privacyMode === "all" || body.privacyMode === "private"
+      ? body.privacyMode
+      : "public";
+    const nowTs = new Date().toISOString();
+
+    const { data, error } = await client.rpc("rpc_get_walk_live_presence", {
+      in_min_lat: body.minLat,
+      in_max_lat: body.maxLat,
+      in_min_lng: body.minLng,
+      in_max_lng: body.maxLng,
+      in_max_rows: maxRows,
+      in_privacy_mode: normalizedPrivacyMode,
+      in_now_ts: nowTs,
+    });
+    if (error) return json({ error: error.message }, 500);
+
+    return json({ presence: (data ?? []) as ResponseLivePresenceDTO[] });
   }
 
   return json({ error: "UNSUPPORTED_ACTION" }, 400);

--- a/supabase/migrations/20260305103000_walk_live_presence_schema_rpc_ttl_rls.sql
+++ b/supabase/migrations/20260305103000_walk_live_presence_schema_rpc_ttl_rls.sql
@@ -1,0 +1,372 @@
+-- #237 Live Presence 스키마 + RPC + TTL + RLS
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.walk_live_presence (
+  owner_user_id uuid primary key,
+  session_id uuid not null,
+  lat_rounded double precision not null,
+  lng_rounded double precision not null,
+  geohash7 text not null,
+  speed_mps double precision,
+  sequence bigint not null default 0,
+  idempotency_key text not null default gen_random_uuid()::text,
+  updated_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '90 seconds'),
+  created_at timestamptz not null default now(),
+  constraint walk_live_presence_speed_non_negative
+    check (speed_mps is null or speed_mps >= 0),
+  constraint walk_live_presence_lat_range
+    check (lat_rounded between -90 and 90),
+  constraint walk_live_presence_lng_range
+    check (lng_rounded between -180 and 180)
+);
+
+create index if not exists idx_walk_live_presence_geohash7
+  on public.walk_live_presence(geohash7);
+
+create index if not exists idx_walk_live_presence_updated_at
+  on public.walk_live_presence(updated_at desc);
+
+create index if not exists idx_walk_live_presence_expires_at
+  on public.walk_live_presence(expires_at asc);
+
+create index if not exists idx_walk_live_presence_owner_user_id
+  on public.walk_live_presence(owner_user_id);
+
+alter table public.walk_live_presence enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'walk_live_presence'
+      and policyname = 'walk_live_presence_select_visible_or_own'
+  ) then
+    create policy walk_live_presence_select_visible_or_own
+      on public.walk_live_presence
+      for select
+      using (
+        auth.role() = 'service_role'
+        or auth.uid() = owner_user_id
+        or (
+          auth.role() = 'authenticated'
+          and exists (
+            select 1
+            from public.user_visibility_settings v
+            where v.user_id = owner_user_id
+              and v.location_sharing_enabled = true
+          )
+        )
+      );
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'walk_live_presence'
+      and policyname = 'walk_live_presence_write_own_or_service'
+  ) then
+    create policy walk_live_presence_write_own_or_service
+      on public.walk_live_presence
+      for all
+      using (auth.role() = 'service_role' or auth.uid() = owner_user_id)
+      with check (auth.role() = 'service_role' or auth.uid() = owner_user_id);
+  end if;
+end $$;
+
+grant select, insert, update, delete on public.walk_live_presence to authenticated, service_role;
+
+drop function if exists public.rpc_upsert_walk_live_presence(
+  uuid,
+  uuid,
+  double precision,
+  double precision,
+  text,
+  double precision,
+  bigint,
+  text,
+  timestamptz,
+  integer
+);
+
+create or replace function public.rpc_upsert_walk_live_presence(
+  in_owner_user_id uuid,
+  in_session_id uuid,
+  in_lat_rounded double precision,
+  in_lng_rounded double precision,
+  in_geohash7 text,
+  in_speed_mps double precision default null,
+  in_sequence bigint default 0,
+  in_idempotency_key text default null,
+  in_updated_at timestamptz default now(),
+  in_ttl_seconds integer default 90
+)
+returns table (
+  owner_user_id uuid,
+  session_id uuid,
+  lat_rounded double precision,
+  lng_rounded double precision,
+  geohash7 text,
+  speed_mps double precision,
+  sequence bigint,
+  idempotency_key text,
+  updated_at timestamptz,
+  expires_at timestamptz,
+  write_applied boolean
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  requester_role text := coalesce(auth.role(), '');
+  requester_uid uuid := auth.uid();
+  normalized_lat double precision;
+  normalized_lng double precision;
+  normalized_geohash text;
+  effective_updated_at timestamptz := coalesce(in_updated_at, now());
+  effective_idempotency_key text := coalesce(nullif(trim(in_idempotency_key), ''), gen_random_uuid()::text);
+  effective_sequence bigint := greatest(coalesce(in_sequence, 0), 0);
+  effective_ttl_seconds integer := least(greatest(coalesce(in_ttl_seconds, 90), 60), 90);
+  affected_count integer := 0;
+begin
+  if in_owner_user_id is null or in_session_id is null then
+    raise exception 'owner_user_id and session_id are required';
+  end if;
+
+  if requester_role <> 'service_role' then
+    if requester_uid is null then
+      raise exception 'authenticated session required';
+    end if;
+    if requester_uid <> in_owner_user_id then
+      raise exception 'request user mismatch';
+    end if;
+  end if;
+
+  normalized_lat := round(in_lat_rounded::numeric, 4)::double precision;
+  normalized_lng := round(in_lng_rounded::numeric, 4)::double precision;
+  normalized_geohash := lower(trim(in_geohash7));
+
+  if normalized_geohash = '' then
+    raise exception 'geohash7 is required';
+  end if;
+
+  with upserted as (
+    insert into public.walk_live_presence (
+      owner_user_id,
+      session_id,
+      lat_rounded,
+      lng_rounded,
+      geohash7,
+      speed_mps,
+      sequence,
+      idempotency_key,
+      updated_at,
+      expires_at
+    )
+    values (
+      in_owner_user_id,
+      in_session_id,
+      normalized_lat,
+      normalized_lng,
+      normalized_geohash,
+      in_speed_mps,
+      effective_sequence,
+      effective_idempotency_key,
+      effective_updated_at,
+      effective_updated_at + make_interval(secs => effective_ttl_seconds)
+    )
+    on conflict (owner_user_id) do update
+      set session_id = excluded.session_id,
+          lat_rounded = excluded.lat_rounded,
+          lng_rounded = excluded.lng_rounded,
+          geohash7 = excluded.geohash7,
+          speed_mps = excluded.speed_mps,
+          sequence = excluded.sequence,
+          idempotency_key = excluded.idempotency_key,
+          updated_at = excluded.updated_at,
+          expires_at = excluded.expires_at
+      where public.walk_live_presence.idempotency_key is distinct from excluded.idempotency_key
+        and (
+          excluded.updated_at > public.walk_live_presence.updated_at
+          or (
+            excluded.updated_at = public.walk_live_presence.updated_at
+            and excluded.sequence >= public.walk_live_presence.sequence
+          )
+        )
+    returning 1
+  )
+  select count(*)::integer
+  into affected_count
+  from upserted;
+
+  return query
+  select
+    p.owner_user_id,
+    p.session_id,
+    p.lat_rounded,
+    p.lng_rounded,
+    p.geohash7,
+    p.speed_mps,
+    p.sequence,
+    p.idempotency_key,
+    p.updated_at,
+    p.expires_at,
+    affected_count > 0
+  from public.walk_live_presence p
+  where p.owner_user_id = in_owner_user_id;
+end;
+$$;
+
+grant execute on function public.rpc_upsert_walk_live_presence(
+  uuid,
+  uuid,
+  double precision,
+  double precision,
+  text,
+  double precision,
+  bigint,
+  text,
+  timestamptz,
+  integer
+) to authenticated, service_role;
+
+drop function if exists public.rpc_get_walk_live_presence(
+  double precision,
+  double precision,
+  double precision,
+  double precision,
+  integer,
+  text,
+  timestamptz
+);
+
+create or replace function public.rpc_get_walk_live_presence(
+  in_min_lat double precision,
+  in_max_lat double precision,
+  in_min_lng double precision,
+  in_max_lng double precision,
+  in_max_rows integer default 200,
+  in_privacy_mode text default 'public',
+  in_now_ts timestamptz default now()
+)
+returns table (
+  owner_user_id uuid,
+  session_id uuid,
+  lat_rounded double precision,
+  lng_rounded double precision,
+  geohash7 text,
+  speed_mps double precision,
+  updated_at timestamptz,
+  expires_at timestamptz,
+  privacy_mode text
+)
+language sql
+security definer
+set search_path = public
+as $$
+  with bounded as (
+    select
+      p.owner_user_id,
+      p.session_id,
+      p.lat_rounded,
+      p.lng_rounded,
+      p.geohash7,
+      p.speed_mps,
+      p.updated_at,
+      p.expires_at,
+      coalesce(v.location_sharing_enabled, false) as is_public
+    from public.walk_live_presence p
+    left join public.user_visibility_settings v
+      on v.user_id = p.owner_user_id
+    where p.expires_at > coalesce(in_now_ts, now())
+      and p.lat_rounded between least(in_min_lat, in_max_lat) and greatest(in_min_lat, in_max_lat)
+      and p.lng_rounded between least(in_min_lng, in_max_lng) and greatest(in_min_lng, in_max_lng)
+  )
+  select
+    b.owner_user_id,
+    b.session_id,
+    b.lat_rounded,
+    b.lng_rounded,
+    b.geohash7,
+    b.speed_mps,
+    b.updated_at,
+    b.expires_at,
+    case when b.is_public then 'public' else 'private' end as privacy_mode
+  from bounded b
+  where case lower(coalesce(in_privacy_mode, 'public'))
+    when 'all' then true
+    when 'private' then b.is_public = false
+    else b.is_public = true or b.owner_user_id = auth.uid()
+  end
+  order by b.updated_at desc, b.owner_user_id asc
+  limit greatest(1, least(coalesce(in_max_rows, 200), 1000));
+$$;
+
+grant execute on function public.rpc_get_walk_live_presence(
+  double precision,
+  double precision,
+  double precision,
+  double precision,
+  integer,
+  text,
+  timestamptz
+) to authenticated, service_role;
+
+create or replace function public.rpc_cleanup_walk_live_presence(
+  in_now_ts timestamptz default now()
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  deleted_count integer := 0;
+begin
+  delete from public.walk_live_presence
+  where expires_at <= coalesce(in_now_ts, now());
+
+  get diagnostics deleted_count = row_count;
+  return deleted_count;
+end;
+$$;
+
+grant execute on function public.rpc_cleanup_walk_live_presence(timestamptz) to service_role;
+
+do $$
+declare
+  existing_job_id integer;
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron')
+     and exists (select 1 from pg_namespace where nspname = 'cron') then
+    select jobid
+    into existing_job_id
+    from cron.job
+    where jobname = 'walk_live_presence_ttl_cleanup'
+    limit 1;
+
+    if existing_job_id is not null then
+      perform cron.unschedule(existing_job_id);
+    end if;
+
+    perform cron.schedule(
+      'walk_live_presence_ttl_cleanup',
+      '* * * * *',
+      'select public.rpc_cleanup_walk_live_presence();'
+    );
+  end if;
+exception
+  when undefined_table or undefined_function or invalid_schema_name then
+    raise notice 'walk_live_presence ttl cleanup scheduler skipped (cron unavailable)';
+  when others then
+    raise notice 'walk_live_presence ttl cleanup scheduler skipped: %', sqlerrm;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add migration for `walk_live_presence` with indexes, RLS policies, upsert/query/cleanup RPCs, and TTL cron scheduling
- extend `nearby-presence` edge function with `upsert_live_presence` and `get_live_presence` actions
- keep existing `upsert_presence` hotspot flow while also writing live presence via the new RPC
- add iOS infra DTO/protocol methods for live presence upsert/query (`WalkLivePresenceDTO`, `NearbyPresenceService`)

## Testing
- [x] `bash scripts/ios_pr_check.sh`
- [ ] `bash scripts/run_design_audit_ui_tests.sh` (skipped: non-UI backend/infra scope)

Closes #237
