### PR TITLE
docs: standardize backend edge observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@
 - Supabase integration smoke matrix v1: `docs/supabase-integration-smoke-matrix-v1.md`
 - Backend 계약 버저닝 정책 v1: `docs/backend-contract-versioning-policy-v1.md`
 - Backend 고위험 계약 매트릭스 v1: `docs/backend-high-risk-contract-matrix-v1.md`
+- Backend Edge observability 표준 v1: `docs/backend-edge-observability-standard-v1.md`
+- Backend Edge error taxonomy v1: `docs/backend-edge-error-taxonomy-v1.md`
+- Backend Edge incident runbook v1: `docs/backend-edge-incident-runbook-v1.md`
+- Backend Edge observability adoption matrix v1: `docs/backend-edge-observability-adoption-matrix-v1.md`
 - 릴리즈 회귀 체크리스트 v1: `docs/release-regression-checklist-v1.md`
 - 릴리즈 회귀 실행 리포트(2026-02-26): `docs/release-regression-report-2026-02-26.md`
 - 게임 레이어 공통 관측/QA 기준 v1: `docs/game-layer-observability-qa-v1.md`

--- a/docs/backend-edge-error-taxonomy-v1.md
+++ b/docs/backend-edge-error-taxonomy-v1.md
@@ -1,0 +1,146 @@
+# Backend Edge Error Taxonomy v1
+
+Date: 2026-03-07  
+Issue: #418
+
+## 목적
+
+Edge Function마다 제각각 쓰이던 `error`, `errorCode`, message를 운영/QA/배포 검증이 같은 분류로 읽을 수 있게 정규화합니다.
+
+## Canonical Error Categories
+
+### 1. auth
+
+인증/권한/세션 관련 실패.
+
+대표 코드:
+
+- `UNAUTHORIZED`
+- `AUTH_HEADER_MISSING`
+- `AUTH_TOKEN_EMPTY`
+- `AUTH_SESSION_INVALID`
+- `UNAUTHORIZED_USER_MISMATCH`
+- `AUTH_MODE_NOT_ALLOWED`
+
+### 2. contract
+
+요청 형식이나 action/stage/version 계약 불일치.
+
+대표 코드:
+
+- `METHOD_NOT_ALLOWED`
+- `INVALID_JSON`
+- `ACTION_REQUIRED`
+- `STAGE_REQUIRED`
+- `UNSUPPORTED_ACTION`
+- `UNSUPPORTED_STAGE`
+- `INVALID_VERSION`
+- `CONTRACT_SHAPE_MISMATCH`
+
+### 3. validation
+
+도메인 입력값 자체가 잘못된 경우.
+
+대표 코드:
+
+- `INVALID_PAYLOAD`
+- `INVALID_PET_ID`
+- `PET_NAME_REQUIRED`
+- `INVALID_AGE_RANGE`
+- `OWNER_ID_REQUIRED`
+- `INVALID_OWNER_ID`
+- `INVALID_IMAGE_BASE64`
+- `INVALID_IMAGE_SIZE`
+
+### 4. unavailable
+
+배포 누락, RPC 미배포, 설정 누락, 일시 unavailable.
+
+대표 코드:
+
+- `SERVER_MISCONFIGURED`
+- `FUNCTION_NOT_DEPLOYED`
+- `RPC_NOT_FOUND`
+- `COOLDOWN_ACTIVE`
+- `RATE_LIMITED`
+- `SERVICE_UNAVAILABLE`
+
+### 5. privacy
+
+privacy guard / suppression / visibility policy 관련 차단 또는 마스킹.
+
+대표 코드:
+
+- `LOCATION_SHARING_DISABLED`
+- `PRIVACY_GUARD_BLOCKED`
+- `HOTSPOT_SUPPRESSED_K_ANON`
+- `HOTSPOT_SUPPRESSED_SENSITIVE_MASK`
+- `LIVE_PRESENCE_DELAYED`
+
+### 6. upstream
+
+DB, Storage, provider, RPC 등 외부 의존성 실패.
+
+대표 코드:
+
+- `RPC_FAILED`
+- `DB_WRITE_FAILED`
+- `DB_READ_FAILED`
+- `STORAGE_UPLOAD_FAILED`
+- `PUBLIC_URL_FAILED`
+- `UPSTREAM_TIMEOUT`
+- `ALL_PROVIDERS_FAILED`
+- `SOURCE_IMAGE_NOT_FOUND`
+
+### 7. abuse
+
+anti-abuse / sanction / moderation에 의해 제한된 경우.
+
+대표 코드:
+
+- `ABUSE_BLOCKED`
+- `SANCTION_ACTIVE`
+- `MODERATION_BLOCKED`
+
+## Response Mapping Rule
+
+- legacy `error` 필드는 유지 가능
+- canonical machine-readable 값은 `code`에 둡니다
+- `message`는 운영자 해석에 충분한 설명을 넣습니다
+- 가능한 경우 `category`는 로그/문서에서 유추 가능해야 합니다
+
+예시:
+
+```json
+{
+  "ok": false,
+  "error": "UNAUTHORIZED",
+  "code": "UNAUTHORIZED",
+  "message": "authorization header required",
+  "request_id": "req_123",
+  "version": "2026-03-07.v1"
+}
+```
+
+## Category-to-runbook 연결
+
+- `auth` -> 세션/Authorization 헤더/anon retry 확인
+- `contract` -> payload/version/action/stage와 compat matrix 확인
+- `validation` -> caller payload 검증 실패 확인
+- `unavailable` -> 배포 매트릭스, migration drift, cooldown 확인
+- `privacy` -> suppression / visibility / audit log 확인
+- `upstream` -> RPC/Storage/provider dependency 확인
+- `abuse` -> sanction / anti-abuse guard 확인
+
+## Current Mapping Guidance
+
+현재 함수가 `error`만 반환하더라도, 운영 문서/후속 refactor에서는 아래처럼 읽습니다.
+
+- `METHOD_NOT_ALLOWED`, `INVALID_JSON`, `ACTION_REQUIRED`, `UNSUPPORTED_ACTION`, `UNSUPPORTED_STAGE` -> `contract`
+- `INVALID_PAYLOAD`, `INVALID_PET_ID`, `PET_NAME_REQUIRED` 등 -> `validation`
+- `SERVER_MISCONFIGURED`, `404`, `cooldown` -> `unavailable`
+- DB/RPC/Storage/provider message -> `upstream`
+
+## Validation
+
+- `swift scripts/backend_edge_observability_unit_check.swift`

--- a/docs/backend-edge-incident-runbook-v1.md
+++ b/docs/backend-edge-incident-runbook-v1.md
@@ -1,0 +1,168 @@
+# Backend Edge Incident Runbook v1
+
+Date: 2026-03-07  
+Issue: #418
+
+## 목적
+
+Edge Function 장애가 발생했을 때 함수별 감이 아니라 공통 절차로 역추적할 수 있도록 triage 순서를 고정합니다.
+
+## 1. 최초 분류
+
+장애를 보면 먼저 아래를 채웁니다.
+
+- `function_name`
+- `request_id`
+- `version`
+- `auth_mode`
+- `error_code`
+- `fallback_used`
+- `rpc_name`
+- `latency_ms`
+
+이 필드가 응답/로그/DB audit 중 어디에 남았는지 찾는 것이 첫 단계입니다.
+
+## 2. 로그/응답에서 읽을 순서
+
+1. `error_code` 또는 legacy `error`
+2. `function_name`
+3. `request_id`
+4. `fallback_used`
+5. `rpc_name`
+6. privacy / abuse 메타 (`suppression_reason`, `abuse_reason`, `sanction_level`)
+7. `latency_ms`
+
+## 3. 분류별 대응
+
+### auth
+
+확인:
+
+- bearer 헤더 존재 여부
+- member token 유효성
+- anon retry가 있었는지
+- 함수 auth mode가 의도와 맞는지
+
+관련 이슈/문서:
+
+- `#419`
+- `#431`
+
+### contract
+
+확인:
+
+- `action`, `stage`, `payload`, `version` shape
+- canonical route / legacy route fallback 여부
+- RPC positional vs `payload jsonb` 경로
+
+관련 문서:
+
+- `docs/backend-contract-versioning-policy-v1.md`
+- `docs/backend-high-risk-contract-matrix-v1.md`
+- `docs/sync-walk-404-fallback-policy-v1.md`
+
+### unavailable
+
+확인:
+
+- 함수가 실제 배포되었는지
+- RPC/migration drift가 없는지
+- 404 cooldown 또는 rollout block이 걸렸는지
+- config/secret 누락인지
+
+실행 커맨드:
+
+```bash
+bash scripts/backend_pr_check.sh
+DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/backend_pr_check.sh
+```
+
+관련 문서/이슈:
+
+- `#436`
+- `#427`
+- `#439`
+
+### privacy
+
+확인:
+
+- `suppression_reason`
+- `delay_minutes`
+- `required_min_sample`
+- visibility enabled 여부
+- audit log insert 실패 여부
+
+관련 문서:
+
+- `docs/rival-privacy-hard-guard-v1.md`
+- `docs/hotspot-widget-privacy-mapping-v1.md`
+
+### upstream
+
+확인:
+
+- RPC 명과 SQL migration 존재 여부
+- Storage 업로드 실패인지
+- provider/router fallback 사용 여부
+
+관련 이슈:
+
+- `#433`
+- `#438`
+
+### abuse
+
+확인:
+
+- `abuse_reason`
+- `abuse_score`
+- `sanction_level`
+- `sanction_until`
+
+## 4. alert / dashboard 연결
+
+운영자가 기본으로 보는 기준:
+
+- game-layer KPI: `docs/game-layer-observability-qa-v1.md`
+- rollout KPI: `docs/feature-flag-rollout-monitoring-v1.md`
+- live smoke matrix: `docs/supabase-integration-smoke-matrix-v1.md`
+- deploy verification / matrix: `#436`
+
+## 5. 대표 시나리오
+
+### A. 404 / function not deployed
+
+- smoke matrix에서 route 404 확인
+- cooldown 적용 여부 확인
+- deploy matrix와 rollback/roll-forward runbook 확인
+
+### B. anon retry / auth downgrade
+
+- 요청이 `authenticated`였는지, fallback이 `anon`으로 내려갔는지 확인
+- local session invalidate가 실제로 발생했는지 확인
+- 함수가 `mixed` auth mode인지 확인
+
+### C. nearby suppression / privacy guard
+
+- `suppression_reason`와 `privacy_mode` 확인
+- hotspot / live presence audit log 삽입 결과 확인
+- `required_min_sample`, `delay_minutes`, `obfuscation_meters` 확인
+
+### D. provider fallback
+
+- `fallback_used=true`인지 확인
+- primary provider와 fallback provider 중 어느 단계에서 실패했는지 확인
+- `latency_ms`와 provider 실패 코드를 함께 확인
+
+## 6. 운영 후속 조치 규칙
+
+- incident가 contract 문제면 문서/compat matrix도 같이 갱신
+- incident가 deploy 문제면 smoke matrix 케이스를 추가하거나 강화
+- incident가 auth/privacy 문제면 taxonomy와 auth_mode 표준을 같이 수정
+
+## Validation
+
+- `swift scripts/backend_edge_observability_unit_check.swift`
+- `bash scripts/backend_pr_check.sh`

--- a/docs/backend-edge-observability-adoption-matrix-v1.md
+++ b/docs/backend-edge-observability-adoption-matrix-v1.md
@@ -1,0 +1,35 @@
+# Backend Edge Observability Adoption Matrix v1
+
+Date: 2026-03-07  
+Issue: #418
+
+## Matrix
+
+| Function | Current observability signal in source | Current error shape | Special metadata | Gap to standard | Follow-up |
+| --- | --- | --- | --- | --- | --- |
+| `caricature` | `request_id`, `errorCode`, `fallback_used`, `latency_ms` persisted/loggable | `errorCode` + `message` 중심 | provider fallback, storage/provider failure, schema version | 가장 표준에 가까움. success/error envelope helper만 공통화 필요 | `#438` |
+| `nearby-presence` | `console.error`, privacy audit insert, hotspot compat signature logging | legacy `error` + 일부 `code` | `suppression_reason`, `delay_minutes`, `required_min_sample`, `abuse_reason`, `abuse_score`, `sanction_level` | `request_id`, `version`, `latency_ms`, `auth_mode` 메타 추가 필요 | `#425`, `#431`, `#438` |
+| `sync-walk` | 404 fallback 정책은 문서/클라이언트에 존재 | legacy `error` only | route fallback / cooldown은 클라이언트에서 추적 | function-side `request_id`, `version`, `latency_ms`, `fallback_used`, structured error code 필요 | `#424`, `#437`, `#438` |
+| `sync-profile` | auth/user mismatch path 구분 | legacy `error` only | user mismatch `403` | request_id/version/latency/error taxonomy 메타 추가 필요 | `#419`, `#438` |
+| `rival-league` | jsonb RPC wrapper path 사용 | legacy `error` only | leaderboard compat RPC delegate | request_id/version/latency/error taxonomy/fallback_used 추가 필요 | `#419`, `#437`, `#438` |
+| `quest-engine` | `requestId`를 claim RPC에 일부 전달 | legacy `error` only | reward claim idempotency trace 일부 존재 | canonical `request_id`, version, latency, auth_mode, standardized code 필요 | `#419`, `#438` |
+| `feature-control` | rollout KPI/ops 문서 존재 | legacy `error` only | rollout / flags / KPI endpoints | function_name/request_id/version/error taxonomy/log metadata 추가 필요 | `#438` |
+| `upload-profile-image` | storage failure branch 명확 | legacy `error` + `detail` | upload/public URL failure | request_id/version/latency/auth_mode/error taxonomy 추가 필요 | `#433`, `#438` |
+
+## Adoption Rule
+
+- Wave 1: 문서 + static check + smoke 연결
+- Wave 2: shared helper 도입으로 success/error envelope 표준화
+- Wave 3: request_id/version/auth_mode/fallback_used 자동 주입
+
+## 최소 합격선
+
+운영상 "관측 가능"으로 판단하려면 아래 3개가 모두 가능해야 합니다.
+
+1. 함수 이름을 식별할 수 있다
+2. 에러 category 또는 canonical code로 분류할 수 있다
+3. fallback/privacy/abuse 여부를 로그나 응답에서 식별할 수 있다
+
+## Validation
+
+- `swift scripts/backend_edge_observability_unit_check.swift`

--- a/docs/backend-edge-observability-standard-v1.md
+++ b/docs/backend-edge-observability-standard-v1.md
@@ -1,0 +1,208 @@
+# Backend Edge Observability Standard v1
+
+Date: 2026-03-07  
+Issue: #418
+
+## 목적
+
+DogArea Supabase Edge Function이 장애, fallback, privacy suppression, auth mismatch를 겪을 때 운영자가 **같은 해석 체계**로 로그와 응답을 읽을 수 있게 최소 메타데이터와 로그 규칙을 고정합니다.
+
+이 문서는 외부 SaaS 도입 문서가 아닙니다. 함수 내부 로그, 응답 메타, smoke/runbook이 같은 기준을 쓰도록 맞추는 운영 표준입니다.
+
+## 대상 함수
+
+우선순위 대상:
+
+- `feature-control`
+- `sync-walk`
+- `sync-profile`
+- `nearby-presence`
+- `rival-league`
+- `quest-engine`
+- `upload-profile-image`
+- `caricature`
+
+## 공통 로그 메타 필드
+
+모든 고위험 Edge Function은 start / success / failure 로그 또는 동등한 audit 흔적에서 아래 필드를 식별 가능하게 남겨야 합니다.
+
+- `function_name`: canonical Edge Function 이름
+- `request_id`: 요청 상관관계 ID
+- `version`: 협상된 계약 버전 또는 서버 canonical 버전
+- `latency_ms`: 요청 시작부터 응답까지의 처리 시간
+- `auth_mode`: `anon|authenticated|service_role_proxy|mixed`
+- `fallback_used`: compat route / legacy signature / provider fallback 사용 여부
+- `rpc_name`: 주요 DB RPC 호출명이 있으면 기록
+- `error_code`: taxonomy 기준 machine-readable 코드
+- `cooldown_key`: 404 cooldown / rollout cooldown / retry suppression이 있으면 키 기록
+- `policy_key`: privacy / abuse / moderation 정책 이름이 있으면 기록
+
+## 로그 이벤트 규약
+
+### 1. request_received
+
+최소 필드:
+
+- `function_name`
+- `request_id`
+- `version`
+- `auth_mode`
+- `action`
+
+### 2. request_succeeded
+
+최소 필드:
+
+- `function_name`
+- `request_id`
+- `version`
+- `latency_ms`
+- `fallback_used`
+- `rpc_name` 또는 `rpc_names`
+
+### 3. request_failed
+
+최소 필드:
+
+- `function_name`
+- `request_id`
+- `version`
+- `latency_ms`
+- `error_code`
+- `message`
+- `fallback_used`
+- `rpc_name`
+
+## 응답 메타 표준
+
+계약 버전 규칙은 `docs/backend-contract-versioning-policy-v1.md`를 따릅니다.
+
+### Success
+
+고위험 함수 성공 응답은 아래 메타를 목표로 합니다.
+
+```json
+{
+  "ok": true,
+  "version": "2026-03-07.v1",
+  "request_id": "req_123",
+  "latency_ms": 42,
+  "fallback_used": false
+}
+```
+
+도메인 payload는 기존 top-level 키를 유지합니다.
+
+### Error
+
+고위험 함수 오류 응답은 아래 메타를 목표로 합니다.
+
+```json
+{
+  "ok": false,
+  "error": "UNAUTHORIZED",
+  "code": "UNAUTHORIZED",
+  "message": "authorization header required",
+  "request_id": "req_123",
+  "version": "2026-03-07.v1",
+  "latency_ms": 7,
+  "fallback_used": false
+}
+```
+
+규칙:
+
+- `error`는 v1 호환 alias로 유지 가능
+- `code`는 taxonomy canonical 값
+- `message`는 운영자가 원인을 판단할 수 있는 수준으로 남김
+- 기존 앱 파서가 깨지지 않도록 도메인 키는 제거하지 않음
+
+## auth_mode 규칙
+
+- `anon`: anon bearer 또는 public execution
+- `authenticated`: member bearer 검증 완료
+- `service_role_proxy`: 함수 내부에서 service role로 DB 호출하지만 요청은 인증됨
+- `mixed`: anon/app policy와 member policy가 섞인 경우
+
+예시:
+
+- `feature-control`: `anon`
+- `rival-league`: `authenticated`
+- `nearby-presence`: `mixed`
+- `caricature`: `authenticated`
+
+## fallback_used 규칙
+
+`fallback_used=true`로 기록해야 하는 경우:
+
+- legacy route fallback 사용 (`sync_walk` 등)
+- legacy RPC signature delegate 사용
+- provider fallback 사용 (`Gemini -> OpenAI` 등)
+- anon retry / alternate auth path 사용
+
+`fallback_used=false`로 기록해야 하는 경우:
+
+- canonical route / canonical RPC / primary provider만 사용
+
+## privacy / abuse 메타 규칙
+
+아래 도메인은 응답 또는 audit log에서 suppression 정보를 반드시 식별 가능하게 남깁니다.
+
+### nearby-presence
+
+- `suppression_reason`
+- `delay_minutes`
+- `required_min_sample`
+- `abuse_reason`
+- `abuse_score`
+- `sanction_level`
+
+### rival / quest / season 권리경로
+
+- privacy 또는 abuse에 의해 차단되면 `policy_key`와 `error_code`를 함께 남김
+
+## rollout / cooldown 메타 규칙
+
+다음 유형의 보호 장치가 있으면 로그에 표시해야 합니다.
+
+- 404 function cooldown
+- feature flag rollout block
+- auth retry suppression
+- privacy guard suppression
+
+최소 필드:
+
+- `cooldown_key`
+- `cooldown_ttl_sec` 또는 `retry_after_sec`
+- `fallback_used`
+
+## adoption 우선순위
+
+### 1차: 지금 바로 문서/정적 체크에 반영
+
+- 함수별 현재 메타 보유 상태 표준 문서화
+- 에러 taxonomy 명문화
+- runbook 명문화
+- smoke / static check 연결
+
+### 2차: 후속 refactor issue에서 runtime 통일
+
+- 공통 error/helper 모듈 추출
+- request_id/version 자동 주입
+- success/error envelope helper 통일
+- structured log helper 도입
+
+## Validation
+
+- `swift scripts/backend_edge_observability_unit_check.swift`
+- `bash scripts/backend_pr_check.sh`
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
+
+## Related
+
+- `docs/backend-edge-error-taxonomy-v1.md`
+- `docs/backend-edge-incident-runbook-v1.md`
+- `docs/backend-edge-observability-adoption-matrix-v1.md`
+- `docs/backend-contract-versioning-policy-v1.md`
+- `docs/game-layer-observability-qa-v1.md`
+- `docs/feature-flag-rollout-monitoring-v1.md`

--- a/scripts/backend_edge_observability_unit_check.swift
+++ b/scripts/backend_edge_observability_unit_check.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// 조건이 거짓이면 실패 메시지를 출력하고 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 불리언 조건입니다.
+///   - message: 실패 시 stderr에 출력할 설명입니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+/// 저장소 루트 기준 상대 경로 파일을 UTF-8 문자열로 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 상대 경로입니다.
+/// - Returns: 파일 전체 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let standardDoc = load("docs/backend-edge-observability-standard-v1.md")
+let taxonomyDoc = load("docs/backend-edge-error-taxonomy-v1.md")
+let runbookDoc = load("docs/backend-edge-incident-runbook-v1.md")
+let matrixDoc = load("docs/backend-edge-observability-adoption-matrix-v1.md")
+let readme = load("README.md")
+let backendCheck = load("scripts/backend_pr_check.sh")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+let caricature = load("supabase/functions/caricature/index.ts")
+let nearbyPresence = load("supabase/functions/nearby-presence/index.ts")
+let syncWalk = load("supabase/functions/sync-walk/index.ts")
+let questEngine = load("supabase/functions/quest-engine/index.ts")
+let featureControl = load("supabase/functions/feature-control/index.ts")
+let uploadProfileImage = load("supabase/functions/upload-profile-image/index.ts")
+
+for field in ["function_name", "request_id", "version", "latency_ms", "auth_mode", "fallback_used", "rpc_name"] {
+    assertTrue(standardDoc.contains(field), "standard doc should define \(field) field")
+}
+assertTrue(standardDoc.contains("request_received"), "standard doc should define request_received event")
+assertTrue(standardDoc.contains("request_succeeded"), "standard doc should define request_succeeded event")
+assertTrue(standardDoc.contains("request_failed"), "standard doc should define request_failed event")
+assertTrue(standardDoc.contains("service_role_proxy"), "standard doc should define auth_mode values")
+assertTrue(standardDoc.contains("policy_key"), "standard doc should define policy key metadata")
+assertTrue(standardDoc.contains("cooldown_key"), "standard doc should define cooldown metadata")
+
+for category in ["auth", "contract", "validation", "unavailable", "privacy", "upstream", "abuse"] {
+    assertTrue(taxonomyDoc.contains("### 1. auth") || category != "auth", "taxonomy doc should keep category headers")
+    assertTrue(taxonomyDoc.contains(category), "taxonomy doc should mention category \(category)")
+}
+for code in ["UNAUTHORIZED", "INVALID_JSON", "INVALID_PAYLOAD", "SERVER_MISCONFIGURED", "PRIVACY_GUARD_BLOCKED", "STORAGE_UPLOAD_FAILED", "ABUSE_BLOCKED"] {
+    assertTrue(taxonomyDoc.contains(code), "taxonomy doc should include canonical code \(code)")
+}
+
+for term in ["function_name", "request_id", "fallback_used", "rpc_name", "404 / function not deployed", "anon retry / auth downgrade", "nearby suppression / privacy guard", "provider fallback"] {
+    assertTrue(runbookDoc.contains(term), "runbook doc should include \(term)")
+}
+
+for functionName in ["caricature", "nearby-presence", "sync-walk", "sync-profile", "rival-league", "quest-engine", "feature-control", "upload-profile-image"] {
+    assertTrue(matrixDoc.contains("`\(functionName)`"), "adoption matrix should include \(functionName)")
+}
+assertTrue(matrixDoc.contains("Wave 1") && matrixDoc.contains("Wave 2") && matrixDoc.contains("Wave 3"), "adoption matrix should describe staged adoption")
+
+assertTrue(caricature.contains("request_id") && caricature.contains("fallback_used") && caricature.contains("latency_ms"), "caricature should expose advanced observability metadata in source")
+assertTrue(nearbyPresence.contains("suppression_reason") && nearbyPresence.contains("abuse_reason"), "nearby presence should expose privacy and abuse metadata in source")
+assertTrue(nearbyPresence.contains("console.error(\"nearby hotspot rpc failed\""), "nearby presence should log hotspot rpc failure")
+assertTrue(syncWalk.contains("json({ error: \"UNAUTHORIZED\" }"), "sync-walk should still expose legacy error shape covered by the adoption matrix")
+assertTrue(questEngine.contains("request_id: asString(body.requestId)"), "quest-engine should expose partial request id trace mentioned in the matrix")
+assertTrue(featureControl.contains("json({ error: \"SERVER_MISCONFIGURED\" }"), "feature-control should expose legacy error shape covered by the matrix")
+assertTrue(uploadProfileImage.contains("UPLOAD_FAILED") && uploadProfileImage.contains("PUBLIC_URL_FAILED"), "upload-profile-image should expose storage failure codes")
+
+assertTrue(readme.contains("docs/backend-edge-observability-standard-v1.md"), "README should link backend edge observability standard doc")
+assertTrue(readme.contains("docs/backend-edge-error-taxonomy-v1.md"), "README should link backend edge error taxonomy doc")
+assertTrue(readme.contains("docs/backend-edge-incident-runbook-v1.md"), "README should link backend edge incident runbook doc")
+assertTrue(readme.contains("docs/backend-edge-observability-adoption-matrix-v1.md"), "README should link backend edge adoption matrix doc")
+assertTrue(backendCheck.contains("backend_edge_observability_unit_check.swift"), "backend_pr_check should run backend edge observability unit check")
+assertTrue(iosPRCheck.contains("backend_edge_observability_unit_check.swift"), "ios_pr_check should run backend edge observability unit check")
+
+print("PASS: backend edge observability unit checks")

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -7,6 +7,7 @@ cd "$ROOT_DIR"
 echo "[dogArea-backend] running integration harness structure checks"
 swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/backend_contract_versioning_unit_check.swift
+swift scripts/backend_edge_observability_unit_check.swift
 
 if [[ "${DOGAREA_RUN_SUPABASE_SMOKE:-0}" != "1" ]]; then
   echo "[dogArea-backend] DOGAREA_RUN_SUPABASE_SMOKE=1 이 아니므로 실 Supabase smoke matrix는 건너뜁니다."

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -41,6 +41,7 @@ swift scripts/realtime_ops_rollout_gate.swift --input docs/realtime-ops-kpi-samp
 swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/backend_contract_versioning_unit_check.swift
+swift scripts/backend_edge_observability_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift
 swift scripts/rival_privacy_policy_confirmed_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift


### PR DESCRIPTION
## Summary
- add a backend edge observability standard covering common metadata, auth mode, fallback, privacy, and cooldown logging rules
- add an error taxonomy, incident runbook, and current adoption matrix for high-risk Supabase Edge Functions
- add a static observability unit check and wire it into `backend_pr_check` and `ios_pr_check`

## Testing
- `swift scripts/backend_edge_observability_unit_check.swift`
- `bash scripts/backend_pr_check.sh`
- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #418
