### PR TITLE
[Auth] 401 전수조사: 세션 무효화 정책 보정 + edge anon fallback 확장

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -206,9 +206,16 @@ private extension SupabaseAuthResponseDTO {
 struct SupabaseHTTPClient {
     static let live = SupabaseHTTPClient()
     private static let edgeFunctionAnonRetryAllowlist: Set<String> = [
+        "feature-control",
         "nearby-presence",
         "upload-profile-image"
     ]
+
+    private enum AccessTokenValidationState {
+        case valid
+        case invalid
+        case inconclusive
+    }
 
     private let session: URLSession
     private let configLoader: () -> SupabaseRuntimeConfig?
@@ -314,9 +321,12 @@ struct SupabaseHTTPClient {
                 }
             }
 
-            if shouldInvalidateTokenSession(
+            if await shouldInvalidateTokenSession(
                 statusCode: statusCode,
-                usedAuthenticatedAccessToken: authorization.usedAuthenticatedAccessToken
+                endpoint: endpoint,
+                usedAuthenticatedAccessToken: authorization.usedAuthenticatedAccessToken,
+                accessToken: authorization.accessToken,
+                config: config
             ) {
                 authSessionStore.clearTokenSession()
                 #if DEBUG
@@ -338,27 +348,61 @@ struct SupabaseHTTPClient {
 
     /// 현재 저장된 사용자 세션을 기준으로 Authorization 헤더 값을 계산합니다.
     /// - Parameter config: Supabase 런타임 기본 구성입니다.
-    /// - Returns: 헤더 값과 사용자 토큰 사용 여부 튜플을 반환합니다.
+    /// - Returns: 헤더 값, 사용자 토큰 사용 여부, 실제 access token을 포함한 인증 컨텍스트입니다.
     private func resolvedAuthorizationHeader(
         config: SupabaseRuntimeConfig
-    ) async -> (headerValue: String, usedAuthenticatedAccessToken: Bool) {
+    ) async -> (
+        headerValue: String,
+        usedAuthenticatedAccessToken: Bool,
+        accessToken: String?
+    ) {
         guard let accessToken = await validAccessToken(config: config) else {
-            return ("Bearer \(config.anonKey)", false)
+            return ("Bearer \(config.anonKey)", false, nil)
         }
-        return ("Bearer \(accessToken)", true)
+        return ("Bearer \(accessToken)", true, accessToken)
     }
 
     /// 인증 토큰으로 호출한 요청이 401/403을 반환했는지 판정해 세션 무효화 여부를 결정합니다.
     /// - Parameters:
     ///   - statusCode: 응답 HTTP 상태 코드입니다.
+    ///   - endpoint: 인증 실패가 발생한 Supabase 엔드포인트입니다.
     ///   - usedAuthenticatedAccessToken: 해당 요청이 사용자 access token으로 호출됐는지 여부입니다.
-    /// - Returns: 사용자 토큰 호출에서 401/403 응답이면 `true`입니다.
+    ///   - accessToken: 해당 요청에 사용한 사용자 access token 문자열입니다.
+    ///   - config: Supabase 런타임 기본 구성입니다.
+    /// - Returns: 토큰이 실제 만료/무효로 판정되면 `true`, 게이트/권한 이슈면 `false`입니다.
     private func shouldInvalidateTokenSession(
         statusCode: Int,
-        usedAuthenticatedAccessToken: Bool
-    ) -> Bool {
+        endpoint: SupabaseEndpoint,
+        usedAuthenticatedAccessToken: Bool,
+        accessToken: String?,
+        config: SupabaseRuntimeConfig
+    ) async -> Bool {
         guard usedAuthenticatedAccessToken else { return false }
-        return statusCode == 401 || statusCode == 403
+        guard statusCode == 401 || statusCode == 403 else { return false }
+
+        if case .auth = endpoint {
+            return true
+        }
+
+        guard let accessToken, accessToken.isEmpty == false else {
+            return false
+        }
+
+        let validation = await validateAccessTokenRemotely(accessToken: accessToken, config: config)
+        switch validation {
+        case .valid:
+            #if DEBUG
+            print("[SupabaseAuth] preserve local token session: remote auth user check is still valid")
+            #endif
+            return false
+        case .invalid:
+            return true
+        case .inconclusive:
+            #if DEBUG
+            print("[SupabaseAuth] skip local token invalidation: remote auth user check inconclusive")
+            #endif
+            return false
+        }
     }
 
     /// 인증 토큰 호출이 401/403일 때, 서버 게이트 이슈 회피용 anon 재시도를 수행할지 판단합니다.
@@ -376,6 +420,48 @@ struct SupabaseHTTPClient {
         guard statusCode == 401 || statusCode == 403 else { return false }
         guard case .function(let functionName) = endpoint else { return false }
         return Self.edgeFunctionAnonRetryAllowlist.contains(functionName)
+    }
+
+    /// `auth/v1/user` 검증으로 현재 access token이 실제 만료/무효인지 확인합니다.
+    /// - Parameters:
+    ///   - accessToken: 검증할 사용자 access token 문자열입니다.
+    ///   - config: Supabase 런타임 기본 구성입니다.
+    /// - Returns: 원격 검증 결과(`valid/invalid/inconclusive`)를 반환합니다.
+    private func validateAccessTokenRemotely(
+        accessToken: String,
+        config: SupabaseRuntimeConfig
+    ) async -> AccessTokenValidationState {
+        let endpoint = SupabaseEndpoint.auth(path: "user")
+        let url = endpoint.resolveURL(baseURL: config.baseURL)
+        var request = URLRequest(url: url)
+        request.httpMethod = HTTPMethod.get.rawValue
+        request.setValue(config.anonKey, forHTTPHeaderField: "apikey")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        let startedAt = Date()
+
+        do {
+            let (_, response) = try await session.data(for: request)
+            guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+                return .inconclusive
+            }
+            if (200..<300).contains(statusCode) {
+                return .valid
+            }
+            if statusCode == 401 || statusCode == 403 {
+                return .invalid
+            }
+            #if DEBUG
+            let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+            print("[SupabaseAuth] auth-user probe status=\(statusCode) elapsed=\(elapsedMs)ms")
+            #endif
+            return .inconclusive
+        } catch {
+            #if DEBUG
+            let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+            print("[SupabaseAuth] auth-user probe failed elapsed=\(elapsedMs)ms error=\(error.localizedDescription)")
+            #endif
+            return .inconclusive
+        }
     }
 
     /// 저장된 access token의 유효성을 확인하고 필요 시 refresh를 수행합니다.

--- a/scripts/auth_edge_function_anon_retry_unit_check.swift
+++ b/scripts/auth_edge_function_anon_retry_unit_check.swift
@@ -22,8 +22,10 @@ assertTrue(
     "http client should define allowlist for anon fallback retry"
 )
 assertTrue(
-    infra.contains("\"nearby-presence\"") && infra.contains("\"upload-profile-image\""),
-    "anon fallback allowlist should include nearby-presence and upload-profile-image"
+    infra.contains("\"feature-control\"")
+        && infra.contains("\"nearby-presence\"")
+        && infra.contains("\"upload-profile-image\""),
+    "anon fallback allowlist should include feature-control, nearby-presence and upload-profile-image"
 )
 assertTrue(
     infra.contains("private func shouldRetryWithAnonAuthorization("),

--- a/scripts/auth_http_401_session_invalidation_unit_check.swift
+++ b/scripts/auth_http_401_session_invalidation_unit_check.swift
@@ -30,8 +30,24 @@ assertTrue(
     "http client should define token session invalidation guard"
 )
 assertTrue(
-    infra.contains("return statusCode == 401 || statusCode == 403"),
-    "invalidation guard should classify 401 and 403 as auth failure"
+    infra.contains("if case .auth = endpoint"),
+    "invalidation guard should treat auth endpoint failures as immediate invalidation"
+)
+assertTrue(
+    infra.contains("validateAccessTokenRemotely(accessToken: accessToken, config: config)"),
+    "invalidation guard should validate token remotely before clearing local session"
+)
+assertTrue(
+    infra.contains("preserve local token session: remote auth user check is still valid"),
+    "invalidation guard should preserve token session when auth probe confirms validity"
+)
+assertTrue(
+    infra.contains("skip local token invalidation: remote auth user check inconclusive"),
+    "invalidation guard should avoid forced logout when auth probe is inconclusive"
+)
+assertTrue(
+    infra.contains("private func validateAccessTokenRemotely("),
+    "http client should expose remote token validation helper"
 )
 assertTrue(
     infra.contains("invalidate local token session from response status="),


### PR DESCRIPTION
## 작업 개요
- #362
- 로그인 직후 일부 Function에서 `401 Invalid JWT`가 발생해 세션이 즉시 무효화(강제 로그아웃)되던 경로를 보정했습니다.

## 변경 사항
1. `SupabaseHTTPClient` 세션 무효화 정책 개선
- 기존: 사용자 토큰 요청에서 401/403이면 무조건 로컬 토큰 세션 삭제
- 변경: `auth/v1/user` 원격 검증으로 실제 토큰 유효성 확인 후에만 세션 삭제
  - valid: 세션 유지
  - invalid: 세션 삭제
  - inconclusive(네트워크/기타): 세션 유지

2. Edge anon fallback allowlist 확장
- `feature-control` 추가
- 유지: `nearby-presence`, `upload-profile-image`

3. 스크립트 체크 업데이트
- `auth_http_401_session_invalidation_unit_check.swift`
- `auth_edge_function_anon_retry_unit_check.swift`

## 검증
- `swift scripts/auth_http_401_session_invalidation_unit_check.swift`
- `swift scripts/auth_edge_function_anon_retry_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`
- 실서버 반복 검증(5회)
  - `auth/v1/user`: 200
  - `nearby-presence`: user 401 / anon 200
  - `upload-profile-image`: user 401 / anon 200

## 참고
- 워킹트리의 DesignAuditShots 및 xcuserdata 변경은 사용자 작업분으로 포함하지 않았습니다.