### PR TITLE
[Issue #310] feature-control 404 쿨다운 가드

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -747,31 +747,89 @@ protocol HotspotWidgetSnapshotSyncing {
 
 struct FeatureControlService: FeatureFlagRemoteServiceProtocol {
     static let shared = FeatureControlService()
+    private static let functionUnavailableUntilKey = "feature.control.unavailable.until.v1"
+    private static let functionUnavailableCooldownSeconds: TimeInterval = 10 * 60
 
     private let client: SupabaseHTTPClient
+    private let cooldownStore: UserDefaults
 
-    init(client: SupabaseHTTPClient = .live) {
+    init(
+        client: SupabaseHTTPClient = .live,
+        cooldownStore: UserDefaults = .standard
+    ) {
         self.client = client
+        self.cooldownStore = cooldownStore
     }
 
     func post(payload: [String: Any]) async throws -> Data {
+        guard isFunctionTemporarilyUnavailable(now: Date()) == false else {
+            #if DEBUG
+            print("[FeatureControl] blocked: function cooldown active")
+            #endif
+            throw SupabaseHTTPError.notConfigured
+        }
         let body = try JSONSerialization.data(withJSONObject: payload)
-        return try await client.request(
-            .function(name: "feature-control"),
-            method: .post,
-            bodyData: body
-        )
-    }
-
-    func postFireAndForget(payload: [String: Any]) {
-        guard let body = try? JSONSerialization.data(withJSONObject: payload) else { return }
-        Task.detached(priority: .utility) {
-            _ = try? await client.request(
+        do {
+            let data = try await client.request(
                 .function(name: "feature-control"),
                 method: .post,
                 bodyData: body
             )
+            clearFunctionUnavailableMarker()
+            return data
+        } catch let error as SupabaseHTTPError {
+            if case .unexpectedStatusCode(404) = error {
+                markFunctionTemporarilyUnavailable(now: Date())
+                throw SupabaseHTTPError.notConfigured
+            }
+            throw error
         }
+    }
+
+    func postFireAndForget(payload: [String: Any]) {
+        guard isFunctionTemporarilyUnavailable(now: Date()) == false else {
+            return
+        }
+        guard let body = try? JSONSerialization.data(withJSONObject: payload) else { return }
+        Task.detached(priority: .utility) {
+            do {
+                _ = try await client.request(
+                    .function(name: "feature-control"),
+                    method: .post,
+                    bodyData: body
+                )
+                clearFunctionUnavailableMarker()
+            } catch let error as SupabaseHTTPError {
+                if case .unexpectedStatusCode(404) = error {
+                    markFunctionTemporarilyUnavailable(now: Date())
+                }
+            } catch {
+                return
+            }
+        }
+    }
+
+    /// `feature-control` 함수가 최근 404로 비가용 처리됐는지 확인합니다.
+    /// - Parameter now: 쿨다운 만료 판정 기준 시각입니다.
+    /// - Returns: 쿨다운 기간이 남아 있으면 `true`, 아니면 `false`입니다.
+    private func isFunctionTemporarilyUnavailable(now: Date) -> Bool {
+        let unavailableUntil = cooldownStore.double(forKey: Self.functionUnavailableUntilKey)
+        return unavailableUntil > now.timeIntervalSince1970
+    }
+
+    /// `feature-control` 함수 404 감지 시 재시도 폭주를 막기 위해 쿨다운 마커를 기록합니다.
+    /// - Parameter now: 쿨다운 만료시각 계산 기준 시각입니다.
+    private func markFunctionTemporarilyUnavailable(now: Date) {
+        let unavailableUntil = now.timeIntervalSince1970 + Self.functionUnavailableCooldownSeconds
+        cooldownStore.set(unavailableUntil, forKey: Self.functionUnavailableUntilKey)
+        #if DEBUG
+        print("[FeatureControl] marked unavailable for \(Int(Self.functionUnavailableCooldownSeconds))s due to 404")
+        #endif
+    }
+
+    /// `feature-control` 함수 호출이 성공하면 404 쿨다운 마커를 제거합니다.
+    private func clearFunctionUnavailableMarker() {
+        cooldownStore.removeObject(forKey: Self.functionUnavailableUntilKey)
     }
 }
 

--- a/scripts/feature_control_404_cooldown_unit_check.swift
+++ b/scripts/feature_control_404_cooldown_unit_check.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let infra = load("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+
+assertTrue(
+    infra.contains("feature.control.unavailable.until.v1"),
+    "feature-control service should persist 404 cooldown marker key"
+)
+assertTrue(
+    infra.contains("functionUnavailableCooldownSeconds: TimeInterval = 10 * 60"),
+    "feature-control service should define cooldown duration for 404 guard"
+)
+assertTrue(
+    infra.contains("guard isFunctionTemporarilyUnavailable(now: Date()) == false else"),
+    "feature-control post path should short-circuit when cooldown is active"
+)
+assertTrue(
+    infra.contains("if case .unexpectedStatusCode(404) = error"),
+    "feature-control service should detect 404 and mark cooldown"
+)
+assertTrue(
+    infra.contains("markFunctionTemporarilyUnavailable(now: Date())"),
+    "feature-control service should mark cooldown on 404"
+)
+assertTrue(
+    infra.contains("clearFunctionUnavailableMarker()"),
+    "feature-control service should clear cooldown marker after successful call"
+)
+
+print("PASS: feature-control 404 cooldown unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -82,6 +82,7 @@ swift scripts/walk_return_to_origin_suggestion_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/live_presence_uplink_policy_unit_check.swift
 swift scripts/sync_walk_404_policy_unit_check.swift
+swift scripts/feature_control_404_cooldown_unit_check.swift
 swift scripts/home_guest_upgrade_retry_cta_unit_check.swift
 swift scripts/home_weather_status_card_restore_unit_check.swift
 swift scripts/home_area_milestone_feedback_unit_check.swift


### PR DESCRIPTION
## 요약
- `FeatureControlService`에 404 기반 함수 비가용 쿨다운 가드 추가
- 404 감지 시 10분 쿨다운 마커 저장 후 `notConfigured`로 전환
- 쿨다운 동안 `feature-control` 요청(`post`, `postFireAndForget`) 단락 처리
- 성공 응답 시 쿨다운 마커 해제
- 회귀 체크 스크립트 추가 및 `ios_pr_check`에 포함

## 기대 효과
- `feature-control` 미배포 상태(404)에서 반복 호출/로그 스팸/불필요 네트워크 감소

## 검증
- swift scripts/feature_control_404_cooldown_unit_check.swift
- swift scripts/project_stability_unit_check.swift
- swift scripts/sync_walk_404_policy_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #310
