### PR TITLE
fix: prevent rival auth downgrade on preserved 401

### DIFF
--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -308,6 +308,7 @@ struct SupabaseHTTPClient {
             var resolvedStatusCode = statusCode
             var resolvedData = data
             var resolvedAccessToken = authorization.accessToken
+            var authenticatedStatusCodeForSessionDecision = statusCode
 
             if let recoveryResult = await retryUnauthorizedRequestWithRefreshedSessionIfNeeded(
                 request: request,
@@ -332,6 +333,7 @@ struct SupabaseHTTPClient {
                     resolvedStatusCode = retryStatusCode
                     resolvedData = retryData
                     resolvedAccessToken = refreshedAccessToken ?? resolvedAccessToken
+                    authenticatedStatusCodeForSessionDecision = retryStatusCode
                 }
             }
 
@@ -377,7 +379,7 @@ struct SupabaseHTTPClient {
             }
 
             if await shouldInvalidateTokenSession(
-                statusCode: resolvedStatusCode,
+                statusCode: authenticatedStatusCodeForSessionDecision,
                 endpoint: endpoint,
                 usedAuthenticatedAccessToken: authorizationContext.usedAuthenticatedAccessToken,
                 accessToken: resolvedAccessToken,
@@ -388,6 +390,13 @@ struct SupabaseHTTPClient {
                 print("[SupabaseAuth] invalidate local token session from response status=\(resolvedStatusCode)")
                 #endif
             }
+            #if DEBUG
+            if authenticatedStatusCodeForSessionDecision != resolvedStatusCode {
+                print(
+                    "[SupabaseAuth] auth-session decision status=\(authenticatedStatusCodeForSessionDecision) final-response status=\(resolvedStatusCode)"
+                )
+            }
+            #endif
             #if DEBUG
             let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
             print("[SupabaseHTTP] <- \(method.rawValue) \(url.absoluteString) status=\(resolvedStatusCode) elapsed=\(elapsedMs)ms response=\(resolvedData.count)B")

--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -322,7 +322,7 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
                 persistLocationSharingPreference(false, for: userId)
                 locationSharingEnabled = false
                 refreshViewState()
-                showToast(RivalNetworkErrorInterpreter.visibilityFailureMessage(from: error))
+                showToast(visibilityFailureMessage(for: error))
             }
         }
     }
@@ -852,7 +852,34 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
               case .unexpectedStatusCode(let statusCode) = supabaseError else {
             return false
         }
-        return statusCode == 401 || statusCode == 403
+        guard statusCode == 401 || statusCode == 403 else {
+            return false
+        }
+        return authSessionStore.currentTokenSession() == nil
+    }
+
+    /// 로컬 토큰 세션이 유지된 상태에서 서버 게이트 401/403이 발생했는지 판정합니다.
+    /// - Parameter error: 판정할 원본 오류입니다.
+    /// - Returns: 토큰 세션이 남아 있고 401/403만 발생한 상태면 `true`, 아니면 `false`입니다.
+    private func isSessionPreservedUnauthorizedStatus(_ error: Error) -> Bool {
+        guard let supabaseError = error as? SupabaseHTTPError,
+              case .unexpectedStatusCode(let statusCode) = supabaseError else {
+            return false
+        }
+        guard statusCode == 401 || statusCode == 403 else {
+            return false
+        }
+        return authSessionStore.currentTokenSession() != nil
+    }
+
+    /// 공유 설정 실패 시 유효 세션 여부를 반영한 사용자 안내 메시지를 생성합니다.
+    /// - Parameter error: 원본 네트워크 오류입니다.
+    /// - Returns: 현재 인증 상태를 고려한 사용자 안내 메시지입니다.
+    private func visibilityFailureMessage(for error: Error) -> String {
+        if isSessionPreservedUnauthorizedStatus(error) {
+            return "로그인은 유지되어 있어요. 서버 인증 상태를 다시 확인 중이니 잠시 후 다시 시도해주세요."
+        }
+        return RivalNetworkErrorInterpreter.visibilityFailureMessage(from: error)
     }
 
     /// 인증 실패를 감지하면 세션/공유 상태를 정리하고 재로그인 안내 UX로 전환합니다.

--- a/scripts/auth_edge_function_anon_retry_unit_check.swift
+++ b/scripts/auth_edge_function_anon_retry_unit_check.swift
@@ -36,6 +36,15 @@ assertTrue(
     "http client should log anon retry attempts in debug builds"
 )
 assertTrue(
+    infra.contains("resolvedStatusCode = retryStatusCode")
+        && infra.contains("resolvedData = retryData"),
+    "anon retry non-2xx responses should become the final surfaced HTTP status/data"
+)
+assertTrue(
+    infra.contains("auth-session decision status="),
+    "http client should emit debug logs when auth-session invalidation uses a different status than the final anon retry response"
+)
+assertTrue(
     infra.contains("(anon-retry)"),
     "http client should annotate successful anon retry responses"
 )

--- a/scripts/auth_http_401_session_invalidation_unit_check.swift
+++ b/scripts/auth_http_401_session_invalidation_unit_check.swift
@@ -43,6 +43,14 @@ assertTrue(
     "invalidation guard should preserve token session when auth probe confirms validity"
 )
 assertTrue(
+    infra.contains("var authenticatedStatusCodeForSessionDecision = statusCode"),
+    "http client should track authenticated-response status separately from anon retry status"
+)
+assertTrue(
+    infra.contains("statusCode: authenticatedStatusCodeForSessionDecision"),
+    "token invalidation should use the authenticated-response status instead of final anon retry status"
+)
+assertTrue(
     infra.contains("skip local token invalidation: remote auth user check inconclusive"),
     "invalidation guard should avoid forced logout when auth probe is inconclusive"
 )

--- a/scripts/rival_auth_session_guard_unit_check.swift
+++ b/scripts/rival_auth_session_guard_unit_check.swift
@@ -26,6 +26,18 @@ assertTrue(
     "rival tab should classify auth failure status codes explicitly"
 )
 assertTrue(
+    rivalViewModel.contains("return authSessionStore.currentTokenSession() == nil"),
+    "rival tab should only downgrade to re-login UX when the local token session is actually gone"
+)
+assertTrue(
+    rivalViewModel.contains("private func isSessionPreservedUnauthorizedStatus(_ error: Error) -> Bool"),
+    "rival tab should distinguish session-preserved 401/403 responses from real auth expiry"
+)
+assertTrue(
+    rivalViewModel.contains("로그인은 유지되어 있어요. 서버 인증 상태를 다시 확인 중이니 잠시 후 다시 시도해주세요."),
+    "rival tab should show a non-login retry message when a valid session still exists"
+)
+assertTrue(
     rivalViewModel.contains("persistLocationSharingPreference(false, for: affectedUserId)"),
     "rival tab should disable location sharing state on auth failure"
 )


### PR DESCRIPTION
## Summary
- keep auth-session invalidation decisions based on the authenticated response even when anon fallback retry returns a different status
- stop Rival from downgrading to re-login UX while a local token session is still present
- strengthen static regression checks for preserved-session 401 handling and anon retry status tracking

## Testing
- swift scripts/rival_auth_session_guard_unit_check.swift
- swift scripts/auth_http_401_session_invalidation_unit_check.swift
- swift scripts/auth_edge_function_anon_retry_unit_check.swift
- DOGAREA_DERIVED_DATA_PATH=.build/codex-378-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh
- xcodebuild -scheme dogArea -derivedDataPath .build/codex-378-build -destination "platform=iOS Simulator,name=iPhone 16,OS=18.5" "-only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_RivalAuthRevalidationFlow" test

Closes #366