### PR TITLE
[Home/Refactor] HomeView 카드/행 렌더링 분리

### DIFF
--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -10,8 +10,13 @@
 		02B810B0791CFB600F8406EB /* HomeSelectedPetEmptyStateCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D14629580BEDCDCAE5B9EC3 /* HomeSelectedPetEmptyStateCardView.swift */; };
 		0ADA547D465997E8A4EFE806 /* HomeSeasonResetTransitionBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7F38C996B1C42E27210E77 /* HomeSeasonResetTransitionBannerView.swift */; };
 		106E27D50C08D7997FD7982D /* RivalNetworkErrorInterpreter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4548C0C604B933CC43644FA /* RivalNetworkErrorInterpreter.swift */; };
+		17BEA4EED401E70749B3A96B /* HomeQuestWidgetTabSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B94FEE2D80935CA3AA5917 /* HomeQuestWidgetTabSelectorView.swift */; };
 		1A87E29B8817434BC0210F5F /* WalkControlIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B86CA6EAAA6D2939A4516B9 /* WalkControlIntents.swift */; };
+		1BCE551255C692E2B20F154E /* HomeIndoorMissionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C12577FC501DA46E9411D5 /* HomeIndoorMissionRowView.swift */; };
 		1CCC7F48BF06FD4BCECF4286 /* TerritoryGoalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5CB737B1C8D8A675B6A43B /* TerritoryGoalView.swift */; };
+		1ED977BE7E5D9002AE1B92AD /* HomeQuestAlternativeSuggestionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70B19034ADC4071F655ED9E /* HomeQuestAlternativeSuggestionCardView.swift */; };
+		219A97F376AF1948198AF4DD /* HomeGuestDataUpgradeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61462EBA7433ED6BC68778D /* HomeGuestDataUpgradeCardView.swift */; };
+		21E7CDE1A8E20F90F24FB0C1 /* HomeWeeklyQuestSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E5D37200B02E2F8E26B734 /* HomeWeeklyQuestSummaryView.swift */; };
 		22EA9355CC79568490A94348 /* dogAreaUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626E89852AADA163B53AB03D /* dogAreaUITestsLaunchTests.swift */; };
 		23CB28F896D94B88CEF351F7 /* DesignAuditUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D982F3BFEE53C6D1333FF67 /* DesignAuditUITests.swift */; };
 		23F65BCBE5B31BA26CAFD1A5 /* WalkWidgetBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9750A3E12F227C859B34AF85 /* WalkWidgetBridge.swift */; };
@@ -25,11 +30,13 @@
 		316EF137D15633B33FDB93A3 /* ProfileFieldEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C8E7D8185E273FFD5B84579 /* ProfileFieldEditSheet.swift */; };
 		32009EE2A174DAB07F3DD64D /* RivalTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70172018FBBE6C94AB182660 /* RivalTabViewModel.swift */; };
 		32212CE8E65DCE8A3F54F209 /* HomeSeasonDetailSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163BA83441FB36D4D40305D8 /* HomeSeasonDetailSheetView.swift */; };
+		337C89763F94598EAAF98C3A /* HomeWeatherMissionStatusCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A003918476944D94F7E3DC99 /* HomeWeatherMissionStatusCardView.swift */; };
 		356D2ACD7D5FE5E6B735BBC2 /* AreaDetailReferenceCatalogSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7E3AA66F47CA884B345956 /* AreaDetailReferenceCatalogSectionView.swift */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		35EBB882681A45D25A948235 /* TerritoryGoalRecentListSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1256D9DE5D8E63B795C90401 /* TerritoryGoalRecentListSectionView.swift */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		37382EBDCEA90A2E818A05BB /* ProfileFieldEditSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF0E17B2BF40E97DBA5E07 /* ProfileFieldEditSheetViewModel.swift */; };
 		3B09EF73E528C78FEEE2AB01 /* SeasonProfileFrameStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CEBC83AFF321A2E3D10E8A0 /* SeasonProfileFrameStyle.swift */; };
 		3CEE77AA95703F198AC644B2 /* AreaDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76E1FA7BD23351B788C716B /* AreaDetailViewModel.swift */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		43441ACB76FB0EC0CA929CD8 /* HomeAnimatedSeasonGaugeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26182C87E44E1C0D9629CD03 /* HomeAnimatedSeasonGaugeView.swift */; };
 		45CA89EBC76C1FE5200FD88D /* HomeSelectedPetContextBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7738E4A04B406F4D70AE19 /* HomeSelectedPetContextBannerView.swift */; };
 		4C8C66B1707DD603359C2C39 /* dogAreaWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E916788F22F3DDF144CCE8D4 /* dogAreaWidgetExtension.appex */; };
 		4D741EB8E7EC826A55FCC5A5 /* WalkWidgetSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5D5C2E004FD37BC9E65790 /* WalkWidgetSnapshotStore.swift */; };
@@ -38,6 +45,7 @@
 		541633F39AA01B555EA4A904 /* HomeRecentConqueredSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3FDEC98167CC2EA0DAFA5E /* HomeRecentConqueredSectionView.swift */; };
 		5951E893E8CBC77DCA82E00F /* WalkDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A775802DB2A590A7C7DA0978 /* WalkDetailViewModel.swift */; };
 		5B03A082491706A835733386 /* GuestDataUpgradeResultBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEF5E5853DABE804BDEDE35 /* GuestDataUpgradeResultBanner.swift */; };
+		5F1E96498F8FFB6EC57536E9 /* HomeMissionDifficultySummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD790E9DD29E9185CE6A851 /* HomeMissionDifficultySummaryView.swift */; };
 		5F3ED37B0435F882BC90593E /* HomePetSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA31AC1DF69B7CA85070D28 /* HomePetSelectorView.swift */; };
 		6795215D0AFF8CD32FC1D207 /* TerritoryGoalActionHintCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DE6E868D63B43E48E230CFC /* TerritoryGoalActionHintCardView.swift */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		68DE48DFEF4001E3F518BF10 /* HomeTerritoryHeaderSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FFE492DDD22A6AC1319D9D /* HomeTerritoryHeaderSectionView.swift */; };
@@ -49,6 +57,7 @@
 		80D291562959288398B71B2A /* TerritoryGoalHeaderSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12397094BA00E47FD8BE76B0 /* TerritoryGoalHeaderSectionView.swift */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		82C0FE1F9DF4A147D4C6A02C /* RecoveryActionBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63D5D25262A8E2185005C50 /* RecoveryActionBanner.swift */; };
 		8705C4CE77BEE3DAEF07A78B /* SimpleKeyValueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376D30D4A7542596A014DEE1 /* SimpleKeyValueView.swift */; };
+		8801A48808105C4480F81F16 /* HomeWeatherShieldSummaryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745503CBDBC7737E36C35467 /* HomeWeatherShieldSummaryCardView.swift */; };
 		8A40430FD15CD439469AC981 /* RivalViewStateResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D5D8D51AC30DA6DB60A871 /* RivalViewStateResolver.swift */; };
 		8AB9332023AB8DBFF5657767 /* HomeHeaderSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBDE81DFC43DCD56546D775 /* HomeHeaderSectionView.swift */; };
 		8CD54D2F099991B9C308F493 /* MapViewModelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964083A1B8DE944291FAD56C /* MapViewModelStore.swift */; };
@@ -78,11 +87,17 @@
 		A37700010000000000000002 /* AreaDetailCatalogSnapshotSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37700010000000000000012 /* AreaDetailCatalogSnapshotSectionView.swift */; };
 		A37800010000000000000001 /* AppTabScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37800010000000000000002 /* AppTabScaffold.swift */; };
 		A37900010000000000000001 /* FeatureRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37900010000000000000002 /* FeatureRegressionUITests.swift */; };
+		A52752451CC8AC21215318DE /* HomeAnimatedQuestProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2B32A76C99094D54CD044D /* HomeAnimatedQuestProgressBarView.swift */; };
 		A83350BB79B3CBB09B4C4963 /* RivalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CE83B02069A8E4171B35DE /* RivalTabView.swift */; };
 		A9F5F361DE66BF266C36FED0 /* PositionMarkerViewWithSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C5F96B5D23BD6D36935CA0 /* PositionMarkerViewWithSelection.swift */; };
 		AC04B82FF13073F98E2EE459 /* AreaDetailRecentConquestSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4863F9787EC32E41B731A8 /* AreaDetailRecentConquestSectionView.swift */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		AEC5862872E6BF3231D08C90 /* HomeScrollToTopFloatingButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4122ED3DF3668790F606D542 /* HomeScrollToTopFloatingButtonView.swift */; };
+		B40D68BD38F0288BF600B11C /* HomeSeasonMotionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C671468D748C3AD8C0A7DB8A /* HomeSeasonMotionCardView.swift */; };
+		B6ABF3F12D7A7F8761D68EB2 /* HomeSeasonShieldBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBF6EC9508CA4C5CC954AF8 /* HomeSeasonShieldBadgeView.swift */; };
+		BA480FDD8F1E663F6CF6F9BF /* HomeSeasonMetricPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1882845C4C15BF66EF58B401 /* HomeSeasonMetricPillView.swift */; };
 		C047F1CA5DC13CAE4F03AE90 /* RivalHotspotSummaryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2B2A868B6FD9035AC5214F /* RivalHotspotSummaryBuilder.swift */; };
 		C93E65F4BA4229D430ED1AD9 /* AreaDetailSummaryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4340122AB9FE3F16F12570B /* AreaDetailSummaryCardView.swift */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		C9FE9795EDE724EE7C96A8F0 /* HomeQuestReminderToggleRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012C06744E292D894BC4661B /* HomeQuestReminderToggleRowView.swift */; };
 		CAB8947D9039E6F839F12EA4 /* GuestDataUpgradePromptSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F07A82B4C3550CACA2C6ED /* GuestDataUpgradePromptSheetView.swift */; };
 		CD071DCF8ABBABED0F998B66 /* HomeScrollOffsetPreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3087DB4DD4BFDA3FC923B011 /* HomeScrollOffsetPreferenceKey.swift */; };
 		CEDA085DD93B4102FE55229E /* HomeGoalTrackerCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C566C61F8B5520FEC3406DFF /* HomeGoalTrackerCardView.swift */; };
