### PR TITLE
fix: 위젯 탭 무반응 경로 제거 (OpenURLIntent)

### DIFF
--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -208,19 +208,31 @@ struct RootView: View {
     /// 위젯에서 전달된 딥링크를 파싱해 지도 탭 액션으로 전달합니다.
     /// - Parameter url: 앱으로 유입된 URL 스킴 딥링크입니다.
     private func routeWidgetDeepLinkIfNeeded(_ url: URL) {
+        #if DEBUG
+        print("[WidgetAction] onOpenURL received: \(url.absoluteString)")
+        #endif
         guard let route = WalkWidgetActionRoute.parse(from: url) else { return }
+        #if DEBUG
+        print("[WidgetAction] parsed deep link kind=\(route.kind.rawValue) actionId=\(route.actionId) source=\(route.source)")
+        #endif
         dispatchWidgetAction(route)
     }
 
     /// 공유 저장소에 대기 중인 위젯 액션 요청을 소비해 앱 내부 액션으로 전달합니다.
     private func consumePendingWidgetActionIfNeeded() {
         guard let request = widgetActionStore.consumePending() else { return }
+        #if DEBUG
+        print("[WidgetAction] consumed pending request kind=\(request.kind.rawValue) actionId=\(request.actionId) source=\(request.source)")
+        #endif
         dispatchWidgetAction(request.asRoute())
     }
 
     /// 위젯 액션 라우트를 종류에 맞는 탭/서비스로 전달합니다.
     /// - Parameter route: 앱 내부에서 처리할 위젯 액션 라우트입니다.
     private func dispatchWidgetAction(_ route: WalkWidgetActionRoute) {
+        #if DEBUG
+        print("[WidgetAction] dispatch kind=\(route.kind.rawValue) actionId=\(route.actionId) source=\(route.source)")
+        #endif
         switch route.kind {
         case .startWalk, .endWalk:
             dispatchWalkWidgetAction(route)
@@ -238,12 +250,18 @@ struct RootView: View {
         if isAuthenticationOverlayActive {
             pendingWalkWidgetRoute = route
             selectedTab = 2
+            #if DEBUG
+            print("[WidgetAction] deferred walk action during auth overlay actionId=\(route.actionId)")
+            #endif
             return
         }
         pendingWalkWidgetRoute = nil
         mapViewModelStore.prepareIfNeeded()
         selectedTab = 2
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            #if DEBUG
+            print("[WidgetAction] posting walkWidgetActionRequested kind=\(route.kind.rawValue) actionId=\(route.actionId)")
+            #endif
             NotificationCenter.default.post(
                 name: .walkWidgetActionRequested,
                 object: nil,

--- a/dogAreaWidgetExtension/WalkControlIntents.swift
+++ b/dogAreaWidgetExtension/WalkControlIntents.swift
@@ -7,14 +7,14 @@ struct StartWalkIntent: AppIntent {
 
     /// 위젯에서 산책 시작 액션을 앱 공유 저장소에 기록합니다.
     /// - Returns: 앱 실행 후 소비할 요청을 기록한 인텐트 결과입니다.
-    func perform() async throws -> some IntentResult {
+    func perform() async throws -> some IntentResult & OpensIntent {
         routeToApp(kind: .startWalk)
     }
 
     /// 공통 위젯 액션 요청을 공유 저장소에 기록합니다.
     /// - Parameter kind: 요청할 위젯 액션 종류입니다.
     /// - Returns: 요청 기록 완료를 나타내는 인텐트 결과입니다.
-    private func routeToApp(kind: WalkWidgetActionKind) -> some IntentResult {
+    private func routeToApp(kind: WalkWidgetActionKind) -> some IntentResult & OpensIntent {
         let route = WalkWidgetActionRequest(
             kind: kind,
             actionId: UUID().uuidString.lowercased(),
@@ -36,7 +36,8 @@ struct StartWalkIntent: AppIntent {
                 updatedAt: Date().timeIntervalSince1970
             )
         )
-        return .result()
+        let openURL = route.asRoute().makeURL() ?? URL(string: "dogarea://widget/walk")!
+        return .result(opensIntent: OpenURLIntent(openURL))
     }
 }
 
@@ -46,14 +47,14 @@ struct EndWalkIntent: AppIntent {
 
     /// 위젯에서 산책 종료 액션을 앱 공유 저장소에 기록합니다.
     /// - Returns: 앱 실행 후 소비할 요청을 기록한 인텐트 결과입니다.
-    func perform() async throws -> some IntentResult {
+    func perform() async throws -> some IntentResult & OpensIntent {
         routeToApp(kind: .endWalk)
     }
 
     /// 공통 위젯 액션 요청을 공유 저장소에 기록합니다.
     /// - Parameter kind: 요청할 위젯 액션 종류입니다.
     /// - Returns: 요청 기록 완료를 나타내는 인텐트 결과입니다.
-    private func routeToApp(kind: WalkWidgetActionKind) -> some IntentResult {
+    private func routeToApp(kind: WalkWidgetActionKind) -> some IntentResult & OpensIntent {
         let route = WalkWidgetActionRequest(
             kind: kind,
             actionId: UUID().uuidString.lowercased(),
@@ -75,7 +76,8 @@ struct EndWalkIntent: AppIntent {
                 updatedAt: Date().timeIntervalSince1970
             )
         )
-        return .result()
+        let openURL = route.asRoute().makeURL() ?? URL(string: "dogarea://widget/walk")!
+        return .result(opensIntent: OpenURLIntent(openURL))
     }
 }
 
@@ -85,7 +87,7 @@ struct ClaimQuestRewardIntent: AppIntent {
 
     /// 위젯에서 퀘스트 보상 수령 액션을 앱 공유 저장소에 기록합니다.
     /// - Returns: 앱 실행 후 소비할 요청을 기록한 인텐트 결과입니다.
-    func perform() async throws -> some IntentResult {
+    func perform() async throws -> some IntentResult & OpensIntent {
         let snapshotStore = DefaultQuestRivalWidgetSnapshotStore.shared
         let current = snapshotStore.load()
         let questInstanceId = current.summary?.questInstanceId
@@ -111,7 +113,8 @@ struct ClaimQuestRewardIntent: AppIntent {
                 updatedAt: Date().timeIntervalSince1970
             )
         )
-        return .result()
+        let openURL = route.asRoute().makeURL() ?? URL(string: "dogarea://widget/walk")!
+        return .result(opensIntent: OpenURLIntent(openURL))
     }
 }
 
@@ -121,7 +124,7 @@ struct OpenRivalTabIntent: AppIntent {
 
     /// 위젯에서 라이벌 탭 열기 액션을 앱 공유 저장소에 기록합니다.
     /// - Returns: 앱 실행 후 소비할 요청을 기록한 인텐트 결과입니다.
-    func perform() async throws -> some IntentResult {
+    func perform() async throws -> some IntentResult & OpensIntent {
         let route = WalkWidgetActionRequest(
             kind: .openRivalTab,
             actionId: UUID().uuidString.lowercased(),
@@ -130,6 +133,7 @@ struct OpenRivalTabIntent: AppIntent {
             requestedAt: Date().timeIntervalSince1970
         )
         DefaultWalkWidgetActionRequestStore.shared.setPending(route)
-        return .result()
+        let openURL = route.asRoute().makeURL() ?? URL(string: "dogarea://widget/walk")!
+        return .result(opensIntent: OpenURLIntent(openURL))
     }
 }

--- a/scripts/widget_intent_openapp_unit_check.swift
+++ b/scripts/widget_intent_openapp_unit_check.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let intents = load("dogAreaWidgetExtension/WalkControlIntents.swift")
+let rootView = load("dogArea/Views/GlobalViews/BaseView/RootView.swift")
+
+assertTrue(intents.contains("func perform() async throws -> some IntentResult & OpensIntent"), "widget intents should return OpensIntent to guarantee app launch route")
+assertTrue(intents.contains("OpenURLIntent"), "widget intents should open app via OpenURLIntent")
+assertTrue(intents.contains("route.asRoute().makeURL()"), "widget intents should serialize action route into deep link URL")
+assertTrue(rootView.contains("[WidgetAction] onOpenURL received:"), "RootView should log incoming widget deep links in debug")
+assertTrue(rootView.contains("consumePendingWidgetActionIfNeeded"), "RootView should keep pending widget action consumption path")
+
+print("PASS: widget intent open-app unit checks")


### PR DESCRIPTION
## 문제
- 위젯 버튼 탭 시 앱 반응이 없고 Xcode 로그도 없는 현상 재현
- 기존 구현은 위젯 인텐트에서 요청 저장 후 `.result()`만 반환하여 앱 오픈 보장이 약한 경로가 있었습니다.

## 변경
- `StartWalkIntent`, `EndWalkIntent`, `ClaimQuestRewardIntent`, `OpenRivalTabIntent`의 `perform()` 반환 타입을 `some IntentResult & OpensIntent`로 변경
- 각 인텐트에서 `OpenURLIntent(dogarea://widget/walk...)`를 명시적으로 반환해 앱 오픈/딥링크 라우팅 강제
- `RootView`에 위젯 액션 수신/파싱/디스패치 DEBUG 로그 추가
- 회귀 방지 스크립트 `scripts/widget_intent_openapp_unit_check.swift` 추가

## 검증
- `swift scripts/widget_intent_openapp_unit_check.swift`
- `swift scripts/auth_overlay_widget_action_defer_unit_check.swift`
- `swift scripts/rival_hotspot_backoff_unit_check.swift`
