### PR TITLE
refactor: split sync-walk stage handlers

### DIFF
--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -9,6 +9,7 @@ swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/backend_contract_versioning_unit_check.swift
 swift scripts/backend_edge_observability_unit_check.swift
 swift scripts/backend_edge_auth_unification_unit_check.swift
+swift scripts/sync_walk_stage_handler_split_unit_check.swift
 
 if [[ "${DOGAREA_RUN_SUPABASE_SMOKE:-0}" != "1" ]]; then
   echo "[dogArea-backend] DOGAREA_RUN_SUPABASE_SMOKE=1 이 아니므로 실 Supabase smoke matrix는 건너뜁니다."

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -43,6 +43,7 @@ swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/backend_contract_versioning_unit_check.swift
 swift scripts/backend_edge_observability_unit_check.swift
 swift scripts/backend_edge_auth_unification_unit_check.swift
+swift scripts/sync_walk_stage_handler_split_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift
 swift scripts/rival_privacy_policy_confirmed_unit_check.swift
 swift scripts/rival_privacy_hard_guard_unit_check.swift

--- a/scripts/quest_stage2_engine_unit_check.swift
+++ b/scripts/quest_stage2_engine_unit_check.swift
@@ -23,8 +23,18 @@ func load(_ relativePath: String) -> String {
     return String(decoding: data, as: UTF8.self)
 }
 
+func loadMany(_ relativePaths: [String]) -> String {
+    relativePaths.map(load).joined(separator: "\n")
+}
+
 let migration = load("supabase/migrations/20260303120000_quest_stage2_progress_claim_engine.sql")
-let syncWalk = load("supabase/functions/sync-walk/index.ts")
+let syncWalk = loadMany([
+    "supabase/functions/sync-walk/index.ts",
+    "supabase/functions/sync-walk/support/core.ts",
+    "supabase/functions/sync-walk/support/types.ts",
+    "supabase/functions/sync-walk/handlers/points_stage.ts",
+    "supabase/functions/sync-walk/handlers/points_stage_post_processing.ts"
+])
 let questEngine = load("supabase/functions/quest-engine/index.ts")
 let doc = load("docs/quest-stage2-progress-claim-engine-v1.md")
 let report = load("docs/cycle-205-quest-stage2-engine-report-2026-03-03.md")

--- a/scripts/season_anti_farming_unit_check.swift
+++ b/scripts/season_anti_farming_unit_check.swift
@@ -109,8 +109,18 @@ func load(_ relativePath: String) -> String {
     return String(decoding: data, as: UTF8.self)
 }
 
+func loadMany(_ relativePaths: [String]) -> String {
+    relativePaths.map(load).joined(separator: "\n")
+}
+
 let migration = load("supabase/migrations/20260227195500_season_anti_farming_rules.sql")
-let syncWalkFunction = load("supabase/functions/sync-walk/index.ts")
+let syncWalkFunction = loadMany([
+    "supabase/functions/sync-walk/index.ts",
+    "supabase/functions/sync-walk/support/core.ts",
+    "supabase/functions/sync-walk/support/types.ts",
+    "supabase/functions/sync-walk/handlers/points_stage.ts",
+    "supabase/functions/sync-walk/handlers/points_stage_post_processing.ts"
+])
 let doc = load("docs/season-anti-farming-v1.md")
 let schemaDoc = load("docs/supabase-schema-v1.md")
 let migrationDoc = load("docs/supabase-migration.md")

--- a/scripts/season_comeback_catchup_unit_check.swift
+++ b/scripts/season_comeback_catchup_unit_check.swift
@@ -80,7 +80,13 @@ func loadMany(_ relativePaths: [String]) -> String {
 }
 
 let migration = load("supabase/migrations/20260227223000_season_comeback_catchup_buff.sql")
-let syncWalkFunction = load("supabase/functions/sync-walk/index.ts")
+let syncWalkFunction = loadMany([
+    "supabase/functions/sync-walk/index.ts",
+    "supabase/functions/sync-walk/support/core.ts",
+    "supabase/functions/sync-walk/support/types.ts",
+    "supabase/functions/sync-walk/handlers/points_stage.ts",
+    "supabase/functions/sync-walk/handlers/points_stage_post_processing.ts"
+])
 let userDefaultsStore = loadMany([
     "dogArea/Source/UserdefaultSetting.swift",
     "dogArea/Source/UserDefaultsSupport/UserSessionModels.swift",

--- a/scripts/season_stage2_pipeline_unit_check.swift
+++ b/scripts/season_stage2_pipeline_unit_check.swift
@@ -52,8 +52,19 @@ func load(_ relativePath: String) -> String {
     return String(decoding: data, as: UTF8.self)
 }
 
+func loadMany(_ relativePaths: [String]) -> String {
+    relativePaths.map(load).joined(separator: "\n")
+}
+
 let migration = load("supabase/migrations/20260301090000_season_stage2_batch_pipeline.sql")
-let syncWalk = load("supabase/functions/sync-walk/index.ts")
+let syncWalk = loadMany([
+    "supabase/functions/sync-walk/index.ts",
+    "supabase/functions/sync-walk/support/core.ts",
+    "supabase/functions/sync-walk/support/types.ts",
+    "supabase/functions/sync-walk/handlers/points_stage.ts",
+    "supabase/functions/sync-walk/handlers/points_stage_post_processing.ts",
+    "supabase/functions/sync-walk/handlers/stage_dispatcher.ts"
+])
 let schemaDoc = load("docs/supabase-schema-v1.md")
 let migrationDoc = load("docs/supabase-migration.md")
 let stage2Doc = load("docs/season-stage2-pipeline-v1.md")

--- a/scripts/sync_walk_stage_handler_split_unit_check.swift
+++ b/scripts/sync_walk_stage_handler_split_unit_check.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// 조건식을 검증하고 실패 시 오류 메시지를 출력한 뒤 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 조건식입니다.
+///   - message: 검증 실패 시 출력할 메시지입니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 파일을 UTF-8 문자열로 읽어옵니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: UTF-8 디코딩된 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let index = load("supabase/functions/sync-walk/index.ts")
+let types = load("supabase/functions/sync-walk/support/types.ts")
+let core = load("supabase/functions/sync-walk/support/core.ts")
+let backfill = load("supabase/functions/sync-walk/handlers/backfill_summary.ts")
+let sessionStage = load("supabase/functions/sync-walk/handlers/session_stage.ts")
+let metaStage = load("supabase/functions/sync-walk/handlers/meta_stage.ts")
+let pointsStage = load("supabase/functions/sync-walk/handlers/points_stage.ts")
+let pointsPost = load("supabase/functions/sync-walk/handlers/points_stage_post_processing.ts")
+let dispatcher = load("supabase/functions/sync-walk/handlers/stage_dispatcher.ts")
+let backendCheck = load("scripts/backend_pr_check.sh")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(index.contains("handleBackfillSummary"), "index should delegate backfill summary to dedicated handler")
+assertTrue(index.contains("dispatchSyncWalkStage"), "index should delegate sync_walk_stage dispatch")
+assertTrue(index.contains("resolveEdgeAuthContext"), "index should keep auth boundary")
+assertTrue(!index.contains("rpc_apply_weather_replacement"), "index should not inline points post-processing RPC calls")
+assertTrue(!index.contains("from(\"walk_points\")"), "index should not persist walk points inline")
+
+assertTrue(types.contains("type SyncWalkStageRequestContext"), "types file should define stage request context")
+assertTrue(core.contains("buildBaseSession"), "core support should build base session payload")
+assertTrue(core.contains("logSyncWalkStageFailure"), "core support should expose stage failure logger")
+
+assertTrue(backfill.contains("handleBackfillSummary"), "backfill handler file should define summary handler")
+assertTrue(sessionStage.contains("handleSessionStage"), "session stage file should define session handler")
+assertTrue(metaStage.contains("handleMetaStage"), "meta stage file should define meta handler")
+assertTrue(pointsStage.contains("handlePointsStage"), "points stage file should define points handler")
+assertTrue(pointsPost.contains("runPointsStagePostProcessing"), "points post-processing file should orchestrate downstream RPC calls")
+assertTrue(pointsPost.contains("rpc_score_walk_session_anti_farming"), "points post-processing should handle season scoring")
+assertTrue(pointsPost.contains("rpc_ingest_season_tile_events"), "points post-processing should handle season pipeline ingest")
+assertTrue(pointsPost.contains("rpc_apply_weather_replacement"), "points post-processing should handle weather replacement")
+assertTrue(pointsPost.contains("rpc_apply_quest_progress_event"), "points post-processing should handle quest progress")
+assertTrue(dispatcher.contains("syncWalkStageHandlers"), "stage dispatcher should define stage handler map")
+assertTrue(dispatcher.contains("isSupportedSyncStage"), "stage dispatcher should validate supported stages")
+
+assertTrue(backendCheck.contains("sync_walk_stage_handler_split_unit_check.swift"), "backend_pr_check should run sync-walk split check")
+assertTrue(iosPRCheck.contains("sync_walk_stage_handler_split_unit_check.swift"), "ios_pr_check should run sync-walk split check")
+
+print("PASS: sync-walk stage handler split unit checks")

--- a/scripts/weather_stage2_engine_unit_check.swift
+++ b/scripts/weather_stage2_engine_unit_check.swift
@@ -41,8 +41,18 @@ func load(_ relativePath: String) -> String {
     return String(decoding: data, as: UTF8.self)
 }
 
+func loadMany(_ relativePaths: [String]) -> String {
+    relativePaths.map(load).joined(separator: "\n")
+}
+
 let migration = load("supabase/migrations/20260228003000_weather_replacement_shield_engine.sql")
-let syncWalk = load("supabase/functions/sync-walk/index.ts")
+let syncWalk = loadMany([
+    "supabase/functions/sync-walk/index.ts",
+    "supabase/functions/sync-walk/support/core.ts",
+    "supabase/functions/sync-walk/support/types.ts",
+    "supabase/functions/sync-walk/handlers/points_stage.ts",
+    "supabase/functions/sync-walk/handlers/points_stage_post_processing.ts"
+])
 let policyDoc = load("docs/weather-replacement-shield-engine-v1.md")
 let schemaDoc = load("docs/supabase-schema-v1.md")
 let migrationDoc = load("docs/supabase-migration.md")

--- a/supabase/functions/_shared/edge_auth.ts
+++ b/supabase/functions/_shared/edge_auth.ts
@@ -38,7 +38,7 @@ export type EdgeAuthContext = {
   authHeader: string;
   accessToken: string;
   userId: string | null;
-  userClient: ReturnType<typeof createClient> | null;
+  userClient: any | null;
 };
 
 type EdgeAuthSuccess = {
@@ -190,7 +190,7 @@ const resolveMemberContext = async (
   supabaseAnonKey: string,
   authHeader: string,
   accessToken: string,
-): Promise<{ userId: string; userClient: ReturnType<typeof createClient> } | null> => {
+): Promise<{ userId: string; userClient: any } | null> => {
   const userClient = createClient(supabaseURL, supabaseAnonKey, {
     global: { headers: { Authorization: authHeader } },
   });

--- a/supabase/functions/sync-walk/handlers/backfill_summary.ts
+++ b/supabase/functions/sync-walk/handlers/backfill_summary.ts
@@ -1,0 +1,57 @@
+import { asString, json, logSyncWalkStageFailure, toNumber } from "../support/core.ts";
+import type { BackfillSummaryRequestContext } from "../support/types.ts";
+
+export async function handleBackfillSummary(
+  context: BackfillSummaryRequestContext,
+): Promise<Response> {
+  let sessionsQuery = context.userClient
+    .from("walk_sessions")
+    .select("id,area_m2,duration_sec")
+    .order("started_at", { ascending: false });
+
+  if (context.sessionIds.length > 0) {
+    sessionsQuery = sessionsQuery.in("id", context.sessionIds);
+  }
+
+  const { data: sessions, error: sessionError } = await sessionsQuery;
+  if (sessionError) {
+    logSyncWalkStageFailure(context.requestId, "get_backfill_summary", "load_sessions", sessionError.message);
+    return json({ error: sessionError.message }, 500);
+  }
+
+  const safeSessions = sessions ?? [];
+  const sessionIds = safeSessions
+    .map((row: Record<string, unknown>) => asString(row.id))
+    .filter((id: string | null): id is string => Boolean(id));
+
+  let pointCount = 0;
+  if (sessionIds.length > 0) {
+    const { count, error: pointError } = await context.userClient
+      .from("walk_points")
+      .select("id", { count: "exact", head: true })
+      .in("walk_session_id", sessionIds);
+    if (pointError) {
+      logSyncWalkStageFailure(context.requestId, "get_backfill_summary", "count_points", pointError.message);
+      return json({ error: pointError.message }, 500);
+    }
+    pointCount = count ?? 0;
+  }
+
+  const totalArea = safeSessions.reduce(
+    (acc: number, row: Record<string, unknown>) => acc + Math.max(0, toNumber(row.area_m2, 0)),
+    0,
+  );
+  const totalDuration = safeSessions.reduce(
+    (acc: number, row: Record<string, unknown>) => acc + Math.max(0, toNumber(row.duration_sec, 0)),
+    0,
+  );
+
+  return json({
+    summary: {
+      session_count: safeSessions.length,
+      point_count: pointCount,
+      total_area_m2: totalArea,
+      total_duration_sec: totalDuration,
+    },
+  });
+}

--- a/supabase/functions/sync-walk/handlers/meta_stage.ts
+++ b/supabase/functions/sync-walk/handlers/meta_stage.ts
@@ -1,0 +1,27 @@
+import { asString, json, logSyncWalkStageFailure } from "../support/core.ts";
+import type { SyncWalkStageRequestContext } from "../support/types.ts";
+
+export async function handleMetaStage(
+  context: SyncWalkStageRequestContext,
+): Promise<Response> {
+  const mapImageURL = asString(context.payload.map_image_url);
+  const hasImage = asString(context.payload.has_image) === "true";
+  const patch: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+  if (hasImage && mapImageURL) {
+    patch.map_image_url = mapImageURL;
+  }
+
+  const { error } = await context.userClient
+    .from("walk_sessions")
+    .update(patch)
+    .eq("id", context.walkSessionId)
+    .eq("owner_user_id", context.userId);
+  if (error) {
+    logSyncWalkStageFailure(context.requestId, "meta", "update_session_meta", error.message);
+    return json({ error: error.message }, 500);
+  }
+
+  return json({ ok: true, stage: "meta", walk_session_id: context.walkSessionId });
+}

--- a/supabase/functions/sync-walk/handlers/points_stage.ts
+++ b/supabase/functions/sync-walk/handlers/points_stage.ts
@@ -1,0 +1,87 @@
+import { asRecord, asString, buildBaseSession, epochToIso, json, logSyncWalkStageFailure, toNumber } from "../support/core.ts";
+import type { SyncWalkPointRow, SyncWalkStageRequestContext } from "../support/types.ts";
+import { runPointsStagePostProcessing } from "./points_stage_post_processing.ts";
+
+function parsePointRows(
+  context: SyncWalkStageRequestContext,
+  createdEpoch: number,
+): { ok: true; rows: SyncWalkPointRow[] } | { ok: false; response: Response } {
+  let parsedPoints: unknown[] = [];
+  const rawPointsJSON = asString(context.payload.points_json);
+  if (rawPointsJSON) {
+    try {
+      const decoded = JSON.parse(rawPointsJSON);
+      if (Array.isArray(decoded)) parsedPoints = decoded;
+    } catch {
+      logSyncWalkStageFailure(context.requestId, "points", "parse_points_json", "INVALID_POINTS_JSON");
+      return { ok: false, response: json({ error: "INVALID_POINTS_JSON" }, 400) };
+    }
+  }
+
+  const rows = parsedPoints
+    .map((raw, index) => {
+      const point = asRecord(raw);
+      const seqNo = Math.max(0, Math.trunc(toNumber(point.seq_no ?? point.seqNo, index)));
+      const lat = toNumber(point.lat, NaN);
+      const lng = toNumber(point.lng, NaN);
+      const recordedAt = epochToIso(point.recorded_at ?? point.recordedAt, createdEpoch);
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+      return {
+        walk_session_id: context.walkSessionId,
+        seq_no: seqNo,
+        lat,
+        lng,
+        recorded_at: recordedAt,
+        created_at: new Date().toISOString(),
+      };
+    })
+    .filter((row): row is SyncWalkPointRow => Boolean(row));
+
+  return { ok: true, rows };
+}
+
+export async function handlePointsStage(
+  context: SyncWalkStageRequestContext,
+): Promise<Response> {
+  const { baseSession, createdEpoch, durationSec } = buildBaseSession(context);
+  const { error: sessionUpsertError } = await context.userClient
+    .from("walk_sessions")
+    .upsert(baseSession, { onConflict: "id" });
+  if (sessionUpsertError) {
+    logSyncWalkStageFailure(context.requestId, "points", "upsert_session", sessionUpsertError.message);
+    return json({ error: sessionUpsertError.message }, 500);
+  }
+
+  const parsedRows = parsePointRows(context, createdEpoch);
+  if (!parsedRows.ok) {
+    return parsedRows.response;
+  }
+
+  if (parsedRows.rows.length > 0) {
+    const { error: pointsError } = await context.userClient
+      .from("walk_points")
+      .upsert(parsedRows.rows, { onConflict: "walk_session_id,seq_no" });
+    if (pointsError) {
+      logSyncWalkStageFailure(context.requestId, "points", "upsert_points", pointsError.message);
+      return json({ error: pointsError.message }, 500);
+    }
+  }
+
+  const postProcessing = await runPointsStagePostProcessing({
+    ...context,
+    createdEpoch,
+    durationSec,
+    pointRows: parsedRows.rows,
+  });
+
+  return json({
+    ok: true,
+    stage: "points",
+    walk_session_id: context.walkSessionId,
+    point_count: parsedRows.rows.length,
+    season_score_summary: postProcessing.seasonScoreSummary,
+    season_pipeline_summary: postProcessing.seasonPipelineSummary,
+    weather_replacement_summary: postProcessing.weatherReplacementSummary,
+    quest_progress_summary: postProcessing.questProgressSummary,
+  });
+}

--- a/supabase/functions/sync-walk/handlers/points_stage_post_processing.ts
+++ b/supabase/functions/sync-walk/handlers/points_stage_post_processing.ts
@@ -1,0 +1,185 @@
+import { asRecord, asString, logSyncWalkStageFailure, toNumber, toUUIDOrNull } from "../support/core.ts";
+import type {
+  QuestProgressSummaryDTO,
+  SeasonPipelineSummaryDTO,
+  SeasonScoreSummaryDTO,
+  SyncWalkPointRow,
+  SyncWalkStageRequestContext,
+  WeatherReplacementSummaryDTO,
+} from "../support/types.ts";
+
+type PointsPostProcessingContext = SyncWalkStageRequestContext & {
+  createdEpoch: number;
+  durationSec: number;
+  pointRows: SyncWalkPointRow[];
+};
+
+type PointsPostProcessingResult = {
+  seasonScoreSummary: SeasonScoreSummaryDTO | null;
+  seasonPipelineSummary: SeasonPipelineSummaryDTO | null;
+  weatherReplacementSummary: WeatherReplacementSummaryDTO | null;
+  questProgressSummary: QuestProgressSummaryDTO[];
+};
+
+async function loadSeasonScoreSummary(
+  context: PointsPostProcessingContext,
+  nowISO: string,
+): Promise<SeasonScoreSummaryDTO | null> {
+  const { data, error } = await context.userClient.rpc(
+    "rpc_score_walk_session_anti_farming",
+    {
+      target_walk_session_id: context.walkSessionId,
+      now_ts: nowISO,
+    },
+  );
+
+  if (error) {
+    logSyncWalkStageFailure(context.requestId, "points", "season_score", error.message);
+    return null;
+  }
+
+  return Array.isArray(data) && data.length > 0 ? data[0] as SeasonScoreSummaryDTO : null;
+}
+
+async function loadSeasonPipelineSummary(
+  context: PointsPostProcessingContext,
+  nowISO: string,
+): Promise<SeasonPipelineSummaryDTO | null> {
+  const { data, error } = await context.userClient.rpc(
+    "rpc_ingest_season_tile_events",
+    {
+      target_walk_session_id: context.walkSessionId,
+      now_ts: nowISO,
+    },
+  );
+
+  if (error) {
+    logSyncWalkStageFailure(context.requestId, "points", "season_pipeline", error.message);
+    return null;
+  }
+
+  return Array.isArray(data) && data.length > 0 ? data[0] as SeasonPipelineSummaryDTO : null;
+}
+
+async function loadWeatherReplacementSummary(
+  context: PointsPostProcessingContext,
+  nowISO: string,
+): Promise<WeatherReplacementSummaryDTO | null> {
+  const weatherRiskLevel = asString(context.payload.weather_risk_level) ?? "clear";
+  const sourceQuestId = asString(context.payload.source_quest_id) ?? "outdoor.default";
+  const replacementQuestId = asString(context.payload.replacement_quest_id) ?? "indoor.light";
+  const { data, error } = await context.userClient.rpc(
+    "rpc_apply_weather_replacement",
+    {
+      target_user_id: context.userId,
+      target_walk_session_id: context.walkSessionId,
+      target_risk_level: weatherRiskLevel,
+      source_quest_id: sourceQuestId,
+      replaced_quest_id: replacementQuestId,
+      now_ts: nowISO,
+    },
+  );
+
+  if (error) {
+    logSyncWalkStageFailure(context.requestId, "points", "weather_replacement", error.message);
+    return null;
+  }
+
+  return Array.isArray(data) && data.length > 0 ? data[0] as WeatherReplacementSummaryDTO : null;
+}
+
+async function loadQuestProgressSummary(
+  context: PointsPostProcessingContext,
+  nowISO: string,
+): Promise<QuestProgressSummaryDTO[]> {
+  const uniqueTileCount = Math.max(
+    0,
+    Math.trunc(toNumber(context.payload.unique_tile_count, context.pointRows.length > 0 ? 1 : 0)),
+  );
+  const deltaByQuestType: Record<string, number> = {
+    walk_duration: Math.max(0, context.durationSec / 60.0),
+    linked_path: Math.max(0, context.pointRows.length - 1),
+    new_tile: uniqueTileCount,
+    streak_days: 0,
+  };
+
+  const { data: activeQuestRows, error: activeQuestError } = await context.userClient
+    .from("quest_instances")
+    .select("id,quest_type")
+    .eq("owner_user_id", context.userId)
+    .in("status", ["generated", "active", "completed"])
+    .limit(20);
+
+  if (activeQuestError) {
+    logSyncWalkStageFailure(context.requestId, "points", "load_active_quests", activeQuestError.message);
+    return [];
+  }
+  if (!Array.isArray(activeQuestRows) || activeQuestRows.length == 0) {
+    return [];
+  }
+
+  const questProgressSummary: QuestProgressSummaryDTO[] = [];
+  const questEventBaseId = `${context.walkSessionId}:points:${context.pointRows.length}:${Math.trunc(context.createdEpoch)}`;
+
+  for (const questRow of activeQuestRows) {
+    const record = asRecord(questRow);
+    const questInstanceId = toUUIDOrNull(record.id);
+    const questType = asString(record.quest_type);
+    if (!questInstanceId || !questType) continue;
+
+    const delta = deltaByQuestType[questType] ?? 0;
+    if (delta <= 0) continue;
+
+    const { data: progressRows, error: progressError } = await context.userClient.rpc(
+      "rpc_apply_quest_progress_event",
+      {
+        target_user_id: context.userId,
+        target_instance_id: questInstanceId,
+        event_id: `${questEventBaseId}:${questType}`,
+        event_type: "walk_sync_points",
+        delta_value: delta,
+        payload: {
+          walk_session_id: context.walkSessionId,
+          point_count: context.pointRows.length,
+          unique_tile_count: uniqueTileCount,
+        },
+        now_ts: nowISO,
+      },
+    );
+
+    if (progressError) {
+      logSyncWalkStageFailure(
+        context.requestId,
+        "points",
+        `quest_progress:${questType}`,
+        progressError.message,
+      );
+      continue;
+    }
+
+    if (Array.isArray(progressRows) && progressRows.length > 0) {
+      questProgressSummary.push(progressRows[0] as QuestProgressSummaryDTO);
+    }
+  }
+
+  return questProgressSummary;
+}
+
+export async function runPointsStagePostProcessing(
+  context: PointsPostProcessingContext,
+): Promise<PointsPostProcessingResult> {
+  const nowISO = new Date().toISOString();
+  const [seasonScoreSummary, seasonPipelineSummary, weatherReplacementSummary, questProgressSummary] = await Promise.all([
+    loadSeasonScoreSummary(context, nowISO),
+    loadSeasonPipelineSummary(context, nowISO),
+    loadWeatherReplacementSummary(context, nowISO),
+    loadQuestProgressSummary(context, nowISO),
+  ]);
+
+  return {
+    seasonScoreSummary,
+    seasonPipelineSummary,
+    weatherReplacementSummary,
+    questProgressSummary,
+  };
+}

--- a/supabase/functions/sync-walk/handlers/session_stage.ts
+++ b/supabase/functions/sync-walk/handlers/session_stage.ts
@@ -1,0 +1,25 @@
+import { buildBaseSession, json, logSyncWalkStageFailure } from "../support/core.ts";
+import type { SyncWalkStageRequestContext } from "../support/types.ts";
+
+export async function handleSessionStage(
+  context: SyncWalkStageRequestContext,
+): Promise<Response> {
+  const { baseSession } = buildBaseSession(context);
+  const { error } = await context.userClient
+    .from("walk_sessions")
+    .upsert(baseSession, { onConflict: "id" });
+  if (error) {
+    logSyncWalkStageFailure(context.requestId, "session", "upsert_session", error.message);
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return json({
+    ok: true,
+    stage: "session",
+    walk_session_id: context.walkSessionId,
+    idempotency_key: context.idempotencyKey,
+  });
+}

--- a/supabase/functions/sync-walk/handlers/stage_dispatcher.ts
+++ b/supabase/functions/sync-walk/handlers/stage_dispatcher.ts
@@ -1,0 +1,26 @@
+import type { SyncStage, SyncWalkStageRequestContext } from "../support/types.ts";
+import { json } from "../support/core.ts";
+import { handleMetaStage } from "./meta_stage.ts";
+import { handlePointsStage } from "./points_stage.ts";
+import { handleSessionStage } from "./session_stage.ts";
+
+const syncWalkStageHandlers: Record<SyncStage, (context: SyncWalkStageRequestContext) => Promise<Response>> = {
+  session: handleSessionStage,
+  points: handlePointsStage,
+  meta: handleMetaStage,
+};
+
+export const isSupportedSyncStage = (value: unknown): value is SyncStage =>
+  value === "session" || value === "points" || value === "meta";
+
+export async function dispatchSyncWalkStage(
+  stage: SyncStage,
+  context: SyncWalkStageRequestContext,
+): Promise<Response> {
+  const handler = syncWalkStageHandlers[stage];
+  if (!handler) {
+    return json({ error: "UNSUPPORTED_STAGE" }, 400);
+  }
+
+  return handler(context);
+}

--- a/supabase/functions/sync-walk/index.ts
+++ b/supabase/functions/sync-walk/index.ts
@@ -1,105 +1,8 @@
 import { resolveEdgeAuthContext } from "../_shared/edge_auth.ts";
-
-type SyncStage = "session" | "points" | "meta";
-type Action = "sync_walk_stage" | "get_backfill_summary";
-
-type RequestDTO = {
-  action?: Action;
-  stage?: SyncStage;
-  walk_session_id?: string;
-  idempotency_key?: string;
-  payload?: Record<string, unknown>;
-  session_ids?: string[];
-};
-
-type SeasonScoreSummaryDTO = {
-  walk_session_id: string;
-  total_points: number;
-  unique_tiles: number;
-  novelty_ratio: number;
-  repeat_suppressed_count: number;
-  suspicious_repeat_count: number;
-  base_score: number;
-  new_route_bonus: number;
-  catchup_bonus?: number;
-  total_score: number;
-  score_blocked: boolean;
-  catchup_buff_active?: boolean;
-  catchup_buff_granted_at?: string | null;
-  catchup_buff_expires_at?: string | null;
-  explain?: Record<string, unknown>;
-};
-
-type WeatherReplacementSummaryDTO = {
-  applied: boolean;
-  shield_applied: boolean;
-  blocked_reason: string | null;
-  risk_level: string | null;
-  replacement_reason: string | null;
-  replacement_count_today: number;
-  daily_replacement_limit: number;
-  shield_used_this_week: number;
-  weekly_shield_limit: number;
-};
-
-type SeasonPipelineSummaryDTO = {
-  season_id: string;
-  season_key: string;
-  ingested_rows: number;
-  tile_rows: number;
-  user_total_score: number;
-  user_rank: number | null;
-  run_status: string;
-};
-
-type QuestProgressSummaryDTO = {
-  quest_instance_id: string;
-  owner_user_id: string;
-  event_id: string;
-  idempotent: boolean;
-  previous_progress: number;
-  current_progress: number;
-  target_progress: number;
-  status: string;
-  completed_at: string | null;
-};
-
-const json = (body: unknown, status = 200) =>
-  new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-
-const asRecord = (value: unknown): Record<string, unknown> =>
-  typeof value === "object" && value !== null ? value as Record<string, unknown> : {};
-
-const asString = (value: unknown): string | null => {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
-const toNumber = (value: unknown, fallback = 0): number => {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return fallback;
-};
-
-const epochToIso = (value: unknown, fallbackEpochSec: number): string => {
-  const epoch = toNumber(value, fallbackEpochSec);
-  return new Date(Math.max(0, epoch) * 1000).toISOString();
-};
-
-const toUUIDOrNull = (value: unknown): string | null => {
-  const raw = asString(value);
-  if (!raw) return null;
-  const normalized = raw.toLowerCase();
-  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-  return uuidPattern.test(normalized) ? normalized : null;
-};
+import { handleBackfillSummary } from "./handlers/backfill_summary.ts";
+import { dispatchSyncWalkStage, isSupportedSyncStage } from "./handlers/stage_dispatcher.ts";
+import { asRecord, json, toUUIDOrNull } from "./support/core.ts";
+import type { RequestDTO } from "./support/types.ts";
 
 Deno.serve(async (req) => {
   if (req.method !== "POST") return json({ error: "METHOD_NOT_ALLOWED" }, 405);
@@ -122,8 +25,10 @@ Deno.serve(async (req) => {
   if (!auth.ok) {
     return auth.response;
   }
+
   const userClient = auth.context.userClient!;
   const userId = auth.context.userId!;
+  const requestId = auth.context.requestId;
 
   let body: RequestDTO;
   try {
@@ -132,290 +37,38 @@ Deno.serve(async (req) => {
     return json({ error: "INVALID_JSON" }, 400);
   }
 
-  const action = body.action;
-  if (!action) return json({ error: "ACTION_REQUIRED" }, 400);
+  if (!body.action) {
+    return json({ error: "ACTION_REQUIRED" }, 400);
+  }
 
-  if (action === "get_backfill_summary") {
-    const requestedIds = (body.session_ids ?? [])
+  if (body.action === "get_backfill_summary") {
+    const sessionIds = (body.session_ids ?? [])
       .map((id) => toUUIDOrNull(id))
       .filter((id): id is string => Boolean(id));
 
-    let sessionsQuery = userClient
-      .from("walk_sessions")
-      .select("id,area_m2,duration_sec")
-      .order("started_at", { ascending: false });
-
-    if (requestedIds.length > 0) {
-      sessionsQuery = sessionsQuery.in("id", requestedIds);
-    }
-
-    const { data: sessions, error: sessionError } = await sessionsQuery;
-    if (sessionError) return json({ error: sessionError.message }, 500);
-
-    const safeSessions = sessions ?? [];
-    const sessionIds = safeSessions
-      .map((row) => asString((row as Record<string, unknown>).id))
-      .filter((id): id is string => Boolean(id));
-
-    let pointCount = 0;
-    if (sessionIds.length > 0) {
-      const { count, error: pointError } = await userClient
-        .from("walk_points")
-        .select("id", { count: "exact", head: true })
-        .in("walk_session_id", sessionIds);
-      if (pointError) return json({ error: pointError.message }, 500);
-      pointCount = count ?? 0;
-    }
-
-    const totalArea = safeSessions.reduce(
-      (acc, row) => acc + Math.max(0, toNumber((row as Record<string, unknown>).area_m2, 0)),
-      0,
-    );
-    const totalDuration = safeSessions.reduce(
-      (acc, row) => acc + Math.max(0, toNumber((row as Record<string, unknown>).duration_sec, 0)),
-      0,
-    );
-
-    return json({
-      summary: {
-        session_count: safeSessions.length,
-        point_count: pointCount,
-        total_area_m2: totalArea,
-        total_duration_sec: totalDuration,
-      },
+    return handleBackfillSummary({
+      userClient,
+      requestId,
+      sessionIds,
     });
   }
 
-  if (action !== "sync_walk_stage") {
+  if (body.action !== "sync_walk_stage") {
     return json({ error: "UNSUPPORTED_ACTION" }, 400);
   }
 
   const walkSessionId = toUUIDOrNull(body.walk_session_id);
-  const stage = body.stage;
   const payload = asRecord(body.payload);
-
-  if (!walkSessionId || !stage) {
+  if (!walkSessionId || !isSupportedSyncStage(body.stage)) {
     return json({ error: "INVALID_PAYLOAD" }, 400);
   }
 
-  const createdEpoch = toNumber(payload.created_at, Date.now() / 1000);
-  const startedEpoch = toNumber(payload.started_at, createdEpoch);
-  const endedEpoch = toNumber(payload.ended_at, createdEpoch);
-  const durationSec = Math.max(0, Math.round(toNumber(payload.duration_sec, Math.max(0, endedEpoch - startedEpoch))));
-  const areaM2 = Math.max(0, toNumber(payload.area_m2, 0));
-  const sourceDevice = asString(payload.source_device) ?? "ios";
-  const petId = toUUIDOrNull(payload.pet_id);
-
-  const baseSession = {
-    id: walkSessionId,
-    owner_user_id: userId,
-    pet_id: petId,
-    started_at: epochToIso(startedEpoch, startedEpoch),
-    ended_at: epochToIso(endedEpoch, endedEpoch),
-    duration_sec: durationSec,
-    area_m2: areaM2,
-    source_device: sourceDevice,
-    created_at: epochToIso(createdEpoch, createdEpoch),
-    updated_at: new Date().toISOString(),
-  };
-
-  if (stage === "session") {
-    const { error } = await userClient
-      .from("walk_sessions")
-      .upsert(baseSession, { onConflict: "id" });
-    if (error) return json({ error: error.message }, 500);
-    return json({ ok: true, stage, walk_session_id: walkSessionId, idempotency_key: body.idempotency_key ?? null });
-  }
-
-  if (stage === "points") {
-    const { error: sessionUpsertError } = await userClient
-      .from("walk_sessions")
-      .upsert(baseSession, { onConflict: "id" });
-    if (sessionUpsertError) return json({ error: sessionUpsertError.message }, 500);
-
-    let parsedPoints: unknown[] = [];
-    const rawPointsJSON = asString(payload.points_json);
-    if (rawPointsJSON) {
-      try {
-        const decoded = JSON.parse(rawPointsJSON);
-        if (Array.isArray(decoded)) parsedPoints = decoded;
-      } catch {
-        return json({ error: "INVALID_POINTS_JSON" }, 400);
-      }
-    }
-
-    const rows = parsedPoints
-      .map((raw, index) => {
-        const point = asRecord(raw);
-        const seqNo = Math.max(0, Math.trunc(toNumber(point.seq_no ?? point.seqNo, index)));
-        const lat = toNumber(point.lat, NaN);
-        const lng = toNumber(point.lng, NaN);
-        const recordedAt = epochToIso(point.recorded_at ?? point.recordedAt, createdEpoch);
-        if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
-        return {
-          walk_session_id: walkSessionId,
-          seq_no: seqNo,
-          lat,
-          lng,
-          recorded_at: recordedAt,
-          created_at: new Date().toISOString(),
-        };
-      })
-      .filter((row): row is {
-        walk_session_id: string;
-        seq_no: number;
-        lat: number;
-        lng: number;
-        recorded_at: string;
-        created_at: string;
-      } => Boolean(row));
-
-    if (rows.length > 0) {
-      const { error: pointsError } = await userClient
-        .from("walk_points")
-        .upsert(rows, { onConflict: "walk_session_id,seq_no" });
-      if (pointsError) return json({ error: pointsError.message }, 500);
-    }
-
-    let seasonScoreSummary: SeasonScoreSummaryDTO | null = null;
-    const { data: seasonScoreRows, error: seasonScoreError } = await userClient.rpc(
-      "rpc_score_walk_session_anti_farming",
-      {
-        target_walk_session_id: walkSessionId,
-        now_ts: new Date().toISOString(),
-      },
-    );
-
-    if (seasonScoreError) {
-      console.warn("season scoring rpc failed", seasonScoreError.message);
-    } else if (Array.isArray(seasonScoreRows) && seasonScoreRows.length > 0) {
-      seasonScoreSummary = seasonScoreRows[0] as SeasonScoreSummaryDTO;
-    }
-
-    let seasonPipelineSummary: SeasonPipelineSummaryDTO | null = null;
-    const { data: seasonPipelineRows, error: seasonPipelineError } = await userClient.rpc(
-      "rpc_ingest_season_tile_events",
-      {
-        target_walk_session_id: walkSessionId,
-        now_ts: new Date().toISOString(),
-      },
-    );
-
-    if (seasonPipelineError) {
-      console.warn("season stage2 pipeline rpc failed", seasonPipelineError.message);
-    } else if (Array.isArray(seasonPipelineRows) && seasonPipelineRows.length > 0) {
-      seasonPipelineSummary = seasonPipelineRows[0] as SeasonPipelineSummaryDTO;
-    }
-
-    const weatherRiskLevel = asString(payload.weather_risk_level) ?? "clear";
-    const sourceQuestId = asString(payload.source_quest_id) ?? "outdoor.default";
-    const replacementQuestId = asString(payload.replacement_quest_id) ?? "indoor.light";
-    let weatherReplacementSummary: WeatherReplacementSummaryDTO | null = null;
-    const { data: weatherReplacementRows, error: weatherReplacementError } = await userClient.rpc(
-      "rpc_apply_weather_replacement",
-      {
-        target_user_id: userId,
-        target_walk_session_id: walkSessionId,
-        target_risk_level: weatherRiskLevel,
-        source_quest_id: sourceQuestId,
-        replaced_quest_id: replacementQuestId,
-        now_ts: new Date().toISOString(),
-      },
-    );
-
-    if (weatherReplacementError) {
-      console.warn("weather replacement rpc failed", weatherReplacementError.message);
-    } else if (Array.isArray(weatherReplacementRows) && weatherReplacementRows.length > 0) {
-      weatherReplacementSummary = weatherReplacementRows[0] as WeatherReplacementSummaryDTO;
-    }
-
-    const uniqueTileCount = Math.max(0, Math.trunc(toNumber(payload.unique_tile_count, rows.length > 0 ? 1 : 0)));
-    const deltaByQuestType: Record<string, number> = {
-      walk_duration: Math.max(0, durationSec / 60.0),
-      linked_path: Math.max(0, rows.length - 1),
-      new_tile: uniqueTileCount,
-      streak_days: 0,
-    };
-
-    const questProgressSummary: QuestProgressSummaryDTO[] = [];
-    const { data: activeQuestRows, error: activeQuestError } = await userClient
-      .from("quest_instances")
-      .select("id,quest_type")
-      .eq("owner_user_id", userId)
-      .in("status", ["generated", "active", "completed"])
-      .limit(20);
-
-    if (activeQuestError) {
-      console.warn("quest active list query failed", activeQuestError.message);
-    } else if (Array.isArray(activeQuestRows) && activeQuestRows.length > 0) {
-      const questEventBaseId = `${walkSessionId}:points:${rows.length}:${Math.trunc(createdEpoch)}`;
-      for (const questRow of activeQuestRows) {
-        const record = asRecord(questRow);
-        const questInstanceId = toUUIDOrNull(record.id);
-        const questType = asString(record.quest_type);
-        if (!questInstanceId || !questType) continue;
-
-        const delta = deltaByQuestType[questType] ?? 0;
-        if (delta <= 0) continue;
-
-        const { data: progressRows, error: progressError } = await userClient.rpc(
-          "rpc_apply_quest_progress_event",
-          {
-            target_user_id: userId,
-            target_instance_id: questInstanceId,
-            event_id: `${questEventBaseId}:${questType}`,
-            event_type: "walk_sync_points",
-            delta_value: delta,
-            payload: {
-              walk_session_id: walkSessionId,
-              point_count: rows.length,
-              unique_tile_count: uniqueTileCount,
-            },
-            now_ts: new Date().toISOString(),
-          },
-        );
-
-        if (progressError) {
-          console.warn("quest progress rpc failed", progressError.message);
-          continue;
-        }
-        if (Array.isArray(progressRows) && progressRows.length > 0) {
-          questProgressSummary.push(progressRows[0] as QuestProgressSummaryDTO);
-        }
-      }
-    }
-
-    return json({
-      ok: true,
-      stage,
-      walk_session_id: walkSessionId,
-      point_count: rows.length,
-      season_score_summary: seasonScoreSummary,
-      season_pipeline_summary: seasonPipelineSummary,
-      weather_replacement_summary: weatherReplacementSummary,
-      quest_progress_summary: questProgressSummary,
-    });
-  }
-
-  if (stage === "meta") {
-    const mapImageURL = asString(payload.map_image_url);
-    const hasImage = asString(payload.has_image) === "true";
-    const patch: Record<string, unknown> = {
-      updated_at: new Date().toISOString(),
-    };
-    if (hasImage && mapImageURL) {
-      patch.map_image_url = mapImageURL;
-    }
-
-    const { error } = await userClient
-      .from("walk_sessions")
-      .update(patch)
-      .eq("id", walkSessionId)
-      .eq("owner_user_id", userId);
-    if (error) return json({ error: error.message }, 500);
-
-    return json({ ok: true, stage, walk_session_id: walkSessionId });
-  }
-
-  return json({ error: "UNSUPPORTED_STAGE" }, 400);
+  return dispatchSyncWalkStage(body.stage, {
+    userClient,
+    userId,
+    requestId,
+    walkSessionId,
+    idempotencyKey: body.idempotency_key ?? null,
+    payload,
+  });
 });

--- a/supabase/functions/sync-walk/support/core.ts
+++ b/supabase/functions/sync-walk/support/core.ts
@@ -1,0 +1,87 @@
+import type {
+  SyncWalkBaseSessionContext,
+  SyncWalkStageRequestContext,
+} from "./types.ts";
+
+export const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+export const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null ? value as Record<string, unknown> : {};
+
+export const asString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export const toNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+};
+
+export const epochToIso = (value: unknown, fallbackEpochSec: number): string => {
+  const epoch = toNumber(value, fallbackEpochSec);
+  return new Date(Math.max(0, epoch) * 1000).toISOString();
+};
+
+export const toUUIDOrNull = (value: unknown): string | null => {
+  const raw = asString(value);
+  if (!raw) return null;
+  const normalized = raw.toLowerCase();
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+  return uuidPattern.test(normalized) ? normalized : null;
+};
+
+export const logSyncWalkStageFailure = (
+  requestId: string,
+  stage: string,
+  scope: string,
+  detail: string,
+) => {
+  console.warn("[sync-walk]", {
+    request_id: requestId,
+    stage,
+    scope,
+    detail,
+  });
+};
+
+export const buildBaseSession = (
+  context: SyncWalkStageRequestContext,
+): SyncWalkBaseSessionContext => {
+  const createdEpoch = toNumber(context.payload.created_at, Date.now() / 1000);
+  const startedEpoch = toNumber(context.payload.started_at, createdEpoch);
+  const endedEpoch = toNumber(context.payload.ended_at, createdEpoch);
+  const durationSec = Math.max(
+    0,
+    Math.round(toNumber(context.payload.duration_sec, Math.max(0, endedEpoch - startedEpoch))),
+  );
+  const areaM2 = Math.max(0, toNumber(context.payload.area_m2, 0));
+  const sourceDevice = asString(context.payload.source_device) ?? "ios";
+  const petId = toUUIDOrNull(context.payload.pet_id);
+
+  return {
+    baseSession: {
+      id: context.walkSessionId,
+      owner_user_id: context.userId,
+      pet_id: petId,
+      started_at: epochToIso(startedEpoch, startedEpoch),
+      ended_at: epochToIso(endedEpoch, endedEpoch),
+      duration_sec: durationSec,
+      area_m2: areaM2,
+      source_device: sourceDevice,
+      created_at: epochToIso(createdEpoch, createdEpoch),
+      updated_at: new Date().toISOString(),
+    },
+    createdEpoch,
+    durationSec,
+  };
+};

--- a/supabase/functions/sync-walk/support/types.ts
+++ b/supabase/functions/sync-walk/support/types.ts
@@ -1,0 +1,110 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+
+export type SyncStage = "session" | "points" | "meta";
+export type Action = "sync_walk_stage" | "get_backfill_summary";
+
+export type RequestDTO = {
+  action?: Action;
+  stage?: SyncStage;
+  walk_session_id?: string;
+  idempotency_key?: string;
+  payload?: Record<string, unknown>;
+  session_ids?: string[];
+};
+
+export type SeasonScoreSummaryDTO = {
+  walk_session_id: string;
+  total_points: number;
+  unique_tiles: number;
+  novelty_ratio: number;
+  repeat_suppressed_count: number;
+  suspicious_repeat_count: number;
+  base_score: number;
+  new_route_bonus: number;
+  catchup_bonus?: number;
+  total_score: number;
+  score_blocked: boolean;
+  catchup_buff_active?: boolean;
+  catchup_buff_granted_at?: string | null;
+  catchup_buff_expires_at?: string | null;
+  explain?: Record<string, unknown>;
+};
+
+export type WeatherReplacementSummaryDTO = {
+  applied: boolean;
+  shield_applied: boolean;
+  blocked_reason: string | null;
+  risk_level: string | null;
+  replacement_reason: string | null;
+  replacement_count_today: number;
+  daily_replacement_limit: number;
+  shield_used_this_week: number;
+  weekly_shield_limit: number;
+};
+
+export type SeasonPipelineSummaryDTO = {
+  season_id: string;
+  season_key: string;
+  ingested_rows: number;
+  tile_rows: number;
+  user_total_score: number;
+  user_rank: number | null;
+  run_status: string;
+};
+
+export type QuestProgressSummaryDTO = {
+  quest_instance_id: string;
+  owner_user_id: string;
+  event_id: string;
+  idempotent: boolean;
+  previous_progress: number;
+  current_progress: number;
+  target_progress: number;
+  status: string;
+  completed_at: string | null;
+};
+
+export type SyncWalkUserClient = ReturnType<typeof createClient>;
+
+export type SyncWalkStageRequestContext = {
+  userClient: SyncWalkUserClient;
+  userId: string;
+  requestId: string;
+  walkSessionId: string;
+  idempotencyKey: string | null;
+  payload: Record<string, unknown>;
+};
+
+export type BackfillSummaryRequestContext = {
+  userClient: SyncWalkUserClient;
+  requestId: string;
+  sessionIds: string[];
+};
+
+export type SyncWalkBaseSessionRecord = {
+  id: string;
+  owner_user_id: string;
+  pet_id: string | null;
+  started_at: string;
+  ended_at: string;
+  duration_sec: number;
+  area_m2: number;
+  source_device: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type SyncWalkBaseSessionContext = {
+  baseSession: SyncWalkBaseSessionRecord;
+  createdEpoch: number;
+  durationSec: number;
+};
+
+export type SyncWalkPointRow = {
+  walk_session_id: string;
+  seq_no: number;
+  lat: number;
+  lng: number;
+  recorded_at: string;
+  created_at: string;
+};


### PR DESCRIPTION
## Summary
- split sync-walk into stage dispatcher, session/meta/points handlers, and shared parsing/session support
- extract points post-processing orchestration for season, weather, and quest summaries without changing response shape
- add structure regression checks and update existing sync-walk dependent checks to read the split sources

## Validation
- swift scripts/sync_walk_stage_handler_split_unit_check.swift
- swift scripts/sync_walk_404_policy_unit_check.swift
- swift scripts/season_anti_farming_unit_check.swift
- swift scripts/season_stage2_pipeline_unit_check.swift
- swift scripts/season_comeback_catchup_unit_check.swift
- swift scripts/weather_stage2_engine_unit_check.swift
- swift scripts/quest_stage2_engine_unit_check.swift
- deno check supabase/functions/sync-walk/index.ts
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #424