### PR TITLE
[P2][Task][UI] CustomAlert 표시 상태 토글 제거

### DIFF
--- a/dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift
+++ b/dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift
@@ -20,11 +20,11 @@ public class CustomAlertViewModel: ObservableObject {
 extension CustomAlertViewModel {
   func callAlert(type: AlertActionType) {
     self.alertType = type
-    isAlert.toggle()
+    isAlert = true
   }
     func callCustomAlert(model: AlertModel,leftAction: @escaping () -> (),rightAction: @escaping () -> () = {}) {
         self.alertType = .custom(model, leftAction, rightAction)
-        isAlert.toggle()
+        isAlert = true
     }
 }
 

--- a/scripts/custom_alert_present_state_unit_check.swift
+++ b/scripts/custom_alert_present_state_unit_check.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+@inline(__always)
+/// Asserts the provided condition and exits with failure when it is false.
+/// - Parameters:
+///   - condition: Boolean expression that must evaluate to true.
+///   - message: Failure reason printed to stderr when assertion fails.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let sourcePath = root.appendingPathComponent("dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift")
+let source = String(decoding: try! Data(contentsOf: sourcePath), as: UTF8.self)
+
+assertTrue(
+    source.contains("func callAlert(type: AlertActionType)"),
+    "callAlert should exist in CustomAlertViewModel"
+)
+assertTrue(
+    source.contains("func callCustomAlert(model: AlertModel,leftAction: @escaping () -> (),rightAction: @escaping () -> () = {})"),
+    "callCustomAlert should exist in CustomAlertViewModel"
+)
+assertTrue(
+    source.contains("isAlert = true"),
+    "Alert presentation state should be set explicitly to true"
+)
+assertTrue(
+    source.contains("isAlert.toggle()") == false,
+    "Alert presentation should not use toggle to avoid accidental dismissals"
+)
+
+print("PASS: custom alert present state unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -101,6 +101,7 @@ swift scripts/home_area_milestone_feedback_unit_check.swift
 swift scripts/settings_profile_account_actions_unit_check.swift
 swift scripts/settings_auth_session_sync_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
+swift scripts/custom_alert_present_state_unit_check.swift
 swift scripts/ios_pr_check_derived_data_path_unit_check.swift
 swift scripts/ios_pr_check_skip_watch_build_unit_check.swift
 swift scripts/project_stability_unit_check.swift


### PR DESCRIPTION
## Summary
- replace toggle-based alert presentation with explicit `isAlert = true` in `CustomAlertViewModel`
- prevent accidental alert dismissal when alert is already presented and a new alert is requested
- add regression unit check and include it in ios_pr_check

## Verification
- swift scripts/custom_alert_present_state_unit_check.swift
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #342
