### PR TITLE
feat: feature-flag refresh single-flight guard

### DIFF
--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -577,6 +577,12 @@ final class FeatureFlagStore {
         let flags: [FeatureFlagRowDTO]
     }
 
+    private enum RefreshGateDecision {
+        case proceed
+        case throttled
+        case inFlight
+    }
+
     private let stateQueue = DispatchQueue(label: "com.th.dogArea.feature-flag-store.state")
     private let cacheStorageKey = "feature.flags.cache.v1"
     private let appInstanceStorageKey = "feature.flags.appInstance.v1"
@@ -584,6 +590,7 @@ final class FeatureFlagStore {
     private let minimumRefreshInterval: TimeInterval = 60
     private var cached: [String: FeatureFlagValue] = [:]
     private var lastRefreshAt: TimeInterval = 0
+    private var isRefreshInFlight: Bool = false
     private let appInstance: String
 
     private let defaults: [String: FeatureFlagValue] = [
@@ -622,14 +629,24 @@ final class FeatureFlagStore {
     /// - Returns: 원격 갱신 성공 또는 스로틀로 인해 캐시 유지가 유효하면 `true`, 실패 시 `false`입니다.
     @discardableResult
     func refresh(force: Bool) async -> Bool {
-        guard shouldSkipRefresh(force: force, now: Date()) == false else {
+        let now = Date()
+        switch evaluateRefreshGate(force: force, now: now) {
+        case .throttled:
             #if DEBUG
             print("[FeatureFlag] refresh skipped: throttled")
             #endif
             return true
+        case .inFlight:
+            #if DEBUG
+            print("[FeatureFlag] refresh skipped: in-flight")
+            #endif
+            return true
+        case .proceed:
+            break
         }
+        defer { finishRefreshCycle() }
         do {
-            let nowEpoch = Date().timeIntervalSince1970
+            let nowEpoch = now.timeIntervalSince1970
             let data = try await FeatureControlService.shared.post(payload: [
                 "action": "get_flags",
                 "keys": AppFeatureFlagKey.allCases.map(\.rawValue)
@@ -715,6 +732,31 @@ final class FeatureFlagStore {
         return stateQueue.sync {
             let elapsed = nowEpoch - lastRefreshAt
             return elapsed >= 0 && elapsed < minimumRefreshInterval
+        }
+    }
+
+    /// 스로틀/동시 실행 상태를 평가해 원격 갱신을 진행할지 여부를 결정합니다.
+    /// - Parameters:
+    ///   - force: `true`면 스로틀 평가를 무시하고 강제 갱신을 허용합니다.
+    ///   - now: 평가 시점 기준 시각입니다.
+    /// - Returns: 이번 호출의 갱신 게이트 결정 결과입니다.
+    private func evaluateRefreshGate(force: Bool, now: Date) -> RefreshGateDecision {
+        if shouldSkipRefresh(force: force, now: now) {
+            return .throttled
+        }
+        return stateQueue.sync {
+            if isRefreshInFlight {
+                return .inFlight
+            }
+            isRefreshInFlight = true
+            return .proceed
+        }
+    }
+
+    /// 원격 feature flag 갱신 시도 종료 시 in-flight 상태를 해제합니다.
+    private func finishRefreshCycle() {
+        stateQueue.sync {
+            isRefreshInFlight = false
         }
     }
 }

--- a/scripts/feature_flag_refresh_singleflight_unit_check.swift
+++ b/scripts/feature_flag_refresh_singleflight_unit_check.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Source/UserdefaultSetting.swift")
+
+assertTrue(
+    source.contains("private enum RefreshGateDecision"),
+    "feature flag store should define refresh gate decision enum"
+)
+assertTrue(
+    source.contains("private var isRefreshInFlight: Bool = false"),
+    "feature flag store should track in-flight refresh state"
+)
+assertTrue(
+    source.contains("switch evaluateRefreshGate(force: force, now: now)"),
+    "refresh(force:) should evaluate single-flight gate before network call"
+)
+assertTrue(
+    source.contains("print(\"[FeatureFlag] refresh skipped: in-flight\")"),
+    "feature flag store should log in-flight dedupe in debug builds"
+)
+assertTrue(
+    source.contains("defer { finishRefreshCycle() }"),
+    "refresh(force:) should always clear in-flight marker after completion"
+)
+assertTrue(
+    source.contains("private func evaluateRefreshGate(force: Bool, now: Date) -> RefreshGateDecision"),
+    "feature flag store should provide gate evaluation helper"
+)
+assertTrue(
+    source.contains("private func finishRefreshCycle()"),
+    "feature flag store should provide explicit in-flight cleanup helper"
+)
+
+print("PASS: feature flag refresh single-flight unit checks")

--- a/scripts/feature_flag_refresh_throttle_unit_check.swift
+++ b/scripts/feature_flag_refresh_throttle_unit_check.swift
@@ -30,7 +30,11 @@ assertTrue(
     "feature flag store should support force refresh entrypoint"
 )
 assertTrue(
-    source.contains("guard shouldSkipRefresh(force: force, now: Date()) == false else"),
+    source.contains("switch evaluateRefreshGate(force: force, now: now)"),
+    "refresh should evaluate refresh gate before remote fetch"
+)
+assertTrue(
+    source.contains("case .throttled:"),
     "refresh should short-circuit when throttled"
 )
 assertTrue(

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -75,6 +75,7 @@ swift scripts/auth_signup_validation_unit_check.swift
 swift scripts/signin_metal_overlay_guard_unit_check.swift
 swift scripts/auth_overlay_widget_action_defer_unit_check.swift
 swift scripts/feature_flag_refresh_throttle_unit_check.swift
+swift scripts/feature_flag_refresh_singleflight_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/tabbar_safearea_regression_unit_check.swift


### PR DESCRIPTION
## Summary\n- add a single-flight gate to FeatureFlagStore refresh to dedupe concurrent refresh calls\n- keep 60s throttle behavior and add explicit in-flight skip path\n- update/extend unit-check scripts for throttle + single-flight checks\n\n## Test\n- swift scripts/feature_flag_refresh_throttle_unit_check.swift\n- swift scripts/feature_flag_refresh_singleflight_unit_check.swift\n- bash scripts/ios_pr_check.sh\n\nCloses #314