### PR TITLE
[Issue #302] SignIn 오버레이 중 Map 렌더 중단으로 Metal 크래시 가드

### DIFF
--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -32,6 +32,9 @@ struct RootView: View {
     private var homeView = HomeView()
     private var walkListView = WalkListView()
     private var notificationCenterView = NotificationCenterView()
+    private var isAuthenticationOverlayActive: Bool {
+        authFlow.shouldShowSignIn || authFlow.shouldShowEntryChoice
+    }
 
     /// UI 테스트 디자인 감사 모드에서는 기본 진입 탭을 홈으로 고정해 초기 렌더링 안정성을 높입니다.
     private static func initialSelectedTabForRuntime() -> Int {
@@ -115,6 +118,13 @@ struct RootView: View {
             .onOpenURL { url in
                 routeWidgetDeepLinkIfNeeded(url)
             }
+            .onChange(of: isAuthenticationOverlayActive) { _, isPresented in
+                if isPresented {
+                    mapViewModelStore.suspendForAuthenticationOverlay()
+                } else if selectedTab == 2 {
+                    mapViewModelStore.prepareIfNeeded()
+                }
+            }
 
     }
 
@@ -137,18 +147,24 @@ struct RootView: View {
         } else if selectedTab == 2 {
             NavigationView {
                 Group {
-                    if let mapViewModel = mapViewModelStore.mapViewModel {
-                        MapView(viewModel: mapViewModel)
-                            .environmentObject(loading)
-                            .accessibilityIdentifier("screen.map")
+                    if isAuthenticationOverlayActive {
+                        Color.appTabScaffoldBackground
+                            .ignoresSafeArea()
+                            .accessibilityIdentifier("screen.map.suspended")
                     } else {
-                        ProgressView("지도 준비 중...")
-                            .font(.appFont(for: .Regular, size: 14))
-                            .foregroundStyle(Color.appTextDarkGray)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .onAppear {
-                                mapViewModelStore.prepareIfNeeded()
-                            }
+                        if let mapViewModel = mapViewModelStore.mapViewModel {
+                            MapView(viewModel: mapViewModel)
+                                .environmentObject(loading)
+                                .accessibilityIdentifier("screen.map")
+                        } else {
+                            ProgressView("지도 준비 중...")
+                                .font(.appFont(for: .Regular, size: 14))
+                                .foregroundStyle(Color.appTextDarkGray)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .onAppear {
+                                    mapViewModelStore.prepareIfNeeded()
+                                }
+                        }
                     }
                 }
                 .navigationBarHidden(selectedTab == 2)
@@ -329,6 +345,11 @@ private final class MapViewModelStore: ObservableObject {
     func prepareIfNeeded() {
         guard mapViewModel == nil else { return }
         mapViewModel = MapViewModel()
+    }
+
+    /// 인증 오버레이가 보이는 동안 Metal 렌더 경합을 막기 위해 지도 ViewModel을 해제합니다.
+    func suspendForAuthenticationOverlay() {
+        mapViewModel = nil
     }
 }
 

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -72,6 +72,7 @@ swift scripts/auth_refresh_resilience_unit_check.swift
 swift scripts/auth_onboarding_session_consistency_unit_check.swift
 swift scripts/auth_signup_entry_ux_unit_check.swift
 swift scripts/auth_signup_validation_unit_check.swift
+swift scripts/signin_metal_overlay_guard_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/tabbar_safearea_regression_unit_check.swift

--- a/scripts/signin_metal_overlay_guard_unit_check.swift
+++ b/scripts/signin_metal_overlay_guard_unit_check.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let rootView = load("dogArea/Views/GlobalViews/BaseView/RootView.swift")
+
+assertTrue(
+    rootView.contains("private var isAuthenticationOverlayActive: Bool"),
+    "RootView should compute authentication overlay visibility"
+)
+assertTrue(
+    rootView.contains(".onChange(of: isAuthenticationOverlayActive)"),
+    "RootView should react to overlay visibility changes"
+)
+assertTrue(
+    rootView.contains("mapViewModelStore.suspendForAuthenticationOverlay()"),
+    "RootView should suspend map view model while auth overlay is active"
+)
+assertTrue(
+    rootView.contains("accessibilityIdentifier(\"screen.map.suspended\")"),
+    "RootView should render suspended placeholder instead of MapView during auth overlay"
+)
+assertTrue(
+    rootView.contains("func suspendForAuthenticationOverlay()"),
+    "MapViewModelStore should provide explicit overlay suspension API"
+)
+
+print("PASS: signin metal overlay guard unit checks")


### PR DESCRIPTION
## 요약
- 인증 오버레이(`Entry/SignIn`)가 표시된 동안 `RootView`에서 지도 탭 렌더를 중단하도록 변경
- 오버레이가 닫히면 지도 탭 선택 상태에서 기존 지연 생성 흐름(`prepareIfNeeded`)으로 재활성화
- `MapViewModelStore.suspendForAuthenticationOverlay()`를 추가해 오버레이 진입 시 map view model을 즉시 해제
- 회귀 방지 스크립트(`signin_metal_overlay_guard_unit_check.swift`) 추가 및 `ios_pr_check`에 포함

## 기대 효과
- 로그인/회원가입 입력 중 배경의 Map/Metal 렌더 경로가 유지되며 발생하던 drawable assertion(SIGABRT) 위험 완화

## 검증
- swift scripts/signin_metal_overlay_guard_unit_check.swift
- swift scripts/tabbar_safearea_regression_unit_check.swift
- swift scripts/project_stability_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #302
