### PR TITLE
[Issue #308] 인증 오버레이 중 위젯 지도 액션 지연 처리

### DIFF
--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -21,6 +21,7 @@ struct RootView: View {
     @StateObject var loading: LoadingViewModel = LoadingViewModel()
     @State private var selectedTab = RootView.initialSelectedTabForRuntime()
     @State private var tabbarHidden = false
+    @State private var pendingWalkWidgetRoute: WalkWidgetActionRoute? = nil
     @StateObject var tabStatus = TabAppear.shared
     @StateObject private var mapViewModelStore = MapViewModelStore()
     private let widgetActionStore: WalkWidgetActionRequestStoring = DefaultWalkWidgetActionRequestStore.shared
@@ -121,9 +122,12 @@ struct RootView: View {
             .onChange(of: isAuthenticationOverlayActive) { _, isPresented in
                 if isPresented {
                     mapViewModelStore.suspendForAuthenticationOverlay()
-                } else if selectedTab == 2 {
+                    return
+                }
+                if selectedTab == 2 {
                     mapViewModelStore.prepareIfNeeded()
                 }
+                dispatchPendingWalkWidgetActionIfNeeded()
             }
 
     }
@@ -219,6 +223,12 @@ struct RootView: View {
     /// 산책 관련 위젯 액션을 지도 탭으로 전달합니다.
     /// - Parameter route: 지도 화면에서 처리할 위젯 액션 라우트입니다.
     private func dispatchWalkWidgetAction(_ route: WalkWidgetActionRoute) {
+        if isAuthenticationOverlayActive {
+            pendingWalkWidgetRoute = route
+            selectedTab = 2
+            return
+        }
+        pendingWalkWidgetRoute = nil
         mapViewModelStore.prepareIfNeeded()
         selectedTab = 2
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
@@ -233,6 +243,12 @@ struct RootView: View {
                 ]
             )
         }
+    }
+
+    /// 인증 오버레이 해제 후 대기 중인 위젯 산책 액션이 있으면 즉시 재처리합니다.
+    private func dispatchPendingWalkWidgetActionIfNeeded() {
+        guard let pendingWalkWidgetRoute else { return }
+        dispatchWalkWidgetAction(pendingWalkWidgetRoute)
     }
 
     /// 위젯 보상 수령 액션을 멱등 요청으로 처리하고 스냅샷 상태를 갱신합니다.

--- a/scripts/auth_overlay_widget_action_defer_unit_check.swift
+++ b/scripts/auth_overlay_widget_action_defer_unit_check.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let rootView = load("dogArea/Views/GlobalViews/BaseView/RootView.swift")
+
+assertTrue(
+    rootView.contains("@State private var pendingWalkWidgetRoute: WalkWidgetActionRoute? = nil"),
+    "RootView should keep pending widget route while auth overlay is active"
+)
+assertTrue(
+    rootView.contains("if isAuthenticationOverlayActive {"),
+    "RootView should guard walk widget dispatch when auth overlay is active"
+)
+assertTrue(
+    rootView.contains("pendingWalkWidgetRoute = route"),
+    "RootView should enqueue walk widget action during auth overlay"
+)
+assertTrue(
+    rootView.contains("dispatchPendingWalkWidgetActionIfNeeded()"),
+    "RootView should replay pending widget action after auth overlay closes"
+)
+assertTrue(
+    rootView.contains("private func dispatchPendingWalkWidgetActionIfNeeded()"),
+    "RootView should define explicit pending widget action replay helper"
+)
+
+print("PASS: auth overlay widget action defer unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -73,6 +73,7 @@ swift scripts/auth_onboarding_session_consistency_unit_check.swift
 swift scripts/auth_signup_entry_ux_unit_check.swift
 swift scripts/auth_signup_validation_unit_check.swift
 swift scripts/signin_metal_overlay_guard_unit_check.swift
+swift scripts/auth_overlay_widget_action_defer_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/tabbar_safearea_regression_unit_check.swift


### PR DESCRIPTION
## 요약
- 인증 오버레이 활성 중(`Entry/SignIn`) 위젯 산책 액션을 즉시 실행하지 않고 `pendingWalkWidgetRoute`로 큐잉
- 오버레이가 닫히면 `dispatchPendingWalkWidgetActionIfNeeded()`로 안전하게 재실행
- 오버레이 동안 `MapViewModelStore.suspendForAuthenticationOverlay()`가 유지되어 배경 지도 렌더 재활성화를 방지
- 회귀 체크 스크립트(`auth_overlay_widget_action_defer_unit_check.swift`) 추가 및 `ios_pr_check`에 포함

## 기대 효과
- 인증 UI 표시 중 위젯 액션으로 배경 지도 렌더가 다시 살아나는 경로 차단
- 로그인 입력 중 렌더 수명주기 충돌 리스크 추가 완화

## 검증
- swift scripts/auth_overlay_widget_action_defer_unit_check.swift
- swift scripts/signin_metal_overlay_guard_unit_check.swift
- swift scripts/project_stability_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #308
