### PR TITLE
refactor: standardize request correlation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - Supabase integration smoke matrix v1: `docs/supabase-integration-smoke-matrix-v1.md`
 - Backend 계약 버저닝 정책 v1: `docs/backend-contract-versioning-policy-v1.md`
 - Backend 고위험 계약 매트릭스 v1: `docs/backend-high-risk-contract-matrix-v1.md`
+- Backend request correlation/idempotency 정책 v1: `docs/backend-request-correlation-idempotency-policy-v1.md`
 - Backend Edge auth policy v1: `docs/backend-edge-auth-policy-v1.md`
 - Backend Edge observability 표준 v1: `docs/backend-edge-observability-standard-v1.md`
 - Backend Edge error taxonomy v1: `docs/backend-edge-error-taxonomy-v1.md`

--- a/docs/backend-request-correlation-idempotency-policy-v1.md
+++ b/docs/backend-request-correlation-idempotency-policy-v1.md
@@ -1,0 +1,103 @@
+# Backend Request Correlation / Idempotency Policy v1
+
+Date: 2026-03-07  
+Issue: #426
+
+## 목적
+
+DogArea backend 경계에서 `request_id`, `idempotency_key`, `event_id`, `action_id`의 역할을 분리해,
+중복 처리와 장애 추적 시 어떤 키를 기준으로 봐야 하는지 고정합니다.
+
+## Canonical Rule
+
+### 1. `request_id`
+
+요청 상관관계용 키입니다.
+
+규칙:
+- 함수 로그/응답/에러에서 같은 요청을 묶는 기준입니다.
+- 재시도 시 동일 값을 재사용할 수 있지만, **주 목적은 correlation**입니다.
+- canonical 이름은 `request_id`입니다.
+- legacy alias는 `requestId`, `action_id`를 허용합니다.
+
+### 2. `idempotency_key`
+
+재전송 중복 방지용 키입니다.
+
+규칙:
+- retry 가능한 write path에서 canonical 이름은 `idempotency_key`입니다.
+- legacy alias는 `idempotencyKey`를 허용합니다.
+- 경로 특성상 별도 키가 없으면 `request_id`를 fallback으로 사용할 수 있습니다.
+
+### 3. `event_id`
+
+도메인 원장용 이벤트 키입니다.
+
+규칙:
+- quest progress처럼 원장/ledger가 `event_id`를 유니크 키로 쓰는 경우 유지합니다.
+- transport canonical 이름은 여전히 `idempotency_key`지만,
+  quest ingest 경로에서는 `event_id`를 최종 RPC 필드로 사용합니다.
+- `idempotency_key`가 들어오면 `event_id`로 매핑할 수 있습니다.
+
+### 4. `action_id`
+
+watch/widget 같은 로컬 transport의 액션 dedupe 키입니다.
+
+규칙:
+- 앱 내부 transport에서는 유지할 수 있습니다.
+- backend 경계를 넘을 때는 `request_id` 또는 `idempotency_key`로 번역합니다.
+- backend canonical field로 직접 확장하지 않습니다.
+
+## 고위험 경로 표준
+
+### `sync-walk`
+- canonical request key: `request_id`
+- canonical idempotency key: `idempotency_key`
+- legacy alias: `requestId`, `idempotencyKey`
+- stage write 응답은 `request_id`와 `idempotency_key`를 함께 반환할 수 있습니다.
+
+### `nearby-presence`
+- canonical request key: `request_id`
+- canonical idempotency key: `idempotency_key`
+- legacy alias: `requestId`, `idempotencyKey`, `action_id`
+- `upsert_presence` / `upsert_live_presence`는 `idempotency_key`를 live presence RPC에 전달합니다.
+- hotspot / live presence read 응답은 `request_id`를 반환해 trace를 고정합니다.
+
+### `quest-engine`
+- canonical request key: `request_id`
+- canonical idempotency key: `idempotency_key`
+- legacy alias: `requestId`, `action_id`
+- `claim_reward`는 canonical `request_id`를 reward claim RPC에 전달합니다.
+- `ingest_walk_event`는 canonical transport key를 받아 최종 `event_id`로 매핑할 수 있습니다.
+- legacy alias `instanceId`, `target_instance_id`, `eventId`도 계속 허용합니다.
+
+### widget / watch action bridge
+- 앱 내부 dedupe는 `action_id` 유지
+- backend 함수 호출 시 `request_id` 또는 `idempotency_key`로 번역
+- bridge 문서/코드에서는 `action_id -> request_id` 변환을 표준으로 간주
+
+## Helper
+
+공통 helper:
+- `supabase/functions/_shared/request_keys.ts`
+
+helper 책임:
+- canonical `request_id` 선택
+- canonical `idempotency_key` 선택
+- legacy alias fallback 정리
+
+## Validation
+
+- `swift scripts/backend_request_id_idempotency_unit_check.swift`
+- `swift scripts/backend_contract_versioning_unit_check.swift`
+- `swift scripts/backend_edge_observability_unit_check.swift`
+- `deno check supabase/functions/sync-walk/index.ts`
+- `deno check supabase/functions/nearby-presence/index.ts`
+- `deno check supabase/functions/quest-engine/index.ts`
+
+## Related
+
+- `docs/backend-contract-versioning-policy-v1.md`
+- `docs/backend-high-risk-contract-matrix-v1.md`
+- `docs/watch-connectivity-reliability-v1.md`
+- `#420`

