### PR TITLE
fix: RivalTabViewModel CLLocation delegate concurrency 경고 제거

### DIFF
--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -82,7 +82,7 @@ private enum RivalCoreLocationCallTracer {
 }
 
 @MainActor
-final class RivalTabViewModel: NSObject, ObservableObject, CLLocationManagerDelegate {
+final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLocationManagerDelegate {
     struct HotspotPreviewRow {
         let title: String
         let value: String

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -48,6 +48,7 @@ swift scripts/rival_stage2_backend_unit_check.swift
 swift scripts/rival_stage3_client_ux_unit_check.swift
 swift scripts/rival_auth_session_guard_unit_check.swift
 swift scripts/rival_auth_session_sync_unit_check.swift
+swift scripts/rival_cllocation_delegate_preconcurrency_unit_check.swift
 swift scripts/season_anti_farming_unit_check.swift
 swift scripts/season_comeback_catchup_unit_check.swift
 swift scripts/season_stage2_pipeline_unit_check.swift

--- a/scripts/rival_cllocation_delegate_preconcurrency_unit_check.swift
+++ b/scripts/rival_cllocation_delegate_preconcurrency_unit_check.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let sourceURL = root.appendingPathComponent("dogArea/Views/ProfileSettingView/RivalTabViewModel.swift")
+let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+assertTrue(
+    source.contains("final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLocationManagerDelegate"),
+    "RivalTabViewModel should adopt CLLocationManagerDelegate with @preconcurrency to avoid Swift 6 concurrency warnings"
+)
+assertTrue(
+    source.contains("@MainActor\nfinal class RivalTabViewModel"),
+    "RivalTabViewModel should remain main-actor isolated"
+)
+
+print("PASS: rival CLLocation delegate preconcurrency unit checks")


### PR DESCRIPTION
## Summary
- apply `@preconcurrency` to `CLLocationManagerDelegate` conformance in `RivalTabViewModel`
- keep `@MainActor` isolation on `RivalTabViewModel` for UI state safety
- add regression unit check and include it in `ios_pr_check`

## Testing
- `swift scripts/rival_cllocation_delegate_preconcurrency_unit_check.swift`
- `DOGAREA_DERIVED_DATA_PATH=/Users/gimtaehun/멋사/dogArea/.build/ios_pr_check_derived_data_1772697304_84322 bash scripts/ios_pr_check.sh`

Closes #330
