### PR TITLE
fix: remove rival mainactor callback warnings

### DIFF
--- a/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
+++ b/dogArea/Views/ProfileSettingView/RivalTabViewModel.swift
@@ -776,9 +776,11 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
     private func startPollingIfNeeded() {
         pollingTimer?.invalidate()
         pollingTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            self.refreshHotspots(force: false)
-            self.refreshLeaderboard(force: false)
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.refreshHotspots(force: false)
+                self.refreshLeaderboard(force: false)
+            }
         }
     }
 
@@ -790,7 +792,9 @@ final class RivalTabViewModel: NSObject, ObservableObject, @preconcurrency CLLoc
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.handleAuthSessionDidChange()
+            Task { @MainActor [weak self] in
+                self?.handleAuthSessionDidChange()
+            }
         }
     }
 

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -49,6 +49,7 @@ swift scripts/rival_stage3_client_ux_unit_check.swift
 swift scripts/rival_auth_session_guard_unit_check.swift
 swift scripts/rival_auth_session_sync_unit_check.swift
 swift scripts/rival_cllocation_delegate_preconcurrency_unit_check.swift
+swift scripts/rival_mainactor_callback_unit_check.swift
 swift scripts/season_anti_farming_unit_check.swift
 swift scripts/season_comeback_catchup_unit_check.swift
 swift scripts/season_stage2_pipeline_unit_check.swift

--- a/scripts/rival_mainactor_callback_unit_check.swift
+++ b/scripts/rival_mainactor_callback_unit_check.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@inline(__always)
+/// Asserts the provided condition and exits with failure when it is false.
+/// - Parameters:
+///   - condition: Boolean expression that must evaluate to true.
+///   - message: Failure reason printed to stderr when assertion fails.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let sourceURL = root.appendingPathComponent("dogArea/Views/ProfileSettingView/RivalTabViewModel.swift")
+let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+assertTrue(
+    source.contains("Task { @MainActor [weak self] in\n                guard let self else { return }\n                self.refreshHotspots(force: false)\n                self.refreshLeaderboard(force: false)\n            }"),
+    "Polling timer should hop to MainActor before refreshing Rival state"
+)
+assertTrue(
+    source.contains("Task { @MainActor [weak self] in\n                self?.handleAuthSessionDidChange()\n            }"),
+    "Auth session observer should hop to MainActor before mutating Rival state"
+)
+
+print("PASS: rival mainactor callback unit checks")


### PR DESCRIPTION
## Summary
- hop Rival polling timer callbacks onto MainActor before mutating view model state
- hop auth session observer callbacks onto MainActor as well
- add a regression unit check and wire it into ios_pr_check

## Testing
- swift scripts/rival_mainactor_callback_unit_check.swift
- DOGAREA_DERIVED_DATA_PATH=.build/codex-389-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -derivedDataPath .build/codex-389-build -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build 2>&1 | rg "warning:|RivalTabViewModel.swift"

Closes #389