### PR TITLE
[P3][Task][Refactor] AlertModel 미사용 height 오버로드 제거

### DIFF
--- a/dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift
+++ b/dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift
@@ -117,7 +117,4 @@ struct AlertModel {
         
         
     }
-    func height(_ setHeight: CGFloat) -> CGFloat {
-        return setHeight
-    }
 }

--- a/scripts/alert_model_height_overload_cleanup_unit_check.swift
+++ b/scripts/alert_model_height_overload_cleanup_unit_check.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@inline(__always)
+/// Asserts the provided condition and exits with failure when it is false.
+/// - Parameters:
+///   - condition: Boolean expression that must evaluate to true.
+///   - message: Failure reason printed to stderr when assertion fails.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let sourcePath = root.appendingPathComponent("dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift")
+let source = String(decoding: try! Data(contentsOf: sourcePath), as: UTF8.self)
+
+assertTrue(
+    source.contains("func height(isShowVerticalButtons: Bool = false) -> CGFloat"),
+    "AlertModel should keep height(isShowVerticalButtons:) API used by CustomAlertView"
+)
+assertTrue(
+    source.contains("func height(_ setHeight: CGFloat) -> CGFloat") == false,
+    "unused AlertModel height overload should be removed"
+)
+
+print("PASS: alert model height overload cleanup unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -106,6 +106,7 @@ swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/custom_alert_present_state_unit_check.swift
 swift scripts/custom_alert_mainactor_unit_check.swift
 swift scripts/custom_alert_unused_type_cleanup_unit_check.swift
+swift scripts/alert_model_height_overload_cleanup_unit_check.swift
 swift scripts/ios_pr_check_derived_data_path_unit_check.swift
 swift scripts/ios_pr_check_skip_watch_build_unit_check.swift
 swift scripts/project_stability_unit_check.swift


### PR DESCRIPTION
## Summary
- remove unused `AlertModel.height(_ setHeight:)` overload from `CustomAlertConfigure`
- keep only `height(isShowVerticalButtons:)` API used by `CustomAlertView`
- add regression unit check and wire it into ios_pr_check

## Verification
- swift scripts/alert_model_height_overload_cleanup_unit_check.swift
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #352
