### PR TITLE
chore: clean unreachable debug branches in map log helpers

### DIFF
--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -3310,9 +3310,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             print("nearby hotspot fetch failed: \(error.localizedDescription)")
         }
         lastNearbyHotspotErrorLogAt = Date()
-        return
-        #endif
-
+        #else
         let now = Date()
         if now.timeIntervalSince(lastNearbyHotspotErrorLogAt) < nearbyHotspotErrorLogInterval {
             suppressedNearbyHotspotErrorCount += 1
@@ -3326,6 +3324,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             print("nearby hotspot fetch failed: \(error.localizedDescription)")
         }
         lastNearbyHotspotErrorLogAt = now
+        #endif
     }
 
     /// 가시성(Visibility) 동기화 에러 로그를 일정 주기로만 출력해 콘솔 노이즈를 줄입니다.
@@ -3339,9 +3338,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             print("visibility sync failed: \(error.localizedDescription)")
         }
         lastVisibilitySyncErrorLogAt = Date()
-        return
-        #endif
-
+        #else
         let now = Date()
         if now.timeIntervalSince(lastVisibilitySyncErrorLogAt) < nearbyHotspotErrorLogInterval {
             suppressedVisibilitySyncErrorCount += 1
@@ -3355,6 +3352,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             print("visibility sync failed: \(error.localizedDescription)")
         }
         lastVisibilitySyncErrorLogAt = now
+        #endif
     }
 
     private func syncVisibilitySettingIfNeeded() {

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -84,6 +84,7 @@ swift scripts/tabbar_safearea_regression_unit_check.swift
 swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/walk_return_to_origin_suggestion_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
+swift scripts/map_log_unreachable_cleanup_unit_check.swift
 swift scripts/map_auth_session_sync_unit_check.swift
 swift scripts/live_presence_uplink_policy_unit_check.swift
 swift scripts/sync_walk_404_policy_unit_check.swift

--- a/scripts/map_log_unreachable_cleanup_unit_check.swift
+++ b/scripts/map_log_unreachable_cleanup_unit_check.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Views/MapView/MapViewModel.swift")
+
+assertTrue(
+    source.contains("private func logNearbyHotspotErrorIfNeeded(_ error: Error)"),
+    "map view model should expose nearby hotspot error log helper"
+)
+assertTrue(
+    source.contains("private func logVisibilitySyncErrorIfNeeded(_ error: Error)"),
+    "map view model should expose visibility error log helper"
+)
+assertTrue(
+    source.contains("#else\n        let now = Date()"),
+    "debug/release log branches should be separated with #else path"
+)
+assertTrue(
+    source.contains("lastNearbyHotspotErrorLogAt = Date()\n        #else"),
+    "nearby hotspot debug log path should no longer return before #endif"
+)
+assertTrue(
+    source.contains("lastVisibilitySyncErrorLogAt = Date()\n        #else"),
+    "visibility debug log path should no longer return before #endif"
+)
+assertTrue(
+    !source.contains("lastNearbyHotspotErrorLogAt = Date()\n        return\n        #endif"),
+    "nearby hotspot logger should not include unreachable code pattern"
+)
+assertTrue(
+    !source.contains("lastVisibilitySyncErrorLogAt = Date()\n        return\n        #endif"),
+    "visibility logger should not include unreachable code pattern"
+)
+
+print("PASS: map log unreachable cleanup unit checks")


### PR DESCRIPTION
## Summary
- restructure `logNearbyHotspotErrorIfNeeded` with explicit `#if DEBUG / #else` branch split
- restructure `logVisibilitySyncErrorIfNeeded` with explicit `#if DEBUG / #else` branch split
- preserve existing behavior: debug immediate logging, release throttled logging
- add `map_log_unreachable_cleanup_unit_check.swift`
- wire new check into `ios_pr_check.sh`

## Test
- swift scripts/map_log_unreachable_cleanup_unit_check.swift
- bash scripts/ios_pr_check.sh

Closes #324
