### PR TITLE
fix: CoreLocation tracer idle 로그 스팸 제거

### DIFF
--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -264,11 +264,8 @@ private enum MapCoreLocationCallTracer {
         lock.unlock()
 
         guard elapsed >= 0.95 else { return }
-        if summary.isEmpty {
-            print("[CoreLocationTrace][Map][1s] idle")
-        } else {
-            print("[CoreLocationTrace][Map][1s] \(summary)")
-        }
+        guard summary.isEmpty == false else { return }
+        print("[CoreLocationTrace][Map][1s] \(summary)")
     }
 }
 

--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -73,11 +73,8 @@ private enum RivalCoreLocationCallTracer {
         lock.unlock()
 
         guard elapsed >= 0.95 else { return }
-        if summary.isEmpty {
-            print("[CoreLocationTrace][Rival][1s] idle")
-        } else {
-            print("[CoreLocationTrace][Rival][1s] \(summary)")
-        }
+        guard summary.isEmpty == false else { return }
+        print("[CoreLocationTrace][Rival][1s] \(summary)")
     }
 }
 

--- a/scripts/corelocation_trace_idle_log_suppression_unit_check.swift
+++ b/scripts/corelocation_trace_idle_log_suppression_unit_check.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let mapSource = load("dogArea/Views/MapView/MapViewModel.swift")
+let rivalSource = load("dogArea/Views/ProfileSettingView/RivalTabViewModel.swift")
+
+assertTrue(
+    mapSource.contains("guard summary.isEmpty == false else { return }"),
+    "Map tracer should skip empty 1-second summary windows"
+)
+assertTrue(
+    rivalSource.contains("guard summary.isEmpty == false else { return }"),
+    "Rival tracer should skip empty 1-second summary windows"
+)
+assertTrue(
+    mapSource.contains("[CoreLocationTrace][Map][1s] \\(summary)"),
+    "Map tracer should still print non-empty 1-second summary logs"
+)
+assertTrue(
+    rivalSource.contains("[CoreLocationTrace][Rival][1s] \\(summary)"),
+    "Rival tracer should still print non-empty 1-second summary logs"
+)
+assertTrue(
+    mapSource.contains("[CoreLocationTrace][Map][1s] idle") == false,
+    "Map tracer should not emit idle spam logs"
+)
+assertTrue(
+    rivalSource.contains("[CoreLocationTrace][Rival][1s] idle") == false,
+    "Rival tracer should not emit idle spam logs"
+)
+
+print("PASS: corelocation trace idle log suppression unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -88,6 +88,7 @@ swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/map_log_unreachable_cleanup_unit_check.swift
 swift scripts/map_append_walk_point_discardable_unit_check.swift
 swift scripts/map_auth_session_sync_unit_check.swift
+swift scripts/corelocation_trace_idle_log_suppression_unit_check.swift
 swift scripts/live_presence_uplink_policy_unit_check.swift
 swift scripts/sync_walk_404_policy_unit_check.swift
 swift scripts/feature_control_404_cooldown_unit_check.swift


### PR DESCRIPTION
## Summary
- stop printing `[1s] idle` in map/rival CoreLocation trace heartbeat
- keep non-empty 1-second summary logging unchanged
- add regression unit check and wire it into `ios_pr_check`

## Testing
- `swift scripts/corelocation_trace_idle_log_suppression_unit_check.swift`
- `DOGAREA_DERIVED_DATA_PATH=/Users/gimtaehun/멋사/dogArea/.build/ios_pr_check_derived_data_1772697304_84322 bash scripts/ios_pr_check.sh`

Closes #332
