### PR TITLE
[P3][Task][Refactor] CustomAlert 미사용 타입 제거

### DIFF
--- a/dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift
+++ b/dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift
@@ -35,13 +35,3 @@ extension CustomAlertViewModel {
         isAlert = true
     }
 }
-
-struct AlertViewModifier: ViewModifier {
-  @EnvironmentObject var AlertVM: CustomAlertViewModel
-  func body(content: Content) -> some View {
-    content
-  }
-}
-protocol AlertCallable {
-  var AlertVM: CustomAlertViewModel { get }
-}

--- a/scripts/custom_alert_unused_type_cleanup_unit_check.swift
+++ b/scripts/custom_alert_unused_type_cleanup_unit_check.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@inline(__always)
+/// Asserts the provided condition and exits with failure when it is false.
+/// - Parameters:
+///   - condition: Boolean expression that must evaluate to true.
+///   - message: Failure reason printed to stderr when assertion fails.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let sourcePath = root.appendingPathComponent("dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift")
+let source = String(decoding: try! Data(contentsOf: sourcePath), as: UTF8.self)
+
+assertTrue(
+    source.contains("struct AlertViewModifier") == false,
+    "unused AlertViewModifier should be removed from CustomAlertViewModel.swift"
+)
+assertTrue(
+    source.contains("protocol AlertCallable") == false,
+    "unused AlertCallable should be removed from CustomAlertViewModel.swift"
+)
+assertTrue(
+    source.contains("func callAlert(type: AlertActionType)") && source.contains("func callCustomAlert("),
+    "CustomAlertViewModel public alert trigger APIs should remain available"
+)
+
+print("PASS: custom alert unused type cleanup unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -105,6 +105,7 @@ swift scripts/settings_auth_session_sync_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/custom_alert_present_state_unit_check.swift
 swift scripts/custom_alert_mainactor_unit_check.swift
+swift scripts/custom_alert_unused_type_cleanup_unit_check.swift
 swift scripts/ios_pr_check_derived_data_path_unit_check.swift
 swift scripts/ios_pr_check_skip_watch_build_unit_check.swift
 swift scripts/project_stability_unit_check.swift


### PR DESCRIPTION
## Summary
- remove unused `AlertViewModifier` and `AlertCallable` declarations from `CustomAlertViewModel.swift`
- keep `CustomAlertViewModel` focused on alert presentation state APIs
- add cleanup regression unit check and wire it into ios_pr_check

## Verification
- swift scripts/custom_alert_unused_type_cleanup_unit_check.swift
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #350
