### PR TITLE
[Issue #305] 자동 로그아웃 방지 전역 가드

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -332,11 +332,12 @@ struct SupabaseHTTPClient {
             metricTracker.track(
                 .syncAuthRefreshFailed,
                 userKey: refreshed.identity.userId,
-                payload: ["reason": "missing_token_session"]
+                payload: ["reason": "missing_token_session_soft_fail"]
             )
-            authSessionStore.clearTokenSession()
-            notifyAuthSessionExpired(reason: "missing_token_session")
-            return nil
+            #if DEBUG
+            print("[SupabaseAuth] refresh missing token_session: keep current access token and request re-auth lazily")
+            #endif
+            return current.accessToken
         case .retryableFailure:
             metricTracker.track(
                 .syncAuthRefreshFailed,
@@ -351,11 +352,12 @@ struct SupabaseHTTPClient {
             metricTracker.track(
                 .syncAuthRefreshFailed,
                 userKey: currentIdentityUserId(),
-                payload: ["reason": "terminal_failure"]
+                payload: ["reason": "terminal_failure_deferred"]
             )
-            authSessionStore.clearTokenSession()
-            notifyAuthSessionExpired(reason: "terminal_failure")
-            return nil
+            #if DEBUG
+            print("[SupabaseAuth] refresh terminal-failure: preserve local session and request re-auth lazily")
+            #endif
+            return current.accessToken
         }
     }
 
@@ -363,19 +365,6 @@ struct SupabaseHTTPClient {
     /// - Returns: 로컬에 사용자 식별자가 있으면 해당 userId, 없으면 `nil`입니다.
     private func currentIdentityUserId() -> String? {
         authSessionStore.currentIdentity()?.userId
-    }
-
-    /// 인증 토큰을 더 이상 복구할 수 없는 상태를 앱 전역에 브로드캐스트합니다.
-    /// - Parameter reason: 세션 만료로 판정된 내부 원인 식별자입니다.
-    private func notifyAuthSessionExpired(reason: String) {
-        NotificationCenter.default.post(
-            name: .authSessionExpired,
-            object: self,
-            userInfo: ["reason": reason]
-        )
-        #if DEBUG
-        print("[SupabaseAuth] session-expired reason=\(reason)")
-        #endif
     }
 
     /// refresh token으로 새 세션 토큰을 발급받고 사용자 식별 정보를 복원합니다.

--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -92,7 +92,6 @@ class UserdefaultSetting {
 extension Notification.Name {
     static let walkPointRecordedForQuest = Notification.Name("walk.point.recorded.for.quest")
     static let authSessionDidChange = Notification.Name("auth.session.didChange")
-    static let authSessionExpired = Notification.Name("auth.session.expired")
 }
 struct UserInfo: TimeCheckable {
     let id: String
@@ -1526,23 +1525,6 @@ final class AuthFlowCoordinator: ObservableObject {
         guestDataUpgradeResult = nil
         onAuthenticated = nil
         refresh()
-    }
-
-    /// 토큰 만료 등으로 세션이 무효화되었을 때 로컬 상태를 정리하고 재로그인 플로우를 강제합니다.
-    func handleSessionExpired() {
-        authSessionStore.clear()
-        profileStore.removeAll()
-        petSelectionStore.clearSelectionState()
-        walkSessionMetadataStore.clearPreferences()
-        UserDefaults.standard.set(false, forKey: guestModeKey)
-        UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
-        pendingUpgradeRequest = nil
-        pendingGuestDataUpgradePrompt = nil
-        guestDataUpgradeInProgress = false
-        guestDataUpgradeResult = nil
-        onAuthenticated = nil
-        shouldShowEntryChoice = false
-        shouldShowSignIn = true
     }
 
     func startGuestDataUpgrade(forceRetry: Bool = false) {

--- a/dogArea/dogAreaApp.swift
+++ b/dogArea/dogAreaApp.swift
@@ -146,9 +146,6 @@ struct dogAreaApp: App {
             .onReceive(NotificationCenter.default.publisher(for: .authSessionDidChange)) { _ in
                 authFlow.refresh()
             }
-            .onReceive(NotificationCenter.default.publisher(for: .authSessionExpired)) { _ in
-                authFlow.handleSessionExpired()
-            }
 
         if shouldAutoGuestForUITest {
             baseRoot

--- a/scripts/auth_refresh_resilience_unit_check.swift
+++ b/scripts/auth_refresh_resilience_unit_check.swift
@@ -23,6 +23,10 @@ assertTrue(
     "retryable refresh failure should keep current access token instead of anon fallback"
 )
 assertTrue(
+    infra.contains("terminal-failure: preserve local session and request re-auth lazily"),
+    "terminal refresh failure should avoid immediate local logout"
+)
+assertTrue(
     infra.contains("return current.accessToken"),
     "validAccessToken should return current access token on retryable refresh failure"
 )
@@ -40,7 +44,7 @@ assertTrue(
 )
 assertTrue(
     infra.contains("if normalized.contains(\"invalid_grant\") { return true }"),
-    "invalid_grant should remain terminal and clear session"
+    "invalid_grant should remain terminal for refresh classification"
 )
 
 print("PASS: auth refresh resilience unit checks")


### PR DESCRIPTION
## 요약
- refresh 실패(재시도/종단) 시 로컬 세션을 즉시 삭제하지 않도록 정책 변경
- background 요청 실패가 자동 guest 전환/자동 로그아웃 체감으로 이어지는 흐름 차단
- `authSessionExpired` 강제 처리 경로 제거(전역 강제 재로그인 트리거 제거)
- auth refresh 회귀 체크 스크립트 기대값을 새 정책에 맞게 갱신

## 사용자 영향
- 네트워크/일시 장애나 일부 auth edge 오류에서 앱이 스스로 로그아웃된 것처럼 보이던 혼란을 줄임
- 명시적 로그아웃/회원탈퇴 전에는 로컬 인증 상태를 보존

## 검증
- swift scripts/auth_refresh_resilience_unit_check.swift
- swift scripts/auth_session_autologin_unit_check.swift
- swift scripts/rival_auth_session_guard_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #305
