### PR TITLE
fix: 게스트 이관 재시도 no-op 경로 해소

### DIFF
--- a/dogArea/Source/UserdefaultSetting.swift
+++ b/dogArea/Source/UserdefaultSetting.swift
@@ -1254,6 +1254,14 @@ struct GuestDataUpgradePrompt: Identifiable {
 final class GuestDataUpgradeService {
     static let shared = GuestDataUpgradeService()
 
+    private struct ReportSeed {
+        let signature: String
+        let sessionCount: Int
+        let pointCount: Int
+        let totalAreaM2: Double
+        let totalDurationSec: Double
+    }
+
     private let syncOutbox = SyncOutboxStore.shared
     private let syncTransport = SupabaseSyncOutboxTransport()
     private let walkRepository: WalkRepositoryProtocol
@@ -1294,39 +1302,48 @@ final class GuestDataUpgradeService {
     }
 
     func runUpgrade(for userId: String, forceRetry: Bool = false) async -> GuestDataUpgradeReport? {
-        guard let snapshot = localSnapshot(), snapshot.sessionCount > 0 else {
-            #if DEBUG
-            print("[GuestUpgrade] runUpgrade skipped: no local sessions user=\(userId)")
-            #endif
-            return nil
-        }
-        #if DEBUG
-        print(
-            "[GuestUpgrade] runUpgrade start user=\(userId) forceRetry=\(forceRetry) sessions=\(snapshot.sessionCount) points=\(snapshot.pointCount)"
-        )
-        #endif
+        let snapshot = localSnapshot()
+        let previousReport = latestReport(for: userId)
 
         if forceRetry {
-            syncOutbox.requeuePermanentFailures(walkSessionIds: Set(snapshot.sessionIds))
-            #if DEBUG
-            print("[GuestUpgrade] requeue permanent failures for \(snapshot.sessionIds.count) sessions")
-            #endif
+            if let snapshot, snapshot.sessionIds.isEmpty == false {
+                syncOutbox.requeuePermanentFailures(walkSessionIds: Set(snapshot.sessionIds))
+                #if DEBUG
+                print("[GuestUpgrade] requeue permanent failures for \(snapshot.sessionIds.count) local sessions")
+                #endif
+            } else {
+                syncOutbox.requeuePermanentFailures()
+                #if DEBUG
+                print("[GuestUpgrade] requeue permanent failures for all outbox sessions")
+                #endif
+            }
         }
 
-        var enqueuedSessionCount = 0
-        for polygon in walkRepository.fetchPolygons() {
-            guard let sessionDTO = WalkBackfillDTOConverter.makeSessionDTO(
-                from: polygon,
-                ownerUserId: userId,
-                petId: nil,
-                sourceDevice: "ios"
-            ) else { continue }
-            syncOutbox.enqueueWalkStages(sessionDTO: sessionDTO)
-            enqueuedSessionCount += 1
+        if let snapshot, snapshot.sessionCount > 0 {
+            #if DEBUG
+            print(
+                "[GuestUpgrade] runUpgrade start user=\(userId) forceRetry=\(forceRetry) sessions=\(snapshot.sessionCount) points=\(snapshot.pointCount)"
+            )
+            #endif
+            var enqueuedSessionCount = 0
+            for polygon in walkRepository.fetchPolygons() {
+                guard let sessionDTO = WalkBackfillDTOConverter.makeSessionDTO(
+                    from: polygon,
+                    ownerUserId: userId,
+                    petId: nil,
+                    sourceDevice: "ios"
+                ) else { continue }
+                syncOutbox.enqueueWalkStages(sessionDTO: sessionDTO)
+                enqueuedSessionCount += 1
+            }
+            #if DEBUG
+            print("[GuestUpgrade] enqueue completed: \(enqueuedSessionCount) sessions queued")
+            #endif
+        } else {
+            #if DEBUG
+            print("[GuestUpgrade] runUpgrade continue without local sessions user=\(userId)")
+            #endif
         }
-        #if DEBUG
-        print("[GuestUpgrade] enqueue completed: \(enqueuedSessionCount) sessions queued")
-        #endif
 
         let summary = await syncOutbox.flush(using: syncTransport, now: Date())
         #if DEBUG
@@ -1334,31 +1351,48 @@ final class GuestDataUpgradeService {
             "[GuestUpgrade] flush summary pending=\(summary.pendingCount) permanent=\(summary.permanentFailureCount) lastError=\(summary.lastErrorCode?.rawValue ?? "none")"
         )
         #endif
-        let remoteSummary = await syncTransport.fetchBackfillValidationSummary(sessionIds: snapshot.sessionIds)
-        #if DEBUG
-        if let remoteSummary {
-            print(
-                "[GuestUpgrade] remote summary sessions=\(remoteSummary.sessionCount) points=\(remoteSummary.pointCount) area=\(remoteSummary.totalAreaM2) duration=\(remoteSummary.totalDurationSec)"
-            )
-        } else {
-            print("[GuestUpgrade] remote summary unavailable")
+
+        let hasOutstanding = summary.pendingCount > 0 || summary.permanentFailureCount > 0
+        guard hasOutstanding || snapshot != nil || previousReport != nil else {
+            clearPersistedReport(for: userId)
+            #if DEBUG
+            print("[GuestUpgrade] runUpgrade done: no local sessions and no outbox work user=\(userId)")
+            #endif
+            return nil
         }
-        #endif
-        let validation = validate(local: snapshot, remote: remoteSummary)
+
+        let seed = reportSeed(snapshot: snapshot, fallback: previousReport)
+        var remoteSummary: SyncBackfillValidationSummary? = nil
+        var validation: (passed: Bool?, message: String?) = (nil, hasOutstanding ? "local_snapshot_unavailable" : nil)
+
+        if let snapshot {
+            remoteSummary = await syncTransport.fetchBackfillValidationSummary(sessionIds: snapshot.sessionIds)
+            #if DEBUG
+            if let remoteSummary {
+                print(
+                    "[GuestUpgrade] remote summary sessions=\(remoteSummary.sessionCount) points=\(remoteSummary.pointCount) area=\(remoteSummary.totalAreaM2) duration=\(remoteSummary.totalDurationSec)"
+                )
+            } else {
+                print("[GuestUpgrade] remote summary unavailable")
+            }
+            #endif
+            validation = validate(local: snapshot, remote: remoteSummary)
+        }
+
         let report = GuestDataUpgradeReport(
             userId: userId,
-            signature: snapshot.signature,
-            sessionCount: snapshot.sessionCount,
-            pointCount: snapshot.pointCount,
-            totalAreaM2: snapshot.totalAreaM2,
-            totalDurationSec: snapshot.totalDurationSec,
+            signature: seed.signature,
+            sessionCount: seed.sessionCount,
+            pointCount: seed.pointCount,
+            totalAreaM2: seed.totalAreaM2,
+            totalDurationSec: seed.totalDurationSec,
             pendingCount: summary.pendingCount,
             permanentFailureCount: summary.permanentFailureCount,
             lastErrorCode: summary.lastErrorCode?.rawValue,
-            remoteSessionCount: remoteSummary?.sessionCount,
-            remotePointCount: remoteSummary?.pointCount,
-            remoteTotalAreaM2: remoteSummary?.totalAreaM2,
-            remoteTotalDurationSec: remoteSummary?.totalDurationSec,
+            remoteSessionCount: remoteSummary?.sessionCount ?? previousReport?.remoteSessionCount,
+            remotePointCount: remoteSummary?.pointCount ?? previousReport?.remotePointCount,
+            remoteTotalAreaM2: remoteSummary?.totalAreaM2 ?? previousReport?.remoteTotalAreaM2,
+            remoteTotalDurationSec: remoteSummary?.totalDurationSec ?? previousReport?.remoteTotalDurationSec,
             validationPassed: validation.passed,
             validationMessage: validation.message,
             executedAt: Date().timeIntervalSince1970
@@ -1366,7 +1400,10 @@ final class GuestDataUpgradeService {
 
         persist(report: report, for: userId)
         if report.hasOutstandingWork == false {
-            UserDefaults.standard.set(snapshot.signature, forKey: signatureKey(for: userId))
+            UserDefaults.standard.set(seed.signature, forKey: signatureKey(for: userId))
+            if seed.sessionCount == 0, seed.pointCount == 0 {
+                clearPersistedReport(for: userId)
+            }
         }
         #if DEBUG
         let validationText: String = {
@@ -1404,11 +1441,48 @@ final class GuestDataUpgradeService {
         )
     }
 
+    /// 게스트 이관 리포트 작성을 위한 기준 값을 계산합니다.
+    /// - Parameters:
+    ///   - snapshot: 현재 로컬 산책 스냅샷입니다.
+    ///   - fallback: 기존에 저장된 마지막 리포트입니다.
+    /// - Returns: 로컬 스냅샷이 있으면 우선 사용하고, 없으면 기존 리포트 기반으로 복원한 기준 값입니다.
+    private func reportSeed(
+        snapshot: GuestDataUpgradeSnapshot?,
+        fallback: GuestDataUpgradeReport?
+    ) -> ReportSeed {
+        if let snapshot {
+            return ReportSeed(
+                signature: snapshot.signature,
+                sessionCount: snapshot.sessionCount,
+                pointCount: snapshot.pointCount,
+                totalAreaM2: snapshot.totalAreaM2,
+                totalDurationSec: snapshot.totalDurationSec
+            )
+        }
+        return ReportSeed(
+            signature: fallback?.signature ?? "outbox-only",
+            sessionCount: fallback?.sessionCount ?? 0,
+            pointCount: fallback?.pointCount ?? 0,
+            totalAreaM2: fallback?.totalAreaM2 ?? 0,
+            totalDurationSec: fallback?.totalDurationSec ?? 0
+        )
+    }
+
     private func persist(report: GuestDataUpgradeReport, for userId: String) {
         guard let data = try? JSONEncoder().encode(report) else { return }
         UserDefaults.standard.set(data, forKey: reportKey(for: userId))
         #if DEBUG
         print("[GuestUpgrade] report persisted user=\(userId) key=\(reportKey(for: userId))")
+        #endif
+    }
+
+    /// 저장된 게스트 이관 리포트를 제거해 stale 카드 노출을 방지합니다.
+    /// - Parameter userId: 리포트를 삭제할 멤버 사용자 식별자입니다.
+    /// - Returns: 없음. 지정 사용자의 로컬 리포트 캐시를 삭제합니다.
+    private func clearPersistedReport(for userId: String) {
+        UserDefaults.standard.removeObject(forKey: reportKey(for: userId))
+        #if DEBUG
+        print("[GuestUpgrade] report cleared user=\(userId) key=\(reportKey(for: userId))")
         #endif
     }
 

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -209,7 +209,7 @@ struct HomeView: View {
                 }.onChange(of: viewModel.areaMilestonePresentation) { _, event in
                 guard event != nil else { return }
                 presentAreaMilestoneOverlay()
-                }.onChange(of: authFlow.guestDataUpgradeResult?.id) { _, _ in
+                }.onChange(of: authFlow.guestDataUpgradeResult?.executedAt) { _, _ in
                 viewModel.refreshGuestDataUpgradeReport()
                 }.onChange(of: isLowPowerModeEnabled) { _, enabled in
                 if enabled {

--- a/scripts/guest_data_upgrade_retry_unit_check.swift
+++ b/scripts/guest_data_upgrade_retry_unit_check.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if condition == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let authFlowSource = load("dogArea/Source/UserdefaultSetting.swift")
+let homeViewSource = load("dogArea/Views/HomeView/HomeView.swift")
+
+assertTrue(
+    authFlowSource.contains("runUpgrade continue without local sessions"),
+    "runUpgrade should continue even when local sessions are missing"
+)
+assertTrue(
+    authFlowSource.contains("syncOutbox.requeuePermanentFailures()"),
+    "force retry should support requeueing all outbox sessions without local snapshot"
+)
+assertTrue(
+    authFlowSource.contains("let summary = await syncOutbox.flush(using: syncTransport, now: Date())"),
+    "runUpgrade should still flush sync outbox"
+)
+assertTrue(
+    authFlowSource.contains("clearPersistedReport(for: userId)"),
+    "stale upgrade report should be clearable"
+)
+assertTrue(
+    homeViewSource.contains(".onChange(of: authFlow.guestDataUpgradeResult?.executedAt)"),
+    "HomeView should observe executedAt to refresh card after retry"
+)
+
+print("PASS: guest data upgrade retry unit checks")


### PR DESCRIPTION
## 배경
- 홈 카드에서 `이관 재시도`를 눌러도 로컬 세션이 없으면 `runUpgrade`가 즉시 `nil` 반환되어 실제 flush/retry가 실행되지 않았습니다.
- 또한 홈은 `guestDataUpgradeResult.id` 변경만 구독하고 있어, 같은 signature 재시도 시 카드가 갱신되지 않는 경로가 있었습니다.

## 변경
- `GuestDataUpgradeService.runUpgrade`를 개선해 로컬 세션이 없어도 outbox pending/permanent 항목이 있으면 `requeue + flush`를 수행하도록 수정
- 로컬 스냅샷이 없는 경우에도 이전 리포트 기반 seed로 결과 리포트를 생성하도록 보강
- outbox와 로컬 데이터가 모두 없는 경우 stale 리포트 제거
- 홈 `onChange` 대상을 `guestDataUpgradeResult?.executedAt`으로 변경해 재시도마다 카드 갱신 보장
- 회귀 방지 스크립트 `scripts/guest_data_upgrade_retry_unit_check.swift` 추가

## 검증
- `swift scripts/guest_data_upgrade_retry_unit_check.swift`
- `swift scripts/auth_401_refresh_retry_unit_check.swift`
- `swift scripts/auth_http_401_session_invalidation_unit_check.swift`