@@ -272,6 +287,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		012C06744E292D894BC4661B /* HomeQuestReminderToggleRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeQuestReminderToggleRowView.swift; sourceTree = "<group>"; };
 		020BF5BBC530202A931EEA4B /* WalkControlWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = dogAreaWidgetExtension/WalkControlWidgetBundle.swift; sourceTree = SOURCE_ROOT; };
 		078B330462EB7C7D535B09F1 /* AppleSigninButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppleSigninButton.swift; sourceTree = "<group>"; };
 		081AACF20D304E61699D792F /* HomeSeasonResultOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSeasonResultOverlayView.swift; path = HomeSeasonResultOverlayView.swift; sourceTree = "<group>"; };
@@ -280,33 +296,41 @@
 		12397094BA00E47FD8BE76B0 /* TerritoryGoalHeaderSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerritoryGoalHeaderSectionView.swift; sourceTree = "<group>"; };
 		1256D9DE5D8E63B795C90401 /* TerritoryGoalRecentListSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerritoryGoalRecentListSectionView.swift; sourceTree = "<group>"; };
 		163BA83441FB36D4D40305D8 /* HomeSeasonDetailSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSeasonDetailSheetView.swift; path = HomeSeasonDetailSheetView.swift; sourceTree = "<group>"; };
+		1882845C4C15BF66EF58B401 /* HomeSeasonMetricPillView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeSeasonMetricPillView.swift; sourceTree = "<group>"; };
 		19B0F89F9FF220625F0008DB /* RivalTabModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalTabModels.swift; path = dogArea/Views/ProfileSettingView/RivalTabModels.swift; sourceTree = "<group>"; };
 		1C4863F9787EC32E41B731A8 /* AreaDetailRecentConquestSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AreaDetailRecentConquestSectionView.swift; sourceTree = "<group>"; };
 		1D982F3BFEE53C6D1333FF67 /* DesignAuditUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignAuditUITests.swift; sourceTree = "<group>"; };
+		1DBF6EC9508CA4C5CC954AF8 /* HomeSeasonShieldBadgeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeSeasonShieldBadgeView.swift; sourceTree = "<group>"; };
 		21CE83B02069A8E4171B35DE /* RivalTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalTabView.swift; path = dogArea/Views/ProfileSettingView/RivalTabView.swift; sourceTree = "<group>"; };
 		2615443270FF3222AEBDE893 /* ThumbnailImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailImageView.swift; sourceTree = "<group>"; };
+		26182C87E44E1C0D9629CD03 /* HomeAnimatedSeasonGaugeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeAnimatedSeasonGaugeView.swift; sourceTree = "<group>"; };
 		29F07A82B4C3550CACA2C6ED /* GuestDataUpgradePromptSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GuestDataUpgradePromptSheetView.swift; sourceTree = "<group>"; };
 		2D030E0DFD8D49558700ACB1 /* WalkControlWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = dogAreaWidgetExtension/WalkControlWidget.swift; sourceTree = SOURCE_ROOT; };
 		3087DB4DD4BFDA3FC923B011 /* HomeScrollOffsetPreferenceKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeScrollOffsetPreferenceKey.swift; path = HomeScrollOffsetPreferenceKey.swift; sourceTree = "<group>"; };
 		30BF0E17B2BF40E97DBA5E07 /* ProfileFieldEditSheetViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileFieldEditSheetViewModel.swift; path = dogArea/Views/ProfileSettingView/ProfileFieldEditSheetViewModel.swift; sourceTree = "<group>"; };
 		363FE1044470B273CAB987E0 /* HomeQuestReminderSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeQuestReminderSupport.swift; sourceTree = "<group>"; };
 		376D30D4A7542596A014DEE1 /* SimpleKeyValueView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SimpleKeyValueView.swift; sourceTree = "<group>"; };
+		3B2B32A76C99094D54CD044D /* HomeAnimatedQuestProgressBarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeAnimatedQuestProgressBarView.swift; sourceTree = "<group>"; };
 		3B7E3AA66F47CA884B345956 /* AreaDetailReferenceCatalogSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AreaDetailReferenceCatalogSectionView.swift; sourceTree = "<group>"; };
+		4122ED3DF3668790F606D542 /* HomeScrollToTopFloatingButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeScrollToTopFloatingButtonView.swift; sourceTree = "<group>"; };
 		414CE261F0EB5ECCEED97F09 /* MemberUpgradeSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemberUpgradeSheetView.swift; sourceTree = "<group>"; };
 		44BB9B1737AC410B5104ECFD /* AreaDetailHeaderSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AreaDetailHeaderSectionView.swift; sourceTree = "<group>"; };
 		4A1B2C487816AA2CCCA6186F /* HomeStatusBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeStatusBannerView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeStatusBannerView.swift; sourceTree = "<group>"; };
 		4D14629580BEDCDCAE5B9EC3 /* HomeSelectedPetEmptyStateCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSelectedPetEmptyStateCardView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeSelectedPetEmptyStateCardView.swift; sourceTree = "<group>"; };
 		626E89852AADA163B53AB03D /* dogAreaUITestsLaunchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = dogAreaUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		649E88696A0B4425210BB446 /* HomeGoalMetricColumnView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeGoalMetricColumnView.swift; sourceTree = "<group>"; };
+		66C12577FC501DA46E9411D5 /* HomeIndoorMissionRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeIndoorMissionRowView.swift; sourceTree = "<group>"; };
 		688E8E192EA6BCB551D19759 /* dogAreaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = dogAreaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C8E7D8185E273FFD5B84579 /* ProfileFieldEditSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileFieldEditSheet.swift; path = dogArea/Views/ProfileSettingView/ProfileFieldEditSheet.swift; sourceTree = "<group>"; };
 		6E3FDEC98167CC2EA0DAFA5E /* HomeRecentConqueredSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeRecentConqueredSectionView.swift; sourceTree = "<group>"; };
 		6E7F38C996B1C42E27210E77 /* HomeSeasonResetTransitionBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSeasonResetTransitionBannerView.swift; path = HomeSeasonResetTransitionBannerView.swift; sourceTree = "<group>"; };
 		70172018FBBE6C94AB182660 /* RivalTabViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalTabViewModel.swift; path = dogArea/Views/ProfileSettingView/RivalTabViewModel.swift; sourceTree = "<group>"; };
 		722875CA7B7EAB511CCC1590 /* RivalModerationStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalModerationStore.swift; path = dogArea/Views/ProfileSettingView/RivalModerationStore.swift; sourceTree = "<group>"; };
+		745503CBDBC7737E36C35467 /* HomeWeatherShieldSummaryCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeWeatherShieldSummaryCardView.swift; sourceTree = "<group>"; };
 		7E44AFE17DBAADDCF10DB273 /* HomeQuestWidgetTab.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeQuestWidgetTab.swift; path = HomeQuestWidgetTab.swift; sourceTree = "<group>"; };
 		81CDB8AB4C8855FE6D106BF3 /* WalkDetailContextProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WalkDetailContextProvider.swift; path = dogArea/Views/MapView/WalkDetailContextProvider.swift; sourceTree = "<group>"; };
 		82C7B17BDEEF3C827C152659 /* TerritoryGoalInsightSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerritoryGoalInsightSectionView.swift; sourceTree = "<group>"; };
+		84B94FEE2D80935CA3AA5917 /* HomeQuestWidgetTabSelectorView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeQuestWidgetTabSelectorView.swift; sourceTree = "<group>"; };
 		86FFE492DDD22A6AC1319D9D /* HomeTerritoryHeaderSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeTerritoryHeaderSectionView.swift; sourceTree = "<group>"; };
 		8B7738E4A04B406F4D70AE19 /* HomeSelectedPetContextBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSelectedPetContextBannerView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeSelectedPetContextBannerView.swift; sourceTree = "<group>"; };
 		8BD638413305E314572CB8D9 /* HomeQuestCompletionOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeQuestCompletionOverlayView.swift; path = HomeQuestCompletionOverlayView.swift; sourceTree = "<group>"; };
@@ -320,6 +344,7 @@
 		9CEE482A71915D1493456DEC /* AreaDetailActionHintCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AreaDetailActionHintCardView.swift; sourceTree = "<group>"; };
 		9EEF5E5853DABE804BDEDE35 /* GuestDataUpgradeResultBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GuestDataUpgradeResultBanner.swift; sourceTree = "<group>"; };
 		9FFD83BC3079033CF24E9D6A /* PetProfileImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PetProfileImageView.swift; path = dogArea/Views/ProfileSettingView/PetProfileImageView.swift; sourceTree = "<group>"; };
+		A003918476944D94F7E3DC99 /* HomeWeatherMissionStatusCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeWeatherMissionStatusCardView.swift; sourceTree = "<group>"; };
 		A37500010000000000000011 /* HomeMissionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMissionModels.swift; sourceTree = "<group>"; };
 		A37500010000000000000012 /* IndoorMissionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndoorMissionStore.swift; sourceTree = "<group>"; };
 		A37500010000000000000013 /* SeasonMotionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonMotionStore.swift; sourceTree = "<group>"; };
@@ -345,11 +370,14 @@
 		B76E1FA7BD23351B788C716B /* AreaDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AreaDetailViewModel.swift; sourceTree = "<group>"; };
 		C566C61F8B5520FEC3406DFF /* HomeGoalTrackerCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeGoalTrackerCardView.swift; sourceTree = "<group>"; };
 		C63D5D25262A8E2185005C50 /* RecoveryActionBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecoveryActionBanner.swift; sourceTree = "<group>"; };
+		C671468D748C3AD8C0A7DB8A /* HomeSeasonMotionCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeSeasonMotionCardView.swift; sourceTree = "<group>"; };
+		CCD790E9DD29E9185CE6A851 /* HomeMissionDifficultySummaryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeMissionDifficultySummaryView.swift; sourceTree = "<group>"; };
 		CE5D5C2E004FD37BC9E65790 /* WalkWidgetSnapshotStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift; sourceTree = SOURCE_ROOT; };
 		CEBDE81DFC43DCD56546D775 /* HomeHeaderSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeHeaderSectionView.swift; sourceTree = "<group>"; };
 		D4340122AB9FE3F16F12570B /* AreaDetailSummaryCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AreaDetailSummaryCardView.swift; sourceTree = "<group>"; };
 		D457F4903D0BCF9B5C9B7EFC /* HomeAreaMilestoneBadgeOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeAreaMilestoneBadgeOverlayView.swift; path = HomeAreaMilestoneBadgeOverlayView.swift; sourceTree = "<group>"; };
 		D8458EB9DE9760D52537B4B6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		D8E5D37200B02E2F8E26B734 /* HomeWeeklyQuestSummaryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeWeeklyQuestSummaryView.swift; sourceTree = "<group>"; };
 		DA0FB2082AD7B21C00B235CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DA16C1D82B05DCC8008FC133 /* CornerShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerShape.swift; sourceTree = "<group>"; };
 		DA16C1DB2B05E4DF008FC133 /* TimeCheckable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeCheckable.swift; sourceTree = "<group>"; };
@@ -456,6 +484,8 @@
 		F2D5D8D51AC30DA6DB60A871 /* RivalViewStateResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RivalViewStateResolver.swift; path = dogArea/Views/ProfileSettingView/RivalViewStateResolver.swift; sourceTree = "<group>"; };
 		F54DF2E65C59A1E8B1F95D8A /* TerritoryGoalViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerritoryGoalViewModel.swift; sourceTree = "<group>"; };
 		F59FE8AF61BF3AE3B6C99D77 /* HomeWeeklySnapshotSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeWeeklySnapshotSectionView.swift; sourceTree = "<group>"; };
+		F61462EBA7433ED6BC68778D /* HomeGuestDataUpgradeCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeGuestDataUpgradeCardView.swift; sourceTree = "<group>"; };
+		F70B19034ADC4071F655ED9E /* HomeQuestAlternativeSuggestionCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeQuestAlternativeSuggestionCardView.swift; sourceTree = "<group>"; };
 		F73B707BA77AC2C69A6BC62B /* UserProfileImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserProfileImageView.swift; path = dogArea/Views/ProfileSettingView/UserProfileImageView.swift; sourceTree = "<group>"; };
 		FDA31AC1DF69B7CA85070D28 /* HomePetSelectorView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomePetSelectorView.swift; path = dogArea/Views/HomeView/HomeSubView/HomePetSelectorView.swift; sourceTree = "<group>"; };
 		FE5CB737B1C8D8A675B6A43B /* TerritoryGoalView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerritoryGoalView.swift; sourceTree = "<group>"; };
@@ -508,6 +538,29 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		20A02CEAEBD1733F530616EE /* Cards */ = {
+			isa = PBXGroup;
+			children = (
+				3B2B32A76C99094D54CD044D /* HomeAnimatedQuestProgressBarView.swift */,
+				26182C87E44E1C0D9629CD03 /* HomeAnimatedSeasonGaugeView.swift */,
+				F61462EBA7433ED6BC68778D /* HomeGuestDataUpgradeCardView.swift */,
+				66C12577FC501DA46E9411D5 /* HomeIndoorMissionRowView.swift */,
+				CCD790E9DD29E9185CE6A851 /* HomeMissionDifficultySummaryView.swift */,
+				F70B19034ADC4071F655ED9E /* HomeQuestAlternativeSuggestionCardView.swift */,
+				012C06744E292D894BC4661B /* HomeQuestReminderToggleRowView.swift */,
+				84B94FEE2D80935CA3AA5917 /* HomeQuestWidgetTabSelectorView.swift */,
+				4122ED3DF3668790F606D542 /* HomeScrollToTopFloatingButtonView.swift */,
+				1882845C4C15BF66EF58B401 /* HomeSeasonMetricPillView.swift */,
+				C671468D748C3AD8C0A7DB8A /* HomeSeasonMotionCardView.swift */,
+				1DBF6EC9508CA4C5CC954AF8 /* HomeSeasonShieldBadgeView.swift */,
+				A003918476944D94F7E3DC99 /* HomeWeatherMissionStatusCardView.swift */,
+				745503CBDBC7737E36C35467 /* HomeWeatherShieldSummaryCardView.swift */,
+				D8E5D37200B02E2F8E26B734 /* HomeWeeklyQuestSummaryView.swift */,
+			);
+			name = Cards;
+			path = Cards;
+			sourceTree = "<group>";
+		};
 		28124A9857F1E4CF96CF6415 /* dogAreaUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -949,6 +1002,7 @@
 				6E9414A4C2CD31522376808E /* Sections */,
 				B76E1FA7BD23351B788C716B /* AreaDetailViewModel.swift */,
 				BBEA26F77AB8339FAAB30583 /* Presentation */,
+				20A02CEAEBD1733F530616EE /* Cards */,
 			);
 			path = HomeSubView;
 			sourceTree = "<group>";
@@ -1520,6 +1574,21 @@
 				32212CE8E65DCE8A3F54F209 /* HomeSeasonDetailSheetView.swift in Sources */,
 				0ADA547D465997E8A4EFE806 /* HomeSeasonResetTransitionBannerView.swift in Sources */,
 				D706184062CE7DA65FC2FE16 /* HomeAreaMilestoneBadgeOverlayView.swift in Sources */,
+				A52752451CC8AC21215318DE /* HomeAnimatedQuestProgressBarView.swift in Sources */,
+				43441ACB76FB0EC0CA929CD8 /* HomeAnimatedSeasonGaugeView.swift in Sources */,
+				219A97F376AF1948198AF4DD /* HomeGuestDataUpgradeCardView.swift in Sources */,
+				1BCE551255C692E2B20F154E /* HomeIndoorMissionRowView.swift in Sources */,
+				5F1E96498F8FFB6EC57536E9 /* HomeMissionDifficultySummaryView.swift in Sources */,
+				1ED977BE7E5D9002AE1B92AD /* HomeQuestAlternativeSuggestionCardView.swift in Sources */,
+				C9FE9795EDE724EE7C96A8F0 /* HomeQuestReminderToggleRowView.swift in Sources */,
+				17BEA4EED401E70749B3A96B /* HomeQuestWidgetTabSelectorView.swift in Sources */,
+				AEC5862872E6BF3231D08C90 /* HomeScrollToTopFloatingButtonView.swift in Sources */,
+				BA480FDD8F1E663F6CF6F9BF /* HomeSeasonMetricPillView.swift in Sources */,
+				B40D68BD38F0288BF600B11C /* HomeSeasonMotionCardView.swift in Sources */,
+				B6ABF3F12D7A7F8761D68EB2 /* HomeSeasonShieldBadgeView.swift in Sources */,
+				337C89763F94598EAAF98C3A /* HomeWeatherMissionStatusCardView.swift in Sources */,
+				8801A48808105C4480F81F16 /* HomeWeatherShieldSummaryCardView.swift in Sources */,
+				21E7CDE1A8E20F90F24FB0C1 /* HomeWeeklyQuestSummaryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeAnimatedQuestProgressBarView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeAnimatedQuestProgressBarView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct HomeAnimatedQuestProgressBarView: View {
+    let progress: Double
+    let isCompleted: Bool
+    let showPulse: Bool
+    let isMotionReduced: Bool
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.appTextLightGray.opacity(0.28))
+                Capsule()
+                    .fill(isCompleted ? Color.appGreen : Color.appYellow)
+                    .frame(width: proxy.size.width * progress)
+                if showPulse && isMotionReduced == false {
+                    Capsule()
+                        .fill(Color.white.opacity(0.35))
+                        .frame(width: proxy.size.width * progress)
+                        .blur(radius: 2.5)
+                }
+            }
+        }
+        .frame(height: 8)
+        .animation(isMotionReduced ? nil : .easeOut(duration: 0.34), value: progress)
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeAnimatedSeasonGaugeView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeAnimatedSeasonGaugeView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct HomeAnimatedSeasonGaugeView: View {
+    let progress: Double
+    let isMotionReduced: Bool
+    let waveOffset: CGFloat
+
+    var body: some View {
+        let clampedProgress = min(1.0, max(0.0, progress))
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.appTextLightGray.opacity(0.24))
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            colors: [Color.appGreen.opacity(0.75), Color.appYellow.opacity(0.85)],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: proxy.size.width * clampedProgress)
+                    .overlay(alignment: .leading) {
+                        if isMotionReduced == false && clampedProgress > 0 {
+                            Rectangle()
+                                .fill(
+                                    LinearGradient(
+                                        colors: [
+                                            Color.white.opacity(0.0),
+                                            Color.white.opacity(0.34),
+                                            Color.white.opacity(0.0)
+                                        ],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    )
+                                )
+                                .frame(width: 120)
+                                .offset(x: waveOffset)
+                        }
+                    }
+                    .clipShape(Capsule())
+            }
+        }
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeGuestDataUpgradeCardView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeGuestDataUpgradeCardView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct HomeGuestDataUpgradeCardView: View {
+    let report: GuestDataUpgradeReport
+    let validationText: String?
+    let lastErrorMessage: String?
+    let isRetryInProgress: Bool
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(report.hasOutstandingWork ? "데이터 이관 재시도 필요" : "게스트 데이터 이관 완료")
+                .font(.appFont(for: .SemiBold, size: 13))
+            Text(
+                "세션 \(report.sessionCount)건 · 포인트 \(report.pointCount)건 · 면적 \(report.totalAreaM2.calculatedAreaString)"
+            )
+            .font(.appFont(for: .Light, size: 11))
+            .foregroundStyle(Color.appTextDarkGray)
+
+            if let lastErrorMessage, report.hasOutstandingWork {
+                Text("최근 오류: \(lastErrorMessage)")
+                    .font(.appFont(for: .Light, size: 11))
+                    .foregroundStyle(Color.appRed)
+            }
+            if let validationText {
+                Text(validationText)
+                    .font(.appFont(for: .Light, size: 11))
+                    .foregroundStyle(report.validationPassed == true ? Color.appGreen : Color.appRed)
+            }
+            if report.hasOutstandingWork {
+                Button(isRetryInProgress ? "재시도 중..." : "이관 재시도", action: onRetry)
+                    .accessibilityIdentifier("home.guestUpgrade.retry")
+                    .disabled(isRetryInProgress)
+                    .buttonStyle(AppFilledButtonStyle(role: .secondary, fillsWidth: false))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(Color.white)
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(report.hasOutstandingWork ? Color.appRed : Color.appGreen, lineWidth: 0.4)
+        )
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeIndoorMissionRowView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeIndoorMissionRowView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+struct HomeIndoorMissionRowView: View {
+    let mission: IndoorMissionCardModel
+    let animatedProgress: Double
+    let isQuestMotionReduced: Bool
+    let claimable: Bool
+    let claimed: Bool
+    let showClaimPulse: Bool
+    let showProgressPulse: Bool
+    let onRecordAction: () -> Void
+    let onFinalize: () -> Void
+    let onAppearSync: () -> Void
+    let onProgressSync: (Double) -> Void
+
+    private var folded: Bool {
+        isQuestMotionReduced ? false : (claimable || claimed)
+    }
+
+    private var claimTitle: String {
+        claimed ? "수령 완료" : (claimable ? "즉시 수령" : "완료 확인")
+    }
+
+    private var claimButtonColor: Color {
+        claimed ? Color.appGreen : (claimable ? Color.appYellow : Color.appTextLightGray)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack {
+                Text(mission.title)
+                    .font(.appFont(for: .SemiBold, size: 14))
+                if mission.isExtension {
+                    Text("연장 슬롯")
+                        .font(.appFont(for: .SemiBold, size: 10))
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 4)
+                        .background(Color.appYellowPale)
+                        .cornerRadius(6)
+                }
+                Spacer()
+                Text("보상 \(mission.rewardPoint)pt")
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .foregroundStyle(Color.appTextDarkGray)
+            }
+            if folded == false {
+                Text(mission.description)
+                    .font(.appFont(for: .Light, size: 12))
+                    .foregroundStyle(Color.appTextDarkGray)
+                if mission.isExtension {
+                    Text("전일 미션 연장 · 보상 70% · 시즌 점수/연속 보상 제외")
+                        .font(.appFont(for: .Light, size: 10))
+                        .foregroundStyle(Color.appTextDarkGray)
+                }
+            }
+            HomeAnimatedQuestProgressBarView(
+                progress: animatedProgress,
+                isCompleted: mission.progress.isCompleted,
+                showPulse: showProgressPulse,
+                isMotionReduced: isQuestMotionReduced
+            )
+            Text("행동량 \(mission.progress.actionCount)/\(mission.minimumActionCount)")
+                .font(.appFont(for: .Light, size: 11))
+                .foregroundStyle(Color.appTextDarkGray)
+            HStack(spacing: 8) {
+                Button("행동 +1", action: onRecordAction)
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(Color.appYellowPale)
+                    .cornerRadius(8)
+                    .disabled(claimed)
+
+                Button(claimTitle, action: onFinalize)
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(claimButtonColor)
+                    .cornerRadius(8)
+                    .scaleEffect(showClaimPulse ? 1.06 : 1.0)
+                    .animation(
+                        isQuestMotionReduced ? nil : .spring(response: 0.3, dampingFraction: 0.74),
+                        value: showClaimPulse
+                    )
+            }
+        }
+        .padding(10)
+        .background(Color.appYellowPale.opacity(0.45))
+        .cornerRadius(10)
+        .scaleEffect(folded ? 0.985 : 1.0)
+        .animation(isQuestMotionReduced ? nil : .easeInOut(duration: 0.22), value: folded)
+        .onAppear(perform: onAppearSync)
+        .onChange(of: mission.progress.progressRatio) { _, next in
+            onProgressSync(next)
+        }
+        .accessibilityIdentifier("home.quest.row.\(mission.id)")
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeMissionDifficultySummaryView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeMissionDifficultySummaryView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct HomeMissionDifficultySummaryView: View {
+    let summary: IndoorMissionDifficultySummary
+    let onActivateEasyDayMode: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("\(summary.petName) 기준 난이도: \(summary.adjustmentDescription)")
+                .font(.appFont(for: .SemiBold, size: 12))
+            Text("연령 \(summary.ageBand.title) · 활동 \(summary.activityLevel.title) · 빈도 \(summary.walkFrequency.title)")
+                .font(.appFont(for: .Light, size: 11))
+                .foregroundStyle(Color.appTextDarkGray)
+            ForEach(summary.reasons.prefix(2), id: \.self) { reason in
+                Text("• \(reason)")
+                    .font(.appFont(for: .Light, size: 10))
+                    .foregroundStyle(Color.appTextDarkGray)
+            }
+            Text(summary.easyDayMessage)
+                .font(.appFont(for: .Light, size: 10))
+                .foregroundStyle(Color.appTextDarkGray)
+
+            if summary.easyDayState == .available {
+                Button("쉬운 날 모드 사용 (보상 -20%)", action: onActivateEasyDayMode)
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.appYellow)
+                    .cornerRadius(8)
+            } else if summary.easyDayState == .active {
+                Text("오늘 쉬운 날 모드 적용됨")
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.appYellowPale)
+                    .cornerRadius(8)
+            }
+
+            if summary.history.isEmpty == false {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("최근 난이도 히스토리")
+                        .font(.appFont(for: .SemiBold, size: 11))
+                    ForEach(Array(summary.history.prefix(3))) { history in
+                        let deltaPercent = Int(((history.multiplier - 1.0) * 100).rounded())
+                        let multiplierText = deltaPercent == 0
+                            ? "기본"
+                            : (deltaPercent > 0 ? "+\(deltaPercent)%" : "\(deltaPercent)%")
+                        Text(
+                            "\(history.dayKey) · \(multiplierText)\(history.easyDayApplied ? " · 쉬운 날" : "")"
+                        )
+                        .font(.appFont(for: .Light, size: 10))
+                        .foregroundStyle(Color.appTextDarkGray)
+                    }
+                }
+                .padding(.top, 2)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(Color.appYellowPale.opacity(0.45))
+        .cornerRadius(8)
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestAlternativeSuggestionCardView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestAlternativeSuggestionCardView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct HomeQuestAlternativeSuggestionCardView: View {
+    let text: String
+
+    var body: some View {
+        HStack {
+            Text(text)
+                .font(.appFont(for: .Light, size: 11))
+                .foregroundStyle(Color.appTextDarkGray)
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(Color.appYellowPale.opacity(0.65))
+        .cornerRadius(8)
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestReminderToggleRowView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestReminderToggleRowView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct HomeQuestReminderToggleRowView: View {
+    @Binding var isEnabled: Bool
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("퀘스트 리마인드")
+                    .font(.appScaledFont(for: .SemiBold, size: 14, relativeTo: .subheadline))
+                Text("매일 20:00 · 하루 최대 1회")
+                    .font(.appScaledFont(for: .Regular, size: 11, relativeTo: .caption))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x94A3B8, dark: 0xCBD5E1))
+            }
+            Spacer()
+            Toggle("", isOn: $isEnabled)
+                .labelsHidden()
+                .tint(Color.appDynamicHex(light: 0xF59E0B, dark: 0xEAB308))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color.appDynamicHex(light: 0xF8FAFC, dark: 0x1E293B))
+        .cornerRadius(14)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155), lineWidth: 1)
+        )
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestWidgetTabSelectorView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestWidgetTabSelectorView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct HomeQuestWidgetTabSelectorView: View {
+    let selectedTab: HomeQuestWidgetTab
+    let onSelectTab: (HomeQuestWidgetTab) -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(HomeQuestWidgetTab.allCases) { tab in
+                Button(tab.title) {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        onSelectTab(tab)
+                    }
+                }
+                .font(.appFont(for: .SemiBold, size: 11))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(selectedTab == tab ? Color.appYellow : Color.appTextLightGray.opacity(0.35))
+                .cornerRadius(8)
+            }
+            Spacer()
+        }
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeScrollToTopFloatingButtonView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeScrollToTopFloatingButtonView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct HomeScrollToTopFloatingButtonView: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 14, weight: .semibold))
+                Text("맨 위로")
+                    .font(.appScaledFont(for: .SemiBold, size: 12, relativeTo: .caption))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.86)
+            }
+            .foregroundStyle(Color.appDynamicHex(light: 0x334155, dark: 0xE2E8F0))
+            .padding(.horizontal, 12)
+            .frame(minHeight: 44)
+            .background(Color.appDynamicHex(light: 0xFFFFFF, dark: 0x1E293B))
+            .clipShape(Capsule())
+            .shadow(color: Color.black.opacity(0.12), radius: 12, x: 0, y: 8)
+        }
+        .accessibilityLabel("홈 상단으로 이동")
+        .accessibilityHint("스크롤 위치를 맨 위로 이동합니다")
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeSeasonMetricPillView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeSeasonMetricPillView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct HomeSeasonMetricPillView: View {
+    let title: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.appFont(for: .Light, size: 10))
+                .foregroundStyle(Color.appTextDarkGray)
+            Text(value)
+                .font(.appFont(for: .SemiBold, size: 12))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 9)
+        .padding(.vertical, 7)
+        .background(color)
+        .cornerRadius(8)
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeSeasonMotionCardView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeSeasonMotionCardView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+struct HomeSeasonMotionCardView: View {
+    let summary: SeasonMotionSummary
+    let animatedProgress: Double
+    let isMotionReduced: Bool
+    let gaugeWaveOffset: CGFloat
+    let shieldRotation: Double
+    let remainingTimeText: String
+    let onOpenDetail: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 10) {
+                ZStack {
+                    Circle()
+                        .fill(Color.appDynamicHex(light: 0xF59E0B, dark: 0xEAB308))
+                        .frame(width: 30, height: 30)
+                    Image(systemName: "medal.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+                Text("시즌 게이지")
+                    .font(.appScaledFont(for: .SemiBold, size: 24, relativeTo: .title3))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
+                Spacer()
+                Text(summary.rankTier.title)
+                    .font(.appScaledFont(for: .SemiBold, size: 11, relativeTo: .caption))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155))
+                    .cornerRadius(9)
+            }
+
+            HStack(alignment: .firstTextBaseline) {
+                Text("시즌 점수 \(Int(summary.score.rounded())) / \(Int(summary.targetScore.rounded()))")
+                    .font(.appScaledFont(for: .SemiBold, size: 15, relativeTo: .subheadline))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x334155, dark: 0xCBD5E1))
+                Spacer()
+                Text("+\(summary.todayScoreDelta) today")
+                    .font(.appScaledFont(for: .SemiBold, size: 12, relativeTo: .caption))
+                    .foregroundStyle(Color.appDynamicHex(light: 0xF59E0B, dark: 0xFACC15))
+            }
+
+            HomeAnimatedSeasonGaugeView(
+                progress: animatedProgress,
+                isMotionReduced: isMotionReduced,
+                waveOffset: gaugeWaveOffset
+            )
+            .frame(height: 10)
+
+            HStack(alignment: .center) {
+                Text("목표까지 \(max(0, Int((summary.targetScore - summary.score).rounded())))점 남았어요")
+                    .font(.appScaledFont(for: .Regular, size: 12, relativeTo: .caption))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x64748B, dark: 0xCBD5E1))
+                Spacer()
+                HomeSeasonShieldBadgeView(active: summary.weatherShieldActive, rotation: shieldRotation)
+            }
+
+            HStack(spacing: 8) {
+                Image(systemName: "clock")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x94A3B8, dark: 0xCBD5E1))
+                Text("남은 시간 \(remainingTimeText)")
+                    .font(.appScaledFont(for: .Regular, size: 11, relativeTo: .caption))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x94A3B8, dark: 0xCBD5E1))
+                Spacer()
+                Button("상세보기 >", action: onOpenDetail)
+                    .font(.appScaledFont(for: .SemiBold, size: 12, relativeTo: .caption))
+                    .foregroundStyle(Color.appDynamicHex(light: 0x334155, dark: 0xE2E8F0))
+                    .accessibilityIdentifier("home.season.detail")
+                    .frame(minHeight: 44)
+            }
+
+            HStack(spacing: 8) {
+                HomeSeasonMetricPillView(
+                    title: "기여",
+                    value: "\(summary.contributionCount)회",
+                    color: Color.appDynamicHex(light: 0xEFF6FF, dark: 0x1E3A8A, alpha: 0.24)
+                )
+                HomeSeasonMetricPillView(
+                    title: "Shield",
+                    value: "\(summary.weatherShieldApplyCount)회",
+                    color: Color.appDynamicHex(light: 0xDCFCE7, dark: 0x14532D, alpha: 0.34)
+                )
+                HomeSeasonMetricPillView(
+                    title: "주차",
+                    value: summary.weekKey.isEmpty ? "-" : summary.weekKey,
+                    color: Color.appDynamicHex(light: 0xFEF3C7, dark: 0x78350F, alpha: 0.34)
+                )
+            }
+        }
+        .padding(16)
+        .background(Color.appDynamicHex(light: 0xFFFFFF, dark: 0x1E293B))
+        .cornerRadius(20)
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.04), radius: 8, x: 0, y: 3)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "시즌 점수 \(Int(summary.score.rounded()))점, 랭크 \(summary.rankTier.title), 보호 \(summary.weatherShieldApplyCount)회, 남은 시간 \(remainingTimeText)"
+        )
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeSeasonShieldBadgeView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeSeasonShieldBadgeView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct HomeSeasonShieldBadgeView: View {
+    let active: Bool
+    let rotation: Double
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.appTextLightGray.opacity(0.5), lineWidth: 1)
+                .frame(width: 28, height: 28)
+            if active {
+                Circle()
+                    .trim(from: 0.1, to: 0.9)
+                    .stroke(Color.appGreen, style: StrokeStyle(lineWidth: 1.8, lineCap: .round))
+                    .frame(width: 28, height: 28)
+                    .rotationEffect(.degrees(rotation))
+            }
+            Text("S")
+                .font(.appFont(for: .SemiBold, size: 11))
+        }
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeWeatherMissionStatusCardView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeWeatherMissionStatusCardView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct HomeWeatherMissionStatusCardView: View {
+    let summary: WeatherMissionStatusSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack {
+                Text(summary.title)
+                    .font(.appFont(for: .SemiBold, size: 15))
+                Spacer()
+                Text(summary.badgeText)
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(summary.isFallback ? Color.appTextLightGray.opacity(0.35) : Color.appYellowPale)
+                    .cornerRadius(8)
+            }
+            Text(summary.reasonText)
+                .font(.appFont(for: .Light, size: 12))
+                .foregroundStyle(Color.appTextDarkGray)
+            HStack(spacing: 8) {
+                Text(summary.appliedAtText)
+                    .font(.appFont(for: .Light, size: 11))
+                    .foregroundStyle(Color.appTextDarkGray)
+                Spacer()
+                Text(summary.shieldUsageText)
+                    .font(.appFont(for: .SemiBold, size: 11))
+                    .foregroundStyle(summary.riskLevel == .clear ? Color.appTextDarkGray : Color.appGreen)
+            }
+            if let fallbackNotice = summary.fallbackNotice {
+                Text(fallbackNotice)
+                    .font(.appFont(for: .Light, size: 10))
+                    .foregroundStyle(Color.appTextDarkGray)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(Color.appTextLightGray.opacity(0.2))
+                    .cornerRadius(8)
+            }
+        }
+        .padding(12)
+        .background(Color.white)
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.appTextLightGray, lineWidth: 0.5)
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(summary.accessibilityText)
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeWeatherShieldSummaryCardView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeWeatherShieldSummaryCardView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct HomeWeatherShieldSummaryCardView: View {
+    let summary: WeatherShieldDailySummary
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("오늘 스트릭 보호 요약")
+                    .font(.appFont(for: .SemiBold, size: 13))
+                Text("보호 적용 \(summary.applyCount)회 · 마지막 \(summary.lastAppliedAtText)")
+                    .font(.appFont(for: .Light, size: 11))
+                    .foregroundStyle(Color.appTextDarkGray)
+            }
+            Spacer()
+        }
+        .padding(11)
+        .background(Color.appGreen.opacity(0.22))
+        .cornerRadius(10)
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("오늘 스트릭 보호 요약. 적용 \(summary.applyCount)회, 마지막 \(summary.lastAppliedAtText)")
+    }
+}

--- a/dogArea/Views/HomeView/HomeSubView/Cards/HomeWeeklyQuestSummaryView.swift
+++ b/dogArea/Views/HomeView/HomeSubView/Cards/HomeWeeklyQuestSummaryView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct HomeWeeklyQuestSummaryView: View {
+    let summary: SeasonMotionSummary
+    let completedDailyCount: Int
+    let totalDailyCount: Int
+    let isSeasonMotionReduced: Bool
+    let seasonGaugeWaveOffset: CGFloat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("이번 주 점수 \(Int(summary.score.rounded())) / \(Int(summary.targetScore.rounded()))")
+                .font(.appFont(for: .SemiBold, size: 13))
+            HomeAnimatedSeasonGaugeView(
+                progress: summary.progress,
+                isMotionReduced: isSeasonMotionReduced,
+                waveOffset: seasonGaugeWaveOffset
+            )
+            .frame(height: 8)
+            HStack(spacing: 8) {
+                HomeSeasonMetricPillView(
+                    title: "주간 기여",
+                    value: "\(summary.contributionCount)회",
+                    color: Color.appYellowPale
+                )
+                HomeSeasonMetricPillView(
+                    title: "오늘 완료",
+                    value: "\(completedDailyCount)/\(totalDailyCount)",
+                    color: Color.appGreen.opacity(0.22)
+                )
+            }
+            Text("주간 점수는 미션 완료와 산책 기여로 누적됩니다.")
+                .font(.appFont(for: .Light, size: 11))
+                .foregroundStyle(Color.appTextDarkGray)
+        }
+    }
+}

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -284,30 +284,13 @@ struct HomeView: View {
     @ViewBuilder
     private func scrollToTopFloatingButton(proxy: ScrollViewProxy) -> some View {
         if shouldShowScrollToTopButton {
-            Button {
+            HomeScrollToTopFloatingButtonView {
                 withAnimation(.easeInOut(duration: 0.24)) {
                     proxy.scrollTo("home.scroll.top", anchor: .top)
                 }
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "arrow.up")
-                        .font(.system(size: 14, weight: .semibold))
-                    Text("맨 위로")
-                        .font(.appScaledFont(for: .SemiBold, size: 12, relativeTo: .caption))
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.86)
-                }
-                .foregroundStyle(Color.appDynamicHex(light: 0x334155, dark: 0xE2E8F0))
-                .padding(.horizontal, 12)
-                .frame(minHeight: 44)
-                .background(Color.appDynamicHex(light: 0xFFFFFF, dark: 0x1E293B))
-                .clipShape(Capsule())
-                .shadow(color: Color.black.opacity(0.12), radius: 12, x: 0, y: 8)
             }
             .padding(.trailing, 20)
             .appTabFloatingOverlayPadding(lift: 20)
-            .accessibilityLabel("홈 상단으로 이동")
-            .accessibilityHint("스크롤 위치를 맨 위로 이동합니다")
             .transition(.move(edge: .trailing).combined(with: .opacity))
         }
     }
@@ -318,42 +301,18 @@ struct HomeView: View {
             guard let passed = report.validationPassed else { return nil }
             return passed ? "원격 검증 통과" : "원격 검증 실패: \(report.validationMessage ?? "mismatch")"
         }()
-        VStack(alignment: .leading, spacing: 6) {
-            Text(report.hasOutstandingWork ? "데이터 이관 재시도 필요" : "게스트 데이터 이관 완료")
-                .font(.appFont(for: .SemiBold, size: 13))
-            Text(
-                "세션 \(report.sessionCount)건 · 포인트 \(report.pointCount)건 · 면적 \(report.totalAreaM2.calculatedAreaString)"
-            )
-            .font(.appFont(for: .Light, size: 11))
-            .foregroundStyle(Color.appTextDarkGray)
-            if report.hasOutstandingWork,
-               let rawError = report.lastErrorCode,
-               rawError.isEmpty == false {
-                Text("최근 오류: \(guestDataUpgradeErrorMessage(rawValue: rawError))")
-                    .font(.appFont(for: .Light, size: 11))
-                    .foregroundStyle(Color.appRed)
-            }
-            if let validationText {
-                Text(validationText)
-                    .font(.appFont(for: .Light, size: 11))
-                    .foregroundStyle(report.validationPassed == true ? Color.appGreen : Color.appRed)
-            }
-            if report.hasOutstandingWork {
-                Button(authFlow.guestDataUpgradeInProgress ? "재시도 중..." : "이관 재시도") {
-                    triggerGuestDataUpgradeRetry()
-                }
-                .accessibilityIdentifier("home.guestUpgrade.retry")
-                .disabled(authFlow.guestDataUpgradeInProgress)
-                .buttonStyle(AppFilledButtonStyle(role: .secondary, fillsWidth: false))
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(10)
-        .background(Color.white)
-        .cornerRadius(10)
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(report.hasOutstandingWork ? Color.appRed : Color.appGreen, lineWidth: 0.4)
+        let lastErrorMessage: String? = {
+            guard report.hasOutstandingWork,
+                  let rawError = report.lastErrorCode,
+                  rawError.isEmpty == false else { return nil }
+            return guestDataUpgradeErrorMessage(rawValue: rawError)
+        }()
+        HomeGuestDataUpgradeCardView(
+            report: report,
+            validationText: validationText,
+            lastErrorMessage: lastErrorMessage,
+            isRetryInProgress: authFlow.guestDataUpgradeInProgress,
+            onRetry: triggerGuestDataUpgradeRetry
         )
     }
 
@@ -465,71 +424,11 @@ struct HomeView: View {
     }
 
     private func weatherMissionStatusCard(summary: WeatherMissionStatusSummary) -> some View {
-        VStack(alignment: .leading, spacing: 7) {
-            HStack {
-                Text(summary.title)
-                    .font(.appFont(for: .SemiBold, size: 15))
-                Spacer()
-                Text(summary.badgeText)
-                    .font(.appFont(for: .SemiBold, size: 11))
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 5)
-                    .background(summary.isFallback ? Color.appTextLightGray.opacity(0.35) : Color.appYellowPale)
-                    .cornerRadius(8)
-            }
-            Text(summary.reasonText)
-                .font(.appFont(for: .Light, size: 12))
-                .foregroundStyle(Color.appTextDarkGray)
-            HStack(spacing: 8) {
-                Text(summary.appliedAtText)
-                    .font(.appFont(for: .Light, size: 11))
-                    .foregroundStyle(Color.appTextDarkGray)
-                Spacer()
-                Text(summary.shieldUsageText)
-                    .font(.appFont(for: .SemiBold, size: 11))
-                    .foregroundStyle(summary.riskLevel == .clear ? Color.appTextDarkGray : Color.appGreen)
-            }
-            if let fallbackNotice = summary.fallbackNotice {
-                Text(fallbackNotice)
-                    .font(.appFont(for: .Light, size: 10))
-                    .foregroundStyle(Color.appTextDarkGray)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 6)
-                    .background(Color.appTextLightGray.opacity(0.2))
-                    .cornerRadius(8)
-            }
-        }
-        .padding(12)
-        .background(Color.white)
-        .cornerRadius(10)
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color.appTextLightGray, lineWidth: 0.5)
-        )
-        .padding(.horizontal, 16)
-        .padding(.bottom, 8)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(summary.accessibilityText)
+        HomeWeatherMissionStatusCardView(summary: summary)
     }
 
     private func weatherShieldSummaryCard(summary: WeatherShieldDailySummary) -> some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 3) {
-                Text("오늘 스트릭 보호 요약")
-                    .font(.appFont(for: .SemiBold, size: 13))
-                Text("보호 적용 \(summary.applyCount)회 · 마지막 \(summary.lastAppliedAtText)")
-                    .font(.appFont(for: .Light, size: 11))
-                    .foregroundStyle(Color.appTextDarkGray)
-            }
-            Spacer()
-        }
-        .padding(11)
-        .background(Color.appGreen.opacity(0.22))
-        .cornerRadius(10)
-        .padding(.horizontal, 16)
-        .padding(.bottom, 8)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("오늘 스트릭 보호 요약. 적용 \(summary.applyCount)회, 마지막 \(summary.lastAppliedAtText)")
+        HomeWeatherShieldSummaryCardView(summary: summary)
     }
 
     private func indoorMissionCard(board: IndoorMissionBoard) -> some View {
@@ -636,51 +535,18 @@ struct HomeView: View {
 
     /// 퀘스트 위젯에서 일일/주간 뷰를 전환하는 탭 선택 행입니다.
     private var questWidgetTabSelector: some View {
-        HStack(spacing: 8) {
-            ForEach(HomeQuestWidgetTab.allCases) { tab in
-                Button(tab.title) {
-                    withAnimation(.easeInOut(duration: 0.18)) {
-                        questWidgetTab = tab
-                    }
-                }
-                .font(.appFont(for: .SemiBold, size: 11))
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(questWidgetTab == tab ? Color.appYellow : Color.appTextLightGray.opacity(0.35))
-                .cornerRadius(8)
-            }
-            Spacer()
+        HomeQuestWidgetTabSelectorView(selectedTab: questWidgetTab) { tab in
+            questWidgetTab = tab
         }
     }
 
     /// 하루 1회 퀘스트 리마인드 알림 설정 토글 행입니다.
     private var questReminderToggleRow: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("퀘스트 리마인드")
-                    .font(.appScaledFont(for: .SemiBold, size: 14, relativeTo: .subheadline))
-                Text("매일 20:00 · 하루 최대 1회")
-                    .font(.appScaledFont(for: .Regular, size: 11, relativeTo: .caption))
-                    .foregroundStyle(Color.appDynamicHex(light: 0x94A3B8, dark: 0xCBD5E1))
-            }
-            Spacer()
-            Toggle(
-                "",
-                isOn: Binding(
-                    get: { viewModel.questReminderEnabled },
-                    set: { viewModel.setQuestReminderEnabled($0) }
-                )
+        HomeQuestReminderToggleRowView(
+            isEnabled: Binding(
+                get: { viewModel.questReminderEnabled },
+                set: { viewModel.setQuestReminderEnabled($0) }
             )
-            .labelsHidden()
-            .tint(Color.appDynamicHex(light: 0xF59E0B, dark: 0xEAB308))
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .background(Color.appDynamicHex(light: 0xF8FAFC, dark: 0x1E293B))
-        .cornerRadius(14)
-        .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155), lineWidth: 1)
         )
     }
 
@@ -690,262 +556,49 @@ struct HomeView: View {
         let completedDaily = board.missions.filter { $0.progress.isCompleted }.count
         let totalDaily = board.missions.count
 
-        return VStack(alignment: .leading, spacing: 8) {
-            Text("이번 주 점수 \(Int(summary.score.rounded())) / \(Int(summary.targetScore.rounded()))")
-                .font(.appFont(for: .SemiBold, size: 13))
-            animatedSeasonGauge(progress: summary.progress)
-                .frame(height: 8)
-            HStack(spacing: 8) {
-                seasonMetricPill(
-                    title: "주간 기여",
-                    value: "\(summary.contributionCount)회",
-                    color: Color.appYellowPale
-                )
-                seasonMetricPill(
-                    title: "오늘 완료",
-                    value: "\(completedDaily)/\(totalDaily)",
-                    color: Color.appGreen.opacity(0.22)
-                )
-            }
-            Text("주간 점수는 미션 완료와 산책 기여로 누적됩니다.")
-                .font(.appFont(for: .Light, size: 11))
-                .foregroundStyle(Color.appTextDarkGray)
-        }
+        return HomeWeeklyQuestSummaryView(
+            summary: summary,
+            completedDailyCount: completedDaily,
+            totalDailyCount: totalDaily,
+            isSeasonMotionReduced: isSeasonMotionReduced,
+            seasonGaugeWaveOffset: seasonGaugeWaveOffset
+        )
     }
 
     /// 퀘스트 실패/만료 시 다음 행동을 안내하는 제안 카드입니다.
     private func questAlternativeSuggestionCard(_ text: String) -> some View {
-        HStack {
-            Text(text)
-                .font(.appFont(for: .Light, size: 11))
-                .foregroundStyle(Color.appTextDarkGray)
-            Spacer()
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 7)
-        .background(Color.appYellowPale.opacity(0.65))
-        .cornerRadius(8)
+        HomeQuestAlternativeSuggestionCardView(text: text)
     }
 
     private func missionDifficultySummary(_ summary: IndoorMissionDifficultySummary) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("\(summary.petName) 기준 난이도: \(summary.adjustmentDescription)")
-                .font(.appFont(for: .SemiBold, size: 12))
-            Text("연령 \(summary.ageBand.title) · 활동 \(summary.activityLevel.title) · 빈도 \(summary.walkFrequency.title)")
-                .font(.appFont(for: .Light, size: 11))
-                .foregroundStyle(Color.appTextDarkGray)
-            ForEach(summary.reasons.prefix(2), id: \.self) { reason in
-                Text("• \(reason)")
-                    .font(.appFont(for: .Light, size: 10))
-                    .foregroundStyle(Color.appTextDarkGray)
+        HomeMissionDifficultySummaryView(
+            summary: summary,
+            onActivateEasyDayMode: {
+                viewModel.activateEasyDayMode()
             }
-            Text(summary.easyDayMessage)
-                .font(.appFont(for: .Light, size: 10))
-                .foregroundStyle(Color.appTextDarkGray)
-
-            if summary.easyDayState == .available {
-                Button("쉬운 날 모드 사용 (보상 -20%)") {
-                    viewModel.activateEasyDayMode()
-                }
-                .font(.appFont(for: .SemiBold, size: 11))
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(Color.appYellow)
-                .cornerRadius(8)
-            } else if summary.easyDayState == .active {
-                Text("오늘 쉬운 날 모드 적용됨")
-                    .font(.appFont(for: .SemiBold, size: 11))
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(Color.appYellowPale)
-                    .cornerRadius(8)
-            }
-
-            if summary.history.isEmpty == false {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("최근 난이도 히스토리")
-                        .font(.appFont(for: .SemiBold, size: 11))
-                    ForEach(Array(summary.history.prefix(3))) { history in
-                        Text(
-                            "\(history.dayKey) · \(multiplierDescription(history.multiplier))\(history.easyDayApplied ? " · 쉬운 날" : "")"
-                        )
-                        .font(.appFont(for: .Light, size: 10))
-                        .foregroundStyle(Color.appTextDarkGray)
-                    }
-                }
-                .padding(.top, 2)
-            }
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 7)
-        .background(Color.appYellowPale.opacity(0.45))
-        .cornerRadius(8)
+        )
     }
 
     private func seasonMotionCard(summary: SeasonMotionSummary) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .center, spacing: 10) {
-                ZStack {
-                    Circle()
-                        .fill(Color.appDynamicHex(light: 0xF59E0B, dark: 0xEAB308))
-                        .frame(width: 30, height: 30)
-                    Image(systemName: "medal.fill")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(.white)
-                }
-                Text("시즌 게이지")
-                    .font(.appScaledFont(for: .SemiBold, size: 24, relativeTo: .title3))
-                    .foregroundStyle(Color.appDynamicHex(light: 0x0F172A, dark: 0xF8FAFC))
-                Spacer()
-                Text(summary.rankTier.title)
-                    .font(.appScaledFont(for: .SemiBold, size: 11, relativeTo: .caption))
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155))
-                    .cornerRadius(9)
+        HomeSeasonMotionCardView(
+            summary: summary,
+            animatedProgress: seasonAnimatedProgress,
+            isMotionReduced: isSeasonMotionReduced,
+            gaugeWaveOffset: seasonGaugeWaveOffset,
+            shieldRotation: seasonShieldRotation,
+            remainingTimeText: viewModel.seasonRemainingTimeText,
+            onOpenDetail: {
+                isSeasonDetailPresented = true
             }
-
-            HStack(alignment: .firstTextBaseline) {
-                Text("시즌 점수 \(Int(summary.score.rounded())) / \(Int(summary.targetScore.rounded()))")
-                    .font(.appScaledFont(for: .SemiBold, size: 15, relativeTo: .subheadline))
-                    .foregroundStyle(Color.appDynamicHex(light: 0x334155, dark: 0xCBD5E1))
-                Spacer()
-                Text("+\(summary.todayScoreDelta) today")
-                    .font(.appScaledFont(for: .SemiBold, size: 12, relativeTo: .caption))
-                    .foregroundStyle(Color.appDynamicHex(light: 0xF59E0B, dark: 0xFACC15))
-            }
-
-            animatedSeasonGauge(progress: seasonAnimatedProgress)
-                .frame(height: 10)
-
-            HStack(spacing: 8) {
-                Image(systemName: "clock")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Color.appDynamicHex(light: 0x94A3B8, dark: 0xCBD5E1))
-                Text("남은 시간 \(viewModel.seasonRemainingTimeText)")
-                    .font(.appScaledFont(for: .Regular, size: 11, relativeTo: .caption))
-                    .foregroundStyle(Color.appDynamicHex(light: 0x94A3B8, dark: 0xCBD5E1))
-                Spacer()
-                Button("상세보기 >") {
-                    isSeasonDetailPresented = true
-                }
-                .font(.appScaledFont(for: .SemiBold, size: 12, relativeTo: .caption))
-                .foregroundStyle(Color.appDynamicHex(light: 0x334155, dark: 0xE2E8F0))
-                .accessibilityIdentifier("home.season.detail")
-                .frame(minHeight: 44)
-            }
-
-            HStack(spacing: 8) {
-                seasonMetricPill(
-                    title: "기여",
-                    value: "\(summary.contributionCount)회",
-                    color: Color.appDynamicHex(light: 0xEFF6FF, dark: 0x1E3A8A, alpha: 0.24)
-                )
-                seasonMetricPill(
-                    title: "Shield",
-                    value: "\(summary.weatherShieldApplyCount)회",
-                    color: Color.appDynamicHex(light: 0xDCFCE7, dark: 0x14532D, alpha: 0.34)
-                )
-                seasonMetricPill(
-                    title: "주차",
-                    value: summary.weekKey.isEmpty ? "-" : summary.weekKey,
-                    color: Color.appDynamicHex(light: 0xFEF3C7, dark: 0x78350F, alpha: 0.34)
-                )
-            }
-        }
-        .padding(16)
-        .background(Color.appDynamicHex(light: 0xFFFFFF, dark: 0x1E293B))
-        .cornerRadius(20)
-        .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(Color.appDynamicHex(light: 0xE2E8F0, dark: 0x334155), lineWidth: 1)
         )
-        .shadow(color: Color.black.opacity(0.04), radius: 8, x: 0, y: 3)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(
-            "시즌 점수 \(Int(summary.score.rounded()))점, 랭크 \(summary.rankTier.title), 보호 \(summary.weatherShieldApplyCount)회, 남은 시간 \(viewModel.seasonRemainingTimeText)"
-        )
-    }
-
-    private func seasonMetricPill(title: String, value: String, color: Color) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(title)
-                .font(.appFont(for: .Light, size: 10))
-                .foregroundStyle(Color.appTextDarkGray)
-            Text(value)
-                .font(.appFont(for: .SemiBold, size: 12))
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 9)
-        .padding(.vertical, 7)
-        .background(color)
-        .cornerRadius(8)
     }
 
     private func animatedSeasonGauge(progress: Double) -> some View {
-        let clampedProgress = min(1.0, max(0.0, progress))
-        return GeometryReader { proxy in
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(Color.appTextLightGray.opacity(0.24))
-                Capsule()
-                    .fill(
-                        LinearGradient(
-                            colors: [Color.appGreen.opacity(0.75), Color.appYellow.opacity(0.85)],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: proxy.size.width * clampedProgress)
-                    .overlay(alignment: .leading) {
-                        if isSeasonMotionReduced == false && clampedProgress > 0 {
-                            Rectangle()
-                                .fill(
-                                    LinearGradient(
-                                        colors: [
-                                            Color.white.opacity(0.0),
-                                            Color.white.opacity(0.34),
-                                            Color.white.opacity(0.0)
-                                        ],
-                                        startPoint: .leading,
-                                        endPoint: .trailing
-                                    )
-                                )
-                                .frame(width: 120)
-                                .offset(x: seasonGaugeWaveOffset)
-                        }
-                    }
-                    .clipShape(Capsule())
-            }
-        }
-    }
-
-    private func seasonShieldBadge(active: Bool) -> some View {
-        ZStack {
-            Circle()
-                .stroke(Color.appTextLightGray.opacity(0.5), lineWidth: 1)
-                .frame(width: 28, height: 28)
-            if active {
-                Circle()
-                    .trim(from: 0.1, to: 0.9)
-                    .stroke(Color.appGreen, style: StrokeStyle(lineWidth: 1.8, lineCap: .round))
-                    .frame(width: 28, height: 28)
-                    .rotationEffect(.degrees(seasonShieldRotation))
-            }
-            Text("S")
-                .font(.appFont(for: .SemiBold, size: 11))
-        }
-    }
-
-    private func multiplierDescription(_ multiplier: Double) -> String {
-        let deltaPercent = Int(((multiplier - 1.0) * 100).rounded())
-        if deltaPercent == 0 {
-            return "기본"
-        }
-        if deltaPercent > 0 {
-            return "+\(deltaPercent)%"
-        }
-        return "\(deltaPercent)%"
+        HomeAnimatedSeasonGaugeView(
+            progress: progress,
+            isMotionReduced: isSeasonMotionReduced,
+            waveOffset: seasonGaugeWaveOffset
+        )
     }
 
     private func questProgressValue(for mission: IndoorMissionCardModel) -> Double {
@@ -1186,115 +839,42 @@ struct HomeView: View {
     @ViewBuilder
     private func animatedQuestProgressBar(mission: IndoorMissionCardModel) -> some View {
         let progress = min(1.0, max(0.0, questProgressValue(for: mission)))
-        GeometryReader { proxy in
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(Color.appTextLightGray.opacity(0.28))
-                Capsule()
-                    .fill(mission.progress.isCompleted ? Color.appGreen : Color.appYellow)
-                    .frame(width: proxy.size.width * progress)
-                if questProgressPulseMissionId == mission.id, isQuestMotionReduced == false {
-                    Capsule()
-                        .fill(Color.white.opacity(0.35))
-                        .frame(width: proxy.size.width * progress)
-                        .blur(radius: 2.5)
-                }
-            }
-        }
-        .frame(height: 8)
-        .animation(
-            isQuestMotionReduced ? nil : .easeOut(duration: 0.34),
-            value: progress
+        HomeAnimatedQuestProgressBarView(
+            progress: progress,
+            isCompleted: mission.progress.isCompleted,
+            showPulse: questProgressPulseMissionId == mission.id,
+            isMotionReduced: isQuestMotionReduced
         )
     }
 
     private func indoorMissionRow(mission: IndoorMissionCardModel) -> some View {
         let claimable = missionIsClaimable(mission)
         let claimed = mission.progress.isCompleted
-        let folded = isQuestMotionReduced ? false : (claimable || claimed)
-        let claimTitle = claimed ? "수령 완료" : (claimable ? "즉시 수령" : "완료 확인")
-        let claimButtonColor = claimed ? Color.appGreen : (claimable ? Color.appYellow : Color.appTextLightGray)
-
-        return VStack(alignment: .leading, spacing: 7) {
-            HStack {
-                Text(mission.title)
-                    .font(.appFont(for: .SemiBold, size: 14))
-                if mission.isExtension {
-                    Text("연장 슬롯")
-                        .font(.appFont(for: .SemiBold, size: 10))
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 4)
-                        .background(Color.appYellowPale)
-                        .cornerRadius(6)
+        return HomeIndoorMissionRowView(
+            mission: mission,
+            animatedProgress: questProgressValue(for: mission),
+            isQuestMotionReduced: isQuestMotionReduced,
+            claimable: claimable,
+            claimed: claimed,
+            showClaimPulse: questClaimPulseMissionId == mission.id,
+            showProgressPulse: questProgressPulseMissionId == mission.id,
+            onRecordAction: { viewModel.recordIndoorMissionAction(mission.id) },
+            onFinalize: { viewModel.finalizeIndoorMission(mission.id) },
+            onAppearSync: {
+                if animatedQuestProgress[mission.id] == nil {
+                    animatedQuestProgress[mission.id] = mission.progress.progressRatio
                 }
-                Spacer()
-                Text("보상 \(mission.rewardPoint)pt")
-                    .font(.appFont(for: .SemiBold, size: 11))
-                    .foregroundStyle(Color.appTextDarkGray)
-            }
-            if folded == false {
-                Text(mission.description)
-                    .font(.appFont(for: .Light, size: 12))
-                    .foregroundStyle(Color.appTextDarkGray)
-                if mission.isExtension {
-                    Text("전일 미션 연장 · 보상 70% · 시즌 점수/연속 보상 제외")
-                        .font(.appFont(for: .Light, size: 10))
-                        .foregroundStyle(Color.appTextDarkGray)
-                }
-            }
-            animatedQuestProgressBar(mission: mission)
-            Text("행동량 \(mission.progress.actionCount)/\(mission.minimumActionCount)")
-                .font(.appFont(for: .Light, size: 11))
-                .foregroundStyle(Color.appTextDarkGray)
-            HStack(spacing: 8) {
-                Button("행동 +1") {
-                    viewModel.recordIndoorMissionAction(mission.id)
-                }
-                .font(.appFont(for: .SemiBold, size: 11))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
-                .background(Color.appYellowPale)
-                .cornerRadius(8)
-                .disabled(claimed)
-
-                Button(claimTitle) {
-                    viewModel.finalizeIndoorMission(mission.id)
-                }
-                .font(.appFont(for: .SemiBold, size: 11))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
-                .background(claimButtonColor)
-                .cornerRadius(8)
-                .scaleEffect(questClaimPulseMissionId == mission.id ? 1.06 : 1.0)
-                .animation(
-                    isQuestMotionReduced ? nil : .spring(response: 0.3, dampingFraction: 0.74),
-                    value: questClaimPulseMissionId == mission.id
-                )
-            }
-        }
-        .padding(10)
-        .background(Color.appYellowPale.opacity(0.45))
-        .cornerRadius(10)
-        .scaleEffect(folded ? 0.985 : 1.0)
-        .animation(
-            isQuestMotionReduced ? nil : .easeInOut(duration: 0.22),
-            value: folded
-        )
-        .onAppear {
-            if animatedQuestProgress[mission.id] == nil {
-                animatedQuestProgress[mission.id] = mission.progress.progressRatio
-            }
-        }
-        .onChange(of: mission.progress.progressRatio) { _, next in
-            if isQuestMotionReduced {
-                animatedQuestProgress[mission.id] = next
-            } else {
-                withAnimation(.easeOut(duration: 0.34)) {
+            },
+            onProgressSync: { next in
+                if isQuestMotionReduced {
                     animatedQuestProgress[mission.id] = next
+                } else {
+                    withAnimation(.easeOut(duration: 0.34)) {
+                        animatedQuestProgress[mission.id] = next
+                    }
                 }
             }
-        }
-        .accessibilityIdentifier("home.quest.row.\(mission.id)")
+        )
     }
 }
 

--- a/scripts/home_card_row_rendering_split_unit_check.swift
+++ b/scripts/home_card_row_rendering_split_unit_check.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// 검증 실패 시 즉시 종료합니다.
+/// - Parameters:
+///   - condition: 통과 여부입니다.
+///   - message: 실패 시 출력할 설명입니다.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+/// 저장소 루트 기준 상대 경로 파일을 문자열로 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 경로입니다.
+/// - Returns: UTF-8 문자열로 디코딩된 파일 내용입니다.
+func load(_ relativePath: String) -> String {
+    let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let project = load("dogArea.xcodeproj/project.pbxproj")
+
+let expectedReferences: [(String, String)] = [
+    ("HomeScrollToTopFloatingButtonView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeScrollToTopFloatingButtonView.swift"),
+    ("HomeGuestDataUpgradeCardView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeGuestDataUpgradeCardView.swift"),
+    ("HomeWeatherMissionStatusCardView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeWeatherMissionStatusCardView.swift"),
+    ("HomeWeatherShieldSummaryCardView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeWeatherShieldSummaryCardView.swift"),
+    ("HomeQuestWidgetTabSelectorView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestWidgetTabSelectorView.swift"),
+    ("HomeQuestReminderToggleRowView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestReminderToggleRowView.swift"),
+    ("HomeWeeklyQuestSummaryView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeWeeklyQuestSummaryView.swift"),
+    ("HomeQuestAlternativeSuggestionCardView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestAlternativeSuggestionCardView.swift"),
+    ("HomeMissionDifficultySummaryView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeMissionDifficultySummaryView.swift"),
+    ("HomeSeasonMotionCardView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeSeasonMotionCardView.swift"),
+    ("HomeAnimatedSeasonGaugeView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeAnimatedSeasonGaugeView.swift"),
+    ("HomeAnimatedQuestProgressBarView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeAnimatedQuestProgressBarView.swift"),
+    ("HomeIndoorMissionRowView", "dogArea/Views/HomeView/HomeSubView/Cards/HomeIndoorMissionRowView.swift")
+]
+
+for (reference, path) in expectedReferences {
+    assertTrue(homeView.contains(reference), "HomeView should reference \(reference)")
+    let fileContents = load(path)
+    assertTrue(fileContents.contains("struct "), "\(path) should declare a view struct")
+    assertTrue(project.contains((path as NSString).lastPathComponent), "project should include \((path as NSString).lastPathComponent)")
+}
+
+let removedInlineSnippets = [
+    "private func seasonMetricPill(title: String, value: String, color: Color)",
+    "private func seasonShieldBadge(active: Bool)",
+    "private func multiplierDescription(_ multiplier: Double)"
+]
+
+for snippet in removedInlineSnippets {
+    assertTrue(homeView.contains(snippet) == false, "HomeView should not keep inline helper \(snippet)")
+}
+
+print("PASS: home card row rendering split unit checks")

--- a/scripts/home_guest_upgrade_retry_cta_unit_check.swift
+++ b/scripts/home_guest_upgrade_retry_cta_unit_check.swift
@@ -15,7 +15,17 @@ func load(_ relativePath: String) -> String {
     return String(decoding: data, as: UTF8.self)
 }
 
-let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+/// 여러 상대 경로 파일을 하나의 문자열로 이어 붙여 읽습니다.
+/// - Parameter relativePaths: 저장소 루트 기준 파일 경로 목록입니다.
+/// - Returns: 각 파일 내용을 줄바꿈으로 연결한 문자열입니다.
+func loadMany(_ relativePaths: [String]) -> String {
+    relativePaths.map(load).joined(separator: "\n")
+}
+
+let homeView = loadMany([
+    "dogArea/Views/HomeView/HomeView.swift",
+    "dogArea/Views/HomeView/HomeSubView/Cards/HomeGuestDataUpgradeCardView.swift"
+])
 
 assertTrue(
     homeView.contains(".accessibilityIdentifier(\"home.guestUpgrade.retry\")"),

--- a/scripts/home_presentation_split_unit_check.swift
+++ b/scripts/home_presentation_split_unit_check.swift
@@ -15,7 +15,17 @@ func load(_ relativePath: String) -> String {
     return String(decoding: data, as: UTF8.self)
 }
 
-let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+/// 여러 상대 경로 파일을 하나의 문자열로 결합해 읽습니다.
+/// - Parameter relativePaths: 저장소 루트 기준 파일 경로 목록입니다.
+/// - Returns: 각 파일 내용을 줄바꿈으로 합친 문자열입니다.
+func loadMany(_ relativePaths: [String]) -> String {
+    relativePaths.map(load).joined(separator: "\n")
+}
+
+let homeView = loadMany([
+    "dogArea/Views/HomeView/HomeView.swift",
+    "dogArea/Views/HomeView/HomeSubView/Cards/HomeQuestWidgetTabSelectorView.swift"
+])
 assertTrue(homeView.contains("HomeSeasonDetailSheetView("), "HomeView should present external season detail sheet view")
 assertTrue(homeView.contains("HomeQuestCompletionOverlayView("), "HomeView should present external quest completion overlay view")
 assertTrue(homeView.contains("HomeSeasonResultOverlayView("), "HomeView should present external season result overlay view")

--- a/scripts/indoor_weather_mission_unit_check.swift
+++ b/scripts/indoor_weather_mission_unit_check.swift
@@ -25,7 +25,10 @@ let homeVM = loadMany([
     "dogArea/Source/Domain/Home/Stores/IndoorMissionStore.swift",
     "dogArea/Source/Domain/Home/Stores/SeasonMotionStore.swift"
 ])
-let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let homeView = loadMany([
+    "dogArea/Views/HomeView/HomeView.swift",
+    "dogArea/Views/HomeView/HomeSubView/Cards/HomeIndoorMissionRowView.swift"
+])
 let metrics = loadMany([
     "dogArea/Source/UserdefaultSetting.swift",
     "dogArea/Source/AppSession/AppFeatureGate.swift",

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -93,6 +93,7 @@ swift scripts/map_home_viewmodel_boundary_unit_check.swift
 swift scripts/tabbar_safearea_regression_unit_check.swift
 swift scripts/root_view_supporting_type_split_unit_check.swift
 swift scripts/home_presentation_split_unit_check.swift
+swift scripts/home_card_row_rendering_split_unit_check.swift
 swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/walk_return_to_origin_suggestion_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift

--- a/scripts/pet_adaptive_quest_unit_check.swift
+++ b/scripts/pet_adaptive_quest_unit_check.swift
@@ -105,7 +105,10 @@ let homeVM = loadMany([
     "dogArea/Source/Domain/Home/Stores/IndoorMissionStore.swift",
     "dogArea/Source/Domain/Home/Stores/SeasonMotionStore.swift"
 ])
-let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let homeView = loadMany([
+    "dogArea/Views/HomeView/HomeView.swift",
+    "dogArea/Views/HomeView/HomeSubView/Cards/HomeMissionDifficultySummaryView.swift"
+])
 let metrics = loadMany([
     "dogArea/Source/UserdefaultSetting.swift",
     "dogArea/Source/AppSession/AppFeatureGate.swift",

--- a/scripts/quest_failure_buffer_unit_check.swift
+++ b/scripts/quest_failure_buffer_unit_check.swift
@@ -60,7 +60,10 @@ let homeVM = loadMany([
     "dogArea/Source/Domain/Home/Stores/IndoorMissionStore.swift",
     "dogArea/Source/Domain/Home/Stores/SeasonMotionStore.swift"
 ])
-let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let homeView = loadMany([
+    "dogArea/Views/HomeView/HomeView.swift",
+    "dogArea/Views/HomeView/HomeSubView/Cards/HomeIndoorMissionRowView.swift"
+])
 let metrics = loadMany([
     "dogArea/Source/UserdefaultSetting.swift",
     "dogArea/Source/AppSession/AppFeatureGate.swift",

--- a/scripts/quest_stage3_ux_reminder_unit_check.swift
+++ b/scripts/quest_stage3_ux_reminder_unit_check.swift
@@ -23,6 +23,7 @@ let homeView = load("dogArea/Views/HomeView/HomeView.swift")
 let homeViewModel = loadMany([
     "dogArea/Views/HomeView/HomeViewModel.swift",
     "dogArea/Source/Domain/Home/Models/HomeMissionModels.swift",
+    "dogArea/Source/Domain/Home/Services/HomeQuestReminderSupport.swift",
     "dogArea/Source/Domain/Home/Stores/IndoorMissionStore.swift",
     "dogArea/Source/Domain/Home/Stores/SeasonMotionStore.swift"
 ])

--- a/scripts/season_stage3_ui_unit_check.swift
+++ b/scripts/season_stage3_ui_unit_check.swift
@@ -19,7 +19,10 @@ func loadMany(_ relativePaths: [String]) -> String {
     relativePaths.map(load).joined(separator: "\n")
 }
 
-let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let homeView = loadMany([
+    "dogArea/Views/HomeView/HomeView.swift",
+    "dogArea/Views/HomeView/HomeSubView/Cards/HomeSeasonMotionCardView.swift"
+])
 let homeViewModel = loadMany([
     "dogArea/Views/HomeView/HomeViewModel.swift",
     "dogArea/Source/Domain/Home/Stores/SeasonMotionStore.swift"

--- a/scripts/sync_walk_404_policy_unit_check.swift
+++ b/scripts/sync_walk_404_policy_unit_check.swift
@@ -27,7 +27,10 @@ let syncStore = loadMany([
     "dogArea/Source/AppSession/AuthFlowCoordinator.swift"
 ])
 let mapVM = load("dogArea/Views/MapView/MapViewModel.swift")
-let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let homeView = loadMany([
+    "dogArea/Views/HomeView/HomeView.swift",
+    "dogArea/Views/HomeView/HomeSubView/Cards/HomeGuestDataUpgradeCardView.swift"
+])
 
 assertTrue(
     infra.contains("private enum SyncWalkFunctionRoute"),

--- a/scripts/weather_ux_stage3_unit_check.swift
+++ b/scripts/weather_ux_stage3_unit_check.swift
@@ -19,7 +19,11 @@ func loadMany(_ relativePaths: [String]) -> String {
     relativePaths.map(load).joined(separator: "\n")
 }
 
-let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let homeView = loadMany([
+    "dogArea/Views/HomeView/HomeView.swift",
+    "dogArea/Views/HomeView/HomeSubView/Cards/HomeWeatherMissionStatusCardView.swift",
+    "dogArea/Views/HomeView/HomeSubView/Cards/HomeWeatherShieldSummaryCardView.swift"
+])
 let homeViewModel = loadMany([
     "dogArea/Views/HomeView/HomeViewModel.swift",
     "dogArea/Source/Domain/Home/Models/HomeMissionModels.swift",


### PR DESCRIPTION
## Summary
- extract remaining HomeView card/row rendering blocks into dedicated `HomeSubView/Cards` files
- keep HomeView as a thinner composition layer while preserving existing state and data flow
- update regression/unit scripts to follow the new card split structure

## Testing
- `DOGAREA_DERIVED_DATA_PATH=.build/codex-399-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`
- `xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -derivedDataPath .build/codex-399-ui-tests -destination "platform=iOS Simulator,name=iPhone 16,OS=18.5" "-only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_TerritoryGoalNavigationHidesAndRestoresTabBar" "-only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_TerritoryGoalOpensSeparatedAreaDetailCatalog" test`

Closes #399