### PR TITLE
[P3][Privacy] 실시간 공유 프라이버시 가드 v2

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -466,6 +466,10 @@ struct WalkLivePresenceDTO: Identifiable, Equatable {
     let updatedAtEpoch: TimeInterval
     let expiresAtEpoch: TimeInterval
     let privacyMode: String?
+    let suppressionReason: String?
+    let delayMinutes: Int?
+    let requiredMinSample: Int?
+    let obfuscationMeters: Int?
     let writeApplied: Bool?
 
     var id: String { ownerUserId }
@@ -486,6 +490,10 @@ struct WalkLivePresenceDTO: Identifiable, Equatable {
         lhs.updatedAtEpoch == rhs.updatedAtEpoch &&
         lhs.expiresAtEpoch == rhs.expiresAtEpoch &&
         lhs.privacyMode == rhs.privacyMode &&
+        lhs.suppressionReason == rhs.suppressionReason &&
+        lhs.delayMinutes == rhs.delayMinutes &&
+        lhs.requiredMinSample == rhs.requiredMinSample &&
+        lhs.obfuscationMeters == rhs.obfuscationMeters &&
         lhs.writeApplied == rhs.writeApplied
     }
 }
@@ -521,6 +529,8 @@ protocol NearbyPresenceServiceProtocol {
     ///   - maxLongitude: 조회 최대 경도 경계입니다.
     ///   - maxRows: 최대 반환 row 수입니다.
     ///   - privacyMode: 조회 프라이버시 모드(`public`/`private`/`all`)입니다.
+    ///   - requesterUserId: 요청자 사용자 UUID 문자열입니다. 자기 row의 예외 처리 판단에 사용됩니다.
+    ///   - excludedUserIds: 차단/숨김 등으로 즉시 제외할 사용자 UUID 목록입니다.
     /// - Returns: viewport 범위와 프라이버시 필터가 적용된 실시간 프레즌스 목록입니다.
     func getLivePresence(
         minLatitude: Double,
@@ -528,7 +538,9 @@ protocol NearbyPresenceServiceProtocol {
         minLongitude: Double,
         maxLongitude: Double,
         maxRows: Int,
-        privacyMode: String
+        privacyMode: String,
+        requesterUserId: String?,
+        excludedUserIds: [String]
     ) async throws -> [WalkLivePresenceDTO]
 }
 
@@ -1244,11 +1256,15 @@ struct NearbyPresenceService: NearbyPresenceServiceProtocol {
         let lat_rounded: Double
         let lng_rounded: Double
         let speed_mps: Double?
-        let sequence: Int
-        let idempotency_key: String
+        let sequence: Int?
+        let idempotency_key: String?
         let updated_at: String?
         let expires_at: String?
         let privacy_mode: String?
+        let suppression_reason: String?
+        let delay_minutes: Int?
+        let required_min_sample: Int?
+        let obfuscation_meters: Int?
         let write_applied: Bool?
     }
 
@@ -1352,6 +1368,8 @@ struct NearbyPresenceService: NearbyPresenceServiceProtocol {
     ///   - maxLongitude: 조회 최대 경도 경계입니다.
     ///   - maxRows: 조회 최대 반환 row 수입니다.
     ///   - privacyMode: 조회 프라이버시 모드(`public`/`private`/`all`)입니다.
+    ///   - requesterUserId: 요청자 사용자 UUID 문자열입니다.
+    ///   - excludedUserIds: 즉시 비노출할 사용자 UUID 목록입니다.
     /// - Returns: 만료/프라이버시 필터가 적용된 실시간 presence 목록입니다.
     func getLivePresence(
         minLatitude: Double,
@@ -1359,9 +1377,11 @@ struct NearbyPresenceService: NearbyPresenceServiceProtocol {
         minLongitude: Double,
         maxLongitude: Double,
         maxRows: Int = 200,
-        privacyMode: String = "public"
+        privacyMode: String = "public",
+        requesterUserId: String? = nil,
+        excludedUserIds: [String] = []
     ) async throws -> [WalkLivePresenceDTO] {
-        let payload: [String: Any] = [
+        var payload: [String: Any] = [
             "action": "get_live_presence",
             "minLat": minLatitude,
             "maxLat": maxLatitude,
@@ -1370,6 +1390,12 @@ struct NearbyPresenceService: NearbyPresenceServiceProtocol {
             "maxRows": maxRows,
             "privacyMode": privacyMode
         ]
+        if let requesterUserId, requesterUserId.isEmpty == false {
+            payload["userId"] = requesterUserId
+        }
+        if excludedUserIds.isEmpty == false {
+            payload["excludedUserIds"] = excludedUserIds
+        }
 
         let data = try await client.request(
             .function(name: "nearby-presence"),
@@ -1422,16 +1448,21 @@ struct NearbyPresenceService: NearbyPresenceServiceProtocol {
     /// - Parameter row: `rpc_get_walk_live_presence` 또는 `rpc_upsert_walk_live_presence` 응답 행입니다.
     /// - Returns: UI/도메인 계층에서 바로 사용할 수 있는 라이브 프레즌스 DTO입니다.
     private static func makeLivePresenceDTO(from row: ResponseLivePresenceDTO) -> WalkLivePresenceDTO {
-        WalkLivePresenceDTO(
+        let effectiveIdempotencyKey = row.idempotency_key ?? "\(row.owner_user_id):\(row.session_id):\(row.updated_at ?? "0")"
+        return WalkLivePresenceDTO(
             ownerUserId: row.owner_user_id,
             sessionId: row.session_id,
             coordinate: CLLocationCoordinate2D(latitude: row.lat_rounded, longitude: row.lng_rounded),
             speedMetersPerSecond: row.speed_mps,
-            sequence: row.sequence,
-            idempotencyKey: row.idempotency_key,
+            sequence: row.sequence ?? 0,
+            idempotencyKey: effectiveIdempotencyKey,
             updatedAtEpoch: SupabaseISO8601.parseEpoch(row.updated_at) ?? 0,
             expiresAtEpoch: SupabaseISO8601.parseEpoch(row.expires_at) ?? 0,
             privacyMode: row.privacy_mode,
+            suppressionReason: row.suppression_reason,
+            delayMinutes: row.delay_minutes,
+            requiredMinSample: row.required_min_sample,
+            obfuscationMeters: row.obfuscation_meters,
             writeApplied: row.write_applied
         )
     }

--- a/supabase/functions/nearby-presence/index.ts
+++ b/supabase/functions/nearby-presence/index.ts
@@ -10,6 +10,7 @@ type Action =
 type RequestDTO = {
   action: Action;
   userId?: string;
+  excludedUserIds?: string[];
   enabled?: boolean;
   lat?: number;
   lng?: number;
@@ -50,12 +51,16 @@ type ResponseLivePresenceDTO = {
   lng_rounded: number;
   geohash7: string;
   speed_mps?: number | null;
-  sequence: number;
-  idempotency_key: string;
+  sequence?: number;
+  idempotency_key?: string;
   updated_at: string;
   expires_at: string;
   write_applied?: boolean;
   privacy_mode?: string;
+  suppression_reason?: string | null;
+  delay_minutes?: number;
+  required_min_sample?: number;
+  obfuscation_meters?: number;
 };
 
 const json = (body: unknown, status = 200) =>
@@ -95,6 +100,13 @@ const asNonEmptyTextOrNull = (value: unknown): string | null => {
   if (typeof value !== "string") return null;
   const normalized = value.trim();
   return normalized.length > 0 ? normalized : null;
+};
+
+const asUUIDArray = (value: unknown): string[] => {
+  if (Array.isArray(value) === false) return [];
+  return value
+    .map((entry) => asUUIDOrNull(entry))
+    .filter((entry): entry is string => entry != null);
 };
 
 const geohashEncode = (lat: number, lng: number, precision = 7): string => {
@@ -374,6 +386,8 @@ Deno.serve(async (req) => {
     const normalizedPrivacyMode = body.privacyMode === "all" || body.privacyMode === "private"
       ? body.privacyMode
       : "public";
+    const requestUserId = asUUIDOrNull(body.userId);
+    const excludedUserIds = asUUIDArray(body.excludedUserIds);
     const nowTs = new Date().toISOString();
 
     const { data, error } = await client.rpc("rpc_get_walk_live_presence", {
@@ -384,10 +398,50 @@ Deno.serve(async (req) => {
       in_max_rows: maxRows,
       in_privacy_mode: normalizedPrivacyMode,
       in_now_ts: nowTs,
+      in_request_user_id: requestUserId,
+      in_excluded_user_ids: excludedUserIds,
     });
     if (error) return json({ error: error.message }, 500);
 
-    return json({ presence: (data ?? []) as ResponseLivePresenceDTO[] });
+    const presence = (data ?? []) as ResponseLivePresenceDTO[];
+    const suppressedCount = presence.filter((row) => row.suppression_reason != null).length;
+    const delayedCount = presence.filter((row) => row.suppression_reason === "delayed").length;
+    const sensitiveCount = presence.filter((row) => row.suppression_reason === "sensitive_mask").length;
+    const kAnonCount = presence.filter((row) => row.suppression_reason === "k_anon").length;
+    const excludedCount = excludedUserIds.length;
+    const obfuscationMeters = presence.reduce((max, row) => {
+      const value = typeof row.obfuscation_meters === "number" ? row.obfuscation_meters : 0;
+      return Math.max(max, value);
+    }, 0);
+
+    const { error: auditError } = await client.from("privacy_guard_audit_logs").insert({
+      policy_key: "walk_live_presence",
+      request_action: "get_live_presence",
+      request_user_id: requestUserId,
+      request_min_lat: body.minLat,
+      request_max_lat: body.maxLat,
+      request_min_lng: body.minLng,
+      request_max_lng: body.maxLng,
+      total_presence: presence.length,
+      suppressed_presence: suppressedCount,
+      delayed_presence: delayedCount,
+      sensitive_presence: sensitiveCount,
+      k_anon_presence: kAnonCount,
+      excluded_presence: excludedCount,
+      obfuscation_meters: obfuscationMeters,
+      delay_minutes: presence.find((row) => typeof row.delay_minutes === "number")?.delay_minutes ?? 0,
+      alert_level: "info",
+      payload: {
+        requested_max_rows: maxRows,
+        privacy_mode: normalizedPrivacyMode,
+      },
+    });
+
+    if (auditError) {
+      console.error("privacy live audit insert failed", auditError.message);
+    }
+
+    return json({ presence });
   }
 
   return json({ error: "UNSUPPORTED_ACTION" }, 400);

--- a/supabase/migrations/20260305152000_walk_live_presence_privacy_guard_v2.sql
+++ b/supabase/migrations/20260305152000_walk_live_presence_privacy_guard_v2.sql
@@ -1,0 +1,293 @@
+-- #240 live presence privacy guard v2
+
+insert into public.privacy_guard_policies (
+  policy_key,
+  min_sample_size,
+  percentile_fallback,
+  daytime_delay_minutes,
+  nighttime_delay_minutes,
+  active_window_minutes,
+  night_start_hour,
+  night_end_hour,
+  policy_timezone,
+  sensitive_mask_enabled
+)
+values (
+  'walk_live_presence',
+  3,
+  0.80,
+  1,
+  3,
+  10,
+  22,
+  6,
+  'Asia/Seoul',
+  true
+)
+on conflict (policy_key) do update
+set
+  min_sample_size = excluded.min_sample_size,
+  percentile_fallback = excluded.percentile_fallback,
+  daytime_delay_minutes = excluded.daytime_delay_minutes,
+  nighttime_delay_minutes = excluded.nighttime_delay_minutes,
+  active_window_minutes = excluded.active_window_minutes,
+  night_start_hour = excluded.night_start_hour,
+  night_end_hour = excluded.night_end_hour,
+  policy_timezone = excluded.policy_timezone,
+  sensitive_mask_enabled = excluded.sensitive_mask_enabled,
+  updated_at = now();
+
+alter table public.privacy_guard_audit_logs
+  add column if not exists request_min_lat double precision,
+  add column if not exists request_max_lat double precision,
+  add column if not exists request_min_lng double precision,
+  add column if not exists request_max_lng double precision,
+  add column if not exists total_presence integer not null default 0,
+  add column if not exists suppressed_presence integer not null default 0,
+  add column if not exists delayed_presence integer not null default 0,
+  add column if not exists sensitive_presence integer not null default 0,
+  add column if not exists k_anon_presence integer not null default 0,
+  add column if not exists excluded_presence integer not null default 0,
+  add column if not exists obfuscation_meters integer not null default 0;
+
+drop function if exists public.rpc_get_walk_live_presence(
+  double precision,
+  double precision,
+  double precision,
+  double precision,
+  integer,
+  text,
+  timestamptz
+);
+
+create or replace function public.rpc_get_walk_live_presence(
+  in_min_lat double precision,
+  in_max_lat double precision,
+  in_min_lng double precision,
+  in_max_lng double precision,
+  in_max_rows integer default 200,
+  in_privacy_mode text default 'public',
+  in_now_ts timestamptz default now(),
+  in_request_user_id uuid default null,
+  in_excluded_user_ids uuid[] default null
+)
+returns table (
+  owner_user_id uuid,
+  session_id uuid,
+  lat_rounded double precision,
+  lng_rounded double precision,
+  geohash7 text,
+  speed_mps double precision,
+  updated_at timestamptz,
+  expires_at timestamptz,
+  privacy_mode text,
+  suppression_reason text,
+  delay_minutes integer,
+  required_min_sample integer,
+  obfuscation_meters integer
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  policy_row public.privacy_guard_policies%rowtype;
+  requester_id uuid := coalesce(in_request_user_id, auth.uid());
+  local_now timestamp;
+  local_hour integer;
+  is_night boolean;
+  effective_delay integer;
+  min_samples integer;
+  timezone_name text;
+  mask_enabled boolean;
+  max_rows integer := greatest(1, least(coalesce(in_max_rows, 200), 1000));
+begin
+  select *
+  into policy_row
+  from public.privacy_guard_policies
+  where policy_key = 'walk_live_presence'
+  limit 1;
+
+  if not found then
+    min_samples := 3;
+    effective_delay := 1;
+    timezone_name := 'Asia/Seoul';
+    mask_enabled := true;
+    local_now := coalesce(in_now_ts, now()) at time zone timezone_name;
+    local_hour := extract(hour from local_now)::integer;
+    is_night := local_hour >= 22 or local_hour < 6;
+    if is_night then
+      effective_delay := 3;
+    end if;
+  else
+    min_samples := greatest(2, coalesce(policy_row.min_sample_size, 3));
+    mask_enabled := coalesce(policy_row.sensitive_mask_enabled, true);
+    timezone_name := coalesce(nullif(policy_row.policy_timezone, ''), 'Asia/Seoul');
+
+    local_now := coalesce(in_now_ts, now()) at time zone timezone_name;
+    local_hour := extract(hour from local_now)::integer;
+
+    if policy_row.night_start_hour = policy_row.night_end_hour then
+      is_night := false;
+    elsif policy_row.night_start_hour < policy_row.night_end_hour then
+      is_night := local_hour >= policy_row.night_start_hour
+        and local_hour < policy_row.night_end_hour;
+    else
+      is_night := local_hour >= policy_row.night_start_hour
+        or local_hour < policy_row.night_end_hour;
+    end if;
+
+    effective_delay := case
+      when is_night then greatest(0, coalesce(policy_row.nighttime_delay_minutes, 3))
+      else greatest(0, coalesce(policy_row.daytime_delay_minutes, 1))
+    end;
+  end if;
+
+  return query
+  with base as (
+    select
+      p.owner_user_id,
+      p.session_id,
+      p.lat_rounded,
+      p.lng_rounded,
+      p.geohash7,
+      p.speed_mps,
+      p.updated_at,
+      p.expires_at,
+      coalesce(v.location_sharing_enabled, false) as is_public
+    from public.walk_live_presence p
+    left join public.user_visibility_settings v
+      on v.user_id = p.owner_user_id
+    where p.expires_at > coalesce(in_now_ts, now())
+      and p.lat_rounded between least(in_min_lat, in_max_lat) and greatest(in_min_lat, in_max_lat)
+      and p.lng_rounded between least(in_min_lng, in_max_lng) and greatest(in_min_lng, in_max_lng)
+  ),
+  scoped as (
+    select
+      b.*,
+      (requester_id is not null and b.owner_user_id = requester_id) as is_own,
+      (
+        in_excluded_user_ids is not null
+        and cardinality(in_excluded_user_ids) > 0
+        and b.owner_user_id = any(in_excluded_user_ids)
+      ) as is_excluded,
+      case
+        when mask_enabled then public.is_coordinate_in_sensitive_mask(b.lat_rounded, b.lng_rounded)
+        else false
+      end as is_sensitive,
+      count(*) over (partition by b.geohash7) as sample_count
+    from base b
+  ),
+  guarded as (
+    select
+      s.*,
+      case
+        when s.is_own then null
+        when s.is_excluded then 'excluded'
+        when s.is_sensitive then 'sensitive_mask'
+        when s.updated_at > coalesce(in_now_ts, now()) - make_interval(mins => effective_delay) then 'delayed'
+        when s.sample_count < min_samples then 'k_anon'
+        else null
+      end as suppression_reason,
+      case
+        when s.is_own then 0
+        else 30 + mod(
+          get_byte(
+            decode(md5(s.owner_user_id::text || ':' || date_trunc('minute', s.updated_at)::text || ':' || s.geohash7), 'hex'),
+            0
+          ),
+          21
+        )
+      end as obfuscation_meters
+    from scoped s
+  ),
+  included as (
+    select *
+    from guarded g
+    where g.suppression_reason is null
+      and case lower(coalesce(in_privacy_mode, 'public'))
+        when 'all' then true
+        when 'private' then g.is_public = false
+        else g.is_public = true or g.is_own
+      end
+  ),
+  transformed as (
+    select
+      i.owner_user_id,
+      i.session_id,
+      round((
+        i.lat_rounded +
+        case
+          when i.obfuscation_meters <= 0 then 0
+          else (
+            (i.obfuscation_meters::double precision / 111320.0) *
+            sin(radians(mod(
+              (get_byte(decode(md5(i.owner_user_id::text || ':lat:' || i.geohash7), 'hex'), 1)::integer * 256)
+              + get_byte(decode(md5(i.owner_user_id::text || ':lat:' || i.geohash7), 'hex'), 2)::integer,
+              360
+            )::double precision))
+          )
+        end
+      )::numeric, 4)::double precision as masked_lat,
+      round((
+        i.lng_rounded +
+        case
+          when i.obfuscation_meters <= 0 then 0
+          else (
+            (i.obfuscation_meters::double precision /
+              (111320.0 * greatest(0.2, abs(cos(radians(i.lat_rounded)))))) *
+            cos(radians(mod(
+              (get_byte(decode(md5(i.owner_user_id::text || ':lng:' || i.geohash7), 'hex'), 1)::integer * 256)
+              + get_byte(decode(md5(i.owner_user_id::text || ':lng:' || i.geohash7), 'hex'), 2)::integer,
+              360
+            )::double precision))
+          )
+        end
+      )::numeric, 4)::double precision as masked_lng,
+      i.geohash7,
+      i.speed_mps,
+      i.updated_at,
+      i.expires_at,
+      case
+        when i.is_own then coalesce(case when i.is_public then 'public' else 'private' end, 'private')
+        when i.obfuscation_meters > 0 then 'guarded'
+        when i.is_public then 'public'
+        else 'private'
+      end as privacy_mode,
+      i.suppression_reason,
+      effective_delay as delay_minutes,
+      min_samples as required_min_sample,
+      i.obfuscation_meters
+    from included i
+  )
+  select
+    t.owner_user_id,
+    t.session_id,
+    t.masked_lat as lat_rounded,
+    t.masked_lng as lng_rounded,
+    t.geohash7,
+    t.speed_mps,
+    t.updated_at,
+    t.expires_at,
+    t.privacy_mode,
+    t.suppression_reason,
+    t.delay_minutes,
+    t.required_min_sample,
+    t.obfuscation_meters
+  from transformed t
+  order by t.updated_at desc, t.owner_user_id asc
+  limit max_rows;
+end;
+$$;
+
+grant execute on function public.rpc_get_walk_live_presence(
+  double precision,
+  double precision,
+  double precision,
+  double precision,
+  integer,
+  text,
+  timestamptz,
+  uuid,
+  uuid[]
+) to authenticated, service_role;


### PR DESCRIPTION
## 요약\n- live presence 조회 RPC에 프라이버시 가드 v2(30~50m 오브퍼스케이션, 민감구역 마스킹, 야간/소표본 지연-차단, excluded 사용자 즉시 비노출) 적용\n- privacy_guard_audit_logs 스키마를 live presence 지표까지 확장\n- nearby-presence edge/get_live_presence 경로에 확장 필드 전달 및 감사로그 기록 추가\n- iOS WalkLivePresence DTO/디코딩 경로에 suppression/obfuscation 표현 필드 반영\n\n## 검증\n- bash scripts/ios_pr_check.sh\n\nCloses #240