### PR TITLE
[P2][Task][Auth] 회원가입 429 오류 메시지 원인 안내 강화

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -3022,8 +3022,13 @@ final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol
                 throw SupabaseAuthError.userAlreadyExists
             }
             if statusCode == 429 {
+                let normalizedRateLimitMessage = normalizedAuthRateLimitMessage(
+                    path: path,
+                    upstreamMessage: responseMessage,
+                    errorCode: responseErrorCode
+                )
                 throw SupabaseAuthError.rateLimited(
-                    message: description,
+                    message: normalizedRateLimitMessage,
                     errorCode: responseErrorCode,
                     retryAfterSeconds: retryAfterSeconds(from: httpResponse)
                 )
@@ -3052,6 +3057,44 @@ final class DeviceAppleCredentialAuthService: AppleCredentialAuthServiceProtocol
             || lowercased.contains("duplicate")
             || lowercased.contains("registered")
             || lowercased.contains("exists")
+    }
+
+    /// Auth 429 응답을 사용자 안내용 메시지로 정규화합니다.
+    /// - Parameters:
+    ///   - path: 요청한 Auth 엔드포인트 경로(`signup`, `token` 등)입니다.
+    ///   - upstreamMessage: 서버 응답 본문에서 추출한 원본 메시지입니다.
+    ///   - errorCode: Supabase 오류 코드(`x-sb-error-code` 포함)입니다.
+    /// - Returns: 사용자에게 노출할 429 안내 메시지입니다.
+    private func normalizedAuthRateLimitMessage(
+        path: String,
+        upstreamMessage: String?,
+        errorCode: String?
+    ) -> String? {
+        let trimmedMessage: String? = {
+            guard let raw = upstreamMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  raw.isEmpty == false else {
+                return nil
+            }
+            return raw
+        }()
+
+        if errorCode == "over_email_send_rate_limit" {
+            return trimmedMessage ?? "회원가입 인증 메일 발송 한도를 초과했습니다."
+        }
+
+        if let trimmedMessage,
+           trimmedMessage.contains("인증에 실패했습니다") == false {
+            return trimmedMessage
+        }
+
+        switch path {
+        case "signup":
+            return "회원가입 요청이 너무 자주 발생해 일시적으로 제한되었습니다."
+        case "token":
+            return "로그인 요청이 너무 자주 발생해 일시적으로 제한되었습니다."
+        default:
+            return "인증 요청이 너무 많아 일시적으로 제한되었습니다."
+        }
     }
 
     /// HTTP 응답에서 `Retry-After` 헤더를 초 단위로 해석합니다.

--- a/scripts/auth_rate_limit_message_unit_check.swift
+++ b/scripts/auth_rate_limit_message_unit_check.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+@inline(__always)
+/// Asserts that the given condition is true and terminates on failure.
+/// - Parameters:
+///   - condition: Boolean expression that must evaluate to true.
+///   - message: Failure reason printed to stderr when the assertion fails.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let sourcePath = root.appendingPathComponent("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+let source = String(decoding: try! Data(contentsOf: sourcePath), as: UTF8.self)
+
+assertTrue(
+    source.contains("private func normalizedAuthRateLimitMessage("),
+    "Supabase auth flow should provide a normalized 429 message helper"
+)
+assertTrue(
+    source.contains("normalizedAuthRateLimitMessage(\n                    path: path,\n                    upstreamMessage: responseMessage,\n                    errorCode: responseErrorCode\n                )"),
+    "429 branch should call normalizedAuthRateLimitMessage with path/message/errorCode"
+)
+assertTrue(
+    source.contains("회원가입 요청이 너무 자주 발생해 일시적으로 제한되었습니다."),
+    "signup-specific rate limit fallback message should exist"
+)
+assertTrue(
+    source.contains("로그인 요청이 너무 자주 발생해 일시적으로 제한되었습니다."),
+    "signin-specific rate limit fallback message should exist"
+)
+
+print("PASS: auth rate limit message unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -74,6 +74,7 @@ swift scripts/auth_refresh_resilience_unit_check.swift
 swift scripts/auth_onboarding_session_consistency_unit_check.swift
 swift scripts/auth_signup_entry_ux_unit_check.swift
 swift scripts/auth_signup_validation_unit_check.swift
+swift scripts/auth_rate_limit_message_unit_check.swift
 swift scripts/signin_metal_overlay_guard_unit_check.swift
 swift scripts/auth_overlay_widget_action_defer_unit_check.swift
 swift scripts/auth_reauth_session_downgrade_unit_check.swift


### PR DESCRIPTION
## Summary
- normalize auth 429 messages by endpoint path to avoid generic "인증에 실패했습니다. (429)" output
- keep Supabase error-code specific behavior while adding signup/signin fallback guidance
- add regression unit check script and wire it to ios_pr_check

## Verification
- swift scripts/auth_rate_limit_message_unit_check.swift
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #340
