### PR TITLE
fix(ci): ios_pr_check DerivedData 충돌 방지

### DIFF
--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -96,6 +96,7 @@ swift scripts/home_area_milestone_feedback_unit_check.swift
 swift scripts/settings_profile_account_actions_unit_check.swift
 swift scripts/settings_auth_session_sync_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
+swift scripts/ios_pr_check_derived_data_path_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 
 if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then
@@ -103,12 +104,18 @@ if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then
   exit 0
 fi
 
+RUN_STAMP="$(date +%s)"
+DERIVED_DATA_PATH="${DOGAREA_DERIVED_DATA_PATH:-$ROOT_DIR/.build/ios_pr_check_derived_data_${RUN_STAMP}_$$}"
+mkdir -p "$DERIVED_DATA_PATH"
+echo "[dogArea] using DerivedData path: $DERIVED_DATA_PATH"
+
 echo "[dogArea] building iOS target"
 xcodebuild \
   -skipPackagePluginValidation \
   -project dogArea.xcodeproj \
   -scheme dogArea \
   -configuration Debug \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
   -destination "generic/platform=iOS Simulator" \
   CODE_SIGNING_ALLOWED=NO \
   build
@@ -119,6 +126,7 @@ xcodebuild \
   -project dogArea.xcodeproj \
   -scheme "dogAreaWatch Watch App" \
   -configuration Debug \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
   -destination "generic/platform=watchOS Simulator" \
   CODE_SIGNING_ALLOWED=NO \
   build

--- a/scripts/ios_pr_check_derived_data_path_unit_check.swift
+++ b/scripts/ios_pr_check_derived_data_path_unit_check.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let scriptURL = root.appendingPathComponent("scripts/ios_pr_check.sh")
+let source = try String(contentsOf: scriptURL, encoding: .utf8)
+
+assertTrue(
+    source.contains("RUN_STAMP=\"$(date +%s)\""),
+    "ios_pr_check should generate a per-run stamp for isolated derived data paths"
+)
+assertTrue(
+    source.contains("DERIVED_DATA_PATH=\"${DOGAREA_DERIVED_DATA_PATH:-$ROOT_DIR/.build/ios_pr_check_derived_data_${RUN_STAMP}_$$}\""),
+    "ios_pr_check should allow derived data path override and use a unique default path"
+)
+assertTrue(
+    source.contains("mkdir -p \"$DERIVED_DATA_PATH\""),
+    "ios_pr_check should create derived data directory before xcodebuild"
+)
+assertTrue(
+    source.contains("-derivedDataPath \"$DERIVED_DATA_PATH\""),
+    "ios_pr_check should pass the isolated derived data path to xcodebuild"
+)
+
+print("PASS: ios_pr_check derived data path unit checks")


### PR DESCRIPTION
## Summary
- make `scripts/ios_pr_check.sh` use an isolated DerivedData path for each run by default
- keep an override via `DOGAREA_DERIVED_DATA_PATH`
- add regression unit check for derived-data path wiring and include it in `ios_pr_check`

## Testing
- `swift scripts/ios_pr_check_derived_data_path_unit_check.swift`
- `bash scripts/ios_pr_check.sh`

Closes #328
