### PR TITLE
fix: keep settings viewmodel synced with auth session changes

### DIFF
--- a/dogArea/Views/ProfileSettingView/SettingViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/SettingViewModel.swift
@@ -76,6 +76,7 @@ final class SettingViewModel: ObservableObject {
         self.authSessionStore = authSessionStore
         self.walkRepository = walkRepository
         bindSelectedPetSync()
+        bindAuthSessionSync()
         fetchModel()
         reloadUserInfo()
     }
@@ -385,6 +386,28 @@ final class SettingViewModel: ObservableObject {
                 self?.reloadUserInfo()
             }
             .store(in: &cancellables)
+    }
+
+    /// 인증 세션 변경 알림을 구독해 설정 화면 상태를 현재 세션과 즉시 동기화합니다.
+    private func bindAuthSessionSync() {
+        NotificationCenter.default.publisher(for: .authSessionDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.handleAuthSessionDidChange()
+            }
+            .store(in: &cancellables)
+    }
+
+    /// 세션 유효성에 따라 설정 화면 캐시를 갱신/정리합니다.
+    private func handleAuthSessionDidChange() {
+        guard authSessionStore.currentTokenSession() != nil else {
+            userInfo = nil
+            selectedPet = nil
+            selectedPetId = ""
+            seasonProfileSummary = nil
+            return
+        }
+        reloadUserInfo()
     }
 
     private func reloadSeasonProfileSummary() {

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -90,6 +90,7 @@ swift scripts/home_guest_upgrade_retry_cta_unit_check.swift
 swift scripts/home_weather_status_card_restore_unit_check.swift
 swift scripts/home_area_milestone_feedback_unit_check.swift
 swift scripts/settings_profile_account_actions_unit_check.swift
+swift scripts/settings_auth_session_sync_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 

--- a/scripts/settings_auth_session_sync_unit_check.swift
+++ b/scripts/settings_auth_session_sync_unit_check.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Views/ProfileSettingView/SettingViewModel.swift")
+
+assertTrue(
+    source.contains("bindAuthSessionSync()"),
+    "setting view model should bind auth-session change notifications"
+)
+assertTrue(
+    source.contains("NotificationCenter.default.publisher(for: .authSessionDidChange)"),
+    "setting view model should subscribe to auth session change notification"
+)
+assertTrue(
+    source.contains("private func handleAuthSessionDidChange()"),
+    "setting view model should provide auth session change handler"
+)
+assertTrue(
+    source.contains("guard authSessionStore.currentTokenSession() != nil else"),
+    "auth session handler should detect guest downgrade by token absence"
+)
+assertTrue(
+    source.contains("userInfo = nil"),
+    "auth session handler should clear cached user info on guest downgrade"
+)
+
+print("PASS: settings auth session sync unit checks")


### PR DESCRIPTION
## Summary
- subscribe `SettingViewModel` to `auth.session.didChange`
- clear cached setting state immediately when token session is missing (guest downgrade)
- reload profile state when session remains valid
- add regression unit-check and wire into ios_pr_check

## Test
- swift scripts/settings_auth_session_sync_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #318
