### PR TITLE
fix: keep rival tab synced with auth-session changes

### DIFF
--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -150,6 +150,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
     private let visibilityOffRetryInterval: TimeInterval = 10
     private let visibilityOffMaxRetries: Int = 3
     private var pollingTimer: Timer? = nil
+    private var authSessionObserver: NSObjectProtocol? = nil
     private var lastRefreshAt: Date = .distantPast
     private var lastLeaderboardRefreshAt: Date = .distantPast
     private var latestRawLeaderboardEntries: [RivalLeaderboardEntryDTO] = []
@@ -178,12 +179,16 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
 
     deinit {
         pollingTimer?.invalidate()
+        if let authSessionObserver {
+            NotificationCenter.default.removeObserver(authSessionObserver)
+        }
     }
 
     /// 탭 진입 시 권한/공유 상태를 불러오고 폴링을 시작합니다.
     func start() {
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        startAuthSessionObserverIfNeeded()
         RivalCoreLocationCallTracer.record(
             "authorizationStatus.read",
             detail: "source=start status=\(locationManager.authorizationStatus.rawValue)"
@@ -211,6 +216,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
     func stop() {
         pollingTimer?.invalidate()
         pollingTimer = nil
+        stopAuthSessionObserver()
         RivalCoreLocationCallTracer.record(
             "stopUpdatingLocation",
             detail: "source=stop"
@@ -716,6 +722,30 @@ final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDele
             self.refreshHotspots(force: false)
             self.refreshLeaderboard(force: false)
         }
+    }
+
+    /// 라이벌 탭 활성화 동안 인증 세션 변경 알림을 구독합니다.
+    private func startAuthSessionObserverIfNeeded() {
+        guard authSessionObserver == nil else { return }
+        authSessionObserver = NotificationCenter.default.addObserver(
+            forName: .authSessionDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleAuthSessionDidChange()
+        }
+    }
+
+    /// 라이벌 탭 비활성화 시 인증 세션 변경 알림 구독을 해제합니다.
+    private func stopAuthSessionObserver() {
+        guard let authSessionObserver else { return }
+        NotificationCenter.default.removeObserver(authSessionObserver)
+        self.authSessionObserver = nil
+    }
+
+    /// 인증 세션 변경 이벤트를 반영해 라이벌 탭 상태를 즉시 동기화합니다.
+    private func handleAuthSessionDidChange() {
+        refreshSessionContext()
     }
 
     /// 저장된 숨김/차단 익명 코드 목록을 불러옵니다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -47,6 +47,7 @@ swift scripts/rival_league_matching_unit_check.swift
 swift scripts/rival_stage2_backend_unit_check.swift
 swift scripts/rival_stage3_client_ux_unit_check.swift
 swift scripts/rival_auth_session_guard_unit_check.swift
+swift scripts/rival_auth_session_sync_unit_check.swift
 swift scripts/season_anti_farming_unit_check.swift
 swift scripts/season_comeback_catchup_unit_check.swift
 swift scripts/season_stage2_pipeline_unit_check.swift

--- a/scripts/rival_auth_session_sync_unit_check.swift
+++ b/scripts/rival_auth_session_sync_unit_check.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Views/ProfileSettingView/RivalTabViewModel.swift")
+
+assertTrue(
+    source.contains("private var authSessionObserver: NSObjectProtocol? = nil"),
+    "rival tab should keep an auth-session observer token"
+)
+assertTrue(
+    source.contains("startAuthSessionObserverIfNeeded()"),
+    "rival tab should start auth-session observer on tab activation"
+)
+assertTrue(
+    source.contains("private func startAuthSessionObserverIfNeeded()"),
+    "rival tab should define observer start helper"
+)
+assertTrue(
+    source.contains("forName: .authSessionDidChange"),
+    "rival tab observer should subscribe auth session changes"
+)
+assertTrue(
+    source.contains("private func handleAuthSessionDidChange()"),
+    "rival tab should define auth-session sync handler"
+)
+assertTrue(
+    source.contains("refreshSessionContext()"),
+    "auth-session sync handler should refresh rival session context immediately"
+)
+assertTrue(
+    source.contains("private func stopAuthSessionObserver()"),
+    "rival tab should define observer cleanup helper"
+)
+
+print("PASS: rival auth session sync unit checks")


### PR DESCRIPTION
## Summary
- add auth-session observer lifecycle to `RivalTabViewModel` (`start`/`stop`/`deinit` cleanup)
- refresh rival session context immediately on `.authSessionDidChange`
- add regression script `rival_auth_session_sync_unit_check.swift`
- wire new check into `ios_pr_check.sh`

## Test
- swift scripts/rival_auth_session_sync_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #322
