### PR TITLE
Extend 401 refresh recovery across non-auth endpoints

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -428,7 +428,9 @@ struct SupabaseHTTPClient {
     ) async -> UnauthorizedRetryRecoveryResult? {
         guard usedAuthenticatedAccessToken else { return nil }
         guard statusCode == 401 || statusCode == 403 else { return nil }
-        guard case .function = endpoint else { return nil }
+        if case .auth = endpoint {
+            return nil
+        }
         guard let currentSession = authSessionStore.currentTokenSession(),
               currentSession.refreshToken.isEmpty == false else {
             return nil

--- a/scripts/auth_401_refresh_retry_unit_check.swift
+++ b/scripts/auth_401_refresh_retry_unit_check.swift
@@ -17,6 +17,10 @@ assertTrue(
     "http client should define unauthorized recovery helper"
 )
 assertTrue(
+    infra.contains("if case .auth = endpoint"),
+    "unauthorized recovery helper should skip auth endpoints and handle non-auth endpoints"
+)
+assertTrue(
     infra.contains("shouldPreferAnonymousAuthorizationForEndpoint(endpoint)"),
     "http client should select anon authorization first for edge-function allowlist endpoints"
 )


### PR DESCRIPTION
## Summary\n- broaden unauthorized refresh-retry recovery from function-only to all non-auth endpoints\n- keep auth endpoints excluded from automatic refresh-retry\n- update the auth 401 unit check to assert the new endpoint guard\n\n## Verification\n- swift scripts/auth_401_refresh_retry_unit_check.swift\n- swift scripts/auth_http_401_session_invalidation_unit_check.swift\n- swift scripts/auth_edge_function_anon_retry_unit_check.swift\n- swift scripts/auth_refresh_resilience_unit_check.swift\n- DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... DOGAREA_AUTH_SMOKE_ITERATIONS=10 bash scripts/auth_member_401_smoke_check.sh\n- DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... DOGAREA_REVALIDATION_MAX_ATTEMPTS=5 bash scripts/run_rival_auth_revalidation_loop.sh\n- DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh