### PR TITLE
test: add supabase integration smoke harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - Swift 안정화(강제 언래핑/타이머 수명) v1: `docs/swift-stability-hardening-v1.md`
 - 프로젝트 설정/의존성 안정화 v1: `docs/project-settings-dependency-stability-v1.md`
 - Supabase 마이그레이션/운영 검증 v1: `docs/supabase-migration.md`
+- Supabase integration smoke matrix v1: `docs/supabase-integration-smoke-matrix-v1.md`
 - 릴리즈 회귀 체크리스트 v1: `docs/release-regression-checklist-v1.md`
 - 릴리즈 회귀 실행 리포트(2026-02-26): `docs/release-regression-report-2026-02-26.md`
 - 게임 레이어 공통 관측/QA 기준 v1: `docs/game-layer-observability-qa-v1.md`
@@ -85,6 +86,8 @@
 
 - 전체 체크(iOS/watchOS build 포함): `bash scripts/ios_pr_check.sh`
 - 문서/유닛만 빠르게 체크: `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
+- Backend smoke entrypoint: `bash scripts/backend_pr_check.sh`
+- Live Supabase smoke matrix: `DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/backend_pr_check.sh`
 
 ## 강아지들의 영역 표시
 

--- a/docs/supabase-integration-smoke-matrix-v1.md
+++ b/docs/supabase-integration-smoke-matrix-v1.md
@@ -1,0 +1,84 @@
+# Supabase Integration Smoke Matrix v1
+
+## 목적
+
+실제 Supabase 프로젝트에 against 하는 최소 smoke/integration 경로를 고정해 backend 리팩터링 회귀를 조기에 찾습니다.
+
+이 문서는 모바일 UI E2E를 대체하지 않습니다. 대신 Edge Function/RPC 계약이 실제 프로젝트에서 살아 있는지 빠르게 확인하는 용도입니다.
+
+## 엔트리포인트
+
+- 구조/문서 연결 체크: `bash scripts/backend_pr_check.sh`
+- 실 Supabase smoke 실행: `DOGAREA_RUN_SUPABASE_SMOKE=1 bash scripts/backend_pr_check.sh`
+- 직접 matrix 실행: `bash scripts/run_supabase_smoke_matrix.sh`
+
+## 필수 환경변수
+
+- `DOGAREA_TEST_EMAIL`: member login에 사용할 테스트 계정 이메일
+- `DOGAREA_TEST_PASSWORD`: member login에 사용할 테스트 계정 비밀번호
+
+## 선택 환경변수
+
+- `DOGAREA_SUPABASE_CONFIG`: 기본값 `./supabaseConfig.xcconfig`, Supabase URL/anon key를 읽을 xcconfig 경로
+- `SUPABASE_URL`: xcconfig 대신 직접 override할 URL
+- `SUPABASE_ANON_KEY`: xcconfig 대신 직접 override할 anon key
+- `PROJECT_REF`: 출력용 project ref override
+- `DOGAREA_SUPABASE_CASE_FILTER`: 정규식 기반 case 필터. 예: `rival|quest-engine`
+- `DOGAREA_SUPABASE_SMOKE_TIMEOUT`: curl 요청 타임아웃 초. 기본값 `20`
+- `DOGAREA_SUPABASE_SMOKE_SESSION_ID`: `sync-walk` smoke가 재사용할 고정 session id
+- `DOGAREA_SUPABASE_FOREIGN_USER_ID`: permission mismatch smoke에 사용할 다른 user id
+
+## 현재 smoke matrix
+
+### 1. member authorization 정상 경로
+
+- `auth.member_login`
+- `sync-profile.snapshot.member`
+- `sync-walk.session.member`
+- `sync-walk.summary.member`
+- `rival-league.leaderboard.member`
+- `quest-engine.list_active.member`
+- `feature-control.flags.anon`
+- `feature-control.rollout_kpis.anon`
+
+### 2. unauthorized / invalid token 경로
+
+- `sync-profile.snapshot.invalid_token` => `401`
+- `sync-walk.summary.invalid_token` => `401`
+- `rival-league.leaderboard.invalid_token` => `401`
+- `quest-engine.list_active.invalid_token` => `401`
+
+### 3. 권한 정책 / 호환성 경로
+
+- `sync-profile.permission.user_mismatch` => `403`
+- `nearby-presence.hotspots.app_policy` => `401`이 아니어야 함
+- `rival-rpc.compat.member` => `/rest/v1/rpc/rpc_get_rival_leaderboard`가 `404` 없이 응답해야 함
+
+## 출력 규약
+
+각 케이스는 아래 형식으로 출력합니다.
+
+- `PASS <case-name> status=<code> route=...`
+- `FAIL <case-name> expected=<code> actual=<code> route=... body=<snippet>`
+
+실패 시 어떤 함수/계약에서 깨졌는지 케이스 이름만 보고 바로 식별할 수 있게 유지합니다.
+
+## 운영 가이드
+
+- `feature-control`, `nearby-presence`는 anon/app authorization 정책을 함께 확인합니다.
+- `sync-walk` smoke는 고정 session id upsert를 사용해 데이터를 무한 증가시키지 않습니다.
+- `sync-profile`, `quest-engine`, `rival-league`는 읽기 또는 제한된 contract 호출 위주로 구성합니다.
+- 실 smoke는 secrets가 필요한 만큼 로컬/CI에서 opt-in으로만 실행합니다.
+
+## CI 연결 포인트
+
+추천 커맨드:
+
+```bash
+DOGAREA_RUN_SUPABASE_SMOKE=1 \
+DOGAREA_TEST_EMAIL="$DOGAREA_TEST_EMAIL" \
+DOGAREA_TEST_PASSWORD="$DOGAREA_TEST_PASSWORD" \
+bash scripts/backend_pr_check.sh
+```
+
+PR 기본 체크에는 `scripts/supabase_integration_harness_unit_check.swift`를 포함하고, secrets가 주입되는 backend job에서만 live smoke를 켭니다.

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[dogArea-backend] running integration harness structure checks"
+swift scripts/supabase_integration_harness_unit_check.swift
+
+if [[ "${DOGAREA_RUN_SUPABASE_SMOKE:-0}" != "1" ]]; then
+  echo "[dogArea-backend] DOGAREA_RUN_SUPABASE_SMOKE=1 이 아니므로 실 Supabase smoke matrix는 건너뜁니다."
+  echo "[dogArea-backend] run: DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/backend_pr_check.sh"
+  exit 0
+fi
+
+bash scripts/run_supabase_smoke_matrix.sh

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -39,6 +39,7 @@ swift scripts/fault_injection_matrix_unit_check.swift
 swift scripts/realtime_ops_rollout_unit_check.swift
 swift scripts/realtime_ops_rollout_gate.swift --input docs/realtime-ops-kpi-sample-pass.json
 swift scripts/supabase_ops_hardening_unit_check.swift
+swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift
 swift scripts/rival_privacy_policy_confirmed_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift

--- a/scripts/lib/supabase_integration_harness.sh
+++ b/scripts/lib/supabase_integration_harness.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+
+if [[ -n "${DOGAREA_SUPABASE_HARNESS_LIB_LOADED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+DOGAREA_SUPABASE_HARNESS_LIB_LOADED=1
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG_FILE="${DOGAREA_SUPABASE_CONFIG:-$ROOT_DIR/supabaseConfig.xcconfig}"
+CURL_TIMEOUT="${DOGAREA_SUPABASE_SMOKE_TIMEOUT:-20}"
+CASE_FILTER="${DOGAREA_SUPABASE_CASE_FILTER:-}"
+HARNESS_CASE_TOTAL=0
+HARNESS_CASE_FAILED=0
+HARNESS_LAST_LOGIN_STATUS=""
+HARNESS_LAST_LOGIN_BODY=""
+HARNESS_MEMBER_TOKEN=""
+HARNESS_MEMBER_USER_ID=""
+HARNESS_PROJECT_REF=""
+
+resolve_xcconfig_value() {
+  local key="$1"
+  local file="$2"
+  python3 - "$file" "$key" <<'PY'
+import re
+import sys
+
+path, key = sys.argv[1], sys.argv[2]
+variables = {}
+
+with open(path, "r", encoding="utf-8") as f:
+    for line in f:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//") or "=" not in stripped:
+            continue
+        k, v = stripped.split("=", 1)
+        variables[k.strip()] = v.strip().strip('"')
+
+pattern = re.compile(r"\$\(([^)]+)\)")
+
+def resolve(value: str, depth: int = 0) -> str:
+    if depth > 16:
+        return value
+    def repl(match):
+        name = match.group(1)
+        replacement = variables.get(name, "")
+        return resolve(replacement, depth + 1)
+    return pattern.sub(repl, value)
+
+print(resolve(variables.get(key, "")))
+PY
+}
+
+harness_note() {
+  printf '[SupabaseSmoke] %s\n' "$*"
+}
+
+harness_require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    harness_note "required file missing: $path"
+    exit 1
+  fi
+}
+
+harness_load_env() {
+  harness_require_file "$CONFIG_FILE"
+
+  SUPABASE_URL="${SUPABASE_URL:-$(resolve_xcconfig_value SUPABASE_URL "$CONFIG_FILE")}"
+  SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY:-$(resolve_xcconfig_value SUPABASE_ANON_KEY "$CONFIG_FILE")}"
+  HARNESS_PROJECT_REF="${PROJECT_REF:-$(resolve_xcconfig_value PROJECT_REF "$CONFIG_FILE")}"
+
+  if [[ -z "$SUPABASE_URL" || -z "$SUPABASE_ANON_KEY" ]]; then
+    harness_note "SUPABASE_URL / SUPABASE_ANON_KEY 값을 확인할 수 없습니다."
+    exit 1
+  fi
+
+  if [[ -z "${DOGAREA_TEST_EMAIL:-}" || -z "${DOGAREA_TEST_PASSWORD:-}" ]]; then
+    harness_note "DOGAREA_TEST_EMAIL / DOGAREA_TEST_PASSWORD 환경변수가 필요합니다."
+    exit 1
+  fi
+}
+
+harness_case_enabled() {
+  local name="$1"
+  if [[ -z "$CASE_FILTER" ]]; then
+    return 0
+  fi
+  [[ "$name" =~ $CASE_FILTER ]]
+}
+
+harness_request_json() {
+  local method="$1"
+  local url="$2"
+  local apikey="$3"
+  local authorization="$4"
+  local body="$5"
+  local response=""
+  local status="000"
+  local payload=""
+  local error_file
+  error_file="$(mktemp)"
+
+  if response="$(curl -sS --max-time "$CURL_TIMEOUT" -X "$method" "$url" \
+    -H "Content-Type: application/json" \
+    -H "apikey: $apikey" \
+    -H "Authorization: $authorization" \
+    --data "$body" \
+    -w '\n%{http_code}' 2>"$error_file")"; then
+    status="$(printf '%s' "$response" | tail -n 1)"
+    payload="$(printf '%s' "$response" | sed '$d')"
+  else
+    payload="$(cat "$error_file")"
+  fi
+
+  rm -f "$error_file"
+  printf '%s\n%s' "$status" "$payload"
+}
+
+harness_response_status() {
+  printf '%s' "$1" | head -n 1
+}
+
+harness_response_body() {
+  printf '%s' "$1" | tail -n +2
+}
+
+harness_json_field() {
+  local json="$1"
+  local path="$2"
+  JSON_PAYLOAD="$json" python3 - "$path" <<'PY'
+import json
+import os
+import sys
+
+path = sys.argv[1].split('.')
+raw = os.environ.get('JSON_PAYLOAD', '')
+obj = json.loads(raw)
+for key in path:
+    if isinstance(obj, dict):
+        obj = obj.get(key)
+    else:
+        obj = None
+    if obj is None:
+        print("")
+        raise SystemExit(0)
+if isinstance(obj, (str, int, float, bool)):
+    print(obj)
+else:
+    print("")
+PY
+}
+
+harness_uuid() {
+  python3 - <<'PY'
+import uuid
+print(uuid.uuid4())
+PY
+}
+
+harness_snippet() {
+  local text="$1"
+  TEXT_PAYLOAD="$text" python3 - <<'PY'
+import os
+text = os.environ.get('TEXT_PAYLOAD', '').replace('\n', ' ')
+print(text[:240])
+PY
+}
+
+harness_expect_status() {
+  local name="$1"
+  local expected="$2"
+  local response="$3"
+  local detail="$4"
+  if ! harness_case_enabled "$name"; then
+    harness_note "SKIP $name filter=$CASE_FILTER"
+    return 0
+  fi
+  HARNESS_CASE_TOTAL=$((HARNESS_CASE_TOTAL + 1))
+  local actual body snippet
+  actual="$(harness_response_status "$response")"
+  body="$(harness_response_body "$response")"
+  if [[ "$actual" == "$expected" ]]; then
+    harness_note "PASS $name status=$actual $detail"
+    return 0
+  fi
+  HARNESS_CASE_FAILED=$((HARNESS_CASE_FAILED + 1))
+  snippet="$(harness_snippet "$body")"
+  harness_note "FAIL $name expected=$expected actual=$actual $detail body=$snippet"
+  return 0
+}
+
+harness_expect_not_status() {
+  local name="$1"
+  local rejected="$2"
+  local response="$3"
+  local detail="$4"
+  if ! harness_case_enabled "$name"; then
+    harness_note "SKIP $name filter=$CASE_FILTER"
+    return 0
+  fi
+  HARNESS_CASE_TOTAL=$((HARNESS_CASE_TOTAL + 1))
+  local actual body snippet
+  actual="$(harness_response_status "$response")"
+  body="$(harness_response_body "$response")"
+  if [[ "$actual" != "$rejected" ]]; then
+    harness_note "PASS $name status=$actual $detail"
+    return 0
+  fi
+  HARNESS_CASE_FAILED=$((HARNESS_CASE_FAILED + 1))
+  snippet="$(harness_snippet "$body")"
+  harness_note "FAIL $name rejected=$rejected actual=$actual $detail body=$snippet"
+  return 0
+}
+
+harness_login_member() {
+  local response
+  response="$(harness_request_json \
+    "POST" \
+    "$SUPABASE_URL/auth/v1/token?grant_type=password" \
+    "$SUPABASE_ANON_KEY" \
+    "Bearer $SUPABASE_ANON_KEY" \
+    "{\"email\":\"$DOGAREA_TEST_EMAIL\",\"password\":\"$DOGAREA_TEST_PASSWORD\"}")"
+  HARNESS_LAST_LOGIN_STATUS="$(harness_response_status "$response")"
+  HARNESS_LAST_LOGIN_BODY="$(harness_response_body "$response")"
+  if [[ "$HARNESS_LAST_LOGIN_STATUS" != "200" ]]; then
+    return 1
+  fi
+  HARNESS_MEMBER_TOKEN="$(harness_json_field "$HARNESS_LAST_LOGIN_BODY" "access_token")"
+  HARNESS_MEMBER_USER_ID="$(harness_json_field "$HARNESS_LAST_LOGIN_BODY" "user.id")"
+  [[ -n "$HARNESS_MEMBER_TOKEN" && -n "$HARNESS_MEMBER_USER_ID" ]]
+}
+
+harness_finish() {
+  if (( HARNESS_CASE_FAILED > 0 )); then
+    harness_note "FAIL summary total=$HARNESS_CASE_TOTAL failed=$HARNESS_CASE_FAILED"
+    return 1
+  fi
+  harness_note "PASS summary total=$HARNESS_CASE_TOTAL failed=0 project_ref=${HARNESS_PROJECT_REF:-unknown}"
+}

--- a/scripts/run_supabase_smoke_matrix.sh
+++ b/scripts/run_supabase_smoke_matrix.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+source "$ROOT_DIR/scripts/lib/supabase_integration_harness.sh"
+
+harness_load_env
+harness_note "matrix start project_ref=${HARNESS_PROJECT_REF:-unknown} filter=${DOGAREA_SUPABASE_CASE_FILTER:-all}"
+
+if harness_login_member; then
+  login_response="$(printf '%s\n%s' "$HARNESS_LAST_LOGIN_STATUS" "$HARNESS_LAST_LOGIN_BODY")"
+else
+  login_response="$(printf '%s\n%s' "$HARNESS_LAST_LOGIN_STATUS" "$HARNESS_LAST_LOGIN_BODY")"
+fi
+harness_expect_status "auth.member_login" "200" "$login_response" "route=/auth/v1/token?grant_type=password"
+
+if [[ "$HARNESS_LAST_LOGIN_STATUS" != "200" ]]; then
+  harness_finish
+  exit 1
+fi
+
+member_auth="Bearer $HARNESS_MEMBER_TOKEN"
+anon_auth="Bearer $SUPABASE_ANON_KEY"
+invalid_auth="Bearer invalid.integration.token"
+now_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+fixed_session_id="${DOGAREA_SUPABASE_SMOKE_SESSION_ID:-00000000-0000-4000-8000-000000000416}"
+foreign_user_id="${DOGAREA_SUPABASE_FOREIGN_USER_ID:-00000000-0000-4000-8000-000000000099}"
+
+sync_profile_snapshot_member="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/sync-profile" \
+  "$SUPABASE_ANON_KEY" \
+  "$member_auth" \
+  '{"action":"get_profile_snapshot"}')"
+harness_expect_status "sync-profile.snapshot.member" "200" "$sync_profile_snapshot_member" "route=/functions/v1/sync-profile action=get_profile_snapshot"
+
+sync_profile_invalid_token="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/sync-profile" \
+  "$SUPABASE_ANON_KEY" \
+  "$invalid_auth" \
+  '{"action":"get_profile_snapshot"}')"
+harness_expect_status "sync-profile.snapshot.invalid_token" "401" "$sync_profile_invalid_token" "route=/functions/v1/sync-profile action=get_profile_snapshot"
+
+sync_profile_user_mismatch="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/sync-profile" \
+  "$SUPABASE_ANON_KEY" \
+  "$member_auth" \
+  "{\"action\":\"get_profile_snapshot\",\"user_id\":\"$foreign_user_id\"}")"
+harness_expect_status "sync-profile.permission.user_mismatch" "403" "$sync_profile_user_mismatch" "route=/functions/v1/sync-profile action=get_profile_snapshot"
+
+sync_walk_stage_member="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/sync-walk" \
+  "$SUPABASE_ANON_KEY" \
+  "$member_auth" \
+  "{\"action\":\"sync_walk_stage\",\"stage\":\"session\",\"walk_session_id\":\"$fixed_session_id\",\"idempotency_key\":\"smoke-416-session\",\"payload\":{\"created_at\":1700000000,\"started_at\":1700000000,\"ended_at\":1700000600,\"duration_sec\":600,\"area_m2\":12.5,\"source_device\":\"ios-smoke\"}}")"
+harness_expect_status "sync-walk.session.member" "200" "$sync_walk_stage_member" "route=/functions/v1/sync-walk action=sync_walk_stage"
+
+sync_walk_summary_member="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/sync-walk" \
+  "$SUPABASE_ANON_KEY" \
+  "$member_auth" \
+  "{\"action\":\"get_backfill_summary\",\"session_ids\":[\"$fixed_session_id\"]}")"
+harness_expect_status "sync-walk.summary.member" "200" "$sync_walk_summary_member" "route=/functions/v1/sync-walk action=get_backfill_summary"
+
+sync_walk_invalid_token="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/sync-walk" \
+  "$SUPABASE_ANON_KEY" \
+  "$invalid_auth" \
+  '{"action":"get_backfill_summary","session_ids":[]}')"
+harness_expect_status "sync-walk.summary.invalid_token" "401" "$sync_walk_invalid_token" "route=/functions/v1/sync-walk action=get_backfill_summary"
+
+nearby_hotspots_app_policy="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/nearby-presence" \
+  "$SUPABASE_ANON_KEY" \
+  "$anon_auth" \
+  "{\"action\":\"get_hotspots\",\"userId\":\"$HARNESS_MEMBER_USER_ID\",\"centerLat\":37.42199,\"centerLng\":126.68327,\"radiusKm\":1.0}")"
+harness_expect_not_status "nearby-presence.hotspots.app_policy" "401" "$nearby_hotspots_app_policy" "route=/functions/v1/nearby-presence action=get_hotspots"
+
+rival_league_member="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/rival-league" \
+  "$SUPABASE_ANON_KEY" \
+  "$member_auth" \
+  '{"action":"get_leaderboard","periodType":"week","topN":5}')"
+harness_expect_status "rival-league.leaderboard.member" "200" "$rival_league_member" "route=/functions/v1/rival-league action=get_leaderboard"
+
+rival_league_invalid_token="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/rival-league" \
+  "$SUPABASE_ANON_KEY" \
+  "$invalid_auth" \
+  '{"action":"get_leaderboard","periodType":"week","topN":5}')"
+harness_expect_status "rival-league.leaderboard.invalid_token" "401" "$rival_league_invalid_token" "route=/functions/v1/rival-league action=get_leaderboard"
+
+rival_rpc_member="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/rest/v1/rpc/rpc_get_rival_leaderboard" \
+  "$SUPABASE_ANON_KEY" \
+  "$member_auth" \
+  "{\"payload\":{\"period_type\":\"week\",\"top_n\":5,\"now_ts\":\"$now_ts\"}}")"
+harness_expect_status "rival-rpc.compat.member" "200" "$rival_rpc_member" "route=/rest/v1/rpc/rpc_get_rival_leaderboard"
+
+quest_engine_member="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/quest-engine" \
+  "$SUPABASE_ANON_KEY" \
+  "$member_auth" \
+  '{"action":"list_active"}')"
+harness_expect_status "quest-engine.list_active.member" "200" "$quest_engine_member" "route=/functions/v1/quest-engine action=list_active"
+
+quest_engine_invalid_token="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/quest-engine" \
+  "$SUPABASE_ANON_KEY" \
+  "$invalid_auth" \
+  '{"action":"list_active"}')"
+harness_expect_status "quest-engine.list_active.invalid_token" "401" "$quest_engine_invalid_token" "route=/functions/v1/quest-engine action=list_active"
+
+feature_control_flags="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/feature-control" \
+  "$SUPABASE_ANON_KEY" \
+  "$anon_auth" \
+  '{"action":"get_flags","keys":["ff_heatmap_v1","ff_nearby_hotspot_v1"]}')"
+harness_expect_status "feature-control.flags.anon" "200" "$feature_control_flags" "route=/functions/v1/feature-control action=get_flags"
+
+feature_control_kpis="$(harness_request_json \
+  "POST" \
+  "$SUPABASE_URL/functions/v1/feature-control" \
+  "$SUPABASE_ANON_KEY" \
+  "$anon_auth" \
+  '{"action":"get_rollout_kpis"}')"
+harness_expect_status "feature-control.rollout_kpis.anon" "200" "$feature_control_kpis" "route=/functions/v1/feature-control action=get_rollout_kpis"
+
+harness_finish

--- a/scripts/supabase_integration_harness_unit_check.swift
+++ b/scripts/supabase_integration_harness_unit_check.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// 조건이 거짓이면 실패 메시지를 출력하고 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 불리언 조건입니다.
+///   - message: 실패 시 출력할 설명입니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+/// 저장소 루트 기준 상대 경로 파일을 UTF-8 문자열로 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 상대 경로입니다.
+/// - Returns: 파일 전체 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let readme = load("README.md")
+let backendCheck = load("scripts/backend_pr_check.sh")
+let smokeRunner = load("scripts/run_supabase_smoke_matrix.sh")
+let harnessLib = load("scripts/lib/supabase_integration_harness.sh")
+let matrixDoc = load("docs/supabase-integration-smoke-matrix-v1.md")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(harnessLib.contains("harness_load_env"), "integration harness library should load Supabase env")
+assertTrue(harnessLib.contains("harness_login_member"), "integration harness library should support member login")
+assertTrue(harnessLib.contains("harness_expect_status"), "integration harness library should expose status assertion helper")
+assertTrue(harnessLib.contains("harness_expect_not_status"), "integration harness library should expose non-status assertion helper")
+
+assertTrue(smokeRunner.contains("functions/v1/sync-profile"), "smoke matrix should include sync-profile route")
+assertTrue(smokeRunner.contains("functions/v1/sync-walk"), "smoke matrix should include sync-walk route")
+assertTrue(smokeRunner.contains("functions/v1/nearby-presence"), "smoke matrix should include nearby-presence route")
+assertTrue(smokeRunner.contains("functions/v1/rival-league"), "smoke matrix should include rival-league route")
+assertTrue(smokeRunner.contains("functions/v1/quest-engine"), "smoke matrix should include quest-engine route")
+assertTrue(smokeRunner.contains("functions/v1/feature-control"), "smoke matrix should include feature-control route")
+assertTrue(smokeRunner.contains("rpc_get_rival_leaderboard"), "smoke matrix should include rival RPC compatibility case")
+assertTrue(smokeRunner.contains("sync-profile.permission.user_mismatch"), "smoke matrix should include permission mismatch case")
+assertTrue(smokeRunner.contains("invalid_token"), "smoke matrix should include invalid token cases")
+
+assertTrue(backendCheck.contains("supabase_integration_harness_unit_check.swift"), "backend PR check should run structure unit check")
+assertTrue(backendCheck.contains("run_supabase_smoke_matrix.sh"), "backend PR check should connect to live smoke runner")
+assertTrue(backendCheck.contains("DOGAREA_RUN_SUPABASE_SMOKE"), "backend PR check should guard live smoke behind explicit opt-in")
+
+assertTrue(matrixDoc.contains("DOGAREA_TEST_EMAIL"), "integration smoke doc should document member credential env")
+assertTrue(matrixDoc.contains("DOGAREA_SUPABASE_CASE_FILTER"), "integration smoke doc should document case filter env")
+assertTrue(matrixDoc.contains("rival-rpc.compat.member"), "integration smoke doc should document RPC compatibility case")
+assertTrue(matrixDoc.contains("401"), "integration smoke doc should describe unauthorized expectations")
+
+assertTrue(readme.contains("docs/supabase-integration-smoke-matrix-v1.md"), "README should link integration smoke doc")
+assertTrue(readme.contains("bash scripts/backend_pr_check.sh"), "README should expose backend check entrypoint")
+assertTrue(iosPRCheck.contains("supabase_integration_harness_unit_check.swift"), "ios_pr_check should include integration harness structure check")
+
+print("PASS: supabase integration harness unit checks")


### PR DESCRIPTION
## Summary
- add a shared Supabase integration harness library for xcconfig/env loading, HTTP invocation, login, and PASS/FAIL reporting
- add a live smoke matrix runner and backend PR entrypoint for opt-in Supabase integration checks
- document the smoke matrix and wire the structure check into `ios_pr_check`

## Testing
- `swift scripts/supabase_integration_harness_unit_check.swift`
- `bash scripts/backend_pr_check.sh`
- `DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL='jinnavis1@gmail.com' DOGAREA_TEST_PASSWORD='1q2w3e4r1!' bash scripts/backend_pr_check.sh`
- `DOGAREA_DERIVED_DATA_PATH=.build/codex-416-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`

## Notes
- live smoke surfaced real backend deployment gaps returning `404` for `sync-profile`, `sync-walk`, `rival-league`, `quest-engine`, and `feature-control`
- related backend follow-up is already tracked under `#420` and deploy/verification work under `#436`

Closes #416
