### PR TITLE
fix: force guest downgrade when reauthentication starts

### DIFF
--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -1589,10 +1589,12 @@ final class AuthFlowCoordinator: ObservableObject {
     }
 
     func startReauthenticationFlow() {
+        authSessionStore.clearTokenSession()
         pendingUpgradeRequest = nil
         pendingGuestDataUpgradePrompt = nil
         shouldShowEntryChoice = false
         shouldShowSignIn = true
+        onAuthenticated = nil
     }
 
     func dismissGuestDataUpgradePrompt() {

--- a/scripts/auth_reauth_session_downgrade_unit_check.swift
+++ b/scripts/auth_reauth_session_downgrade_unit_check.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Source/UserdefaultSetting.swift")
+
+assertTrue(
+    source.contains("func startReauthenticationFlow()"),
+    "auth flow coordinator should expose reauthentication entrypoint"
+)
+assertTrue(
+    source.contains("authSessionStore.clearTokenSession()"),
+    "reauthentication flow should downgrade token session before presenting sign-in"
+)
+assertTrue(
+    source.contains("shouldShowSignIn = true"),
+    "reauthentication flow should present sign-in overlay"
+)
+assertTrue(
+    source.contains("onAuthenticated = nil"),
+    "reauthentication flow should clear stale post-auth completion callback"
+)
+
+print("PASS: auth reauthentication session downgrade unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -74,6 +74,7 @@ swift scripts/auth_signup_entry_ux_unit_check.swift
 swift scripts/auth_signup_validation_unit_check.swift
 swift scripts/signin_metal_overlay_guard_unit_check.swift
 swift scripts/auth_overlay_widget_action_defer_unit_check.swift
+swift scripts/auth_reauth_session_downgrade_unit_check.swift
 swift scripts/feature_flag_refresh_throttle_unit_check.swift
 swift scripts/feature_flag_refresh_singleflight_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift


### PR DESCRIPTION
## Summary
- downgrade auth token session at `startReauthenticationFlow()` so feature gates switch to guest immediately
- clear stale post-auth callback when forcing reauth
- add regression unit-check and wire it into ios_pr_check

## Test
- swift scripts/auth_reauth_session_downgrade_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #316
