### PR TITLE
fix: resync map nearby sharing state on auth-session change

### DIFF
--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -2028,6 +2028,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         ) { [weak self] _ in
             self?.reloadSelectedPetContext()
         }
+        let authSessionChanged = eventCenter.addObserver(
+            forName: .authSessionDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleAuthSessionDidChange()
+        }
         #if canImport(UIKit)
         let reduceMotionChanged = eventCenter.addObserver(
             forName: UIAccessibility.reduceMotionStatusDidChangeNotification,
@@ -2045,9 +2052,17 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             self?.flushLivePresenceOutboxIfNeeded()
             self?.refreshPresenceHeartbeatState()
         }
-        lifecycleObservers = [didBecomeActive, willResign, willTerminate, petContextChanged, reduceMotionChanged, lowPowerChanged]
+        lifecycleObservers = [
+            didBecomeActive,
+            willResign,
+            willTerminate,
+            petContextChanged,
+            authSessionChanged,
+            reduceMotionChanged,
+            lowPowerChanged
+        ]
         #else
-        lifecycleObservers = [didBecomeActive, willResign, willTerminate, petContextChanged]
+        lifecycleObservers = [didBecomeActive, willResign, willTerminate, petContextChanged, authSessionChanged]
         #endif
         #endif
     }
@@ -3400,6 +3415,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             self.syncVisibilitySettingIfNeeded()
         }
         handleLivePresenceSharingStateChanged()
+        refreshRenderableNearbyHotspots()
+    }
+
+    /// 인증 세션 변경 알림 수신 시 지도 기능 상태를 즉시 재계산합니다.
+    private func handleAuthSessionDidChange() {
+        applyFeatureFlags()
+        refreshPresenceHeartbeatState()
     }
 
     /// 저장된 날씨 위험도 캐시/환경값을 기준으로 현재 지도 오버레이 상태를 계산합니다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -83,6 +83,7 @@ swift scripts/tabbar_safearea_regression_unit_check.swift
 swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/walk_return_to_origin_suggestion_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
+swift scripts/map_auth_session_sync_unit_check.swift
 swift scripts/live_presence_uplink_policy_unit_check.swift
 swift scripts/sync_walk_404_policy_unit_check.swift
 swift scripts/feature_control_404_cooldown_unit_check.swift

--- a/scripts/map_auth_session_sync_unit_check.swift
+++ b/scripts/map_auth_session_sync_unit_check.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Views/MapView/MapViewModel.swift")
+
+assertTrue(
+    source.contains("forName: .authSessionDidChange"),
+    "map view model should observe auth session changes"
+)
+assertTrue(
+    source.contains("self?.handleAuthSessionDidChange()"),
+    "auth session observer should trigger map session sync handler"
+)
+assertTrue(
+    source.contains("private func handleAuthSessionDidChange()"),
+    "map view model should define auth session sync handler"
+)
+assertTrue(
+    source.contains("applyFeatureFlags()"),
+    "auth session sync handler should reapply feature flag/session gating"
+)
+assertTrue(
+    source.contains("refreshRenderableNearbyHotspots()"),
+    "feature flag application should refresh nearby hotspot render nodes"
+)
+
+print("PASS: map auth session sync unit checks")


### PR DESCRIPTION
## Summary
- add `.authSessionDidChange` observer to `MapViewModel` lifecycle observers
- handle session changes by reapplying feature/session gating in `handleAuthSessionDidChange()`
- refresh nearby hotspot render nodes after feature-flag/session state application
- add `map_auth_session_sync_unit_check.swift` and wire to `ios_pr_check`

## Test
- swift scripts/map_auth_session_sync_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #320
