### PR TITLE
fix: appendWalkPoint unused-result 경고 제거

### DIFF
--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -2073,6 +2073,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     ///   - recordedAt: 포인트 기록 시각입니다.
     ///   - source: 포인트가 추가된 입력 소스(수동/자동/워치)입니다.
     /// - Returns: 세션에 반영된 최종 포인트 모델입니다.
+    @discardableResult
     private func appendWalkPoint(from location: CLLocation, recordedAt: Date, source: PointAppendSource) -> Location {
         let pointRole = pointRole(for: source)
         let appendedPoint = Location(

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -85,6 +85,7 @@ swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/walk_return_to_origin_suggestion_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/map_log_unreachable_cleanup_unit_check.swift
+swift scripts/map_append_walk_point_discardable_unit_check.swift
 swift scripts/map_auth_session_sync_unit_check.swift
 swift scripts/live_presence_uplink_policy_unit_check.swift
 swift scripts/sync_walk_404_policy_unit_check.swift

--- a/scripts/map_append_walk_point_discardable_unit_check.swift
+++ b/scripts/map_append_walk_point_discardable_unit_check.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Views/MapView/MapViewModel.swift")
+
+assertTrue(
+    source.contains("@discardableResult\n    private func appendWalkPoint(from location: CLLocation, recordedAt: Date, source: PointAppendSource) -> Location"),
+    "appendWalkPoint should be marked @discardableResult to avoid unused-result warnings"
+)
+assertTrue(
+    source.contains("appendWalkPoint(from: location, recordedAt: now, source: .auto)"),
+    "auto point recording path should still call appendWalkPoint"
+)
+assertTrue(
+    source.contains("self.appendWalkPoint(from: location, recordedAt: Date(), source: .watch)"),
+    "watch add-point path should still call appendWalkPoint"
+)
+
+print("PASS: map appendWalkPoint discardable-result unit checks")


### PR DESCRIPTION
## Summary
- add `@discardableResult` to `appendWalkPoint` in `MapViewModel`
- keep existing walk-point append flows intact (auto/watch/manual callsites unchanged)
- add regression unit check script and wire it into `ios_pr_check`

## Testing
- `swift scripts/map_append_walk_point_discardable_unit_check.swift`
- `bash scripts/ios_pr_check.sh`

Closes #326
