### PR TITLE
Harden member auth flows to avoid in-app 401 regressions

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -217,6 +217,11 @@ struct SupabaseHTTPClient {
         case inconclusive
     }
 
+    private enum UnauthorizedRetryRecoveryResult {
+        case recovered(data: Data, accessToken: String)
+        case unrecovered(statusCode: Int, data: Data, accessToken: String?)
+    }
+
     private let session: URLSession
     private let configLoader: () -> SupabaseRuntimeConfig?
     private let authSessionStore: AuthSessionStoreProtocol
@@ -267,7 +272,14 @@ struct SupabaseHTTPClient {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(config.anonKey, forHTTPHeaderField: "apikey")
         let authorization = await resolvedAuthorizationHeader(config: config)
-        request.setValue(authorization.headerValue, forHTTPHeaderField: "Authorization")
+        let authorizationContext: (
+            headerValue: String,
+            usedAuthenticatedAccessToken: Bool,
+            accessToken: String?
+        ) = shouldPreferAnonymousAuthorizationForEndpoint(endpoint)
+            ? ("Bearer \(config.anonKey)", false, nil)
+            : authorization
+        request.setValue(authorizationContext.headerValue, forHTTPHeaderField: "Authorization")
         request.httpBody = bodyData
         let startedAt = Date()
         #if DEBUG
@@ -293,10 +305,40 @@ struct SupabaseHTTPClient {
             throw SupabaseHTTPError.invalidResponse
         }
         guard (200..<300).contains(statusCode) else {
+            var resolvedStatusCode = statusCode
+            var resolvedData = data
+            var resolvedAccessToken = authorization.accessToken
+
+            if let recoveryResult = await retryUnauthorizedRequestWithRefreshedSessionIfNeeded(
+                request: request,
+                endpoint: endpoint,
+                method: method,
+                url: url,
+                statusCode: statusCode,
+                data: data,
+                usedAuthenticatedAccessToken: authorizationContext.usedAuthenticatedAccessToken,
+                accessToken: authorizationContext.accessToken,
+                config: config,
+                startedAt: startedAt
+            ) {
+                switch recoveryResult {
+                case .recovered(let recoveredData, _):
+                    #if DEBUG
+                    let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                    print("[SupabaseHTTP] <- \(method.rawValue) \(url.absoluteString) status=200 elapsed=\(elapsedMs)ms response=\(recoveredData.count)B (refresh-retry)")
+                    #endif
+                    return recoveredData
+                case .unrecovered(let retryStatusCode, let retryData, let refreshedAccessToken):
+                    resolvedStatusCode = retryStatusCode
+                    resolvedData = retryData
+                    resolvedAccessToken = refreshedAccessToken ?? resolvedAccessToken
+                }
+            }
+
             if shouldRetryWithAnonAuthorization(
                 endpoint: endpoint,
-                statusCode: statusCode,
-                usedAuthenticatedAccessToken: authorization.usedAuthenticatedAccessToken
+                statusCode: resolvedStatusCode,
+                usedAuthenticatedAccessToken: authorizationContext.usedAuthenticatedAccessToken
             ) {
                 var anonRequest = request
                 anonRequest.setValue("Bearer \(config.anonKey)", forHTTPHeaderField: "Authorization")
@@ -305,45 +347,158 @@ struct SupabaseHTTPClient {
                 #endif
                 do {
                     let (retryData, retryResponse) = try await session.data(for: anonRequest)
-                    if let retryStatusCode = (retryResponse as? HTTPURLResponse)?.statusCode,
-                       (200..<300).contains(retryStatusCode) {
+                    guard let retryStatusCode = (retryResponse as? HTTPURLResponse)?.statusCode else {
+                        #if DEBUG
+                        let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                        print("[SupabaseHTTP] xx retry-anon \(method.rawValue) \(url.absoluteString) elapsed=\(elapsedMs)ms invalid-response")
+                        #endif
+                        throw SupabaseHTTPError.invalidResponse
+                    }
+                    if (200..<300).contains(retryStatusCode) {
                         #if DEBUG
                         let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
                         print("[SupabaseHTTP] <- \(method.rawValue) \(url.absoluteString) status=\(retryStatusCode) elapsed=\(elapsedMs)ms response=\(retryData.count)B (anon-retry)")
                         #endif
                         return retryData
                     }
+                    resolvedStatusCode = retryStatusCode
+                    resolvedData = retryData
+                    #if DEBUG
+                    let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                    print("[SupabaseHTTP] <- \(method.rawValue) \(url.absoluteString) status=\(retryStatusCode) elapsed=\(elapsedMs)ms response=\(retryData.count)B (anon-retry-non2xx)")
+                    #endif
                 } catch {
                     #if DEBUG
                     let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
                     print("[SupabaseHTTP] xx retry-anon \(method.rawValue) \(url.absoluteString) elapsed=\(elapsedMs)ms error=\(error.localizedDescription)")
                     #endif
+                    throw error
                 }
             }
 
             if await shouldInvalidateTokenSession(
-                statusCode: statusCode,
+                statusCode: resolvedStatusCode,
                 endpoint: endpoint,
-                usedAuthenticatedAccessToken: authorization.usedAuthenticatedAccessToken,
-                accessToken: authorization.accessToken,
+                usedAuthenticatedAccessToken: authorizationContext.usedAuthenticatedAccessToken,
+                accessToken: resolvedAccessToken,
                 config: config
             ) {
                 authSessionStore.clearTokenSession()
                 #if DEBUG
-                print("[SupabaseAuth] invalidate local token session from response status=\(statusCode)")
+                print("[SupabaseAuth] invalidate local token session from response status=\(resolvedStatusCode)")
                 #endif
             }
             #if DEBUG
             let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
-            print("[SupabaseHTTP] <- \(method.rawValue) \(url.absoluteString) status=\(statusCode) elapsed=\(elapsedMs)ms response=\(data.count)B")
+            print("[SupabaseHTTP] <- \(method.rawValue) \(url.absoluteString) status=\(resolvedStatusCode) elapsed=\(elapsedMs)ms response=\(resolvedData.count)B")
             #endif
-            throw SupabaseHTTPError.unexpectedStatusCode(statusCode)
+            throw SupabaseHTTPError.unexpectedStatusCode(resolvedStatusCode)
         }
         #if DEBUG
         let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
         print("[SupabaseHTTP] <- \(method.rawValue) \(url.absoluteString) status=\(statusCode) elapsed=\(elapsedMs)ms response=\(data.count)B")
         #endif
         return data
+    }
+
+    /// 사용자 토큰 요청이 401/403일 때 refresh token으로 세션을 갱신한 뒤 동일 요청을 1회 재시도합니다.
+    /// - Parameters:
+    ///   - request: 원본 HTTP 요청입니다.
+    ///   - endpoint: 호출 대상 Supabase 엔드포인트입니다.
+    ///   - method: HTTP 메서드입니다.
+    ///   - url: 호출 대상 URL입니다.
+    ///   - statusCode: 최초 응답의 HTTP 상태 코드입니다.
+    ///   - data: 최초 응답 바디 데이터입니다.
+    ///   - usedAuthenticatedAccessToken: 최초 요청이 사용자 access token을 사용했는지 여부입니다.
+    ///   - accessToken: 최초 요청에 사용한 사용자 access token 문자열입니다.
+    ///   - config: Supabase 런타임 기본 구성입니다.
+    ///   - startedAt: 최초 요청 시작 시각입니다.
+    /// - Returns: refresh 재시도 결과가 있으면 성공/실패 결과를 반환하고, 시도 조건이 아니면 `nil`을 반환합니다.
+    private func retryUnauthorizedRequestWithRefreshedSessionIfNeeded(
+        request: URLRequest,
+        endpoint: SupabaseEndpoint,
+        method: HTTPMethod,
+        url: URL,
+        statusCode: Int,
+        data: Data,
+        usedAuthenticatedAccessToken: Bool,
+        accessToken: String?,
+        config: SupabaseRuntimeConfig,
+        startedAt: Date
+    ) async -> UnauthorizedRetryRecoveryResult? {
+        guard usedAuthenticatedAccessToken else { return nil }
+        guard statusCode == 401 || statusCode == 403 else { return nil }
+        guard case .function = endpoint else { return nil }
+        guard let currentSession = authSessionStore.currentTokenSession(),
+              currentSession.refreshToken.isEmpty == false else {
+            return nil
+        }
+
+        #if DEBUG
+        print("[SupabaseAuth] retry-with-refresh \(method.rawValue) \(url.absoluteString)")
+        #endif
+
+        let refreshOutcome = await refreshCredential(config: config, refreshToken: currentSession.refreshToken)
+        switch refreshOutcome {
+        case .success(let refreshed):
+            authSessionStore.persist(refreshed.identity)
+            guard let tokenSession = refreshed.tokenSession else {
+                return .unrecovered(
+                    statusCode: statusCode,
+                    data: data,
+                    accessToken: accessToken
+                )
+            }
+            authSessionStore.persist(tokenSession: tokenSession)
+
+            var retryRequest = request
+            retryRequest.setValue("Bearer \(tokenSession.accessToken)", forHTTPHeaderField: "Authorization")
+            do {
+                let (retryData, retryResponse) = try await session.data(for: retryRequest)
+                guard let retryStatusCode = (retryResponse as? HTTPURLResponse)?.statusCode else {
+                    #if DEBUG
+                    let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                    print("[SupabaseHTTP] xx refresh-retry \(method.rawValue) \(url.absoluteString) elapsed=\(elapsedMs)ms invalid-response")
+                    #endif
+                    return .unrecovered(
+                        statusCode: statusCode,
+                        data: data,
+                        accessToken: tokenSession.accessToken
+                    )
+                }
+                if (200..<300).contains(retryStatusCode) {
+                    return .recovered(data: retryData, accessToken: tokenSession.accessToken)
+                }
+                return .unrecovered(
+                    statusCode: retryStatusCode,
+                    data: retryData,
+                    accessToken: tokenSession.accessToken
+                )
+            } catch {
+                #if DEBUG
+                let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                print("[SupabaseHTTP] xx refresh-retry \(method.rawValue) \(url.absoluteString) elapsed=\(elapsedMs)ms error=\(error.localizedDescription)")
+                #endif
+                return .unrecovered(
+                    statusCode: statusCode,
+                    data: data,
+                    accessToken: tokenSession.accessToken
+                )
+            }
+        case .retryableFailure:
+            return .unrecovered(
+                statusCode: statusCode,
+                data: data,
+                accessToken: accessToken
+            )
+        case .terminalFailure:
+            authSessionStore.clearTokenSession()
+            return .unrecovered(
+                statusCode: statusCode,
+                data: data,
+                accessToken: accessToken
+            )
+        }
     }
 
     /// 현재 저장된 사용자 세션을 기준으로 Authorization 헤더 값을 계산합니다.
@@ -418,6 +573,14 @@ struct SupabaseHTTPClient {
     ) -> Bool {
         guard usedAuthenticatedAccessToken else { return false }
         guard statusCode == 401 || statusCode == 403 else { return false }
+        guard case .function(let functionName) = endpoint else { return false }
+        return Self.edgeFunctionAnonRetryAllowlist.contains(functionName)
+    }
+
+    /// Edge Function별 인증 우선순위를 판단해 익명 키 선적용 여부를 결정합니다.
+    /// - Parameter endpoint: 호출 대상 Supabase 엔드포인트입니다.
+    /// - Returns: 익명 키 우선 호출이 필요한 함수면 `true`, 아니면 `false`입니다.
+    private func shouldPreferAnonymousAuthorizationForEndpoint(_ endpoint: SupabaseEndpoint) -> Bool {
         guard case .function(let functionName) = endpoint else { return false }
         return Self.edgeFunctionAnonRetryAllowlist.contains(functionName)
     }

--- a/scripts/auth_401_refresh_retry_unit_check.swift
+++ b/scripts/auth_401_refresh_retry_unit_check.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let infraPath = root.appendingPathComponent("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+let infra = String(decoding: try Data(contentsOf: infraPath), as: UTF8.self)
+
+assertTrue(
+    infra.contains("retryUnauthorizedRequestWithRefreshedSessionIfNeeded("),
+    "http client should define unauthorized recovery helper"
+)
+assertTrue(
+    infra.contains("shouldPreferAnonymousAuthorizationForEndpoint(endpoint)"),
+    "http client should select anon authorization first for edge-function allowlist endpoints"
+)
+assertTrue(
+    infra.contains("let refreshOutcome = await refreshCredential(config: config, refreshToken: currentSession.refreshToken)"),
+    "unauthorized recovery helper should refresh credential on 401/403"
+)
+assertTrue(
+    infra.contains("retryRequest.setValue(\"Bearer \\(tokenSession.accessToken)\", forHTTPHeaderField: \"Authorization\")"),
+    "unauthorized recovery helper should retry request with refreshed access token"
+)
+assertTrue(
+    infra.contains("(refresh-retry)"),
+    "http client should annotate successful refresh retry responses"
+)
+assertTrue(
+    infra.contains("resolvedAccessToken = refreshedAccessToken ?? resolvedAccessToken"),
+    "http client should propagate refreshed access token into session invalidation guard"
+)
+
+print("PASS: auth 401 refresh retry unit checks")

--- a/scripts/auth_http_401_session_invalidation_unit_check.swift
+++ b/scripts/auth_http_401_session_invalidation_unit_check.swift
@@ -22,7 +22,8 @@ assertTrue(
     "http client should resolve authorization context before request"
 )
 assertTrue(
-    infra.contains("usedAuthenticatedAccessToken: authorization.usedAuthenticatedAccessToken"),
+    infra.contains("usedAuthenticatedAccessToken: authorization.usedAuthenticatedAccessToken")
+        || infra.contains("usedAuthenticatedAccessToken: authorizationContext.usedAuthenticatedAccessToken"),
     "http client should pass authenticated-token context to invalidation guard"
 )
 assertTrue(

--- a/scripts/auth_member_401_smoke_check.sh
+++ b/scripts/auth_member_401_smoke_check.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_FILE="${DOGAREA_SUPABASE_CONFIG:-$ROOT_DIR/supabaseConfig.xcconfig}"
+ITERATIONS="${DOGAREA_AUTH_SMOKE_ITERATIONS:-3}"
+
+resolve_xcconfig_value() {
+  local key="$1"
+  local file="$2"
+  python3 - "$file" "$key" <<'PY'
+import re
+import sys
+
+path, key = sys.argv[1], sys.argv[2]
+variables = {}
+
+with open(path, "r", encoding="utf-8") as f:
+    for line in f:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//") or "=" not in stripped:
+            continue
+        k, v = stripped.split("=", 1)
+        variables[k.strip()] = v.strip().strip('"')
+
+pattern = re.compile(r"\$\(([^)]+)\)")
+
+def resolve(value: str, depth: int = 0) -> str:
+    if depth > 16:
+        return value
+    def repl(match):
+        name = match.group(1)
+        replacement = variables.get(name, "")
+        return resolve(replacement, depth + 1)
+    return pattern.sub(repl, value)
+
+raw = variables.get(key, "")
+print(resolve(raw))
+PY
+}
+
+if [[ -z "${DOGAREA_TEST_EMAIL:-}" || -z "${DOGAREA_TEST_PASSWORD:-}" ]]; then
+  echo "[AuthSmoke] DOGAREA_TEST_EMAIL / DOGAREA_TEST_PASSWORD 환경변수가 필요합니다."
+  exit 1
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "[AuthSmoke] Supabase config 파일을 찾을 수 없습니다: $CONFIG_FILE"
+  exit 1
+fi
+
+SUPABASE_URL="${SUPABASE_URL:-$(resolve_xcconfig_value SUPABASE_URL "$CONFIG_FILE")}"
+SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY:-$(resolve_xcconfig_value SUPABASE_ANON_KEY "$CONFIG_FILE")}"
+
+if [[ -z "$SUPABASE_URL" || -z "$SUPABASE_ANON_KEY" ]]; then
+  echo "[AuthSmoke] SUPABASE_URL / SUPABASE_ANON_KEY 값을 확인할 수 없습니다."
+  exit 1
+fi
+
+extract_json_field() {
+  local json="$1"
+  local path="$2"
+  JSON_PAYLOAD="$json" python3 - "$path" <<'PY'
+import json
+import os
+import sys
+
+path = sys.argv[1].split(".")
+raw = os.environ.get("JSON_PAYLOAD", "")
+obj = json.loads(raw)
+for key in path:
+    obj = obj.get(key) if isinstance(obj, dict) else None
+    if obj is None:
+        print("")
+        raise SystemExit(0)
+print(obj if isinstance(obj, str) else "")
+PY
+}
+
+request_json() {
+  local method="$1"
+  local url="$2"
+  local apikey="$3"
+  local authorization="$4"
+  local body="$5"
+  local response
+  local status
+  response="$(curl -sS -X "$method" "$url" \
+    -H "Content-Type: application/json" \
+    -H "apikey: $apikey" \
+    -H "Authorization: $authorization" \
+    --data "$body" \
+    -w '\n%{http_code}')"
+  status="$(printf '%s' "$response" | tail -n 1)"
+  body="$(printf '%s' "$response" | sed '$d')"
+  printf '%s\n%s' "$status" "$body"
+}
+
+login_response="$(request_json \
+  "POST" \
+  "$SUPABASE_URL/auth/v1/token?grant_type=password" \
+  "$SUPABASE_ANON_KEY" \
+  "Bearer $SUPABASE_ANON_KEY" \
+  "{\"email\":\"$DOGAREA_TEST_EMAIL\",\"password\":\"$DOGAREA_TEST_PASSWORD\"}")"
+
+login_status="$(printf '%s' "$login_response" | head -n 1)"
+login_body="$(printf '%s' "$login_response" | tail -n +2)"
+
+if [[ "$login_status" != "200" ]]; then
+  echo "[AuthSmoke] 로그인 실패 status=$login_status"
+  exit 1
+fi
+
+access_token="$(extract_json_field "$login_body" "access_token")"
+user_id="$(extract_json_field "$login_body" "user.id")"
+
+if [[ -z "$access_token" || -z "$user_id" ]]; then
+  echo "[AuthSmoke] access_token 또는 user.id 파싱에 실패했습니다."
+  exit 1
+fi
+
+tiny_png_base64="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7+7zEAAAAASUVORK5CYII="
+
+echo "[AuthSmoke] start iterations=$ITERATIONS user_id=${user_id:0:8}..."
+
+iteration=1
+while [[ "$iteration" -le "$ITERATIONS" ]]; do
+  echo "[AuthSmoke] iteration=$iteration"
+
+  nearby_visibility_member="$(request_json \
+    "POST" \
+    "$SUPABASE_URL/functions/v1/nearby-presence" \
+    "$SUPABASE_ANON_KEY" \
+    "Bearer $access_token" \
+    "{\"action\":\"set_visibility\",\"userId\":\"$user_id\",\"enabled\":true}")"
+  nearby_visibility_member_status="$(printf '%s' "$nearby_visibility_member" | head -n 1)"
+  nearby_visibility_app="$(request_json \
+    "POST" \
+    "$SUPABASE_URL/functions/v1/nearby-presence" \
+    "$SUPABASE_ANON_KEY" \
+    "Bearer $SUPABASE_ANON_KEY" \
+    "{\"action\":\"set_visibility\",\"userId\":\"$user_id\",\"enabled\":true}")"
+  nearby_visibility_app_status="$(printf '%s' "$nearby_visibility_app" | head -n 1)"
+  if [[ "$nearby_visibility_app_status" == "401" ]]; then
+    echo "[AuthSmoke] FAIL nearby-presence set_visibility returned 401 with app authorization policy"
+    exit 1
+  fi
+
+  nearby_hotspots_member="$(request_json \
+    "POST" \
+    "$SUPABASE_URL/functions/v1/nearby-presence" \
+    "$SUPABASE_ANON_KEY" \
+    "Bearer $access_token" \
+    "{\"action\":\"get_hotspots\",\"userId\":\"$user_id\",\"centerLat\":37.42199,\"centerLng\":126.68327,\"radiusKm\":1.0}")"
+  nearby_hotspots_member_status="$(printf '%s' "$nearby_hotspots_member" | head -n 1)"
+  nearby_hotspots_app="$(request_json \
+    "POST" \
+    "$SUPABASE_URL/functions/v1/nearby-presence" \
+    "$SUPABASE_ANON_KEY" \
+    "Bearer $SUPABASE_ANON_KEY" \
+    "{\"action\":\"get_hotspots\",\"userId\":\"$user_id\",\"centerLat\":37.42199,\"centerLng\":126.68327,\"radiusKm\":1.0}")"
+  nearby_hotspots_app_status="$(printf '%s' "$nearby_hotspots_app" | head -n 1)"
+  if [[ "$nearby_hotspots_app_status" == "401" ]]; then
+    echo "[AuthSmoke] FAIL nearby-presence get_hotspots returned 401 with app authorization policy"
+    exit 1
+  fi
+
+  upload_profile_member="$(request_json \
+    "POST" \
+    "$SUPABASE_URL/functions/v1/upload-profile-image" \
+    "$SUPABASE_ANON_KEY" \
+    "Bearer $access_token" \
+    "{\"ownerId\":\"$user_id\",\"imageBase64\":\"$tiny_png_base64\",\"imageKind\":\"user\"}")"
+  upload_profile_member_status="$(printf '%s' "$upload_profile_member" | head -n 1)"
+  upload_profile_app="$(request_json \
+    "POST" \
+    "$SUPABASE_URL/functions/v1/upload-profile-image" \
+    "$SUPABASE_ANON_KEY" \
+    "Bearer $SUPABASE_ANON_KEY" \
+    "{\"ownerId\":\"$user_id\",\"imageBase64\":\"$tiny_png_base64\",\"imageKind\":\"user\"}")"
+  upload_profile_app_status="$(printf '%s' "$upload_profile_app" | head -n 1)"
+  if [[ "$upload_profile_app_status" == "401" ]]; then
+    echo "[AuthSmoke] FAIL upload-profile-image returned 401 with app authorization policy"
+    exit 1
+  fi
+
+  echo "[AuthSmoke] nearby_visibility member=$nearby_visibility_member_status app=$nearby_visibility_app_status"
+  echo "[AuthSmoke] nearby_hotspots member=$nearby_hotspots_member_status app=$nearby_hotspots_app_status"
+  echo "[AuthSmoke] upload_profile member=$upload_profile_member_status app=$upload_profile_app_status"
+  iteration=$((iteration + 1))
+done
+
+echo "[AuthSmoke] PASS: app authorization policy endpoints returned no 401 responses"

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -81,6 +81,7 @@ swift scripts/auth_reauth_session_downgrade_unit_check.swift
 swift scripts/auth_flow_session_snapshot_unit_check.swift
 swift scripts/auth_flow_session_observer_unit_check.swift
 swift scripts/auth_http_401_session_invalidation_unit_check.swift
+swift scripts/auth_401_refresh_retry_unit_check.swift
 swift scripts/auth_edge_function_anon_retry_unit_check.swift
 swift scripts/rival_rpc_param_compat_unit_check.swift
 swift scripts/feature_flag_refresh_throttle_unit_check.swift


### PR DESCRIPTION
## Summary
- add 401 recovery path in `SupabaseHTTPClient`:
  - retry function endpoints once with refreshed access token after member-token 401/403
- apply anon-first authorization policy for edge-function allowlist endpoints (`feature-control`, `nearby-presence`, `upload-profile-image`) to prevent repeated member-token 401 spam in app flows
- add auth 401 refresh retry unit check script and wire it into `ios_pr_check`
- add member auth smoke script to repeatedly verify endpoint status behavior

## Verification
- `swift scripts/auth_401_refresh_retry_unit_check.swift`
- `swift scripts/auth_http_401_session_invalidation_unit_check.swift`
- `swift scripts/auth_edge_function_anon_retry_unit_check.swift`
- `swift scripts/auth_refresh_resilience_unit_check.swift`
- `DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... DOGAREA_REVALIDATION_MAX_ATTEMPTS=1 bash scripts/run_rival_auth_revalidation_loop.sh` (3회 반복, 모두 SUCCESS)
- `DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... DOGAREA_AUTH_SMOKE_ITERATIONS=10 bash scripts/auth_member_401_smoke_check.sh`
  - app authorization policy endpoints: 401 없음
- `bash scripts/ios_pr_check.sh` (exit 0)
- `xcodebuild ... test-without-building`:
  - `testFeatureRegression_RivalFooterButtonsRouteToMapAndSettings` pass
  - `testFeatureRegression_SettingsAuthEntryPoints` pass
