### PR TITLE
[P2][Task][QA] ios_pr_check watch 빌드 선택 실행 옵션

### DIFF
--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -101,6 +101,7 @@ swift scripts/settings_profile_account_actions_unit_check.swift
 swift scripts/settings_auth_session_sync_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/ios_pr_check_derived_data_path_unit_check.swift
+swift scripts/ios_pr_check_skip_watch_build_unit_check.swift
 swift scripts/project_stability_unit_check.swift
 
 if [[ "${DOGAREA_SKIP_BUILD:-0}" == "1" ]]; then
@@ -123,6 +124,11 @@ xcodebuild \
   -destination "generic/platform=iOS Simulator" \
   CODE_SIGNING_ALLOWED=NO \
   build
+
+if [[ "${DOGAREA_SKIP_WATCH_BUILD:-0}" == "1" ]]; then
+  echo "[dogArea] DOGAREA_SKIP_WATCH_BUILD=1, skipping watchOS xcodebuild"
+  exit 0
+fi
 
 echo "[dogArea] building watchOS target"
 xcodebuild \

--- a/scripts/ios_pr_check_skip_watch_build_unit_check.swift
+++ b/scripts/ios_pr_check_skip_watch_build_unit_check.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@inline(__always)
+/// Asserts the provided condition and terminates the script when it is false.
+/// - Parameters:
+///   - condition: Boolean expression that must evaluate to true.
+///   - message: Failure reason printed to stderr when the assertion fails.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let scriptPath = root.appendingPathComponent("scripts/ios_pr_check.sh")
+let source = String(decoding: try! Data(contentsOf: scriptPath), as: UTF8.self)
+
+assertTrue(
+    source.contains("if [[ \"${DOGAREA_SKIP_WATCH_BUILD:-0}\" == \"1\" ]]; then"),
+    "ios_pr_check should support DOGAREA_SKIP_WATCH_BUILD flag"
+)
+assertTrue(
+    source.contains("echo \"[dogArea] DOGAREA_SKIP_WATCH_BUILD=1, skipping watchOS xcodebuild\""),
+    "ios_pr_check should print a clear skip-watch message"
+)
+assertTrue(
+    source.contains("echo \"[dogArea] building watchOS target\""),
+    "ios_pr_check should retain default watchOS build path"
+)
+
+print("PASS: ios_pr_check skip watch build unit checks")


### PR DESCRIPTION
## Summary
- add optional DOGAREA_SKIP_WATCH_BUILD=1 gate in scripts/ios_pr_check.sh
- keep default watchOS build path unchanged when the flag is not set
- add unit check script to guard skip-watch behavior and wire it into ios_pr_check
- add Quick Help comments to new function in the unit check script

## Verification
- swift scripts/ios_pr_check_skip_watch_build_unit_check.swift
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #338
