### PR TITLE
[P2][Task][UI] CustomAlertViewModel MainActor 격리

### DIFF
--- a/dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift
+++ b/dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift
@@ -9,7 +9,8 @@ import Foundation
 import SwiftUI
 import MapKit
 import Combine
-public class CustomAlertViewModel: ObservableObject {
+@MainActor
+public final class CustomAlertViewModel: ObservableObject {
   @Published var alertType : AlertActionType
   @Published var isAlert: Bool = false
   init(isAlert: Bool = false, type: AlertActionType = .logOut) {
@@ -18,10 +19,17 @@ public class CustomAlertViewModel: ObservableObject {
   }
 }
 extension CustomAlertViewModel {
+  /// 지정한 알림 타입으로 알림 표시 상태를 활성화합니다.
+  /// - Parameter type: 화면에 표시할 알림 타입입니다.
   func callAlert(type: AlertActionType) {
     self.alertType = type
     isAlert = true
   }
+    /// 커스텀 알림 모델과 버튼 액션을 설정하고 알림 표시 상태를 활성화합니다.
+    /// - Parameters:
+    ///   - model: 알림에 표시할 제목/메시지/버튼 구성을 담은 모델입니다.
+    ///   - leftAction: 좌측(기본) 버튼 탭 시 실행할 동작입니다.
+    ///   - rightAction: 우측 버튼 탭 시 실행할 동작입니다.
     func callCustomAlert(model: AlertModel,leftAction: @escaping () -> (),rightAction: @escaping () -> () = {}) {
         self.alertType = .custom(model, leftAction, rightAction)
         isAlert = true

--- a/scripts/custom_alert_mainactor_unit_check.swift
+++ b/scripts/custom_alert_mainactor_unit_check.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@inline(__always)
+/// Asserts the provided condition and exits with failure when it is false.
+/// - Parameters:
+///   - condition: Boolean expression that must evaluate to true.
+///   - message: Failure reason printed to stderr when assertion fails.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let sourcePath = root.appendingPathComponent("dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift")
+let source = String(decoding: try! Data(contentsOf: sourcePath), as: UTF8.self)
+
+assertTrue(
+    source.contains("@MainActor"),
+    "CustomAlertViewModel should be isolated to MainActor"
+)
+assertTrue(
+    source.contains("public final class CustomAlertViewModel"),
+    "CustomAlertViewModel should be final to keep alert state boundary explicit"
+)
+assertTrue(
+    source.contains("func callAlert(type: AlertActionType)") && source.contains("isAlert = true"),
+    "callAlert should set explicit presentation state"
+)
+
+print("PASS: custom alert mainactor unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -102,6 +102,7 @@ swift scripts/settings_profile_account_actions_unit_check.swift
 swift scripts/settings_auth_session_sync_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/custom_alert_present_state_unit_check.swift
+swift scripts/custom_alert_mainactor_unit_check.swift
 swift scripts/ios_pr_check_derived_data_path_unit_check.swift
 swift scripts/ios_pr_check_skip_watch_build_unit_check.swift
 swift scripts/project_stability_unit_check.swift


### PR DESCRIPTION
## Summary
- isolate `CustomAlertViewModel` to `@MainActor` and mark it `final`
- keep alert state publishing on main-thread-bound actor for safer UI updates
- add Quick Help comments to alert trigger methods
- add regression unit check and wire it into ios_pr_check

## Verification
- swift scripts/custom_alert_mainactor_unit_check.swift
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #344
