### PR TITLE
[Home/Refactor] HomeViewModel 상태·집계 책임 분리

### DIFF
--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		82C0FE1F9DF4A147D4C6A02C /* RecoveryActionBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63D5D25262A8E2185005C50 /* RecoveryActionBanner.swift */; };
 		8705C4CE77BEE3DAEF07A78B /* SimpleKeyValueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376D30D4A7542596A014DEE1 /* SimpleKeyValueView.swift */; };
 		8801A48808105C4480F81F16 /* HomeWeatherShieldSummaryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745503CBDBC7737E36C35467 /* HomeWeatherShieldSummaryCardView.swift */; };
+		882A85330E905DC115EDE641 /* HomePresentationStateModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C1D6AB713A59C8D7034CB8 /* HomePresentationStateModels.swift */; };
 		8A40430FD15CD439469AC981 /* RivalViewStateResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D5D8D51AC30DA6DB60A871 /* RivalViewStateResolver.swift */; };
 		8AB9332023AB8DBFF5657767 /* HomeHeaderSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBDE81DFC43DCD56546D775 /* HomeHeaderSectionView.swift */; };
 		8CD54D2F099991B9C308F493 /* MapViewModelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964083A1B8DE944291FAD56C /* MapViewModelStore.swift */; };
@@ -95,6 +96,8 @@
 		B40D68BD38F0288BF600B11C /* HomeSeasonMotionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C671468D748C3AD8C0A7DB8A /* HomeSeasonMotionCardView.swift */; };
 		B6ABF3F12D7A7F8761D68EB2 /* HomeSeasonShieldBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBF6EC9508CA4C5CC954AF8 /* HomeSeasonShieldBadgeView.swift */; };
 		BA480FDD8F1E663F6CF6F9BF /* HomeSeasonMetricPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1882845C4C15BF66EF58B401 /* HomeSeasonMetricPillView.swift */; };
+		BC8F0111242B7C35E0A8C032 /* HomeAreaAggregationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55F514F099289DA27BC2654 /* HomeAreaAggregationService.swift */; };
+		BFE9FFE6DBDDDBDF1B846C2E /* AreaReferenceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512B7050BD43731047F5D669 /* AreaReferenceModels.swift */; };
 		C047F1CA5DC13CAE4F03AE90 /* RivalHotspotSummaryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2B2A868B6FD9035AC5214F /* RivalHotspotSummaryBuilder.swift */; };
 		C93E65F4BA4229D430ED1AD9 /* AreaDetailSummaryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4340122AB9FE3F16F12570B /* AreaDetailSummaryCardView.swift */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		C9FE9795EDE724EE7C96A8F0 /* HomeQuestReminderToggleRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012C06744E292D894BC4661B /* HomeQuestReminderToggleRowView.swift */; };
@@ -142,7 +145,6 @@
 		DA822CDD2AFB60B6001EC94D /* MapSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA822CDC2AFB60B6001EC94D /* MapSettingView.swift */; };
 		DA8BB9E52B024B1900E350C4 /* MapCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8BB9E42B024B1900E350C4 /* MapCapture.swift */; };
 		DA8BB9E82B0255B700E350C4 /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8BB9E72B0255B700E350C4 /* SettingViewModel.swift */; };
-		DA8BB9EE2B02F0CD00E350C4 /* AreaMeters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8BB9ED2B02F0CD00E350C4 /* AreaMeters.swift */; };
 		DA8BB9F22B02FE3A00E350C4 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8BB9F12B02FE3A00E350C4 /* HomeViewModel.swift */; };
 		DA8BB9F52B032AB000E350C4 /* Calender.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8BB9F42B032AB000E350C4 /* Calender.swift */; };
 		DA933BE92ADD04E70029856C /* CustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA933BE82ADD04E70029856C /* CustomAlertView.swift */; };
@@ -317,9 +319,11 @@
 		44BB9B1737AC410B5104ECFD /* AreaDetailHeaderSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AreaDetailHeaderSectionView.swift; sourceTree = "<group>"; };
 		4A1B2C487816AA2CCCA6186F /* HomeStatusBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeStatusBannerView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeStatusBannerView.swift; sourceTree = "<group>"; };
 		4D14629580BEDCDCAE5B9EC3 /* HomeSelectedPetEmptyStateCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeSelectedPetEmptyStateCardView.swift; path = dogArea/Views/HomeView/HomeSubView/HomeSelectedPetEmptyStateCardView.swift; sourceTree = "<group>"; };
+		512B7050BD43731047F5D669 /* AreaReferenceModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AreaReferenceModels.swift; path = AreaReferenceModels.swift; sourceTree = "<group>"; };
 		626E89852AADA163B53AB03D /* dogAreaUITestsLaunchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = dogAreaUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		649E88696A0B4425210BB446 /* HomeGoalMetricColumnView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeGoalMetricColumnView.swift; sourceTree = "<group>"; };
 		66C12577FC501DA46E9411D5 /* HomeIndoorMissionRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeIndoorMissionRowView.swift; sourceTree = "<group>"; };
+		67C1D6AB713A59C8D7034CB8 /* HomePresentationStateModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomePresentationStateModels.swift; path = HomePresentationStateModels.swift; sourceTree = "<group>"; };
 		688E8E192EA6BCB551D19759 /* dogAreaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = dogAreaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C8E7D8185E273FFD5B84579 /* ProfileFieldEditSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileFieldEditSheet.swift; path = dogArea/Views/ProfileSettingView/ProfileFieldEditSheet.swift; sourceTree = "<group>"; };
 		6E3FDEC98167CC2EA0DAFA5E /* HomeRecentConqueredSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeRecentConqueredSectionView.swift; sourceTree = "<group>"; };
@@ -376,6 +380,7 @@
 		CEBDE81DFC43DCD56546D775 /* HomeHeaderSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeHeaderSectionView.swift; sourceTree = "<group>"; };
 		D4340122AB9FE3F16F12570B /* AreaDetailSummaryCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AreaDetailSummaryCardView.swift; sourceTree = "<group>"; };
 		D457F4903D0BCF9B5C9B7EFC /* HomeAreaMilestoneBadgeOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeAreaMilestoneBadgeOverlayView.swift; path = HomeAreaMilestoneBadgeOverlayView.swift; sourceTree = "<group>"; };
+		D55F514F099289DA27BC2654 /* HomeAreaAggregationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeAreaAggregationService.swift; path = HomeAreaAggregationService.swift; sourceTree = "<group>"; };
 		D8458EB9DE9760D52537B4B6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		D8E5D37200B02E2F8E26B734 /* HomeWeeklyQuestSummaryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeWeeklyQuestSummaryView.swift; sourceTree = "<group>"; };
 		DA0FB2082AD7B21C00B235CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -425,7 +430,6 @@
 		DA822CDC2AFB60B6001EC94D /* MapSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapSettingView.swift; sourceTree = "<group>"; };
 		DA8BB9E42B024B1900E350C4 /* MapCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCapture.swift; sourceTree = "<group>"; };
 		DA8BB9E72B0255B700E350C4 /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
-		DA8BB9ED2B02F0CD00E350C4 /* AreaMeters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaMeters.swift; sourceTree = "<group>"; };
 		DA8BB9F12B02FE3A00E350C4 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		DA8BB9F42B032AB000E350C4 /* Calender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calender.swift; sourceTree = "<group>"; };
 		DA933BE82ADD04E70029856C /* CustomAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertView.swift; sourceTree = "<group>"; };
@@ -538,6 +542,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0DF958EFACCA4449E70C97CD /* HomeViewModelSupport */ = {
+			isa = PBXGroup;
+			children = (
+				67C1D6AB713A59C8D7034CB8 /* HomePresentationStateModels.swift */,
+			);
+			name = HomeViewModelSupport;
+			path = HomeViewModelSupport;
+			sourceTree = "<group>";
+		};
 		20A02CEAEBD1733F530616EE /* Cards */ = {
 			isa = PBXGroup;
 			children = (
@@ -630,6 +643,7 @@
 			isa = PBXGroup;
 			children = (
 				A37500010000000000000011 /* HomeMissionModels.swift */,
+				512B7050BD43731047F5D669 /* AreaReferenceModels.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -759,9 +773,9 @@
 			children = (
 				DA8BB9FA2B03341000E350C4 /* HomeSubView */,
 				DA3F9B992AE0F14F0048550C /* HomeView.swift */,
-				DA8BB9ED2B02F0CD00E350C4 /* AreaMeters.swift */,
 				DA3EB0792B0344CD00AEA65D /* AreaDetailView.swift */,
 				DA8BB9F12B02FE3A00E350C4 /* HomeViewModel.swift */,
+				0DF958EFACCA4449E70C97CD /* HomeViewModelSupport */,
 			);
 			path = HomeView;
 			sourceTree = "<group>";
@@ -1114,6 +1128,7 @@
 				363FE1044470B273CAB987E0 /* HomeQuestReminderSupport.swift */,
 				DAE147A01420000000000001 /* HomeWeeklyStatisticsService.swift */,
 				DAE147A21420000000000001 /* HomeWeatherMissionStatusBuilder.swift */,
+				D55F514F099289DA27BC2654 /* HomeAreaAggregationService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1430,7 +1445,6 @@
 			files = (
 				DA8BB9E52B024B1900E350C4 /* MapCapture.swift in Sources */,
 				DA3F9BA62AE0F14F0048550C /* WalkListView.swift in Sources */,
-				DA8BB9EE2B02F0CD00E350C4 /* AreaMeters.swift in Sources */,
 				DA3F9BD52AE0FF9B0048550C /* CustomTabBar.swift in Sources */,
 				DAC19F1E2B0B331A002FE2E8 /* SigningViewModel.swift in Sources */,
 				DAC19F102B0AF661002FE2E8 /* TitleTextView.swift in Sources */,
@@ -1589,6 +1603,9 @@
 				337C89763F94598EAAF98C3A /* HomeWeatherMissionStatusCardView.swift in Sources */,
 				8801A48808105C4480F81F16 /* HomeWeatherShieldSummaryCardView.swift in Sources */,
 				21E7CDE1A8E20F90F24FB0C1 /* HomeWeeklyQuestSummaryView.swift in Sources */,
+				BFE9FFE6DBDDDBDF1B846C2E /* AreaReferenceModels.swift in Sources */,
+				BC8F0111242B7C35E0A8C032 /* HomeAreaAggregationService.swift in Sources */,
+				882A85330E905DC115EDE641 /* HomePresentationStateModels.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dogArea/Source/Domain/Home/Models/AreaReferenceModels.swift
+++ b/dogArea/Source/Domain/Home/Models/AreaReferenceModels.swift
@@ -1,11 +1,12 @@
 //
-//  AreaMeters.swift
+//  AreaReferenceModels.swift
 //  dogArea
 //
 //  Created by 김태훈 on 11/14/23.
 //
 
 import Foundation
+
 struct AreaMeter: Hashable, Identifiable {
     var id: UUID
     let areaName: String
@@ -16,7 +17,7 @@ struct AreaMeter: Hashable, Identifiable {
         self.area = area
     }
 }
-struct AreaMeterBinding: Hashable, TimeCheckable{
+struct AreaMeterBinding: Hashable, TimeCheckable {
     let areaName: String
     let area: Double
     var createdAt: Double

--- a/dogArea/Source/Domain/Home/Services/HomeAreaAggregationService.swift
+++ b/dogArea/Source/Domain/Home/Services/HomeAreaAggregationService.swift
@@ -1,0 +1,212 @@
+//
+//  HomeAreaAggregationService.swift
+//  dogArea
+//
+//  Created by Codex on 3/7/26.
+//
+
+import Foundation
+
+protocol HomeAreaAggregationServicing {
+    /// 선택 반려견/전체 보기 상태를 반영해 홈 화면에 노출할 산책 기록만 필터링합니다.
+    /// - Parameters:
+    ///   - polygons: 원본 산책 기록 목록입니다.
+    ///   - selectedPetId: 현재 선택된 반려견 식별자입니다. 선택되지 않았으면 `nil`입니다.
+    ///   - showsAllRecords: 전체 기록 강제 표시 상태입니다.
+    /// - Returns: 홈 화면 집계에 사용할 산책 기록 목록입니다.
+    func filteredPolygons(
+        from polygons: [Polygon],
+        selectedPetId: String?,
+        showsAllRecords: Bool
+    ) -> [Polygon]
+
+    /// 홈 화면 현재 영역 모델을 생성합니다.
+    /// - Parameters:
+    ///   - totalArea: 현재 누적 산책 영역(`m²`)입니다.
+    ///   - selectedPetNameWithYi: 조사 보정이 적용된 반려견 이름입니다.
+    /// - Returns: 홈 화면 현재 영역 카드에 표시할 `AreaMeter`입니다.
+    func makeCurrentArea(totalArea: Double, selectedPetNameWithYi: String) -> AreaMeter
+
+    /// 현재 영역 바로 아래의 비교군을 계산합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역 모델입니다.
+    ///   - areaCollection: 기준 비교군 컬렉션입니다.
+    /// - Returns: 현재 영역보다 작은 가장 가까운 비교군입니다. 없으면 `nil`입니다.
+    func previousReferenceArea(
+        currentArea: AreaMeter,
+        areaCollection: AreaMeterCollection
+    ) -> AreaMeter?
+
+    /// 현재 영역 바로 위의 다음 목표 비교군을 계산합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역 모델입니다.
+    ///   - areaCollection: 기본 비교군 컬렉션입니다.
+    ///   - featuredGoalAreas: 원격 featured 정책이 반영된 우선 목표 비교군입니다.
+    /// - Returns: featured 우선 정책이 반영된 다음 목표 비교군입니다. 없으면 `nil`입니다.
+    func nextReferenceArea(
+        currentArea: AreaMeter,
+        areaCollection: AreaMeterCollection,
+        featuredGoalAreas: [AreaMeter]
+    ) -> AreaMeter?
+
+    /// 현재 영역을 비교군 리스트 사이에 삽입한 결합 목록을 생성합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역 모델입니다.
+    ///   - areaCollection: 기준 비교군 컬렉션입니다.
+    /// - Returns: 현재 영역이 올바른 정렬 위치에 삽입된 비교군 목록입니다.
+    func combinedAreas(
+        currentArea: AreaMeter,
+        areaCollection: AreaMeterCollection
+    ) -> [AreaMeter]
+
+    /// 현재 영역 마일스톤을 로컬 저장소에 추가로 저장해야 하는지 판단합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역 모델입니다.
+    ///   - areaCollection: 기준 비교군 컬렉션입니다.
+    ///   - persistedAreas: 이미 저장된 최근 마일스톤 목록입니다.
+    /// - Returns: 새 마일스톤으로 저장할 가치가 있으면 `true`, 아니면 `false`입니다.
+    func shouldPersistCurrentMeter(
+        currentArea: AreaMeter,
+        areaCollection: AreaMeterCollection,
+        persistedAreas: [AreaMeterDTO]
+    ) -> Bool
+
+    /// 영역 마일스톤 감지에 사용할 비교군 후보를 계산합니다.
+    /// - Parameters:
+    ///   - featuredGoalAreas: 원격 featured 목표 목록입니다.
+    ///   - fallbackAreas: featured가 비어 있을 때 사용할 기본 비교군 목록입니다.
+    /// - Returns: 마일스톤 감지용 후보 목록입니다.
+    func milestoneCandidates(
+        featuredGoalAreas: [AreaMeter],
+        fallbackAreas: [AreaMeter]
+    ) -> [AreaMilestoneCandidate]
+}
+
+struct HomeAreaAggregationService: HomeAreaAggregationServicing {
+    /// 선택 반려견/전체 보기 상태를 반영해 홈 화면에 노출할 산책 기록만 필터링합니다.
+    /// - Parameters:
+    ///   - polygons: 원본 산책 기록 목록입니다.
+    ///   - selectedPetId: 현재 선택된 반려견 식별자입니다. 선택되지 않았으면 `nil`입니다.
+    ///   - showsAllRecords: 전체 기록 강제 표시 상태입니다.
+    /// - Returns: 홈 화면 집계에 사용할 산책 기록 목록입니다.
+    func filteredPolygons(
+        from polygons: [Polygon],
+        selectedPetId: String?,
+        showsAllRecords: Bool
+    ) -> [Polygon] {
+        if showsAllRecords {
+            return polygons
+        }
+        guard let selectedPetId, selectedPetId.isEmpty == false else {
+            return polygons
+        }
+
+        let taggedPolygons = polygons.filter { ($0.petId?.isEmpty == false) }
+        let selectedPetPolygons = polygons.filter { $0.petId == selectedPetId }
+
+        // Legacy records created before session->pet tagging should remain visible.
+        if selectedPetPolygons.isEmpty && taggedPolygons.isEmpty {
+            return polygons
+        }
+        return selectedPetPolygons
+    }
+
+    /// 홈 화면 현재 영역 모델을 생성합니다.
+    /// - Parameters:
+    ///   - totalArea: 현재 누적 산책 영역(`m²`)입니다.
+    ///   - selectedPetNameWithYi: 조사 보정이 적용된 반려견 이름입니다.
+    /// - Returns: 홈 화면 현재 영역 카드에 표시할 `AreaMeter`입니다.
+    func makeCurrentArea(totalArea: Double, selectedPetNameWithYi: String) -> AreaMeter {
+        AreaMeter("\(selectedPetNameWithYi)의 영역", totalArea)
+    }
+
+    /// 현재 영역 바로 아래의 비교군을 계산합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역 모델입니다.
+    ///   - areaCollection: 기준 비교군 컬렉션입니다.
+    /// - Returns: 현재 영역보다 작은 가장 가까운 비교군입니다. 없으면 `nil`입니다.
+    func previousReferenceArea(
+        currentArea: AreaMeter,
+        areaCollection: AreaMeterCollection
+    ) -> AreaMeter? {
+        areaCollection.nearistArea(of: currentArea.area)
+    }
+
+    /// 현재 영역 바로 위의 다음 목표 비교군을 계산합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역 모델입니다.
+    ///   - areaCollection: 기본 비교군 컬렉션입니다.
+    ///   - featuredGoalAreas: 원격 featured 정책이 반영된 우선 목표 비교군입니다.
+    /// - Returns: featured 우선 정책이 반영된 다음 목표 비교군입니다. 없으면 `nil`입니다.
+    func nextReferenceArea(
+        currentArea: AreaMeter,
+        areaCollection: AreaMeterCollection,
+        featuredGoalAreas: [AreaMeter]
+    ) -> AreaMeter? {
+        let featuredNext = featuredGoalAreas.first(where: { $0.area > currentArea.area })
+        let defaultNext = areaCollection.closeArea(of: currentArea.area)
+        if let featuredNext, let defaultNext {
+            return featuredNext.area <= defaultNext.area ? featuredNext : defaultNext
+        }
+        return featuredNext ?? defaultNext
+    }
+
+    /// 현재 영역을 비교군 리스트 사이에 삽입한 결합 목록을 생성합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역 모델입니다.
+    ///   - areaCollection: 기준 비교군 컬렉션입니다.
+    /// - Returns: 현재 영역이 올바른 정렬 위치에 삽입된 비교군 목록입니다.
+    func combinedAreas(
+        currentArea: AreaMeter,
+        areaCollection: AreaMeterCollection
+    ) -> [AreaMeter] {
+        let insertionIndex = areaCollection.areas.firstIndex(where: { $0.area > currentArea.area }) ?? areaCollection.areas.count
+        var areas = areaCollection.areas
+        areas.insert(currentArea, at: insertionIndex)
+        return areas
+    }
+
+    /// 현재 영역 마일스톤을 로컬 저장소에 추가로 저장해야 하는지 판단합니다.
+    /// - Parameters:
+    ///   - currentArea: 현재 누적 영역 모델입니다.
+    ///   - areaCollection: 기준 비교군 컬렉션입니다.
+    ///   - persistedAreas: 이미 저장된 최근 마일스톤 목록입니다.
+    /// - Returns: 새 마일스톤으로 저장할 가치가 있으면 `true`, 아니면 `false`입니다.
+    func shouldPersistCurrentMeter(
+        currentArea: AreaMeter,
+        areaCollection: AreaMeterCollection,
+        persistedAreas: [AreaMeterDTO]
+    ) -> Bool {
+        guard let previousReference = previousReferenceArea(currentArea: currentArea, areaCollection: areaCollection) else {
+            return false
+        }
+        guard let lastPersisted = persistedAreas.last else {
+            return true
+        }
+        if lastPersisted.area == previousReference.area && lastPersisted.areaName == previousReference.areaName {
+            return false
+        }
+        if lastPersisted.area > previousReference.area {
+            return false
+        }
+        return true
+    }
+
+    /// 영역 마일스톤 감지에 사용할 비교군 후보를 계산합니다.
+    /// - Parameters:
+    ///   - featuredGoalAreas: 원격 featured 목표 목록입니다.
+    ///   - fallbackAreas: featured가 비어 있을 때 사용할 기본 비교군 목록입니다.
+    /// - Returns: 마일스톤 감지용 후보 목록입니다.
+    func milestoneCandidates(
+        featuredGoalAreas: [AreaMeter],
+        fallbackAreas: [AreaMeter]
+    ) -> [AreaMilestoneCandidate] {
+        let sourceAreas = featuredGoalAreas.isEmpty ? Array(fallbackAreas.suffix(10)) : featuredGoalAreas
+        return sourceAreas.map { area in
+            AreaMilestoneCandidate(
+                landmarkName: area.areaName,
+                thresholdArea: area.area
+            )
+        }
+    }
+}

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -12,112 +12,6 @@ import Combine
 import UIKit
 #endif
 
-enum QuestMotionEventType: String, Equatable {
-    case progress
-    case completed
-    case failed
-    case alreadyCompleted
-}
-
-struct QuestMotionEvent: Identifiable, Equatable {
-    let id = UUID()
-    let missionId: String
-    let missionTitle: String
-    let type: QuestMotionEventType
-    let progress: Double
-}
-
-struct QuestCompletionPresentation: Identifiable, Equatable {
-    let id = UUID()
-    let missionId: String
-    let missionTitle: String
-    let rewardPoint: Int
-}
-
-enum SeasonMotionEventType: String, Equatable {
-    case scoreIncreased
-    case rankUp
-    case shieldApplied
-    case seasonReset
-}
-
-struct SeasonMotionEvent: Identifiable, Equatable {
-    let id = UUID()
-    let type: SeasonMotionEventType
-    let scoreDelta: Double
-    let rankTier: SeasonRankTier
-    let shieldApplied: Bool
-}
-
-struct SeasonMotionSummary: Equatable {
-    let weekKey: String
-    let score: Double
-    let targetScore: Double
-    let progress: Double
-    let rankTier: SeasonRankTier
-    let todayScoreDelta: Int
-    let contributionCount: Int
-    let weatherShieldActive: Bool
-    let weatherShieldApplyCount: Int
-
-    static let empty = SeasonMotionSummary(
-        weekKey: "",
-        score: 0,
-        targetScore: 520,
-        progress: 0,
-        rankTier: .rookie,
-        todayScoreDelta: 0,
-        contributionCount: 0,
-        weatherShieldActive: false,
-        weatherShieldApplyCount: 0
-    )
-}
-
-struct SeasonResultPresentation: Identifiable, Equatable {
-    let id = UUID()
-    let weekKey: String
-    let rankTier: SeasonRankTier
-    let totalScore: Int
-    let contributionCount: Int
-    let shieldApplyCount: Int
-}
-
-enum SeasonRewardClaimStatus: String, Codable, Equatable {
-    case pending
-    case claimed
-    case failed
-}
-
-struct WeatherMissionStatusSummary: Equatable {
-    let badgeText: String
-    let title: String
-    let reasonText: String
-    let appliedAtText: String
-    let shieldUsageText: String
-    let fallbackNotice: String?
-    let accessibilityText: String
-    let isFallback: Bool
-    let riskLevel: IndoorWeatherRiskLevel
-
-    static let empty = WeatherMissionStatusSummary(
-        badgeText: "정상",
-        title: "오늘 날씨 연동 상태",
-        reasonText: "기본 퀘스트 진행",
-        appliedAtText: "적용 시점 -",
-        shieldUsageText: "보호 사용 0회",
-        fallbackNotice: nil,
-        accessibilityText: "오늘 날씨 연동 상태. 기본 퀘스트 진행.",
-        isFallback: false,
-        riskLevel: .clear
-    )
-}
-
-struct WeatherShieldDailySummary: Equatable {
-    let dayKey: String
-    let applyCount: Int
-    let lastAppliedAtText: String
-}
-
 final class HomeViewModel: ObservableObject {
     @Published var polygonList: [Polygon] = []
     @Published var totalArea: Double = 0.0
@@ -170,6 +64,7 @@ final class HomeViewModel: ObservableObject {
     private let userSessionStore: UserSessionStoreProtocol
     private let eventCenter: AppEventCenterProtocol
     private let weeklyStatisticsService: HomeWeeklyStatisticsServicing
+    private let areaAggregationService: HomeAreaAggregationServicing
     private let weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding
     private let areaMilestoneDetector: AreaMilestoneDetecting
     private let areaMilestoneNotificationScheduler: AreaMilestoneNotificationScheduling
@@ -211,7 +106,11 @@ final class HomeViewModel: ObservableObject {
     }
 
     var nextGoalArea: AreaMeter? {
-        nearlistMore()
+        areaAggregationService.nextReferenceArea(
+            currentArea: myArea,
+            areaCollection: krAreas,
+            featuredGoalAreas: featuredGoalAreas
+        )
     }
 
     var weatherFeedbackWeeklyLimit: Int {
@@ -243,6 +142,7 @@ final class HomeViewModel: ObservableObject {
         userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
         eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared,
         weeklyStatisticsService: HomeWeeklyStatisticsServicing = HomeWeeklyStatisticsService(),
+        areaAggregationService: HomeAreaAggregationServicing = HomeAreaAggregationService(),
         weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding = HomeWeatherMissionStatusBuilder(),
         areaMilestoneDetector: AreaMilestoneDetecting = AreaMilestoneDetector(),
         areaMilestoneNotificationScheduler: AreaMilestoneNotificationScheduling = LocalAreaMilestoneNotificationScheduler()
@@ -252,6 +152,7 @@ final class HomeViewModel: ObservableObject {
         self.userSessionStore = userSessionStore
         self.eventCenter = eventCenter
         self.weeklyStatisticsService = weeklyStatisticsService
+        self.areaAggregationService = areaAggregationService
         self.weatherMissionStatusBuilder = weatherMissionStatusBuilder
         self.areaMilestoneDetector = areaMilestoneDetector
         self.areaMilestoneNotificationScheduler = areaMilestoneNotificationScheduler
@@ -549,34 +450,23 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func applySelectedPetStatistics(shouldUpdateMeter: Bool = false) {
-        polygonList = filteredPolygons(from: allPolygons)
+        polygonList = areaAggregationService.filteredPolygons(
+            from: allPolygons,
+            selectedPetId: selectedPet?.petId,
+            showsAllRecords: isShowingAllRecordsOverride
+        )
         totalArea = polygonList.map(\.walkingArea).reduce(0.0, +)
         totalTime = polygonList.map(\.walkingTime).reduce(0.0, +)
-        myArea = .init("\(selectedPetNameWithYi)의 영역", totalArea)
+        myArea = areaAggregationService.makeCurrentArea(
+            totalArea: totalArea,
+            selectedPetNameWithYi: selectedPetNameWithYi
+        )
         boundarySplitContribution = makeDayBoundarySplitContribution(reference: Date())
         refreshIndoorMissions()
         evaluateAreaMilestones()
         if shouldUpdateMeter {
             updateCurrentMeter()
         }
-    }
-
-    private func filteredPolygons(from polygons: [Polygon]) -> [Polygon] {
-        if isShowingAllRecordsOverride {
-            return polygons
-        }
-        guard let selectedPetId = selectedPet?.petId, selectedPetId.isEmpty == false else {
-            return polygons
-        }
-
-        let taggedPolygons = polygons.filter { ($0.petId?.isEmpty == false) }
-        let selectedPetPolygons = polygons.filter { $0.petId == selectedPetId }
-
-        // Legacy records created before session->pet tagging should remain visible.
-        if selectedPetPolygons.isEmpty && taggedPolygons.isEmpty {
-            return polygons
-        }
-        return selectedPetPolygons
     }
 
     func refreshGuestDataUpgradeReport() {
@@ -591,43 +481,34 @@ final class HomeViewModel: ObservableObject {
         myAreaList = walkRepository.fetchAreas()
     }
 
-    private func findIndex() -> Int {
-        guard let i = krAreas.areas.firstIndex(where: {
-            $0.area > myArea.area
-        }) else { return krAreas.areas.count }
-        return i
-    }
-
     func combinedAreas() -> [AreaMeter] {
-        let i = findIndex()
-        var temp = krAreas.areas
-        temp.insert(myArea, at: i)
-        return temp
+        areaAggregationService.combinedAreas(
+            currentArea: myArea,
+            areaCollection: krAreas
+        )
     }
 
     func nearlistLess() -> AreaMeter? {
-        krAreas.nearistArea(of: myArea.area)
+        areaAggregationService.previousReferenceArea(
+            currentArea: myArea,
+            areaCollection: krAreas
+        )
     }
 
     func nearlistMore() -> AreaMeter? {
-        let featuredNext = featuredGoalAreas.first(where: { $0.area > myArea.area })
-        let defaultNext = krAreas.closeArea(of: myArea.area)
-        if let featuredNext, let defaultNext {
-            return featuredNext.area <= defaultNext.area ? featuredNext : defaultNext
-        }
-        return featuredNext ?? defaultNext
+        areaAggregationService.nextReferenceArea(
+            currentArea: myArea,
+            areaCollection: krAreas,
+            featuredGoalAreas: featuredGoalAreas
+        )
     }
 
     private func shouldUpdateMeter() -> Bool {
-        guard let last = walkRepository.fetchAreas().last else { return true }
-        guard let current = nearlistLess() else { return false }
-        if (last.area == current.area && last.areaName == current.areaName) {
-            return false
-        } else if last.area > current.area {
-            return false
-        } else {
-            return true
-        }
+        areaAggregationService.shouldPersistCurrentMeter(
+            currentArea: myArea,
+            areaCollection: krAreas,
+            persistedAreas: walkRepository.fetchAreas()
+        )
     }
 
     private func updateCurrentMeter() {
@@ -673,18 +554,10 @@ final class HomeViewModel: ObservableObject {
     /// 마일스톤 감지에 사용할 비교군 후보를 계산합니다.
     /// - Returns: featured 우선 정책이 적용된 마일스톤 후보 목록입니다.
     private func milestoneCandidates() -> [AreaMilestoneCandidate] {
-        let sourceAreas: [AreaMeter]
-        if featuredGoalAreas.isEmpty {
-            sourceAreas = Array(krAreas.areas.suffix(10))
-        } else {
-            sourceAreas = featuredGoalAreas
-        }
-        return sourceAreas.map { area in
-            AreaMilestoneCandidate(
-                landmarkName: area.areaName,
-                thresholdArea: area.area
-            )
-        }
+        areaAggregationService.milestoneCandidates(
+            featuredGoalAreas: featuredGoalAreas,
+            fallbackAreas: krAreas.areas
+        )
     }
 
     /// 새 마일스톤 이벤트를 큐에 누적하고 즉시 표시 가능한 경우 팝업을 노출합니다.

--- a/dogArea/Views/HomeView/HomeViewModelSupport/HomePresentationStateModels.swift
+++ b/dogArea/Views/HomeView/HomeViewModelSupport/HomePresentationStateModels.swift
@@ -1,0 +1,114 @@
+//
+//  HomePresentationStateModels.swift
+//  dogArea
+//
+//  Created by Codex on 3/7/26.
+//
+
+import Foundation
+
+enum QuestMotionEventType: String, Equatable {
+    case progress
+    case completed
+    case failed
+    case alreadyCompleted
+}
+
+struct QuestMotionEvent: Identifiable, Equatable {
+    let id = UUID()
+    let missionId: String
+    let missionTitle: String
+    let type: QuestMotionEventType
+    let progress: Double
+}
+
+struct QuestCompletionPresentation: Identifiable, Equatable {
+    let id = UUID()
+    let missionId: String
+    let missionTitle: String
+    let rewardPoint: Int
+}
+
+enum SeasonMotionEventType: String, Equatable {
+    case scoreIncreased
+    case rankUp
+    case shieldApplied
+    case seasonReset
+}
+
+struct SeasonMotionEvent: Identifiable, Equatable {
+    let id = UUID()
+    let type: SeasonMotionEventType
+    let scoreDelta: Double
+    let rankTier: SeasonRankTier
+    let shieldApplied: Bool
+}
+
+struct SeasonMotionSummary: Equatable {
+    let weekKey: String
+    let score: Double
+    let targetScore: Double
+    let progress: Double
+    let rankTier: SeasonRankTier
+    let todayScoreDelta: Int
+    let contributionCount: Int
+    let weatherShieldActive: Bool
+    let weatherShieldApplyCount: Int
+
+    static let empty = SeasonMotionSummary(
+        weekKey: "",
+        score: 0,
+        targetScore: 520,
+        progress: 0,
+        rankTier: .rookie,
+        todayScoreDelta: 0,
+        contributionCount: 0,
+        weatherShieldActive: false,
+        weatherShieldApplyCount: 0
+    )
+}
+
+struct SeasonResultPresentation: Identifiable, Equatable {
+    let id = UUID()
+    let weekKey: String
+    let rankTier: SeasonRankTier
+    let totalScore: Int
+    let contributionCount: Int
+    let shieldApplyCount: Int
+}
+
+enum SeasonRewardClaimStatus: String, Codable, Equatable {
+    case pending
+    case claimed
+    case failed
+}
+
+struct WeatherMissionStatusSummary: Equatable {
+    let badgeText: String
+    let title: String
+    let reasonText: String
+    let appliedAtText: String
+    let shieldUsageText: String
+    let fallbackNotice: String?
+    let accessibilityText: String
+    let isFallback: Bool
+    let riskLevel: IndoorWeatherRiskLevel
+
+    static let empty = WeatherMissionStatusSummary(
+        badgeText: "정상",
+        title: "오늘 날씨 연동 상태",
+        reasonText: "기본 퀘스트 진행",
+        appliedAtText: "적용 시점 -",
+        shieldUsageText: "보호 사용 0회",
+        fallbackNotice: nil,
+        accessibilityText: "오늘 날씨 연동 상태. 기본 퀘스트 진행.",
+        isFallback: false,
+        riskLevel: .clear
+    )
+}
+
+struct WeatherShieldDailySummary: Equatable {
+    let dayKey: String
+    let applyCount: Int
+    let lastAppliedAtText: String
+}

--- a/scripts/area_reference_db_ui_unit_check.swift
+++ b/scripts/area_reference_db_ui_unit_check.swift
@@ -19,7 +19,7 @@ func loadMany(_ relativePaths: [String]) -> String {
     relativePaths.map(load).joined(separator: "\n")
 }
 
-let areaMeters = load("dogArea/Views/HomeView/AreaMeters.swift")
+let areaMeters = load("dogArea/Source/Domain/Home/Models/AreaReferenceModels.swift")
 let supabaseInfra = load("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
 let homeVM = loadMany([
     "dogArea/Views/HomeView/HomeViewModel.swift",

--- a/scripts/home_viewmodel_state_aggregation_split_unit_check.swift
+++ b/scripts/home_viewmodel_state_aggregation_split_unit_check.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let homeViewModel = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let presentationModels = load("dogArea/Views/HomeView/HomeViewModelSupport/HomePresentationStateModels.swift")
+let areaModels = load("dogArea/Source/Domain/Home/Models/AreaReferenceModels.swift")
+let aggregationService = load("dogArea/Source/Domain/Home/Services/HomeAreaAggregationService.swift")
+
+assertTrue(!homeViewModel.contains("enum QuestMotionEventType"), "HomeViewModel should no longer inline quest motion presentation types")
+assertTrue(!homeViewModel.contains("struct WeatherMissionStatusSummary"), "HomeViewModel should no longer inline weather presentation summary types")
+assertTrue(homeViewModel.contains("private let areaAggregationService: HomeAreaAggregationServicing"), "HomeViewModel should inject area aggregation service")
+assertTrue(homeViewModel.contains("areaAggregationService.filteredPolygons"), "HomeViewModel should delegate polygon filtering to area aggregation service")
+assertTrue(homeViewModel.contains("areaAggregationService.combinedAreas"), "HomeViewModel should delegate combined area assembly")
+assertTrue(homeViewModel.contains("areaAggregationService.shouldPersistCurrentMeter"), "HomeViewModel should delegate meter persistence decision")
+
+assertTrue(presentationModels.contains("enum QuestMotionEventType"), "presentation support file should define quest motion event type")
+assertTrue(presentationModels.contains("struct SeasonMotionSummary"), "presentation support file should define season motion summary")
+assertTrue(presentationModels.contains("struct WeatherMissionStatusSummary"), "presentation support file should define weather mission summary")
+
+assertTrue(areaModels.contains("struct AreaMeter"), "domain area models file should define AreaMeter")
+assertTrue(areaModels.contains("protocol AreaReferenceRepository"), "domain area models file should define repository contract")
+assertTrue(!FileManager.default.fileExists(atPath: root.appendingPathComponent("dogArea/Views/HomeView/AreaMeters.swift").path), "legacy AreaMeters view file should be removed")
+
+assertTrue(aggregationService.contains("protocol HomeAreaAggregationServicing"), "aggregation service should expose protocol contract")
+assertTrue(aggregationService.contains("struct HomeAreaAggregationService"), "aggregation service should define default implementation")
+assertTrue(aggregationService.contains("func milestoneCandidates"), "aggregation service should own milestone candidate calculation")
+
+print("PASS: home viewmodel state aggregation split unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -94,6 +94,7 @@ swift scripts/tabbar_safearea_regression_unit_check.swift
 swift scripts/root_view_supporting_type_split_unit_check.swift
 swift scripts/home_presentation_split_unit_check.swift
 swift scripts/home_card_row_rendering_split_unit_check.swift
+swift scripts/home_viewmodel_state_aggregation_split_unit_check.swift
 swift scripts/map_camera_jump_fix_unit_check.swift
 swift scripts/walk_return_to_origin_suggestion_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift

--- a/scripts/swift_stability_unit_check.swift
+++ b/scripts/swift_stability_unit_check.swift
@@ -36,12 +36,14 @@ let titleTextView = load("dogArea/Views/GlobalViews/TitleTextView.swift")
 let homeView = load("dogArea/Views/HomeView/HomeView.swift")
 let homeViewModel = loadMany([
     "dogArea/Views/HomeView/HomeViewModel.swift",
+    "dogArea/Views/HomeView/HomeViewModelSupport/HomePresentationStateModels.swift",
+    "dogArea/Source/Domain/Home/Services/HomeAreaAggregationService.swift",
     "dogArea/Source/Domain/Home/Models/HomeMissionModels.swift",
     "dogArea/Source/Domain/Home/Stores/IndoorMissionStore.swift",
     "dogArea/Source/Domain/Home/Stores/SeasonMotionStore.swift"
 ])
 let walkListDetailView = load("dogArea/Views/WalkListView/WalkListDetailView.swift")
-let areaMeters = load("dogArea/Views/HomeView/AreaMeters.swift")
+let areaMeters = load("dogArea/Source/Domain/Home/Models/AreaReferenceModels.swift")
 let mapCapture = load("dogArea/Views/MapView/MapSubViews/MapCapture.swift")
 let viewUtility = load("dogArea/Source/ViewUtility.swift")
 let timeCheckable = load("dogArea/Source/TimeCheckable.swift")


### PR DESCRIPTION
## Summary
- move home presentation state types out of `HomeViewModel` into a dedicated support file
- extract area aggregation and reference lookup logic behind `HomeAreaAggregationServicing`
- relocate area reference models from `Views` into `Source/Domain/Home/Models` and add regression checks

## Verification
- `DOGAREA_DERIVED_DATA_PATH=.build/codex-401-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #401