### PR TITLE
[Issue #303] Auth 세션 만료/상태 불일치 정합성 수정

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -335,6 +335,7 @@ struct SupabaseHTTPClient {
                 payload: ["reason": "missing_token_session"]
             )
             authSessionStore.clearTokenSession()
+            notifyAuthSessionExpired(reason: "missing_token_session")
             return nil
         case .retryableFailure:
             metricTracker.track(
@@ -342,7 +343,10 @@ struct SupabaseHTTPClient {
                 userKey: currentIdentityUserId(),
                 payload: ["reason": "retryable_failure"]
             )
-            return nil
+            #if DEBUG
+            print("[SupabaseAuth] refresh retryable-failure: keep current access token for next retry window")
+            #endif
+            return current.accessToken
         case .terminalFailure:
             metricTracker.track(
                 .syncAuthRefreshFailed,
@@ -350,6 +354,7 @@ struct SupabaseHTTPClient {
                 payload: ["reason": "terminal_failure"]
             )
             authSessionStore.clearTokenSession()
+            notifyAuthSessionExpired(reason: "terminal_failure")
             return nil
         }
     }
@@ -358,6 +363,19 @@ struct SupabaseHTTPClient {
     /// - Returns: 로컬에 사용자 식별자가 있으면 해당 userId, 없으면 `nil`입니다.
     private func currentIdentityUserId() -> String? {
         authSessionStore.currentIdentity()?.userId
+    }
+
+    /// 인증 토큰을 더 이상 복구할 수 없는 상태를 앱 전역에 브로드캐스트합니다.
+    /// - Parameter reason: 세션 만료로 판정된 내부 원인 식별자입니다.
+    private func notifyAuthSessionExpired(reason: String) {
+        NotificationCenter.default.post(
+            name: .authSessionExpired,
+            object: self,
+            userInfo: ["reason": reason]
+        )
+        #if DEBUG
+        print("[SupabaseAuth] session-expired reason=\(reason)")
+        #endif
     }
 
     /// refresh token으로 새 세션 토큰을 발급받고 사용자 식별 정보를 복원합니다.
@@ -384,11 +402,21 @@ struct SupabaseHTTPClient {
         print("[SupabaseAuth] -> POST refresh-token")
         #endif
 
-        guard let (data, response) = try? await session.data(for: request),
-              let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
             #if DEBUG
             let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
-            print("[SupabaseAuth] xx refresh-token elapsed=\(elapsedMs)ms request-failed")
+            print("[SupabaseAuth] xx refresh-token elapsed=\(elapsedMs)ms request-failed error=\(error.localizedDescription)")
+            #endif
+            return .retryableFailure
+        }
+        guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+            #if DEBUG
+            let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+            print("[SupabaseAuth] xx refresh-token elapsed=\(elapsedMs)ms invalid-response")
             #endif
             return .retryableFailure
         }
@@ -398,7 +426,7 @@ struct SupabaseHTTPClient {
             let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
             print("[SupabaseAuth] <- refresh-token status=\(statusCode) elapsed=\(elapsedMs)ms")
             #endif
-            if statusCode == 400 || statusCode == 401 {
+            if isTerminalRefreshFailure(statusCode: statusCode, data: data) {
                 return .terminalFailure
             }
             return .retryableFailure
@@ -413,13 +441,49 @@ struct SupabaseHTTPClient {
             let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
             print("[SupabaseAuth] xx refresh-token decode-failed elapsed=\(elapsedMs)ms")
             #endif
-            return .terminalFailure
+            return .retryableFailure
         }
         #if DEBUG
         let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
         print("[SupabaseAuth] <- refresh-token status=200 elapsed=\(elapsedMs)ms")
         #endif
         return .success(credential)
+    }
+
+    /// 토큰 refresh 실패 응답이 즉시 로그아웃해야 하는 종단 오류인지 판정합니다.
+    /// - Parameters:
+    ///   - statusCode: refresh 엔드포인트 HTTP 상태 코드입니다.
+    ///   - data: 실패 응답 바디 데이터입니다.
+    /// - Returns: refresh token 무효/폐기 계열이면 `true`, 네트워크·일시 오류 성격이면 `false`입니다.
+    private func isTerminalRefreshFailure(statusCode: Int, data: Data) -> Bool {
+        guard statusCode == 400 || statusCode == 401 else {
+            return false
+        }
+        let normalized = refreshFailureMessage(from: data)
+        guard normalized.isEmpty == false else {
+            return false
+        }
+        if normalized.contains("invalid_grant") { return true }
+        if normalized.contains("refresh token") && normalized.contains("invalid") { return true }
+        if normalized.contains("refresh token") && normalized.contains("expired") { return true }
+        if normalized.contains("refresh token") && normalized.contains("not found") { return true }
+        return false
+    }
+
+    /// refresh 실패 응답 바디를 소문자 비교용 문자열로 정규화합니다.
+    /// - Parameter data: refresh 엔드포인트 실패 응답 바디 데이터입니다.
+    /// - Returns: `error_code/message/error_description` 우선순위로 추출한 정규화 문자열입니다.
+    private func refreshFailureMessage(from data: Data) -> String {
+        guard let decoded = try? JSONDecoder().decode(SupabaseAuthResponseDTO.self, from: data) else {
+            return ""
+        }
+        let message = decoded.errorCode
+            ?? decoded.errorDescription
+            ?? decoded.error
+            ?? decoded.message
+            ?? decoded.msg
+            ?? ""
+        return message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
 

--- a/dogArea/Source/ProfileRepository.swift
+++ b/dogArea/Source/ProfileRepository.swift
@@ -84,6 +84,7 @@ final class DefaultAuthSessionStore: AuthSessionStoreProtocol {
     func persist(_ identity: AuthenticatedUserIdentity) {
         defaults.set(identity.userId, forKey: Key.userId)
         defaults.set(identity.email, forKey: Key.email)
+        postSessionDidChange(reason: "persist_identity")
     }
 
     /// 현재 인증된 토큰 세션을 로컬에 저장합니다.
@@ -93,6 +94,7 @@ final class DefaultAuthSessionStore: AuthSessionStoreProtocol {
         defaults.set(tokenSession.refreshToken, forKey: Key.refreshToken)
         defaults.set(tokenSession.expiresAt, forKey: Key.expiresAt)
         defaults.set(tokenSession.tokenType, forKey: Key.tokenType)
+        postSessionDidChange(reason: "persist_token")
     }
 
     /// 로컬에 저장된 사용자 식별 정보를 조회합니다.
@@ -131,17 +133,37 @@ final class DefaultAuthSessionStore: AuthSessionStoreProtocol {
 
     /// 토큰 세션 정보만 제거합니다.
     func clearTokenSession() {
+        clearTokenSessionInternal(notify: true)
+    }
+
+    /// 토큰 세션 정보 제거를 수행하고 필요 시 변경 이벤트를 브로드캐스트합니다.
+    /// - Parameter notify: 세션 변경 이벤트를 발행할지 여부입니다.
+    private func clearTokenSessionInternal(notify: Bool) {
         defaults.removeObject(forKey: Key.accessToken)
         defaults.removeObject(forKey: Key.refreshToken)
         defaults.removeObject(forKey: Key.expiresAt)
         defaults.removeObject(forKey: Key.tokenType)
+        if notify {
+            postSessionDidChange(reason: "clear_token")
+        }
     }
 
     /// 로컬 인증 식별 정보를 제거합니다.
     func clear() {
         defaults.removeObject(forKey: Key.userId)
         defaults.removeObject(forKey: Key.email)
-        clearTokenSession()
+        clearTokenSessionInternal(notify: false)
+        postSessionDidChange(reason: "clear_all")
+    }
+
+    /// 인증 세션 변경 사실을 앱 전역으로 브로드캐스트합니다.
+    /// - Parameter reason: 변경 원인을 식별하기 위한 문자열입니다.
+    private func postSessionDidChange(reason: String) {
+        NotificationCenter.default.post(
+            name: .authSessionDidChange,
+            object: self,
+            userInfo: ["reason": reason]
+        )
     }
 }
 

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -91,6 +91,8 @@ class UserdefaultSetting {
 
 extension Notification.Name {
     static let walkPointRecordedForQuest = Notification.Name("walk.point.recorded.for.quest")
+    static let authSessionDidChange = Notification.Name("auth.session.didChange")
+    static let authSessionExpired = Notification.Name("auth.session.expired")
 }
 struct UserInfo: TimeCheckable {
     let id: String
@@ -1524,6 +1526,23 @@ final class AuthFlowCoordinator: ObservableObject {
         guestDataUpgradeResult = nil
         onAuthenticated = nil
         refresh()
+    }
+
+    /// 토큰 만료 등으로 세션이 무효화되었을 때 로컬 상태를 정리하고 재로그인 플로우를 강제합니다.
+    func handleSessionExpired() {
+        authSessionStore.clear()
+        profileStore.removeAll()
+        petSelectionStore.clearSelectionState()
+        walkSessionMetadataStore.clearPreferences()
+        UserDefaults.standard.set(false, forKey: guestModeKey)
+        UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
+        pendingUpgradeRequest = nil
+        pendingGuestDataUpgradePrompt = nil
+        guestDataUpgradeInProgress = false
+        guestDataUpgradeResult = nil
+        onAuthenticated = nil
+        shouldShowEntryChoice = false
+        shouldShowSignIn = true
     }
 
     func startGuestDataUpgrade(forceRetry: Bool = false) {

--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -776,7 +776,6 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
             return false
         }
         let affectedUserId = currentUserId
-        authSessionStore.clearTokenSession()
         persistLocationSharingPreference(false, for: affectedUserId)
         locationSharingEnabled = false
         hotspots = []
@@ -784,7 +783,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
         leaderboardEntries = []
         latestRawLeaderboardEntries = []
         refreshViewState()
-        showToast("인증 세션이 만료됐어요. 다시 로그인 후 시도해주세요.")
+        showToast("인증 세션 확인이 필요해요. 다시 로그인 후 시도해주세요.")
         return true
     }
 

--- a/dogArea/dogAreaApp.swift
+++ b/dogArea/dogAreaApp.swift
@@ -143,6 +143,12 @@ struct dogAreaApp: App {
                     }
                 }
             }
+            .onReceive(NotificationCenter.default.publisher(for: .authSessionDidChange)) { _ in
+                authFlow.refresh()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .authSessionExpired)) { _ in
+                authFlow.handleSessionExpired()
+            }
 
         if shouldAutoGuestForUITest {
             baseRoot

--- a/scripts/auth_refresh_resilience_unit_check.swift
+++ b/scripts/auth_refresh_resilience_unit_check.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let infra = load("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+
+assertTrue(
+    infra.contains("refresh retryable-failure: keep current access token"),
+    "retryable refresh failure should keep current access token instead of anon fallback"
+)
+assertTrue(
+    infra.contains("return current.accessToken"),
+    "validAccessToken should return current access token on retryable refresh failure"
+)
+assertTrue(
+    infra.contains("return .retryableFailure") && infra.contains("decode-failed"),
+    "refresh decode failure should be classified as retryable"
+)
+assertTrue(
+    infra.contains("func isTerminalRefreshFailure(statusCode: Int, data: Data) -> Bool"),
+    "refresh flow should distinguish terminal refresh failures by payload"
+)
+assertTrue(
+    infra.contains("func refreshFailureMessage(from data: Data) -> String"),
+    "refresh flow should normalize failure payload before terminal decision"
+)
+assertTrue(
+    infra.contains("if normalized.contains(\"invalid_grant\") { return true }"),
+    "invalid_grant should remain terminal and clear session"
+)
+
+print("PASS: auth refresh resilience unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -68,6 +68,7 @@ swift scripts/walk_session_pet_canonicalization_unit_check.swift
 swift scripts/presentation_firebase_boundary_unit_check.swift
 swift scripts/supabase_profile_image_upload_unit_check.swift
 swift scripts/auth_session_autologin_unit_check.swift
+swift scripts/auth_refresh_resilience_unit_check.swift
 swift scripts/auth_onboarding_session_consistency_unit_check.swift
 swift scripts/auth_signup_entry_ux_unit_check.swift
 swift scripts/auth_signup_validation_unit_check.swift

--- a/scripts/rival_auth_session_guard_unit_check.swift
+++ b/scripts/rival_auth_session_guard_unit_check.swift
@@ -26,11 +26,15 @@ assertTrue(
     "rival tab should classify auth failure status codes explicitly"
 )
 assertTrue(
-    rivalViewModel.contains("authSessionStore.clearTokenSession()"),
-    "rival tab should clear stale token session on auth failure"
+    rivalViewModel.contains("persistLocationSharingPreference(false, for: affectedUserId)"),
+    "rival tab should disable location sharing state on auth failure"
 )
 assertTrue(
-    rivalViewModel.contains("인증 세션이 만료됐어요. 다시 로그인 후 시도해주세요."),
+    !rivalViewModel.contains("authSessionStore.clearTokenSession()"),
+    "rival tab should not clear local token session on edge-function auth failure"
+)
+assertTrue(
+    rivalViewModel.contains("인증 세션 확인이 필요해요. 다시 로그인 후 시도해주세요."),
     "rival tab should expose explicit re-login guidance on auth failure"
 )
 


### PR DESCRIPTION
## 요약
- Supabase refresh 재시도 실패를 일시 장애로 분류해 즉시 anon fallback/로그아웃으로 이어지지 않도록 보강
- 토큰 세션 변경 이벤트(`authSessionDidChange`)와 세션 만료 이벤트(`authSessionExpired`)를 추가해 앱 전역 UI 상태를 동기화
- 세션 만료 시 `AuthFlowCoordinator.handleSessionExpired()`로 로컬 인증/프로필 상태를 일관 정리하고 재로그인 플로우 강제
- Rival 탭 401/403 응답에서 로컬 토큰을 즉시 삭제하던 동작 제거(공유 상태만 정리 + 재로그인 안내)
- auth refresh 회귀 방지 단위 체크를 추가하고 `ios_pr_check`에 포함

## 재현/해결 포인트
- 로그인 -> 익명 공유 시도 -> 세션 만료 로그아웃
- 설정 -> 프로필 편집 -> 저장 -> 세션 만료 로그아웃
위 흐름에서 발생하던 불필요한 세션 소거와 UI 불일치 문제를 완화/정합화했습니다.

## 검증
- swift scripts/auth_refresh_resilience_unit_check.swift
- swift scripts/auth_session_autologin_unit_check.swift
- swift scripts/project_stability_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #303
