### PR TITLE
fix: nearby-presence get_hotspots 500 해결

### DIFF
--- a/scripts/auth_member_401_smoke_check.sh
+++ b/scripts/auth_member_401_smoke_check.sh
@@ -96,6 +96,11 @@ request_json() {
   printf '%s\n%s' "$status" "$body"
 }
 
+is_server_error() {
+  local status="$1"
+  [[ "$status" =~ ^5[0-9][0-9]$ ]]
+}
+
 login_response="$(request_json \
   "POST" \
   "$SUPABASE_URL/auth/v1/token?grant_type=password" \
@@ -162,6 +167,12 @@ while [[ "$iteration" -le "$ITERATIONS" ]]; do
   nearby_hotspots_app_status="$(printf '%s' "$nearby_hotspots_app" | head -n 1)"
   if [[ "$nearby_hotspots_app_status" == "401" ]]; then
     echo "[AuthSmoke] FAIL nearby-presence get_hotspots returned 401 with app authorization policy"
+    exit 1
+  fi
+  if is_server_error "$nearby_hotspots_member_status" || is_server_error "$nearby_hotspots_app_status"; then
+    echo "[AuthSmoke] FAIL nearby-presence get_hotspots returned server error member=$nearby_hotspots_member_status app=$nearby_hotspots_app_status"
+    echo "[AuthSmoke] member body=$(printf '%s' "$nearby_hotspots_member" | tail -n +2)"
+    echo "[AuthSmoke] app body=$(printf '%s' "$nearby_hotspots_app" | tail -n +2)"
     exit 1
   fi
 

--- a/supabase/functions/nearby-presence/index.ts
+++ b/supabase/functions/nearby-presence/index.ts
@@ -206,6 +206,53 @@ const upsertLivePresence = async (
   };
 };
 
+const getNearbyHotspotsWithCompatRPC = async (
+  client: ReturnType<typeof createClient>,
+  payload: {
+    centerLat: number;
+    centerLng: number;
+    radiusKm: number;
+    nowTs: string;
+  },
+) => {
+  const latestAttempt = await client.rpc("rpc_get_nearby_hotspots", {
+    in_center_lat: payload.centerLat,
+    in_center_lng: payload.centerLng,
+    in_radius_km: payload.radiusKm,
+    in_now_ts: payload.nowTs,
+  });
+  if (!latestAttempt.error) {
+    return {
+      data: latestAttempt.data,
+      error: null,
+      signature: "latest",
+      latestError: null,
+    };
+  }
+
+  const legacyAttempt = await client.rpc("rpc_get_nearby_hotspots", {
+    center_lat: payload.centerLat,
+    center_lng: payload.centerLng,
+    radius_km: payload.radiusKm,
+    now_ts: payload.nowTs,
+  });
+  if (!legacyAttempt.error) {
+    return {
+      data: legacyAttempt.data,
+      error: null,
+      signature: "legacy",
+      latestError: latestAttempt.error,
+    };
+  }
+
+  return {
+    data: null,
+    error: legacyAttempt.error,
+    signature: "none",
+    latestError: latestAttempt.error,
+  };
+};
+
 Deno.serve(async (req) => {
   if (req.method !== "POST") return json({ error: "METHOD_NOT_ALLOWED" }, 405);
 
@@ -336,15 +383,27 @@ Deno.serve(async (req) => {
     }
 
     const radiusKm = typeof body.radiusKm === "number" ? body.radiusKm : 1.0;
-    const { data, error } = await client.rpc("rpc_get_nearby_hotspots", {
-      center_lat: body.centerLat,
-      center_lng: body.centerLng,
-      radius_km: radiusKm,
-      now_ts: new Date().toISOString(),
+    const rpcResult = await getNearbyHotspotsWithCompatRPC(client, {
+      centerLat: body.centerLat,
+      centerLng: body.centerLng,
+      radiusKm,
+      nowTs: new Date().toISOString(),
     });
-    if (error) return json({ error: error.message }, 500);
+    if (rpcResult.error) {
+      console.error("nearby hotspot rpc failed", {
+        centerLat: body.centerLat,
+        centerLng: body.centerLng,
+        radiusKm,
+        latestError: rpcResult.latestError,
+        fallbackError: rpcResult.error,
+      });
+      return json({
+        error: rpcResult.error.message,
+        code: rpcResult.error.code ?? null,
+      }, 500);
+    }
 
-    const hotspots = (data ?? []) as ResponseHotspotDTO[];
+    const hotspots = (rpcResult.data ?? []) as ResponseHotspotDTO[];
     const suppressedHotspots = hotspots.filter((row) => row.suppression_reason != null);
     const maskedHotspots = suppressedHotspots.filter((row) => row.suppression_reason === "sensitive_mask");
     const kAnonHotspots = suppressedHotspots.filter((row) => row.suppression_reason === "k_anon");


### PR DESCRIPTION
## 변경 사항\n- nearby-presence Edge Function에서 rpc_get_nearby_hotspots 호출을 최신 시그니처(in_*) 우선으로 변경\n- 스키마 드리프트 대비를 위해 레거시 시그니처(center_*) fallback 추가\n- get_hotspots RPC 실패 시 원인 파악 가능한 상세 에러 로그 추가\n- auth_member_401_smoke_check.sh에 get_hotspots 5xx 검출 추가\n\n## 검증\n- swift scripts/rival_privacy_hard_guard_unit_check.swift\n- bash -n scripts/auth_member_401_smoke_check.sh\n- DOGAREA_TEST_EMAIL=jinnavis1@gmail.com DOGAREA_TEST_PASSWORD=*** DOGAREA_AUTH_SMOKE_ITERATIONS=1 bash scripts/auth_member_401_smoke_check.sh\n  - nearby_hotspots app=200 확인\n\n## 배포\n- supabase functions deploy nearby-presence --project-ref ttjiknenynbhbpoqoesq 실행 완료