--- a/dogArea/Source/Infrastructure/Supabase/Services/SupabasePresenceAndQuestServices.swift
+++ b/dogArea/Source/Infrastructure/Supabase/Services/SupabasePresenceAndQuestServices.swift
@@ -118,7 +118,8 @@ struct NearbyPresenceService: NearbyPresenceServiceProtocol {
             payload["sequence"] = sequence
         }
         if let idempotencyKey, idempotencyKey.isEmpty == false {
-            payload["idempotencyKey"] = idempotencyKey
+            payload["request_id"] = idempotencyKey
+            payload["idempotency_key"] = idempotencyKey
         }
         if let deviceKey, deviceKey.isEmpty == false {
             payload["deviceKey"] = deviceKey
@@ -348,7 +349,7 @@ struct QuestRewardClaimService: QuestRewardClaimServiceProtocol {
             : requestId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let payload: [String: Any] = [
             "action": "claim_reward",
-            "target_instance_id": canonicalQuestId,
+            "instance_id": canonicalQuestId,
             "request_id": normalizedRequestId,
             "now_ts": ISO8601DateFormatter().string(from: now)
         ]

--- a/scripts/backend_edge_observability_unit_check.swift
+++ b/scripts/backend_edge_observability_unit_check.swift
@@ -80,7 +80,7 @@ assertTrue(edgeAuthHelper.contains("AUTH_SESSION_INVALID") && edgeAuthHelper.con
 assertTrue(nearbyPresence.contains("suppression_reason") && nearbyPresence.contains("abuse_reason"), "nearby presence should expose privacy and abuse metadata in source")
 assertTrue(nearbyPresence.contains("console.error(\"nearby hotspot rpc failed\""), "nearby presence should log hotspot rpc failure")
 assertTrue(syncWalk.contains("resolveEdgeAuthContext"), "sync-walk should route auth failures through shared helper")
-assertTrue(questEngine.contains("request_id: asString(body.requestId)"), "quest-engine should expose partial request id trace mentioned in the matrix")
+assertTrue(questEngine.contains("resolveCanonicalRequestId") && questEngine.contains("request_id: requestId"), "quest-engine should expose canonical request id trace mentioned in the matrix")
 assertTrue(featureControl.contains("json({ error: \"SERVER_MISCONFIGURED\" }"), "feature-control should expose legacy error shape covered by the matrix")
 assertTrue(uploadProfileImage.contains("UPLOAD_FAILED") && uploadProfileImage.contains("PUBLIC_URL_FAILED"), "upload-profile-image should expose storage failure codes")
 

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -9,6 +9,7 @@ swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/backend_contract_versioning_unit_check.swift
 swift scripts/backend_edge_observability_unit_check.swift
 swift scripts/backend_edge_auth_unification_unit_check.swift
+swift scripts/backend_request_id_idempotency_unit_check.swift
 swift scripts/sync_walk_stage_handler_split_unit_check.swift
 swift scripts/nearby_presence_handler_split_unit_check.swift
 

--- a/scripts/backend_request_id_idempotency_unit_check.swift
+++ b/scripts/backend_request_id_idempotency_unit_check.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// 조건이 거짓이면 실패 메시지를 출력하고 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 조건식입니다.
+///   - message: 검증 실패 시 출력할 메시지입니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 파일을 UTF-8 문자열로 읽어옵니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: UTF-8 디코딩된 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+/// 여러 파일을 순서대로 읽어 한 문자열로 병합합니다.
+/// - Parameter relativePaths: 저장소 루트 기준 상대 경로 배열입니다.
+/// - Returns: 각 파일 본문을 줄바꿈으로 연결한 문자열입니다.
+func loadMany(_ relativePaths: [String]) -> String {
+    relativePaths.map(load).joined(separator: "\n")
+}
+
+let helper = load("supabase/functions/_shared/request_keys.ts")
+let syncWalk = loadMany([
+    "supabase/functions/sync-walk/index.ts",
+    "supabase/functions/sync-walk/support/types.ts",
+    "supabase/functions/sync-walk/handlers/session_stage.ts",
+    "supabase/functions/sync-walk/handlers/points_stage.ts",
+    "supabase/functions/sync-walk/handlers/meta_stage.ts",
+    "supabase/functions/sync-walk/handlers/backfill_summary.ts"
+])
+let nearbyPresence = loadMany([
+    "supabase/functions/nearby-presence/index.ts",
+    "supabase/functions/nearby-presence/support/types.ts",
+    "supabase/functions/nearby-presence/support/visibility.ts",
+    "supabase/functions/nearby-presence/handlers/live_presence_handlers.ts",
+    "supabase/functions/nearby-presence/handlers/hotspot_handler.ts"
+])
+let questEngine = load("supabase/functions/quest-engine/index.ts")
+let presenceQuestService = load("dogArea/Source/Infrastructure/Supabase/Services/SupabasePresenceAndQuestServices.swift")
+let policyDoc = load("docs/backend-request-correlation-idempotency-policy-v1.md")
+let readme = load("README.md")
+let backendCheck = load("scripts/backend_pr_check.sh")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(helper.contains("resolveCanonicalRequestId"), "shared request key helper should define canonical request id resolver")
+assertTrue(helper.contains("resolveCanonicalIdempotencyKey"), "shared request key helper should define canonical idempotency resolver")
+assertTrue(helper.contains("request_id") && helper.contains("action_id"), "shared helper should support request_id and action_id aliases")
+assertTrue(helper.contains("idempotency_key") && helper.contains("idempotencyKey"), "shared helper should support snake/camel idempotency aliases")
+
+assertTrue(syncWalk.contains("resolveCanonicalRequestId"), "sync-walk should resolve canonical request_id")
+assertTrue(syncWalk.contains("resolveCanonicalIdempotencyKey"), "sync-walk should resolve canonical idempotency_key")
+assertTrue(syncWalk.contains("request_id"), "sync-walk responses should expose request_id")
+assertTrue(syncWalk.contains("idempotency_key"), "sync-walk stage responses should expose idempotency_key")
+
+assertTrue(nearbyPresence.contains("resolveCanonicalRequestId"), "nearby-presence should resolve canonical request_id")
+assertTrue(nearbyPresence.contains("resolveCanonicalIdempotencyKey"), "nearby-presence should resolve canonical idempotency key")
+assertTrue(nearbyPresence.contains("action_id"), "nearby-presence should allow action_id alias")
+assertTrue(nearbyPresence.contains("request_id: context.requestId"), "nearby-presence responses should expose request_id")
+assertTrue(nearbyPresence.contains("idempotency_key"), "nearby-presence live upsert should carry canonical idempotency key")
+
+assertTrue(questEngine.contains("resolveCanonicalRequestId"), "quest-engine should resolve canonical request_id")
+assertTrue(questEngine.contains("resolveCanonicalIdempotencyKey"), "quest-engine should resolve canonical idempotency/event key")
+assertTrue(questEngine.contains("instance_id") && questEngine.contains("target_instance_id"), "quest-engine should accept canonical and legacy instance id aliases")
+assertTrue(questEngine.contains("event_id") && questEngine.contains("eventId"), "quest-engine should accept canonical and legacy event id aliases")
+assertTrue(questEngine.contains("request_id: requestId"), "quest-engine success responses should expose request_id")
+
+assertTrue(presenceQuestService.contains("payload[\"request_id\"] = idempotencyKey"), "nearby presence iOS service should send canonical request_id")
+assertTrue(presenceQuestService.contains("payload[\"idempotency_key\"] = idempotencyKey"), "nearby presence iOS service should send canonical idempotency_key")
+assertTrue(presenceQuestService.contains("\"instance_id\": canonicalQuestId"), "quest claim iOS service should send canonical instance_id")
+assertTrue(presenceQuestService.contains("\"request_id\": normalizedRequestId"), "quest claim iOS service should send canonical request_id")
+
+assertTrue(policyDoc.contains("`request_id`"), "policy doc should define request_id canonical name")
+assertTrue(policyDoc.contains("`idempotency_key`"), "policy doc should define idempotency_key canonical name")
+assertTrue(policyDoc.contains("`event_id`"), "policy doc should define event_id role")
+assertTrue(policyDoc.contains("`action_id`"), "policy doc should define action_id translation rule")
+assertTrue(policyDoc.contains("supabase/functions/_shared/request_keys.ts"), "policy doc should reference shared request key helper")
+
+assertTrue(readme.contains("docs/backend-request-correlation-idempotency-policy-v1.md"), "README should link request/idempotency policy doc")
+assertTrue(backendCheck.contains("backend_request_id_idempotency_unit_check.swift"), "backend_pr_check should run request/idempotency check")
+assertTrue(iosPRCheck.contains("backend_request_id_idempotency_unit_check.swift"), "ios_pr_check should run request/idempotency check")
+
+print("PASS: backend request_id/idempotency_key unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -43,6 +43,7 @@ swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/backend_contract_versioning_unit_check.swift
 swift scripts/backend_edge_observability_unit_check.swift
 swift scripts/backend_edge_auth_unification_unit_check.swift
+swift scripts/backend_request_id_idempotency_unit_check.swift
 swift scripts/sync_walk_stage_handler_split_unit_check.swift
 swift scripts/nearby_presence_handler_split_unit_check.swift
 swift scripts/rival_privacy_policy_stage1_unit_check.swift

--- a/scripts/lib/supabase_integration_harness.sh
+++ b/scripts/lib/supabase_integration_harness.sh
@@ -150,6 +150,25 @@ else:
 PY
 }
 
+harness_first_pet_id() {
+  local json="$1"
+  JSON_PAYLOAD="$json" python3 - <<'PY'
+import json
+import os
+
+raw = os.environ.get("JSON_PAYLOAD", "")
+obj = json.loads(raw)
+snapshot = obj.get("snapshot") if isinstance(obj, dict) else None
+pets = snapshot.get("pets") if isinstance(snapshot, dict) else None
+if isinstance(pets, list):
+    for pet in pets:
+        if isinstance(pet, dict) and isinstance(pet.get("id"), str) and pet["id"].strip():
+            print(pet["id"].strip())
+            raise SystemExit(0)
+print("")
+PY
+}
+
 harness_uuid() {
   python3 - <<'PY'
 import uuid

--- a/scripts/run_supabase_smoke_matrix.sh
+++ b/scripts/run_supabase_smoke_matrix.sh
@@ -34,6 +34,8 @@ sync_profile_snapshot_member="$(harness_request_json \
   "$member_auth" \
   '{"action":"get_profile_snapshot"}')"
 harness_expect_status "sync-profile.snapshot.member" "200" "$sync_profile_snapshot_member" "route=/functions/v1/sync-profile action=get_profile_snapshot"
+member_snapshot_body="$(harness_response_body "$sync_profile_snapshot_member")"
+member_pet_id="${DOGAREA_SUPABASE_SMOKE_PET_ID:-$(harness_first_pet_id "$member_snapshot_body")}"
 
 sync_profile_invalid_token="$(harness_request_json \
   "POST" \
@@ -56,7 +58,7 @@ sync_walk_stage_member="$(harness_request_json \
   "$SUPABASE_URL/functions/v1/sync-walk" \
   "$SUPABASE_ANON_KEY" \
   "$member_auth" \
-  "{\"action\":\"sync_walk_stage\",\"stage\":\"session\",\"walk_session_id\":\"$fixed_session_id\",\"idempotency_key\":\"smoke-416-session\",\"payload\":{\"created_at\":1700000000,\"started_at\":1700000000,\"ended_at\":1700000600,\"duration_sec\":600,\"area_m2\":12.5,\"source_device\":\"ios-smoke\"}}")"
+  "{\"action\":\"sync_walk_stage\",\"stage\":\"session\",\"walk_session_id\":\"$fixed_session_id\",\"request_id\":\"smoke-426-sync-walk-session-request\",\"idempotency_key\":\"smoke-416-session\",\"payload\":{\"created_at\":1700000000,\"started_at\":1700000000,\"ended_at\":1700000600,\"duration_sec\":600,\"area_m2\":12.5,\"source_device\":\"ios\",\"pet_id\":\"$member_pet_id\"}}")"
 harness_expect_status "sync-walk.session.member" "200" "$sync_walk_stage_member" "route=/functions/v1/sync-walk action=sync_walk_stage"
 
 sync_walk_summary_member="$(harness_request_json \

--- a/supabase/functions/_shared/request_keys.ts
+++ b/supabase/functions/_shared/request_keys.ts
@@ -1,0 +1,35 @@
+const asTrimmedTextOrNull = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const firstNonEmptyText = (
+  payload: Record<string, unknown>,
+  keys: string[],
+): string | null => {
+  for (const key of keys) {
+    const resolved = asTrimmedTextOrNull(payload[key]);
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return null;
+};
+
+export function resolveCanonicalRequestId(
+  payload: Record<string, unknown>,
+  fallbackRequestId: string,
+): string {
+  return firstNonEmptyText(payload, ["request_id", "requestId", "action_id"]) ?? fallbackRequestId;
+}
+
+export function resolveCanonicalIdempotencyKey(
+  payload: Record<string, unknown>,
+  options: {
+    keys?: string[];
+    fallback?: string | null;
+  } = {},
+): string | null {
+  return firstNonEmptyText(payload, options.keys ?? ["idempotency_key", "idempotencyKey"]) ?? options.fallback ?? null;
+}

--- a/supabase/functions/nearby-presence/handlers/hotspot_handler.ts
+++ b/supabase/functions/nearby-presence/handlers/hotspot_handler.ts
@@ -46,5 +46,5 @@ export async function handleGetHotspots(
     console.error("privacy audit insert failed", audit.error.message);
   }
 
-  return json({ hotspots });
+  return json({ request_id: context.requestId, hotspots });
 }

--- a/supabase/functions/nearby-presence/handlers/live_presence_handlers.ts
+++ b/supabase/functions/nearby-presence/handlers/live_presence_handlers.ts
@@ -1,4 +1,5 @@
-import { asPositiveIntegerOrNull, asUUIDArray, asUUIDOrNull, json } from "../support/core.ts";
+import { asPositiveIntegerOrNull, asRecord, asUUIDArray, asUUIDOrNull, json } from "../support/core.ts";
+import { resolveCanonicalIdempotencyKey } from "../../_shared/request_keys.ts";
 import { insertLivePresencePrivacyAuditLog } from "../support/privacy_audit.ts";
 import { upsertLivePresence } from "../support/live_presence.ts";
 import { readVisibilitySetting } from "../support/visibility.ts";
@@ -20,6 +21,7 @@ export async function handleUpsertLivePresence(
     return json({ ok: true, skipped: "location_sharing_disabled" });
   }
 
+  const bodyRecord = asRecord(context.body)
   const livePresenceResult = await upsertLivePresence(context.client, {
     userId,
     sessionId: context.body.sessionId,
@@ -28,7 +30,10 @@ export async function handleUpsertLivePresence(
     longitude: context.body.lng,
     speedMps: context.body.speedMps,
     sequence: context.body.sequence,
-    idempotencyKey: context.body.idempotencyKey,
+    idempotencyKey: resolveCanonicalIdempotencyKey(bodyRecord, {
+      keys: ["idempotency_key", "idempotencyKey", "request_id", "requestId", "action_id"],
+      fallback: context.requestId,
+    }) ?? undefined,
     updatedAt: context.body.updatedAt,
     ttlSeconds: context.body.ttlSeconds,
   });
@@ -37,7 +42,12 @@ export async function handleUpsertLivePresence(
 
   return json({
     ok: true,
+    request_id: context.requestId,
     geohash7: livePresenceResult.geohash7,
+    idempotency_key: resolveCanonicalIdempotencyKey(bodyRecord, {
+      keys: ["idempotency_key", "idempotencyKey", "request_id", "requestId", "action_id"],
+      fallback: context.requestId,
+    }),
     live_presence: livePresenceResult.row,
   });
 }
@@ -93,5 +103,5 @@ export async function handleGetLivePresence(
     console.error("privacy live audit insert failed", audit.error.message);
   }
 
-  return json({ presence });
+  return json({ request_id: context.requestId, presence });
 }

--- a/supabase/functions/nearby-presence/index.ts
+++ b/supabase/functions/nearby-presence/index.ts
@@ -1,7 +1,8 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
 import { resolveEdgeAuthContext } from "../_shared/edge_auth.ts";
+import { resolveCanonicalRequestId } from "../_shared/request_keys.ts";
 import { dispatchNearbyPresenceAction, isSupportedNearbyPresenceAction } from "./handlers/action_dispatcher.ts";
-import { json } from "./support/core.ts";
+import { asRecord, json } from "./support/core.ts";
 import type { RequestDTO } from "./support/types.ts";
 
 Deno.serve(async (req) => {
@@ -41,8 +42,11 @@ Deno.serve(async (req) => {
     return json({ error: body.action ? "UNSUPPORTED_ACTION" : "ACTION_REQUIRED" }, 400);
   }
 
+  const requestId = resolveCanonicalRequestId(asRecord(body), auth.context.requestId);
+
   return dispatchNearbyPresenceAction(body.action, {
     client,
     body,
+    requestId,
   });
 });

--- a/supabase/functions/nearby-presence/support/core.ts
+++ b/supabase/functions/nearby-presence/support/core.ts
@@ -6,6 +6,9 @@ export const json = (body: unknown, status = 200) =>
 
 export const roundCoord = (value: number) => Math.round(value * 10_000) / 10_000;
 
+export const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null ? value as Record<string, unknown> : {};
+
 export const asUUIDOrNull = (value: unknown): string | null => {
   if (typeof value !== "string") return null;
   const normalized = value.trim().toLowerCase();

--- a/supabase/functions/nearby-presence/support/types.ts
+++ b/supabase/functions/nearby-presence/support/types.ts
@@ -7,6 +7,9 @@ export type Action =
 
 export type RequestDTO = {
   action: Action;
+  request_id?: string;
+  requestId?: string;
+  action_id?: string;
   userId?: string;
   excludedUserIds?: string[];
   deviceKey?: string;
@@ -15,6 +18,7 @@ export type RequestDTO = {
   lng?: number;
   speedMps?: number;
   sequence?: number;
+  idempotency_key?: string;
   idempotencyKey?: string;
   updatedAt?: string;
   ttlSeconds?: number;
@@ -71,6 +75,7 @@ export type NearbyPresenceClient = any;
 export type NearbyPresenceRequestContext = {
   client: NearbyPresenceClient;
   body: RequestDTO;
+  requestId: string;
 };
 
 export type LivePresenceUpsertPayload = {

--- a/supabase/functions/nearby-presence/support/visibility.ts
+++ b/supabase/functions/nearby-presence/support/visibility.ts
@@ -1,4 +1,5 @@
-import { asUUIDOrNull, geohashEncode, json, roundCoord } from "./core.ts";
+import { asRecord, asUUIDOrNull, geohashEncode, json, roundCoord } from "./core.ts";
+import { resolveCanonicalIdempotencyKey } from "../../_shared/request_keys.ts";
 import type { NearbyPresenceClient, RequestDTO } from "./types.ts";
 
 export async function readVisibilitySetting(
@@ -36,7 +37,10 @@ export async function handleSetVisibility(
     updated_at: new Date().toISOString(),
   });
   if (error) return json({ error: error.message }, 500);
-  return json({ ok: true });
+  return json({ ok: true, request_id: resolveCanonicalIdempotencyKey(asRecord(body), {
+    keys: ["request_id", "requestId", "action_id"],
+    fallback: null,
+  }) });
 }
 
 export async function handleUpsertPresence(
@@ -82,6 +86,7 @@ export async function handleUpsertPresence(
   });
   if (error) return json({ error: error.message }, 500);
 
+  const bodyRecord = asRecord(body)
   const livePresenceResult = await upsertLivePresence(client, {
     userId,
     sessionId: body.sessionId,
@@ -90,7 +95,10 @@ export async function handleUpsertPresence(
     longitude: lngRounded,
     speedMps: body.speedMps,
     sequence: body.sequence,
-    idempotencyKey: body.idempotencyKey,
+    idempotencyKey: resolveCanonicalIdempotencyKey(bodyRecord, {
+      keys: ["idempotency_key", "idempotencyKey", "request_id", "requestId", "action_id"],
+      fallback: null,
+    }) ?? undefined,
     updatedAt: body.updatedAt,
     ttlSeconds: body.ttlSeconds,
   });
@@ -98,6 +106,10 @@ export async function handleUpsertPresence(
 
   return json({
     ok: true,
+    request_id: resolveCanonicalIdempotencyKey(bodyRecord, {
+      keys: ["request_id", "requestId", "action_id"],
+      fallback: null,
+    }),
     geohash7,
     live_presence: livePresenceResult.row,
   });

--- a/supabase/functions/quest-engine/README.md
+++ b/supabase/functions/quest-engine/README.md
@@ -20,10 +20,11 @@
 ```json
 {
   "action": "ingest_walk_event",
-  "instanceId": "00000000-0000-0000-0000-000000000000",
-  "eventId": "session-uuid:points:42:walk_duration",
-  "eventType": "walk_sync_points",
-  "deltaValue": 12,
+  "request_id": "quest-progress-0001",
+  "instance_id": "00000000-0000-0000-0000-000000000000",
+  "event_id": "session-uuid:points:42:walk_duration",
+  "event_type": "walk_sync_points",
+  "delta_value": 12,
   "payload": {
     "walk_session_id": "00000000-0000-0000-0000-000000000000"
   }
@@ -40,3 +41,10 @@
   }
 }
 ```
+
+
+## Request Key Rules
+- canonical correlation key: `request_id`
+- canonical idempotency key: `idempotency_key`
+- quest progress ledger key: `event_id`
+- legacy alias `requestId` / `eventId` / `instanceId` / `target_instance_id` are still accepted

--- a/supabase/functions/quest-engine/index.ts
+++ b/supabase/functions/quest-engine/index.ts
@@ -1,4 +1,5 @@
 import { resolveEdgeAuthContext } from "../_shared/edge_auth.ts";
+import { resolveCanonicalIdempotencyKey, resolveCanonicalRequestId } from "../_shared/request_keys.ts";
 
 type Action =
   | "issue_quests"
@@ -13,16 +14,29 @@ type TransitionAction = "expire" | "reroll" | "replace";
 type RequestDTO = {
   action?: Action;
   scope?: QuestScope;
+  cycle_key?: string;
   cycleKey?: string;
+  expires_at?: string;
   expiresAt?: string;
+  instance_id?: string;
   instanceId?: string;
+  target_instance_id?: string;
+  event_id?: string;
   eventId?: string;
+  event_type?: string;
   eventType?: string;
+  delta_value?: number;
   deltaValue?: number;
   payload?: Record<string, unknown>;
+  request_id?: string;
   requestId?: string;
+  idempotency_key?: string;
+  idempotencyKey?: string;
+  transition_action?: TransitionAction;
   transitionAction?: TransitionAction;
+  replacement_template_id?: string;
   replacementTemplateId?: string;
+  now_ts?: string;
 };
 
 const json = (body: unknown, status = 200) =>
@@ -90,13 +104,15 @@ Deno.serve(async (req) => {
 
   if (!body.action) return json({ error: "ACTION_REQUIRED" }, 400);
 
-  const nowISO = new Date().toISOString();
+  const bodyRecord = asRecord(body);
+  const requestId = resolveCanonicalRequestId(bodyRecord, auth.context.requestId);
+  const nowISO = asString(body.now_ts) ?? new Date().toISOString();
 
   switch (body.action) {
     case "issue_quests": {
       const scope = asString(body.scope) ?? "daily";
-      const cycleKey = asString(body.cycleKey);
-      const expiresAt = asString(body.expiresAt);
+      const cycleKey = asString(body.cycle_key ?? body.cycleKey);
+      const expiresAt = asString(body.expires_at ?? body.expiresAt);
 
       const { data, error } = await userClient.rpc("rpc_issue_quest_instances", {
         target_user_id: userId,
@@ -107,12 +123,15 @@ Deno.serve(async (req) => {
       });
       if (error) return json({ error: error.message }, 500);
 
-      return json({ quests: Array.isArray(data) ? data : [] });
+      return json({ request_id: requestId, quests: Array.isArray(data) ? data : [] });
     }
 
     case "ingest_walk_event": {
-      const instanceId = toUUIDOrNull(body.instanceId);
-      const eventId = asString(body.eventId);
+      const instanceId = toUUIDOrNull(body.instance_id ?? body.instanceId ?? body.target_instance_id);
+      const eventId = resolveCanonicalIdempotencyKey(bodyRecord, {
+        keys: ["event_id", "eventId", "idempotency_key", "idempotencyKey", "action_id"],
+        fallback: requestId,
+      });
       if (!instanceId || !eventId) {
         return json({ error: "INVALID_PAYLOAD" }, 400);
       }
@@ -121,36 +140,41 @@ Deno.serve(async (req) => {
         target_user_id: userId,
         target_instance_id: instanceId,
         event_id: eventId,
-        event_type: asString(body.eventType) ?? "walk_event",
-        delta_value: Math.max(0, toNumber(body.deltaValue, 1)),
+        event_type: asString(body.event_type ?? body.eventType) ?? "walk_event",
+        delta_value: Math.max(0, toNumber(body.delta_value ?? body.deltaValue, 1)),
         payload: asRecord(body.payload),
         now_ts: nowISO,
       });
       if (error) return json({ error: error.message }, 500);
 
       const row = Array.isArray(data) && data.length > 0 ? data[0] : null;
-      return json({ progress: row });
+      return json({ request_id: requestId, progress: row });
     }
 
     case "claim_reward": {
-      const instanceId = toUUIDOrNull(body.instanceId);
+      const instanceId = toUUIDOrNull(body.instance_id ?? body.instanceId ?? body.target_instance_id);
       if (!instanceId) return json({ error: "INVALID_PAYLOAD" }, 400);
+
+      const claimRequestId = resolveCanonicalIdempotencyKey(bodyRecord, {
+        keys: ["request_id", "requestId", "idempotency_key", "idempotencyKey", "action_id"],
+        fallback: requestId,
+      });
 
       const { data, error } = await userClient.rpc("rpc_claim_quest_reward", {
         target_user_id: userId,
         target_instance_id: instanceId,
-        request_id: asString(body.requestId),
+        request_id: claimRequestId,
         now_ts: nowISO,
       });
       if (error) return json({ error: error.message }, 500);
 
       const row = Array.isArray(data) && data.length > 0 ? data[0] : null;
-      return json({ claim: row });
+      return json({ request_id: requestId, claim: row });
     }
 
     case "transition_status": {
-      const instanceId = toUUIDOrNull(body.instanceId);
-      const transitionAction = asString(body.transitionAction);
+      const instanceId = toUUIDOrNull(body.instance_id ?? body.instanceId ?? body.target_instance_id);
+      const transitionAction = asString(body.transition_action ?? body.transitionAction);
       if (!instanceId || !transitionAction) {
         return json({ error: "INVALID_PAYLOAD" }, 400);
       }
@@ -159,13 +183,13 @@ Deno.serve(async (req) => {
         target_user_id: userId,
         target_instance_id: instanceId,
         transition_action: transitionAction,
-        replacement_template_id: asString(body.replacementTemplateId),
+        replacement_template_id: asString(body.replacement_template_id ?? body.replacementTemplateId),
         now_ts: nowISO,
       });
       if (error) return json({ error: error.message }, 500);
 
       const row = Array.isArray(data) && data.length > 0 ? data[0] : null;
-      return json({ transition: row });
+      return json({ request_id: requestId, transition: row });
     }
 
     case "list_active": {
@@ -178,7 +202,7 @@ Deno.serve(async (req) => {
         .limit(30);
 
       if (error) return json({ error: error.message }, 500);
-      return json({ quests: data ?? [] });
+      return json({ request_id: requestId, quests: data ?? [] });
     }
 
     default:

--- a/supabase/functions/sync-walk/handlers/backfill_summary.ts
+++ b/supabase/functions/sync-walk/handlers/backfill_summary.ts
@@ -47,6 +47,7 @@ export async function handleBackfillSummary(
   );
 
   return json({
+    request_id: context.requestId,
     summary: {
       session_count: safeSessions.length,
       point_count: pointCount,

--- a/supabase/functions/sync-walk/handlers/meta_stage.ts
+++ b/supabase/functions/sync-walk/handlers/meta_stage.ts
@@ -23,5 +23,5 @@ export async function handleMetaStage(
     return json({ error: error.message }, 500);
   }
 
-  return json({ ok: true, stage: "meta", walk_session_id: context.walkSessionId });
+  return json({ ok: true, request_id: context.requestId, stage: "meta", walk_session_id: context.walkSessionId });
 }

--- a/supabase/functions/sync-walk/handlers/points_stage.ts
+++ b/supabase/functions/sync-walk/handlers/points_stage.ts
@@ -76,9 +76,11 @@ export async function handlePointsStage(
 
   return json({
     ok: true,
+    request_id: context.requestId,
     stage: "points",
     walk_session_id: context.walkSessionId,
     point_count: parsedRows.rows.length,
+    idempotency_key: context.idempotencyKey,
     season_score_summary: postProcessing.seasonScoreSummary,
     season_pipeline_summary: postProcessing.seasonPipelineSummary,
     weather_replacement_summary: postProcessing.weatherReplacementSummary,

--- a/supabase/functions/sync-walk/handlers/session_stage.ts
+++ b/supabase/functions/sync-walk/handlers/session_stage.ts
@@ -18,6 +18,7 @@ export async function handleSessionStage(
 
   return json({
     ok: true,
+    request_id: context.requestId,
     stage: "session",
     walk_session_id: context.walkSessionId,
     idempotency_key: context.idempotencyKey,

--- a/supabase/functions/sync-walk/index.ts
+++ b/supabase/functions/sync-walk/index.ts
@@ -1,4 +1,5 @@
 import { resolveEdgeAuthContext } from "../_shared/edge_auth.ts";
+import { resolveCanonicalIdempotencyKey, resolveCanonicalRequestId } from "../_shared/request_keys.ts";
 import { handleBackfillSummary } from "./handlers/backfill_summary.ts";
 import { dispatchSyncWalkStage, isSupportedSyncStage } from "./handlers/stage_dispatcher.ts";
 import { asRecord, json, toUUIDOrNull } from "./support/core.ts";
@@ -28,7 +29,6 @@ Deno.serve(async (req) => {
 
   const userClient = auth.context.userClient!;
   const userId = auth.context.userId!;
-  const requestId = auth.context.requestId;
 
   let body: RequestDTO;
   try {
@@ -40,6 +40,9 @@ Deno.serve(async (req) => {
   if (!body.action) {
     return json({ error: "ACTION_REQUIRED" }, 400);
   }
+
+  const bodyRecord = asRecord(body);
+  const requestId = resolveCanonicalRequestId(bodyRecord, auth.context.requestId);
 
   if (body.action === "get_backfill_summary") {
     const sessionIds = (body.session_ids ?? [])
@@ -63,12 +66,17 @@ Deno.serve(async (req) => {
     return json({ error: "INVALID_PAYLOAD" }, 400);
   }
 
+  const idempotencyKey = resolveCanonicalIdempotencyKey(bodyRecord, {
+    keys: ["idempotency_key", "idempotencyKey", "request_id", "requestId"],
+    fallback: requestId,
+  });
+
   return dispatchSyncWalkStage(body.stage, {
     userClient,
     userId,
     requestId,
     walkSessionId,
-    idempotencyKey: body.idempotency_key ?? null,
+    idempotencyKey,
     payload,
   });
 });

--- a/supabase/functions/sync-walk/support/types.ts
+++ b/supabase/functions/sync-walk/support/types.ts
@@ -7,7 +7,10 @@ export type RequestDTO = {
   action?: Action;
   stage?: SyncStage;
   walk_session_id?: string;
+  request_id?: string;
+  requestId?: string;
   idempotency_key?: string;
+  idempotencyKey?: string;
   payload?: Record<string, unknown>;
   session_ids?: string[];
 };


### PR DESCRIPTION
## Summary
- standardize `request_id` and `idempotency_key` handling across sync-walk, nearby-presence, and quest-engine
- add shared request key resolver, policy doc, and regression check coverage
- align live Supabase smoke matrix payloads with canonical request keys and current walk session schema constraints

## Verification
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh
- DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=jinnavis1@gmail.com DOGAREA_TEST_PASSWORD=*** bash scripts/backend_pr_check.sh

Closes #426