### PR TITLE
[Issue #312] FeatureFlag refresh 스로틀링

### DIFF
--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -580,7 +580,10 @@ final class FeatureFlagStore {
     private let stateQueue = DispatchQueue(label: "com.th.dogArea.feature-flag-store.state")
     private let cacheStorageKey = "feature.flags.cache.v1"
     private let appInstanceStorageKey = "feature.flags.appInstance.v1"
+    private let lastRefreshAtStorageKey = "feature.flags.last_refresh_at.v1"
+    private let minimumRefreshInterval: TimeInterval = 60
     private var cached: [String: FeatureFlagValue] = [:]
+    private var lastRefreshAt: TimeInterval = 0
     private let appInstance: String
 
     private let defaults: [String: FeatureFlagValue] = [
@@ -595,6 +598,7 @@ final class FeatureFlagStore {
     private init() {
         appInstance = Self.loadOrCreateAppInstance(storageKey: appInstanceStorageKey)
         loadCachedFlags()
+        loadLastRefreshAt()
     }
 
     var appInstanceId: String { appInstance }
@@ -606,9 +610,26 @@ final class FeatureFlagStore {
         }
     }
 
+    /// 원격 feature flag를 갱신하되, 내부 스로틀 정책을 적용해 과도한 재호출을 방지합니다.
+    /// - Returns: 원격 갱신 성공 또는 스로틀로 인해 캐시 유지가 유효하면 `true`, 실패 시 `false`입니다.
     @discardableResult
     func refresh() async -> Bool {
+        await refresh(force: false)
+    }
+
+    /// 원격 feature flag를 갱신하고 성공 시 로컬 캐시를 업데이트합니다.
+    /// - Parameter force: `true`면 최소 갱신 간격 스로틀을 무시하고 즉시 원격 호출합니다.
+    /// - Returns: 원격 갱신 성공 또는 스로틀로 인해 캐시 유지가 유효하면 `true`, 실패 시 `false`입니다.
+    @discardableResult
+    func refresh(force: Bool) async -> Bool {
+        guard shouldSkipRefresh(force: force, now: Date()) == false else {
+            #if DEBUG
+            print("[FeatureFlag] refresh skipped: throttled")
+            #endif
+            return true
+        }
         do {
+            let nowEpoch = Date().timeIntervalSince1970
             let data = try await FeatureControlService.shared.post(payload: [
                 "action": "get_flags",
                 "keys": AppFeatureFlagKey.allCases.map(\.rawValue)
@@ -619,7 +640,9 @@ final class FeatureFlagStore {
             })
             stateQueue.sync {
                 cached.merge(newValues) { _, latest in latest }
+                lastRefreshAt = nowEpoch
                 persistCachedFlags()
+                persistLastRefreshAtLocked()
             }
             return true
         } catch {
@@ -666,6 +689,33 @@ final class FeatureFlagStore {
     private func persistCachedFlags() {
         guard let data = try? JSONEncoder().encode(cached) else { return }
         UserDefaults.standard.set(data, forKey: cacheStorageKey)
+    }
+
+    /// 마지막 원격 갱신 시각을 로드해 스로틀 계산의 기준으로 사용합니다.
+    private func loadLastRefreshAt() {
+        let saved = UserDefaults.standard.double(forKey: lastRefreshAtStorageKey)
+        stateQueue.sync {
+            lastRefreshAt = saved
+        }
+    }
+
+    /// 마지막 원격 갱신 시각을 UserDefaults에 저장합니다.
+    private func persistLastRefreshAtLocked() {
+        UserDefaults.standard.set(lastRefreshAt, forKey: lastRefreshAtStorageKey)
+    }
+
+    /// 최소 갱신 간격 정책에 따라 이번 원격 갱신을 생략할지 판정합니다.
+    /// - Parameters:
+    ///   - force: `true`면 강제 갱신으로 스로틀을 무시합니다.
+    ///   - now: 스로틀 계산 기준 시각입니다.
+    /// - Returns: 스로틀에 의해 원격 갱신을 생략해야 하면 `true`, 아니면 `false`입니다.
+    private func shouldSkipRefresh(force: Bool, now: Date) -> Bool {
+        guard force == false else { return false }
+        let nowEpoch = now.timeIntervalSince1970
+        return stateQueue.sync {
+            let elapsed = nowEpoch - lastRefreshAt
+            return elapsed >= 0 && elapsed < minimumRefreshInterval
+        }
     }
 }
 

--- a/scripts/feature_flag_refresh_throttle_unit_check.swift
+++ b/scripts/feature_flag_refresh_throttle_unit_check.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Source/UserdefaultSetting.swift")
+
+assertTrue(
+    source.contains("private let lastRefreshAtStorageKey = \"feature.flags.last_refresh_at.v1\""),
+    "feature flag store should persist last refresh timestamp key"
+)
+assertTrue(
+    source.contains("private let minimumRefreshInterval: TimeInterval = 60"),
+    "feature flag store should define minimum refresh interval"
+)
+assertTrue(
+    source.contains("func refresh(force: Bool) async -> Bool"),
+    "feature flag store should support force refresh entrypoint"
+)
+assertTrue(
+    source.contains("guard shouldSkipRefresh(force: force, now: Date()) == false else"),
+    "refresh should short-circuit when throttled"
+)
+assertTrue(
+    source.contains("persistLastRefreshAtLocked()"),
+    "refresh should persist last refresh timestamp after success"
+)
+assertTrue(
+    source.contains("private func shouldSkipRefresh(force: Bool, now: Date) -> Bool"),
+    "feature flag store should expose throttle decision helper"
+)
+
+print("PASS: feature flag refresh throttle unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -74,6 +74,7 @@ swift scripts/auth_signup_entry_ux_unit_check.swift
 swift scripts/auth_signup_validation_unit_check.swift
 swift scripts/signin_metal_overlay_guard_unit_check.swift
 swift scripts/auth_overlay_widget_action_defer_unit_check.swift
+swift scripts/feature_flag_refresh_throttle_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/tabbar_safearea_regression_unit_check.swift


### PR DESCRIPTION
## 요약
- `FeatureFlagStore`에 최소 refresh 간격(60초) 스로틀링 도입
- `refresh()`는 기본적으로 스로틀 정책 적용, `refresh(force:)`로 강제 갱신 경로 제공
- 마지막 원격 갱신 시각을 로컬에 저장/복원해 앱 재실행 후에도 스로틀 일관성 유지
- 회귀 체크 스크립트 추가 및 `ios_pr_check`에 포함

## 기대 효과
- 앱 초기화/화면 진입 시 중복 `get_flags` 호출 감소
- 불필요 네트워크/로그 감소 및 초기 구간 성능 안정화

## 검증
- swift scripts/feature_flag_refresh_throttle_unit_check.swift
- swift scripts/feature_control_404_cooldown_unit_check.swift
- swift scripts/project_stability_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #312
