### PR TITLE
fix: auth session state snapshot for immediate UI refresh

### DIFF
--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -1475,6 +1475,7 @@ final class AuthFlowCoordinator: ObservableObject {
     @Published var pendingGuestDataUpgradePrompt: GuestDataUpgradePrompt? = nil
     @Published var guestDataUpgradeInProgress: Bool = false
     @Published var guestDataUpgradeResult: GuestDataUpgradeReport? = nil
+    @Published private(set) var sessionStateSnapshot: AppSessionState = AppFeatureGate.currentSession()
 
     private let guestModeKey = "auth.guest_mode.v1"
     private let entryChoiceCompletedKey = "auth.entry_choice_completed.v1"
@@ -1504,7 +1505,7 @@ final class AuthFlowCoordinator: ObservableObject {
     }
 
     var sessionState: AppSessionState {
-        AppFeatureGate.currentSession()
+        sessionStateSnapshot
     }
 
     var isLoggedIn: Bool {
@@ -1516,6 +1517,7 @@ final class AuthFlowCoordinator: ObservableObject {
     }
 
     func refresh() {
+        syncSessionStateSnapshot()
         if isLoggedIn {
             UserDefaults.standard.set(false, forKey: guestModeKey)
             UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
@@ -1590,6 +1592,7 @@ final class AuthFlowCoordinator: ObservableObject {
 
     func startReauthenticationFlow() {
         authSessionStore.clearTokenSession()
+        syncSessionStateSnapshot()
         pendingUpgradeRequest = nil
         pendingGuestDataUpgradePrompt = nil
         shouldShowEntryChoice = false
@@ -1659,6 +1662,7 @@ final class AuthFlowCoordinator: ObservableObject {
     }
 
     func completeSignIn() {
+        syncSessionStateSnapshot()
         UserDefaults.standard.set(false, forKey: guestModeKey)
         UserDefaults.standard.set(true, forKey: entryChoiceCompletedKey)
         shouldShowSignIn = false
@@ -1684,6 +1688,12 @@ final class AuthFlowCoordinator: ObservableObject {
             return nil
         }
         return sessionUserId
+    }
+
+    /// 저장소 기준 최신 세션 상태를 계산해 `@Published` 스냅샷으로 반영합니다.
+    /// - Returns: 없음. 세션 전환이 있으면 SwiftUI 갱신 트리거를 발생시킵니다.
+    private func syncSessionStateSnapshot() {
+        sessionStateSnapshot = AppFeatureGate.currentSession()
     }
 }
 

--- a/scripts/auth_flow_session_snapshot_unit_check.swift
+++ b/scripts/auth_flow_session_snapshot_unit_check.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Source/UserdefaultSetting.swift")
+
+assertTrue(
+    source.contains("@Published private(set) var sessionStateSnapshot: AppSessionState = AppFeatureGate.currentSession()"),
+    "auth flow should expose a published session state snapshot"
+)
+assertTrue(
+    source.contains("var sessionState: AppSessionState {\n        sessionStateSnapshot\n    }"),
+    "auth flow sessionState should read from published snapshot"
+)
+assertTrue(
+    source.contains("func refresh() {\n        syncSessionStateSnapshot()"),
+    "refresh should sync session snapshot before branch decisions"
+)
+assertTrue(
+    source.contains("func startReauthenticationFlow() {\n        authSessionStore.clearTokenSession()\n        syncSessionStateSnapshot()"),
+    "reauth flow should sync session snapshot right after token session clear"
+)
+assertTrue(
+    source.contains("func completeSignIn() {\n        syncSessionStateSnapshot()"),
+    "completeSignIn should sync session snapshot for immediate UI refresh"
+)
+assertTrue(
+    source.contains("private func syncSessionStateSnapshot()"),
+    "auth flow should define a dedicated session snapshot sync helper"
+)
+
+print("PASS: auth flow session snapshot unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -78,6 +78,7 @@ swift scripts/auth_rate_limit_message_unit_check.swift
 swift scripts/signin_metal_overlay_guard_unit_check.swift
 swift scripts/auth_overlay_widget_action_defer_unit_check.swift
 swift scripts/auth_reauth_session_downgrade_unit_check.swift
+swift scripts/auth_flow_session_snapshot_unit_check.swift
 swift scripts/feature_flag_refresh_throttle_unit_check.swift
 swift scripts/feature_flag_refresh_singleflight_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift


### PR DESCRIPTION
## Summary
- add Published session snapshot state in AuthFlowCoordinator
- sync snapshot during refresh, reauthentication start, and sign-in completion
- add auth flow session snapshot unit check and include it in ios_pr_check

## Validation
- `swift scripts/auth_flow_session_snapshot_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #354
