### PR TITLE
docs: define backend contract versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@
 - 프로젝트 설정/의존성 안정화 v1: `docs/project-settings-dependency-stability-v1.md`
 - Supabase 마이그레이션/운영 검증 v1: `docs/supabase-migration.md`
 - Supabase integration smoke matrix v1: `docs/supabase-integration-smoke-matrix-v1.md`
+- Backend 계약 버저닝 정책 v1: `docs/backend-contract-versioning-policy-v1.md`
+- Backend 고위험 계약 매트릭스 v1: `docs/backend-high-risk-contract-matrix-v1.md`
 - 릴리즈 회귀 체크리스트 v1: `docs/release-regression-checklist-v1.md`
 - 릴리즈 회귀 실행 리포트(2026-02-26): `docs/release-regression-report-2026-02-26.md`
 - 게임 레이어 공통 관측/QA 기준 v1: `docs/game-layer-observability-qa-v1.md`

--- a/docs/backend-contract-versioning-policy-v1.md
+++ b/docs/backend-contract-versioning-policy-v1.md
@@ -1,0 +1,207 @@
+# Backend Contract Versioning Policy v1
+
+Date: 2026-03-07  
+Issue: #417
+
+## 목적
+
+DogArea backend의 Edge Function / RPC 계약을 점진적으로 바꾸더라도 iOS 앱과 운영 스크립트가 깨지지 않도록 버전, 응답 envelope, fallback 수명을 고정합니다.
+
+이 문서는 `전면 즉시 개편`이 아니라 `고위험 경로를 같은 원칙 아래에서 단계적으로 수렴`시키는 기준입니다.
+
+## 적용 범위
+
+우선순위가 높은 경로는 아래와 같습니다.
+
+- `sync-walk`
+- `nearby-presence`
+- `rival-league`
+- `quest-engine`
+- widget summary RPC
+  - `rpc_get_widget_territory_summary`
+  - `rpc_get_widget_hotspot_summary`
+  - `rpc_get_widget_quest_rival_summary`
+- 호환성 민감 RPC
+  - `rpc_get_rival_leaderboard`
+  - `rpc_get_nearby_hotspots`
+
+## Canonical Request Rules
+
+### Edge Function
+
+모든 신규/개정 Edge Function 요청은 아래 top-level 필드를 기준으로 삼습니다.
+
+```json
+{
+  "version": "2026-03-07.v1",
+  "request_id": "client-or-server-generated-id",
+  "action": "domain_action",
+  "payload": {}
+}
+```
+
+규칙:
+
+- `version`
+  - 선택 필드지만, 앱이 명시할 수 있으면 항상 보냅니다.
+  - 서버는 누락 시 현재 canonical contract version으로 보정합니다.
+- `request_id`
+  - 선택 필드지만 idempotency/추적이 필요한 요청에서는 사실상 필수로 취급합니다.
+  - 기존 camelCase 요청(`requestId`, `idempotencyKey`)은 fallback alias로 허용할 수 있습니다.
+- `action`
+  - action router를 쓰는 함수는 필수입니다.
+- `payload`
+  - 도메인 데이터는 `payload` 아래에 두는 것을 기본으로 합니다.
+  - 과거 top-level 필드는 호환성 기간 동안만 alias로 유지합니다.
+
+### RPC
+
+PostgREST 또는 앱이 직접 호출하는 RPC는 **single `payload jsonb` wrapper**를 canonical signature로 삼습니다.
+
+예시:
+
+```sql
+select * from public.rpc_get_rival_leaderboard(
+  jsonb_build_object(
+    'period_type', 'week',
+    'top_n', 20,
+    'now_ts', now()
+  )
+);
+```
+
+규칙:
+
+- 앱/REST에 노출되는 신규 RPC는 `payload jsonb`를 기본으로 합니다.
+- positional arg RPC는 아래 둘 중 하나일 때만 유지합니다.
+  - SQL 내부 호출만 존재하는 경우
+  - 기존 운영 경로가 이미 배포되어 있고 delegate/fallback wrapper가 필요한 경우
+- positional canonical이 남아 있어도, 앱/REST가 직접 호출하는 경로는 `payload jsonb` wrapper를 우선 제공합니다.
+
+## Canonical Response Envelope
+
+### Success
+
+성공 응답은 아래 공통 메타 필드를 가집니다.
+
+```json
+{
+  "ok": true,
+  "version": "2026-03-07.v1",
+  "request_id": "uuid-or-correlation-id"
+}
+```
+
+도메인 데이터는 기존 top-level 키를 유지한 채 추가합니다.
+
+```json
+{
+  "ok": true,
+  "version": "2026-03-07.v1",
+  "request_id": "req_123",
+  "leaderboard": []
+}
+```
+
+`data` 래핑은 강제하지 않습니다. 기존 앱 파서를 깨지 않도록 **공통 메타만 덧붙이는 방식**을 기본으로 합니다.
+
+### Error
+
+오류 응답은 아래 필드를 canonical로 삼습니다.
+
+```json
+{
+  "ok": false,
+  "error": "UNAUTHORIZED",
+  "code": "UNAUTHORIZED",
+  "message": "authorization header required",
+  "request_id": "req_123",
+  "version": "2026-03-07.v1"
+}
+```
+
+규칙:
+
+- `error`는 v1 호환성 기간 동안 legacy alias로 유지할 수 있습니다.
+- `code`는 machine-readable 식별자입니다.
+- `message`는 운영/로그/디버깅에 충분한 사람이 읽을 수 있는 설명입니다.
+- `request_id`는 로그/DB/audit와 연결되는 상관관계 ID입니다.
+- `version`은 요청이 협상한 contract version 또는 서버가 보정한 canonical version입니다.
+
+## Breaking / Non-breaking 기준
+
+### Non-breaking
+
+아래는 non-breaking으로 간주합니다.
+
+- 성공 응답에 새 필드를 추가하는 것
+- 오류 응답에 `code`, `message`, `request_id`, `version`을 추가하는 것
+- 기존 field alias를 유지한 채 canonical field를 추가하는 것
+- RPC positional signature를 유지하면서 `payload jsonb` wrapper를 추가하는 것
+- legacy route가 살아 있는 동안 canonical route를 우선 적용하는 것
+
+### Breaking
+
+아래는 breaking으로 간주합니다.
+
+- 기존 top-level 필드 제거
+- 기존 action 이름 제거 또는 의미 변경
+- 응답의 의미를 바꾸는 필드 rename
+- positional RPC를 제거하면서 wrapper/delegate도 제공하지 않는 것
+- canonical route 미배포 상태에서 legacy route를 제거하는 것
+- 기존에 `200`이던 경로를 schema incompatibility 때문에 `400/404/500`으로 바꾸는 것
+
+## Deprecation / Fallback 기간 규칙
+
+- 최소 유지 기간: **2개 앱 릴리즈 또는 14일**, 둘 중 더 긴 기간
+- 운영 장애 이력이 있는 compat 경로는 **post-deploy smoke 2회 연속 통과** 전까지 제거 금지
+- fallback은 `무제한 누적` 금지
+  - canonical 1개
+  - legacy delegate/fallback 1개
+  - 최대 2계층까지만 허용
+- compat 경로 제거 전에는 다음이 선행되어야 합니다.
+  - 문서 업데이트
+  - smoke / static check 업데이트
+  - 관련 후속 이슈 또는 sunset 계획 등록
+
+## Route / Signature 정책
+
+### Edge route
+
+- canonical route는 kebab-case를 사용합니다.
+- legacy snake_case route는 404 fallback이 필요한 경우에만 잠정 유지합니다.
+- 예: `sync-walk` canonical, `sync_walk` legacy fallback
+
+### RPC signature
+
+- 앱/REST direct path: `payload jsonb`
+- DB 내부 delegate path: positional 허용
+- compat wrapper는 `payload jsonb` -> positional delegate 또는 그 반대 중 하나로 단일화합니다.
+
+## Request ID / Idempotency 규칙
+
+- 쓰기 요청은 `request_id` 또는 `idempotency_key`를 최소 하나 가져야 합니다.
+- 장기적으로는 `request_id`를 canonical 이름으로 삼고, `idempotency_key`는 legacy alias 또는 내부 저장 필드로 정리합니다.
+- retry 가능한 write path는 request_id/idempotency_key가 로그와 DB에 남아야 합니다.
+
+## High-risk First-wave 적용 기준
+
+1. 계약 문서에 canonical shape를 등록한다.
+2. 기존 compat/fallback을 표로 남긴다.
+3. smoke 또는 static check를 연결한다.
+4. runtime 전면 개편은 후속 refactor issue에서 진행한다.
+
+즉, 이 이슈의 1차 목표는 `원칙 없는 hotfix 반복`을 끝내고, 이후 refactor가 따라야 할 단일 계약 기준을 고정하는 것입니다.
+
+## Validation
+
+- `swift scripts/backend_contract_versioning_unit_check.swift`
+- `bash scripts/backend_pr_check.sh`
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
+
+## Related
+
+- `docs/backend-high-risk-contract-matrix-v1.md`
+- `docs/sync-walk-404-fallback-policy-v1.md`
+- `scripts/rival_rpc_param_compat_unit_check.swift`
+- Issue `#419`, `#429`, `#436`, `#437`

--- a/docs/backend-high-risk-contract-matrix-v1.md
+++ b/docs/backend-high-risk-contract-matrix-v1.md
@@ -1,0 +1,54 @@
+# Backend High-risk Contract Matrix v1
+
+Date: 2026-03-07  
+Issue: #417
+
+이 문서는 고위험 Edge Function / RPC가 현재 어떤 canonical contract와 compat 경로를 가지는지 정리합니다.
+
+## Matrix
+
+| Surface | Canonical request/signature | Current compat / fallback | Response envelope status | Validation | Follow-up |
+| --- | --- | --- | --- | --- | --- |
+| `sync-walk` | Edge POST JSON + `action`/`stage`/`payload`, route `sync-walk` | legacy route `sync_walk` 404 fallback 정책 유지 | 문서 기준 `ok/version/request_id` target, runtime 전면 rollout은 후속 | `docs/sync-walk-404-fallback-policy-v1.md`, `scripts/sync_walk_404_policy_unit_check.swift`, smoke matrix route probe | `#424`, `#437` |
+| `nearby-presence` | Edge POST JSON + `action`, hotspot RPC latest signature `in_center_lat/in_center_lng/in_radius_km/in_now_ts` | `rpc_get_nearby_hotspots(center_lat, center_lng, radius_km, now_ts)` legacy signature fallback | 문서 기준 `ok/code/message/request_id/version` target, runtime rollout은 후속 | source compat helper, smoke matrix `nearby-presence.hotspots.app_policy` | `#425`, `#431`, `#437` |
+| `rival-league` | Edge POST JSON + `action`, leaderboard RPC canonical `rpc_get_rival_leaderboard(payload jsonb)` | 3-arg `rpc_get_rival_leaderboard(period_type, top_n, now_ts)` delegate 유지 | 문서 기준 envelope target, leaderboard body top-level 유지 | `scripts/rival_rpc_param_compat_unit_check.swift`, smoke matrix `rival-rpc.compat.member` | `#419`, `#437` |
+| `quest-engine` | Edge POST JSON + `action` + optional `request_id` / `payload` | legacy camelCase request fields 일부 허용 | 문서 기준 envelope target, action payload shape는 유지 | smoke matrix `quest-engine.list_active.member`, static contract doc check | `#419`, `#438` |
+| `rpc_get_widget_quest_rival_summary` | `payload jsonb` wrapper canonical | `timestamptz` positional signature compat 유지 | RPC output contract은 wrapper canonical 기준 | `scripts/rival_rpc_param_compat_unit_check.swift` | `#429`, `#437` |
+| `rpc_get_widget_territory_summary` | 현재 positional `timestamptz` canonical | wrapper 미도입, 차기 표준화 필요 | response model은 유지하되 wrapper 도입 필요 | migration static check + policy doc | `#429` |
+| `rpc_get_widget_hotspot_summary` | 현재 positional `(radius_km, now_ts)` canonical | 내부에서 `rpc_get_nearby_hotspots` positional 의존 | response model은 유지하되 wrapper 도입 필요 | migration static check + policy doc | `#429`, `#437` |
+
+## Canonical Envelope 적용 원칙
+
+고위험 Edge Function은 성공/실패 모두 아래 공통 메타를 목표로 합니다.
+
+- success: `ok`, `version`, `request_id`
+- error: `ok`, `error`, `code`, `message`, `request_id`, `version`
+
+단, 기존 앱 파서를 깨지 않도록 도메인 키(`leaderboard`, `quests`, `summary`, `presence`, `hotspots`)는 top-level 유지가 원칙입니다.
+
+## RPC Parameter Rule Summary
+
+- 앱/REST 직접 호출: `payload jsonb` wrapper canonical
+- 내부 delegate/legacy: positional arg 허용
+- wrapper / delegate는 최대 2계층까지만 허용
+
+정리 대상:
+
+- `rpc_get_rival_leaderboard(payload jsonb)`는 이미 canonical
+- `rpc_get_widget_quest_rival_summary(payload jsonb)`도 canonical
+- `rpc_get_widget_territory_summary` / `rpc_get_widget_hotspot_summary`는 아직 positional canonical이라 차기 랩핑이 필요
+- `rpc_get_nearby_hotspots`는 latest `in_*` 시그니처 우선, legacy positional fallback 유지
+
+## Sunset Rule
+
+아래 조건을 만족하기 전까지 compat 제거 금지:
+
+1. 문서 업데이트 완료
+2. smoke/static check 갱신 완료
+3. post-deploy smoke 2회 연속 통과
+4. 최소 2개 앱 릴리즈 또는 14일 경과
+
+## Validation
+
+- `swift scripts/backend_contract_versioning_unit_check.swift`
+- `bash scripts/backend_pr_check.sh`

--- a/scripts/backend_contract_versioning_unit_check.swift
+++ b/scripts/backend_contract_versioning_unit_check.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// 조건이 거짓이면 실패 메시지를 출력하고 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 불리언 조건입니다.
+///   - message: 실패 시 stderr에 출력할 설명입니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+/// 저장소 루트 기준 상대 경로의 UTF-8 텍스트를 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 상대 경로입니다.
+/// - Returns: 파일 전체 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let policy = load("docs/backend-contract-versioning-policy-v1.md")
+let matrix = load("docs/backend-high-risk-contract-matrix-v1.md")
+let smokeDoc = load("docs/supabase-integration-smoke-matrix-v1.md")
+let readme = load("README.md")
+let backendCheck = load("scripts/backend_pr_check.sh")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+let nearbyPresence = load("supabase/functions/nearby-presence/index.ts")
+let rivalLeague = load("supabase/functions/rival-league/index.ts")
+let rivalCompat = load("supabase/migrations/20260305224000_rival_rpc_postgrest_compat_fix.sql")
+let hotspotWidgetMigration = load("supabase/migrations/20260303203000_hotspot_widget_summary_rpc.sql")
+let territoryWidgetMigration = load("supabase/migrations/20260303190000_territory_widget_summary_rpc.sql")
+
+assertTrue(policy.contains("version"), "policy should define version field rule")
+assertTrue(policy.contains("request_id"), "policy should define request_id rule")
+assertTrue(policy.contains("ok"), "policy should define ok envelope field")
+assertTrue(policy.contains("error"), "policy should define error envelope field")
+assertTrue(policy.contains("code"), "policy should define error code field")
+assertTrue(policy.contains("message"), "policy should define error message field")
+assertTrue(policy.contains("payload jsonb"), "policy should define jsonb payload wrapper rule")
+assertTrue(policy.contains("2개 앱 릴리즈 또는 14일"), "policy should define deprecation minimum window")
+assertTrue(policy.contains("Breaking"), "policy should document breaking change criteria")
+assertTrue(policy.contains("Non-breaking"), "policy should document non-breaking criteria")
+
+for endpoint in ["sync-walk", "nearby-presence", "rival-league", "quest-engine", "rpc_get_widget_quest_rival_summary"] {
+    assertTrue(matrix.contains(endpoint), "matrix should include \(endpoint)")
+}
+assertTrue(matrix.contains("rpc_get_widget_territory_summary"), "matrix should include territory widget RPC")
+assertTrue(matrix.contains("rpc_get_widget_hotspot_summary"), "matrix should include hotspot widget RPC")
+assertTrue(matrix.contains("rpc_get_nearby_hotspots"), "matrix should include nearby hotspot RPC compatibility note")
+assertTrue(matrix.contains("rpc_get_rival_leaderboard(payload jsonb)"), "matrix should declare jsonb leaderboard canonical path")
+assertTrue(matrix.contains("top-level 유지"), "matrix should preserve top-level response keys for compatibility")
+
+assertTrue(nearbyPresence.contains("getNearbyHotspotsWithCompatRPC"), "nearby presence should still expose hotspot RPC compat helper")
+assertTrue(nearbyPresence.contains("in_center_lat") && nearbyPresence.contains("center_lat"), "nearby presence should document latest and legacy hotspot RPC signatures in source")
+assertTrue(rivalLeague.contains("payload:"), "rival league should call leaderboard RPC through payload wrapper")
+assertTrue(rivalCompat.contains("rpc_get_rival_leaderboard(payload jsonb)"), "compat migration should define jsonb leaderboard wrapper")
+assertTrue(rivalCompat.contains("rpc_get_widget_quest_rival_summary(payload jsonb)"), "compat migration should define widget quest/rival jsonb wrapper")
+assertTrue(hotspotWidgetMigration.contains("rpc_get_widget_hotspot_summary"), "hotspot widget migration should exist for matrix coverage")
+assertTrue(territoryWidgetMigration.contains("rpc_get_widget_territory_summary"), "territory widget migration should exist for matrix coverage")
+
+assertTrue(smokeDoc.contains("rival-rpc.compat.member"), "smoke doc should keep rival rpc compatibility coverage")
+assertTrue(smokeDoc.contains("quest-engine.list_active.member"), "smoke doc should keep quest-engine smoke coverage")
+assertTrue(backendCheck.contains("backend_contract_versioning_unit_check.swift"), "backend_pr_check should run contract versioning unit check")
+assertTrue(iosPRCheck.contains("backend_contract_versioning_unit_check.swift"), "ios_pr_check should run contract versioning unit check")
+assertTrue(readme.contains("docs/backend-contract-versioning-policy-v1.md"), "README should link backend contract policy doc")
+assertTrue(readme.contains("docs/backend-high-risk-contract-matrix-v1.md"), "README should link backend contract matrix doc")
+
+print("PASS: backend contract versioning unit checks")

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -6,6 +6,7 @@ cd "$ROOT_DIR"
 
 echo "[dogArea-backend] running integration harness structure checks"
 swift scripts/supabase_integration_harness_unit_check.swift
+swift scripts/backend_contract_versioning_unit_check.swift
 
 if [[ "${DOGAREA_RUN_SUPABASE_SMOKE:-0}" != "1" ]]; then
   echo "[dogArea-backend] DOGAREA_RUN_SUPABASE_SMOKE=1 이 아니므로 실 Supabase smoke matrix는 건너뜁니다."

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -40,6 +40,7 @@ swift scripts/realtime_ops_rollout_unit_check.swift
 swift scripts/realtime_ops_rollout_gate.swift --input docs/realtime-ops-kpi-sample-pass.json
 swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/supabase_integration_harness_unit_check.swift
+swift scripts/backend_contract_versioning_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift
 swift scripts/rival_privacy_policy_confirmed_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift


### PR DESCRIPTION
## Summary
- add a backend contract versioning policy doc that defines canonical `version`, `request_id`, envelope, breaking/non-breaking, and fallback lifetime rules
- add a high-risk contract matrix for `sync-walk`, `nearby-presence`, `rival-league`, `quest-engine`, and widget summary RPC surfaces
- add a static unit check and wire it into `backend_pr_check` and `ios_pr_check`

## Testing
- `swift scripts/backend_contract_versioning_unit_check.swift`
- `swift scripts/rival_rpc_param_compat_unit_check.swift`
- `bash scripts/backend_pr_check.sh`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #417
