### PR TITLE
fix: auto-refresh auth flow on session change

### DIFF
--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -1485,6 +1485,7 @@ final class AuthFlowCoordinator: ObservableObject {
     private let petSelectionStore: PetSelectionStoring
     private let walkSessionMetadataStore: WalkSessionMetadataStore
     private var onAuthenticated: (() -> Void)?
+    private var authSessionObserver: AnyCancellable?
 
     /// 인증/프로필/선호 스토어 의존성을 주입해 인증 플로우 코디네이터를 초기화합니다.
     /// - Parameters:
@@ -1502,6 +1503,11 @@ final class AuthFlowCoordinator: ObservableObject {
         self.profileStore = profileStore
         self.petSelectionStore = petSelectionStore
         self.walkSessionMetadataStore = walkSessionMetadataStore
+        bindAuthSessionSync()
+    }
+
+    deinit {
+        authSessionObserver?.cancel()
     }
 
     var sessionState: AppSessionState {
@@ -1694,6 +1700,15 @@ final class AuthFlowCoordinator: ObservableObject {
     /// - Returns: 없음. 세션 전환이 있으면 SwiftUI 갱신 트리거를 발생시킵니다.
     private func syncSessionStateSnapshot() {
         sessionStateSnapshot = AppFeatureGate.currentSession()
+    }
+
+    /// 인증 세션 변경 알림을 구독해 코디네이터 상태를 즉시 동기화합니다.
+    private func bindAuthSessionSync() {
+        authSessionObserver = NotificationCenter.default.publisher(for: .authSessionDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refresh()
+            }
     }
 }
 

--- a/scripts/auth_flow_session_observer_unit_check.swift
+++ b/scripts/auth_flow_session_observer_unit_check.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let source = load("dogArea/Source/UserdefaultSetting.swift")
+
+assertTrue(
+    source.contains("private var authSessionObserver: AnyCancellable?"),
+    "auth flow should keep a cancellable for auth session observer"
+)
+assertTrue(
+    source.contains("bindAuthSessionSync()"),
+    "auth flow init path should bind auth session sync"
+)
+assertTrue(
+    source.contains("deinit {\n        authSessionObserver?.cancel()\n    }"),
+    "auth flow should cancel auth session observer on deinit"
+)
+assertTrue(
+    source.contains("private func bindAuthSessionSync()"),
+    "auth flow should define auth session sync binding helper"
+)
+assertTrue(
+    source.contains("NotificationCenter.default.publisher(for: .authSessionDidChange)"),
+    "auth flow should subscribe authSessionDidChange notification"
+)
+assertTrue(
+    source.contains("self?.refresh()"),
+    "auth flow observer should trigger refresh on session updates"
+)
+
+print("PASS: auth flow session observer unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -79,6 +79,7 @@ swift scripts/signin_metal_overlay_guard_unit_check.swift
 swift scripts/auth_overlay_widget_action_defer_unit_check.swift
 swift scripts/auth_reauth_session_downgrade_unit_check.swift
 swift scripts/auth_flow_session_snapshot_unit_check.swift
+swift scripts/auth_flow_session_observer_unit_check.swift
 swift scripts/feature_flag_refresh_throttle_unit_check.swift
 swift scripts/feature_flag_refresh_singleflight_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift


### PR DESCRIPTION
## Summary
- bind AuthFlowCoordinator to authSessionDidChange notifications
- trigger refresh() on notification to keep auth-dependent UI in sync
- add auth flow observer unit check and wire it into ios_pr_check

## Validation
- `swift scripts/auth_flow_session_observer_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #356
