### PR TITLE
refactor: separate custom alert auth states

### DIFF
--- a/dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift
+++ b/dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift
@@ -6,20 +6,27 @@
 //
 
 import Foundation
-enum AlertActionType{
-    case custom(AlertModel , () -> () , () -> ())
-    case customThreeButton(AlertModel, () -> (), () -> (), () -> ())
-    case logOut
+
+enum AlertActionType {
+    typealias AlertActionHandler = () -> Void
+
+    case custom(AlertModel, AlertActionHandler, AlertActionHandler)
+    case customThreeButton(AlertModel, AlertActionHandler, AlertActionHandler, AlertActionHandler)
+    case loggedOut
+    case authRequired
     case annotationSelected(Location)
     case deletePolygon(UUID)
+
     var model: AlertModel {
         switch self {
         case .custom(let model, _, _):
             return model
         case .customThreeButton(let model, _, _, _):
             return model
-        case .logOut:
-            return AlertModel(title: "계정 오류", message: "로그아웃 되었습니다.", configure: .oneButton(buttonMsg: "로그인 하기"))
+        case .loggedOut:
+            return AlertModel.loggedOutAlert()
+        case .authRequired:
+            return AlertModel.authRequiredAlert()
         case .annotationSelected(let location):
             return AlertModel(title: "선택된 포인트", message: "\(location.coordinate)", configure: .twoButtonChoice(isVertical: false, first: "확인", second: "삭제"))
         case .deletePolygon(_):
@@ -27,11 +34,13 @@ enum AlertActionType{
         }
     }
 }
+
 enum AlertConfigureType {
     case defaultType
     case twoButtonChoice(isVertical: Bool = false, first: String?, second: String?)
     case threeButtonChoice(first: String?, second: String?, third: String?)
     case oneButton(buttonMsg: String?)
+
     var leftString: String {
         switch self {
         case .defaultType :
@@ -65,24 +74,27 @@ enum AlertConfigureType {
         }
     }
 }
-// MARK: 알림 기능
-// TODO: 로그인 추가 시 권한 없음 case 추가, customView 추가 기능
+
+// MARK: Alert Configuration
 struct AlertModel {
     private let title: String
     private let message: String?
     private let configure: AlertConfigureType
+
     init(title: String, message: String?, configure: AlertConfigureType) {
         self.title = title
         self.message = message
         self.configure = configure
     }
-    static func simpleAlert(title: String, message: String = "" , isOneButton: Bool = false) -> AlertModel{
+
+    static func simpleAlert(title: String, message: String = "", isOneButton: Bool = false) -> AlertModel{
         if isOneButton {
             AlertModel(title: title, message: message, configure: .oneButton(buttonMsg: "확인"))
         } else {
             AlertModel(title: title, message: message, configure: .twoButtonChoice(isVertical: true, first: "예", second: "아니오"))
         }
     }
+
     static func threeChoiceAlert(
         title: String,
         message: String,
@@ -96,6 +108,29 @@ struct AlertModel {
             configure: .threeButtonChoice(first: first, second: second, third: third)
         )
     }
+
+    /// 로그아웃 완료 안내에 사용하는 단일 버튼 알림 모델을 생성합니다.
+    /// - Parameter primaryButtonTitle: 로그인 재진입 버튼에 표시할 문구입니다.
+    /// - Returns: 로그아웃 완료 안내 문구와 단일 버튼 구성을 담은 알림 모델입니다.
+    static func loggedOutAlert(primaryButtonTitle: String = "로그인 하기") -> AlertModel {
+        AlertModel(
+            title: "계정 오류",
+            message: "로그아웃 되었습니다.",
+            configure: .oneButton(buttonMsg: primaryButtonTitle)
+        )
+    }
+
+    /// 인증 세션 확인이 필요한 상태를 안내하는 단일 버튼 알림 모델을 생성합니다.
+    /// - Parameter primaryButtonTitle: 로그인 재진입 버튼에 표시할 문구입니다.
+    /// - Returns: 인증 재확인 안내 문구와 단일 버튼 구성을 담은 알림 모델입니다.
+    static func authRequiredAlert(primaryButtonTitle: String = "로그인 하기") -> AlertModel {
+        AlertModel(
+            title: "인증 필요",
+            message: "인증 세션 확인이 필요합니다. 다시 로그인 후 시도해주세요.",
+            configure: .oneButton(buttonMsg: primaryButtonTitle)
+        )
+    }
+
     func titleStr() -> String {
         return self.title
     }

--- a/dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift
+++ b/dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift
@@ -13,7 +13,8 @@ import Combine
 public final class CustomAlertViewModel: ObservableObject {
   @Published var alertType : AlertActionType
   @Published var isAlert: Bool = false
-  init(isAlert: Bool = false, type: AlertActionType = .logOut) {
+
+  init(isAlert: Bool = false, type: AlertActionType = .loggedOut) {
     self.isAlert = isAlert
     self.alertType = type
   }
@@ -25,13 +26,18 @@ extension CustomAlertViewModel {
     self.alertType = type
     isAlert = true
   }
-    /// 커스텀 알림 모델과 버튼 액션을 설정하고 알림 표시 상태를 활성화합니다.
-    /// - Parameters:
-    ///   - model: 알림에 표시할 제목/메시지/버튼 구성을 담은 모델입니다.
-    ///   - leftAction: 좌측(기본) 버튼 탭 시 실행할 동작입니다.
-    ///   - rightAction: 우측 버튼 탭 시 실행할 동작입니다.
-    func callCustomAlert(model: AlertModel,leftAction: @escaping () -> (),rightAction: @escaping () -> () = {}) {
-        self.alertType = .custom(model, leftAction, rightAction)
-        isAlert = true
-    }
+
+  /// 커스텀 알림 모델과 버튼 액션을 설정하고 알림 표시 상태를 활성화합니다.
+  /// - Parameters:
+  ///   - model: 알림에 표시할 제목/메시지/버튼 구성을 담은 모델입니다.
+  ///   - leftAction: 좌측(기본) 버튼 탭 시 실행할 동작입니다.
+  ///   - rightAction: 우측 버튼 탭 시 실행할 동작입니다.
+  func callCustomAlert(
+    model: AlertModel,
+    leftAction: @escaping () -> Void,
+    rightAction: @escaping () -> Void = {}
+  ) {
+    self.alertType = .custom(model, leftAction, rightAction)
+    isAlert = true
+  }
 }

--- a/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
@@ -32,7 +32,7 @@ struct MapAlertSubView: View {
             middleButtonAction: middleAction,
             rightButtonAction: rightAction
         )
-      case .logOut:
+      case .loggedOut, .authRequired:
         ca = CustomAlert(presentAlert: $myAlert.isAlert,
                          alertModel: myAlert.alertType.model)
       case .deletePolygon(let id):

--- a/scripts/custom_alert_auth_state_unit_check.swift
+++ b/scripts/custom_alert_auth_state_unit_check.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@inline(__always)
+/// Asserts the provided condition and exits with failure when it is false.
+/// - Parameters:
+///   - condition: Boolean expression that must evaluate to true.
+///   - message: Failure reason printed to stderr when assertion fails.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let configurePath = root.appendingPathComponent("dogArea/Views/GlobalViews/AlertView/CustomAlertConfigure.swift")
+let configureSource = String(decoding: try! Data(contentsOf: configurePath), as: UTF8.self)
+let viewModelPath = root.appendingPathComponent("dogArea/Views/GlobalViews/AlertView/CustomAlertViewModel.swift")
+let viewModelSource = String(decoding: try! Data(contentsOf: viewModelPath), as: UTF8.self)
+let mapAlertPath = root.appendingPathComponent("dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift")
+let mapAlertSource = String(decoding: try! Data(contentsOf: mapAlertPath), as: UTF8.self)
+
+assertTrue(
+    configureSource.contains("case loggedOut") && configureSource.contains("case authRequired"),
+    "AlertActionType should distinguish logged-out and auth-required alert states"
+)
+assertTrue(
+    configureSource.contains("static func loggedOutAlert(") &&
+    configureSource.contains("static func authRequiredAlert("),
+    "AlertModel should provide dedicated factory helpers for auth alert states"
+)
+assertTrue(
+    configureSource.contains("TODO: 로그인 추가 시 권한 없음 case 추가") == false,
+    "Legacy auth alert TODO should be removed once explicit auth alert states are implemented"
+)
+assertTrue(
+    viewModelSource.contains("type: AlertActionType = .loggedOut"),
+    "CustomAlertViewModel default state should use the explicit loggedOut alert type"
+)
+assertTrue(
+    mapAlertSource.contains("case .loggedOut, .authRequired:"),
+    "MapAlertSubView should handle both auth alert states"
+)
+
+print("PASS: custom alert auth state unit checks")

--- a/scripts/custom_alert_present_state_unit_check.swift
+++ b/scripts/custom_alert_present_state_unit_check.swift
@@ -21,7 +21,10 @@ assertTrue(
     "callAlert should exist in CustomAlertViewModel"
 )
 assertTrue(
-    source.contains("func callCustomAlert(model: AlertModel,leftAction: @escaping () -> (),rightAction: @escaping () -> () = {})"),
+    source.contains("func callCustomAlert(") &&
+    source.contains("model: AlertModel") &&
+    source.contains("leftAction: @escaping () -> Void") &&
+    source.contains("rightAction: @escaping () -> Void = {}"),
     "callCustomAlert should exist in CustomAlertViewModel"
 )
 assertTrue(

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -117,6 +117,7 @@ swift scripts/settings_auth_session_sync_unit_check.swift
 swift scripts/profile_edit_userinfo_recovery_unit_check.swift
 swift scripts/ui_regression_matrix_unit_check.swift
 swift scripts/custom_alert_present_state_unit_check.swift
+swift scripts/custom_alert_auth_state_unit_check.swift
 swift scripts/custom_alert_mainactor_unit_check.swift
 swift scripts/custom_alert_unused_type_cleanup_unit_check.swift
 swift scripts/alert_model_height_overload_cleanup_unit_check.swift


### PR DESCRIPTION
## Summary
- split CustomAlert auth states into explicit `loggedOut` and `authRequired` cases
- add dedicated AlertModel factories and remove the legacy auth TODO
- add auth-state regression checks and wire them into ios_pr_check

## Testing
- swift scripts/custom_alert_auth_state_unit_check.swift
- swift scripts/custom_alert_present_state_unit_check.swift
- swift scripts/custom_alert_unused_type_cleanup_unit_check.swift
- swift scripts/alert_model_height_overload_cleanup_unit_check.swift
- DOGAREA_DERIVED_DATA_PATH=.build/codex-391-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #391