### PR TITLE
docs: define backend edge failure dashboard view

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - Backend Edge error taxonomy v1: `docs/backend-edge-error-taxonomy-v1.md`
 - Backend Edge incident runbook v1: `docs/backend-edge-incident-runbook-v1.md`
 - Backend Edge observability adoption matrix v1: `docs/backend-edge-observability-adoption-matrix-v1.md`
+- Backend Edge failure dashboard view v1: `docs/backend-edge-failure-dashboard-view-v1.md`
 - 릴리즈 회귀 체크리스트 v1: `docs/release-regression-checklist-v1.md`
 - 릴리즈 회귀 실행 리포트(2026-02-26): `docs/release-regression-report-2026-02-26.md`
 - 게임 레이어 공통 관측/QA 기준 v1: `docs/game-layer-observability-qa-v1.md`

--- a/docs/backend-edge-failure-dashboard-view-v1.md
+++ b/docs/backend-edge-failure-dashboard-view-v1.md
@@ -1,0 +1,247 @@
+# Backend Edge Failure Dashboard View v1
+
+Date: 2026-03-07  
+Issue: #430
+
+## 목적
+
+앱 KPI와 별개로, Supabase backend 장애를 운영자가 backend 관점에서 바로 읽을 수 있는 정규화된 집계 뷰 기준을 고정합니다.
+
+이 문서는 두 가지를 함께 정의합니다.
+
+- `public.view_backend_edge_failure_dashboard_24h`의 Phase 1 정규화 shape
+- 현재 저장소에서 실제로 집계 가능한 failure source와 coverage 한계
+
+## 읽어야 하는 기준 축
+
+대시보드는 아래 축으로 읽을 수 있어야 합니다.
+
+- `function_name`
+- `error_code`
+- `failure_category`
+- `auth_mode`
+- `fallback_used`
+- `hour_bucket`
+- `event_count`
+- `affected_users`
+- `avg_latency_ms`
+- `p95_latency_ms`
+- `data_source`
+
+## Phase 1 데이터 소스
+
+Phase 1은 이미 DB에 durable row가 남는 소스만 포함합니다.
+
+| Data source | Function coverage | What it represents | Notes |
+| --- | --- | --- | --- |
+| `public.caricature_jobs` | `caricature` | provider/storage/db failure, fallback, latency | 현재 가장 표준에 가까운 source |
+| `public.privacy_guard_audit_logs` | `nearby-presence` | privacy suppression / mask / k-anon gate | hotspot/privacy failure 해석용 |
+| `public.live_presence_abuse_events` | `nearby-presence` | abuse sanction / rate / jump / repeat | live presence abuse failure 해석용 |
+
+보조 KPI source:
+
+- `public.view_rollout_kpis_24h`
+  - backend failure source는 아니지만 rollout degradation과 함께 읽을 보조 지표입니다.
+
+## 현재 Phase 1에 없는 함수
+
+아래 함수는 아직 failure dashboard view에 full-fidelity로 들어오지 않습니다.
+
+- `sync-walk`
+- `sync-profile`
+- `rival-league`
+- `quest-engine`
+- `feature-control`
+- `upload-profile-image`
+
+이유:
+
+- request 단위 durable audit row가 아직 없습니다.
+- `function_name / error_code / auth_mode / fallback_used / latency_ms`가 같은 row에서 함께 남지 않습니다.
+
+관련 정리:
+
+- `docs/backend-edge-observability-adoption-matrix-v1.md`
+- `docs/backend-edge-observability-standard-v1.md`
+- `docs/backend-edge-incident-runbook-v1.md`
+
+## 정규화 view shape
+
+`public.view_backend_edge_failure_dashboard_24h`는 아래 shape를 목표로 합니다.
+
+| Column | Meaning |
+| --- | --- |
+| `hour_bucket` | 시간 버킷 |
+| `function_name` | canonical Edge Function 이름 |
+| `error_code` | machine-readable canonical 또는 compat code |
+| `failure_category` | `auth`, `contract`, `validation`, `unavailable`, `privacy`, `upstream`, `abuse` |
+| `auth_mode` | `anon`, `authenticated`, `service_role_proxy`, `mixed` 또는 `NULL` |
+| `fallback_used` | fallback/auth downgrade/provider fallback이 사용되었는지 |
+| `event_count` | 해당 버킷에서의 장애 건수 |
+| `affected_users` | 영향받은 고유 사용자 수 |
+| `avg_latency_ms` | 평균 지연 시간 |
+| `p95_latency_ms` | 95 percentile 지연 시간 |
+| `data_source` | 원본 소스 식별자 |
+
+## Phase 1 SQL view
+
+저장소 migration 초안은 다음 view를 정의합니다.
+
+- `public.view_backend_edge_failure_dashboard_24h`
+
+정규화 전략:
+
+1. `caricature_jobs`는 error/fallback/latency를 거의 그대로 반영
+2. `privacy_guard_audit_logs`는 privacy suppression event를 canonical privacy code로 재매핑
+3. `live_presence_abuse_events`는 event type을 canonical abuse code로 재매핑
+4. 현재 저장되지 않는 값은 `NULL` 허용
+
+## 운영 해석 규칙
+
+### 1. function별 장애 상위 원인
+
+`function_name`, `error_code`, `event_count` 기준으로 읽습니다.
+
+예시:
+
+- `caricature` / `ALL_PROVIDERS_FAILED`
+- `nearby-presence` / `PRIVACY_K_ANON_SUPPRESSED`
+- `nearby-presence` / `ABUSE_RATE_DEVICE`
+
+### 2. auth failure 해석
+
+Phase 1에서는 `auth_mode`가 durable row에 남는 source가 제한적입니다.
+
+- `caricature_jobs`: `source_type` 기반 준-정규화 가능
+- `privacy_guard_audit_logs`: payload에 auth metadata가 들어간 경우만 읽음
+- `live_presence_abuse_events`: detail에 auth metadata가 들어간 경우만 읽음
+
+따라서 `auth_mode`는 현재 nullable dimension으로 해석합니다.
+
+### 3. fallback ratio 해석
+
+현재 `fallback_used`를 신뢰성 있게 읽을 수 있는 source는 사실상 `caricature_jobs`가 중심입니다.
+
+운영상 fallback ratio는 아래 방식으로 봅니다.
+
+- per function fallback rate:
+  - `sum(case when fallback_used then event_count else 0 end) / sum(event_count)`
+- source coverage note:
+  - fallback persisted source가 없는 함수는 ratio를 `N/A`로 취급
+
+## 추천 대시보드 패널
+
+### A. 24h function failure heatmap
+
+축:
+
+- x: `hour_bucket`
+- y: `function_name`
+- metric: `sum(event_count)`
+
+### B. 24h error code leaderboard
+
+축:
+
+- group: `error_code`
+- metric: `sum(event_count)`
+
+### C. nearby-presence privacy vs abuse split
+
+축:
+
+- group: `failure_category`
+- filter: `function_name = 'nearby-presence'`
+- metric: `sum(event_count)`
+
+### D. caricature fallback and upstream failures
+
+축:
+
+- group: `error_code`, `fallback_used`
+- filter: `function_name = 'caricature'`
+- metric: `sum(event_count)`
+
+### E. rollout KPI companion panel
+
+보조 source:
+
+- `public.view_rollout_kpis_24h`
+
+용도:
+
+- backend failure 급증과 rollout KPI degradation을 나란히 확인
+
+## 쿼리 예시
+
+### 1. 함수별 장애 집계
+
+```sql
+select
+  function_name,
+  error_code,
+  sum(event_count) as total_events,
+  sum(affected_users) as total_affected_users
+from public.view_backend_edge_failure_dashboard_24h
+group by function_name, error_code
+order by total_events desc, function_name asc;
+```
+
+### 2. fallback 사용 비율
+
+```sql
+select
+  function_name,
+  sum(case when fallback_used then event_count else 0 end)::double precision
+    / nullif(sum(event_count), 0) as fallback_ratio
+from public.view_backend_edge_failure_dashboard_24h
+group by function_name
+order by fallback_ratio desc nulls last;
+```
+
+### 3. category별 장애 추이
+
+```sql
+select
+  hour_bucket,
+  failure_category,
+  sum(event_count) as event_count
+from public.view_backend_edge_failure_dashboard_24h
+group by hour_bucket, failure_category
+order by hour_bucket desc, failure_category asc;
+```
+
+## Coverage 한계
+
+이 view는 아직 "전체 Edge request audit"이 아닙니다.
+
+해결되지 않은 부분:
+
+- `sync-walk`, `sync-profile`, `rival-league`, `quest-engine`, `feature-control`, `upload-profile-image`는 request row가 없어 Phase 1 dashboard에서 제외
+- `auth_mode`와 `fallback_used`는 source별 coverage 편차가 큼
+- `p95_latency_ms`는 현재 `caricature_jobs` 중심으로만 의미가 있음
+
+즉, 이 view는 **Phase 1 운영 해석용 정규화 view**이지 최종 canonical audit table이 아닙니다.
+
+## 다음 단계
+
+Phase 2 이후 작업:
+
+1. remaining Edge Function에 request audit row 도입
+2. 공통 `function_name / request_id / version / auth_mode / fallback_used / latency_ms / error_code` persisted metadata 확보
+3. `view_backend_edge_failure_dashboard_24h`를 source union이 아니라 canonical audit source 기반으로 재작성
+
+## Validation
+
+- `swift scripts/backend_edge_failure_dashboard_unit_check.swift`
+- `bash scripts/backend_pr_check.sh`
+- `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
+
+## Related
+
+- `docs/backend-edge-observability-standard-v1.md`
+- `docs/backend-edge-error-taxonomy-v1.md`
+- `docs/backend-edge-incident-runbook-v1.md`
+- `docs/backend-edge-observability-adoption-matrix-v1.md`
+- `docs/feature-flag-rollout-monitoring-v1.md`
+- `docs/supabase-integration-smoke-matrix-v1.md`

--- a/docs/backend-edge-incident-runbook-v1.md
+++ b/docs/backend-edge-incident-runbook-v1.md
@@ -125,6 +125,7 @@ DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... ba
 
 운영자가 기본으로 보는 기준:
 
+- backend failure dashboard: `docs/backend-edge-failure-dashboard-view-v1.md`
 - game-layer KPI: `docs/game-layer-observability-qa-v1.md`
 - rollout KPI: `docs/feature-flag-rollout-monitoring-v1.md`
 - live smoke matrix: `docs/supabase-integration-smoke-matrix-v1.md`

--- a/docs/backend-edge-observability-adoption-matrix-v1.md
+++ b/docs/backend-edge-observability-adoption-matrix-v1.md
@@ -33,3 +33,5 @@ Issue: #418
 ## Validation
 
 - `swift scripts/backend_edge_observability_unit_check.swift`
+- `swift scripts/backend_edge_failure_dashboard_unit_check.swift`
+- `docs/backend-edge-failure-dashboard-view-v1.md`

--- a/scripts/backend_edge_failure_dashboard_unit_check.swift
+++ b/scripts/backend_edge_failure_dashboard_unit_check.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// 조건이 거짓이면 stderr에 실패 메시지를 출력하고 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 조건식입니다.
+///   - message: 조건이 거짓일 때 출력할 설명입니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let repositoryRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 파일을 UTF-8 문자열로 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: 파일 전체 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: repositoryRoot.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let doc = load("docs/backend-edge-failure-dashboard-view-v1.md")
+let migration = load("supabase/migrations/20260307193000_backend_edge_failure_dashboard_view.sql")
+let readme = load("README.md")
+let runbook = load("docs/backend-edge-incident-runbook-v1.md")
+let matrix = load("docs/backend-edge-observability-adoption-matrix-v1.md")
+let backendCheck = load("scripts/backend_pr_check.sh")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+
+for token in [
+    "view_backend_edge_failure_dashboard_24h",
+    "function_name",
+    "error_code",
+    "failure_category",
+    "auth_mode",
+    "fallback_used",
+    "hour_bucket",
+    "event_count",
+    "affected_users",
+    "avg_latency_ms",
+    "p95_latency_ms",
+    "data_source"
+] {
+    assertTrue(doc.contains(token), "dashboard doc should mention \(token)")
+}
+
+for source in [
+    "caricature_jobs",
+    "privacy_guard_audit_logs",
+    "live_presence_abuse_events",
+    "view_rollout_kpis_24h"
+] {
+    assertTrue(doc.contains(source), "dashboard doc should mention source \(source)")
+}
+
+for functionName in [
+    "sync-walk",
+    "sync-profile",
+    "rival-league",
+    "quest-engine",
+    "feature-control",
+    "upload-profile-image"
+] {
+    assertTrue(doc.contains(functionName), "dashboard doc should call out uncovered function \(functionName)")
+}
+
+for queryPhrase in [
+    "fallback_ratio",
+    "group by function_name, error_code",
+    "failure_category",
+    "Phase 1 SQL view"
+] {
+    assertTrue(doc.contains(queryPhrase), "dashboard doc should include query/view guidance for \(queryPhrase)")
+}
+
+assertTrue(migration.contains("create or replace view public.view_backend_edge_failure_dashboard_24h"), "migration should create dashboard view")
+assertTrue(migration.contains("'caricature'::text as function_name"), "migration should include caricature source")
+assertTrue(migration.contains("'nearby-presence'::text as function_name"), "migration should include nearby-presence source")
+assertTrue(migration.contains("privacy_guard_audit_logs"), "migration should include privacy guard source")
+assertTrue(migration.contains("live_presence_abuse_events"), "migration should include abuse source")
+assertTrue(migration.contains("AUTH_SESSION_INVALID"), "migration should classify auth failures")
+assertTrue(migration.contains("PRIVACY_K_ANON_SUPPRESSED"), "migration should classify privacy guard failures")
+assertTrue(migration.contains("ABUSE_RATE_DEVICE"), "migration should classify abuse failures")
+assertTrue(migration.contains("grant select on public.view_backend_edge_failure_dashboard_24h to authenticated;"), "migration should grant dashboard view select")
+
+assertTrue(readme.contains("docs/backend-edge-failure-dashboard-view-v1.md"), "README should link dashboard doc")
+assertTrue(runbook.contains("docs/backend-edge-failure-dashboard-view-v1.md"), "runbook should link dashboard doc")
+assertTrue(matrix.contains("docs/backend-edge-failure-dashboard-view-v1.md"), "adoption matrix should link dashboard doc")
+assertTrue(backendCheck.contains("backend_edge_failure_dashboard_unit_check.swift"), "backend_pr_check should run dashboard check")
+assertTrue(iosPRCheck.contains("backend_edge_failure_dashboard_unit_check.swift"), "ios_pr_check should run dashboard check")
+
+print("PASS: backend edge failure dashboard unit checks")

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -8,6 +8,7 @@ echo "[dogArea-backend] running integration harness structure checks"
 swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/backend_contract_versioning_unit_check.swift
 swift scripts/backend_edge_observability_unit_check.swift
+swift scripts/backend_edge_failure_dashboard_unit_check.swift
 swift scripts/backend_edge_auth_unification_unit_check.swift
 swift scripts/backend_request_id_idempotency_unit_check.swift
 swift scripts/backend_scheduler_ops_unit_check.swift

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -42,6 +42,7 @@ swift scripts/supabase_ops_hardening_unit_check.swift
 swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/backend_contract_versioning_unit_check.swift
 swift scripts/backend_edge_observability_unit_check.swift
+swift scripts/backend_edge_failure_dashboard_unit_check.swift
 swift scripts/backend_edge_auth_unification_unit_check.swift
 swift scripts/backend_request_id_idempotency_unit_check.swift
 swift scripts/backend_scheduler_ops_unit_check.swift

--- a/supabase/migrations/20260307193000_backend_edge_failure_dashboard_view.sql
+++ b/supabase/migrations/20260307193000_backend_edge_failure_dashboard_view.sql
@@ -1,0 +1,137 @@
+-- #430 backend edge failure dashboard view (phase 1)
+
+create or replace view public.view_backend_edge_failure_dashboard_24h as
+with caricature_failures as (
+  select
+    date_trunc('hour', coalesce(completed_at, updated_at, created_at)) as hour_bucket,
+    'caricature'::text as function_name,
+    coalesce(nullif(error_code, ''), 'UNKNOWN') as error_code,
+    case
+      when coalesce(error_code, '') in ('AUTH_SESSION_INVALID', 'AUTH_MODE_NOT_ALLOWED', 'UNAUTHORIZED') then 'auth'
+      when coalesce(error_code, '') in ('INVALID_REQUEST', 'INVALID_JSON', 'INVALID_PAYLOAD') then 'validation'
+      when coalesce(error_code, '') in ('METHOD_NOT_ALLOWED') then 'contract'
+      when coalesce(error_code, '') in ('SERVER_MISCONFIGURED', 'SOURCE_IMAGE_NOT_FOUND') then 'unavailable'
+      when coalesce(error_code, '') in ('ALL_PROVIDERS_FAILED', 'STORAGE_UPLOAD_FAILED', 'DB_UPDATE_FAILED') then 'upstream'
+      else 'upstream'
+    end as failure_category,
+    case
+      when lower(coalesce(source_type, '')) in ('authenticated', 'member', 'user') then 'authenticated'
+      when lower(coalesce(source_type, '')) in ('anon', 'public') then 'anon'
+      when lower(coalesce(source_type, '')) in ('service_role', 'service_role_proxy', 'service') then 'service_role_proxy'
+      else nullif(source_type, '')
+    end as auth_mode,
+    fallback_used,
+    count(*)::bigint as event_count,
+    count(distinct user_id)::bigint as affected_users,
+    avg(latency_ms)::double precision as avg_latency_ms,
+    percentile_cont(0.95) within group (order by latency_ms)::double precision as p95_latency_ms,
+    'caricature_jobs'::text as data_source
+  from public.caricature_jobs
+  where coalesce(completed_at, updated_at, created_at) >= now() - interval '24 hours'
+    and (status = 'failed' or error_code is not null)
+  group by
+    date_trunc('hour', coalesce(completed_at, updated_at, created_at)),
+    coalesce(nullif(error_code, ''), 'UNKNOWN'),
+    case
+      when coalesce(error_code, '') in ('AUTH_SESSION_INVALID', 'AUTH_MODE_NOT_ALLOWED', 'UNAUTHORIZED') then 'auth'
+      when coalesce(error_code, '') in ('INVALID_REQUEST', 'INVALID_JSON', 'INVALID_PAYLOAD') then 'validation'
+      when coalesce(error_code, '') in ('METHOD_NOT_ALLOWED') then 'contract'
+      when coalesce(error_code, '') in ('SERVER_MISCONFIGURED', 'SOURCE_IMAGE_NOT_FOUND') then 'unavailable'
+      when coalesce(error_code, '') in ('ALL_PROVIDERS_FAILED', 'STORAGE_UPLOAD_FAILED', 'DB_UPDATE_FAILED') then 'upstream'
+      else 'upstream'
+    end,
+    case
+      when lower(coalesce(source_type, '')) in ('authenticated', 'member', 'user') then 'authenticated'
+      when lower(coalesce(source_type, '')) in ('anon', 'public') then 'anon'
+      when lower(coalesce(source_type, '')) in ('service_role', 'service_role_proxy', 'service') then 'service_role_proxy'
+      else nullif(source_type, '')
+    end,
+    fallback_used
+),
+privacy_failures as (
+  select
+    date_trunc('hour', created_at) as hour_bucket,
+    'nearby-presence'::text as function_name,
+    case
+      when coalesce(masked_hotspots, 0) > 0 then 'PRIVACY_SENSITIVE_MASK'
+      when coalesce(k_anon_hotspots, 0) > 0 then 'PRIVACY_K_ANON_SUPPRESSED'
+      when coalesce(suppressed_hotspots, 0) > 0 then 'PRIVACY_DELAY_SUPPRESSED'
+      else 'PRIVACY_GUARD_EVENT'
+    end as error_code,
+    'privacy'::text as failure_category,
+    nullif(payload ->> 'auth_mode', '') as auth_mode,
+    case
+      when payload ? 'fallback_used' then coalesce((payload ->> 'fallback_used')::boolean, false)
+      else false
+    end as fallback_used,
+    count(*)::bigint as event_count,
+    count(distinct request_user_id)::bigint as affected_users,
+    null::double precision as avg_latency_ms,
+    null::double precision as p95_latency_ms,
+    'privacy_guard_audit_logs'::text as data_source
+  from public.privacy_guard_audit_logs
+  where created_at >= now() - interval '24 hours'
+    and (
+      suppressed_hotspots > 0
+      or masked_hotspots > 0
+      or k_anon_hotspots > 0
+      or alert_level in ('warn', 'critical')
+    )
+  group by
+    date_trunc('hour', created_at),
+    case
+      when coalesce(masked_hotspots, 0) > 0 then 'PRIVACY_SENSITIVE_MASK'
+      when coalesce(k_anon_hotspots, 0) > 0 then 'PRIVACY_K_ANON_SUPPRESSED'
+      when coalesce(suppressed_hotspots, 0) > 0 then 'PRIVACY_DELAY_SUPPRESSED'
+      else 'PRIVACY_GUARD_EVENT'
+    end,
+    nullif(payload ->> 'auth_mode', ''),
+    case
+      when payload ? 'fallback_used' then coalesce((payload ->> 'fallback_used')::boolean, false)
+      else false
+    end
+),
+abuse_failures as (
+  select
+    date_trunc('hour', created_at) as hour_bucket,
+    'nearby-presence'::text as function_name,
+    case event_type
+      when 'speed' then 'ABUSE_SPEED'
+      when 'jump' then 'ABUSE_JUMP'
+      when 'rate_user' then 'ABUSE_RATE_USER'
+      when 'rate_device' then 'ABUSE_RATE_DEVICE'
+      when 'repeat' then 'ABUSE_REPEAT'
+      when 'sanction' then 'ABUSE_SANCTION'
+      else 'ABUSE_EVENT'
+    end as error_code,
+    'abuse'::text as failure_category,
+    nullif(detail ->> 'auth_mode', '') as auth_mode,
+    false as fallback_used,
+    count(*)::bigint as event_count,
+    count(distinct owner_user_id)::bigint as affected_users,
+    null::double precision as avg_latency_ms,
+    null::double precision as p95_latency_ms,
+    'live_presence_abuse_events'::text as data_source
+  from public.live_presence_abuse_events
+  where created_at >= now() - interval '24 hours'
+  group by
+    date_trunc('hour', created_at),
+    case event_type
+      when 'speed' then 'ABUSE_SPEED'
+      when 'jump' then 'ABUSE_JUMP'
+      when 'rate_user' then 'ABUSE_RATE_USER'
+      when 'rate_device' then 'ABUSE_RATE_DEVICE'
+      when 'repeat' then 'ABUSE_REPEAT'
+      when 'sanction' then 'ABUSE_SANCTION'
+      else 'ABUSE_EVENT'
+    end,
+    nullif(detail ->> 'auth_mode', '')
+)
+select * from caricature_failures
+union all
+select * from privacy_failures
+union all
+select * from abuse_failures
+order by hour_bucket desc, event_count desc, function_name asc;
+
+grant select on public.view_backend_edge_failure_dashboard_24h to authenticated;


### PR DESCRIPTION
## Summary
- add phase-1 backend edge failure dashboard doc and normalized SQL view draft
- wire the new dashboard check into backend/iOS PR validation
- connect the dashboard doc from the incident runbook, adoption matrix, and README

## Testing
- swift scripts/backend_edge_failure_dashboard_unit_check.swift
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #430