### PR TITLE
refactor: share detailed weather snapshot contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - 시즌 집계/정산 파이프라인 Stage2 v1: `docs/season-stage2-pipeline-v1.md`
 - 체감 날씨 피드백 루프 v1: `docs/weather-feedback-loop-v1.md`
 - 날씨 리스크 모델/Provider 정책 v1: `docs/weather-risk-provider-policy-v1.md`
+- 날씨 snapshot/provider 확장 v1: `docs/weather-snapshot-provider-v1.md`
 - 날씨 치환/스트릭 보호 서버 엔진 v1: `docs/weather-replacement-shield-engine-v1.md`
 - 날씨 연동 UX/fallback/접근성 v1: `docs/weather-ux-fallback-accessibility-v1.md`
 - 퀘스트 Stage1 템플릿/난이도 정책 v1: `docs/quest-stage1-template-difficulty-policy-v1.md`

--- a/docs/weather-snapshot-provider-v1.md
+++ b/docs/weather-snapshot-provider-v1.md
@@ -1,0 +1,48 @@
+# Weather Snapshot Provider v1
+
+## 1. 목표
+- 홈/맵/실내 미션이 같은 날씨 스냅샷 계약을 공유하도록 표준화한다.
+- 위험도 계산에만 쓰이던 weather provider를 상세 수치 기반 계약으로 확장한다.
+
+## 2. 공통 Snapshot 필드
+- `level`
+- `observedAt`
+- `location.latitude`
+- `location.longitude`
+- `temperatureC`
+- `apparentTemperatureC`
+- `relativeHumidityPercent`
+- `isPrecipitating`
+- `precipitationMMPerHour`
+- `windMps`
+- `pm2_5`
+- `pm10`
+- `weatherSource`
+- `airQualitySource`
+
+## 3. Provider 정책
+- primary weather: `https://api.open-meteo.com/v1/forecast`
+  - current: `temperature_2m,apparent_temperature,relative_humidity_2m,precipitation,wind_speed_10m`
+- optional air quality: `https://air-quality-api.open-meteo.com/v1/air-quality`
+  - current: `pm10,pm2_5`
+- weather endpoint는 위험도 계산의 canonical source다.
+- air quality endpoint는 상세 카드 확장용 보조 source다.
+
+## 4. Null / Fallback 정책
+- `temperatureC`, `apparentTemperatureC`, `relativeHumidityPercent`, `precipitationMMPerHour`, `windMps`는 core weather 필드다.
+- core weather 필드가 누락되면 provider 요청은 실패로 간주한다.
+- `pm2_5`, `pm10`은 optional 필드다.
+- 공기질 endpoint가 실패하거나 값을 주지 않으면 `pm2_5`, `pm10`은 `nil`로 저장하고 `airQualitySource = unavailable`로 기록한다.
+- provider 자체가 실패하면 소비자는 마지막 정상 snapshot을 사용한다.
+- 마지막 snapshot이 `2h`를 초과하면 `clear`로 강등하지 않고 최소 `caution`으로 보수 판정한다.
+
+## 5. 상태 전달 구조
+- Map provider fetch -> `WeatherSnapshotStore` 저장
+- Home -> `WeatherSnapshotStore` 조회
+- Indoor mission -> `WeatherSnapshotStore` 조회 후 risk 계산
+- legacy `weather.risk.level.v1` / `weather.risk.observed_at.v1`는 호환을 위해 함께 유지한다.
+
+## 6. 위치 / 관측 기준
+- `observedAt`은 provider `current.time` 기준 UTC epoch로 저장한다.
+- `location`은 snapshot을 요청한 기준 좌표다.
+- 홈은 이후 `최근 산책 기록` 기준 좌표를 사용해 snapshot을 refresh할 수 있다.

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -99,6 +99,9 @@
 		A50000010000000000000006 /* SettingViewModel+ProductSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50000010000000000000016 /* SettingViewModel+ProductSurface.swift */; };
 		A45200010000000000000001 /* SettingsEditableImageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45200010000000000000011 /* SettingsEditableImageButton.swift */; };
 		A45300010000000000000001 /* HomeIndoorMissionPresentationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45300010000000000000011 /* HomeIndoorMissionPresentationService.swift */; };
+		A45700010000000000000001 /* WeatherSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45700010000000000000011 /* WeatherSnapshot.swift */; };
+		A45700010000000000000002 /* OpenMeteoWeatherSnapshotProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45700010000000000000012 /* OpenMeteoWeatherSnapshotProvider.swift */; };
+		A45700010000000000000003 /* WeatherSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45700010000000000000013 /* WeatherSnapshotStore.swift */; };
 		A37700010000000000000001 /* AreaReferenceCatalogInsightService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37700010000000000000011 /* AreaReferenceCatalogInsightService.swift */; };
 		A37700010000000000000002 /* AreaDetailCatalogSnapshotSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37700010000000000000012 /* AreaDetailCatalogSnapshotSectionView.swift */; };
 		A37800010000000000000001 /* AppTabScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37800010000000000000002 /* AppTabScaffold.swift */; };
@@ -428,6 +431,9 @@
 		A50000010000000000000016 /* SettingViewModel+ProductSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingViewModel+ProductSurface.swift"; sourceTree = "<group>"; };
 		A45200010000000000000011 /* SettingsEditableImageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsEditableImageButton.swift; sourceTree = "<group>"; };
 		A45300010000000000000011 /* HomeIndoorMissionPresentationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeIndoorMissionPresentationService.swift; sourceTree = "<group>"; };
+		A45700010000000000000011 /* WeatherSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherSnapshot.swift; sourceTree = "<group>"; };
+		A45700010000000000000012 /* OpenMeteoWeatherSnapshotProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenMeteoWeatherSnapshotProvider.swift; sourceTree = "<group>"; };
+		A45700010000000000000013 /* WeatherSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherSnapshotStore.swift; sourceTree = "<group>"; };
 		A37700010000000000000011 /* AreaReferenceCatalogInsightService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaReferenceCatalogInsightService.swift; sourceTree = "<group>"; };
 		A37700010000000000000012 /* AreaDetailCatalogSnapshotSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaDetailCatalogSnapshotSectionView.swift; sourceTree = "<group>"; };
 		A37800010000000000000002 /* AppTabScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTabScaffold.swift; sourceTree = "<group>"; };
@@ -1283,6 +1289,7 @@
 				DAF0A0044200000000000001 /* Map */,
 				A37600010000000000000001 /* Profile */,
 				DAF0A0074200000000000001 /* Recovery */,
+				A45700010000000000000021 /* Weather */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -1317,6 +1324,40 @@
 				DAF0A0064200000000000001 /* Services */,
 			);
 			path = Map;
+			sourceTree = "<group>";
+		};
+		A45700010000000000000021 /* Weather */ = {
+			isa = PBXGroup;
+			children = (
+				A45700010000000000000022 /* Models */,
+				A45700010000000000000023 /* Services */,
+				A45700010000000000000024 /* Stores */,
+			);
+			path = Weather;
+			sourceTree = "<group>";
+		};
+		A45700010000000000000022 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A45700010000000000000011 /* WeatherSnapshot.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		A45700010000000000000023 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				A45700010000000000000012 /* OpenMeteoWeatherSnapshotProvider.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		A45700010000000000000024 /* Stores */ = {
+			isa = PBXGroup;
+			children = (
+				A45700010000000000000013 /* WeatherSnapshotStore.swift */,
+			);
+			path = Stores;
 			sourceTree = "<group>";
 		};
 		DAF0A0054200000000000001 /* Models */ = {
@@ -1707,6 +1748,9 @@
 				A37500010000000000000021 /* HomeMissionModels.swift in Sources */,
 				A37500010000000000000022 /* IndoorMissionStore.swift in Sources */,
 				A37500010000000000000023 /* SeasonMotionStore.swift in Sources */,
+				A45700010000000000000001 /* WeatherSnapshot.swift in Sources */,
+				A45700010000000000000002 /* OpenMeteoWeatherSnapshotProvider.swift in Sources */,
+				A45700010000000000000003 /* WeatherSnapshotStore.swift in Sources */,
 				DAE147A11420000000000001 /* HomeWeeklyStatisticsService.swift in Sources */,
 				DAE147A31420000000000001 /* HomeWeatherMissionStatusBuilder.swift in Sources */,
 				A45300010000000000000001 /* HomeIndoorMissionPresentationService.swift in Sources */,

--- a/dogArea/Source/Domain/Home/Models/HomeMissionModels.swift
+++ b/dogArea/Source/Domain/Home/Models/HomeMissionModels.swift
@@ -65,6 +65,7 @@ enum IndoorWeatherRiskLevel: String, CaseIterable {
 
 enum IndoorWeatherRiskSource: String, Equatable {
     case environment
+    case snapshot
     case userOverride
     case fallback
 }
@@ -270,4 +271,3 @@ struct WeatherFeedbackOutcome: Equatable {
     let adjustedRisk: IndoorWeatherRiskLevel
     let remainingWeeklyQuota: Int
 }
-

--- a/dogArea/Source/Domain/Home/Stores/IndoorMissionStore.swift
+++ b/dogArea/Source/Domain/Home/Stores/IndoorMissionStore.swift
@@ -71,6 +71,7 @@ final class IndoorMissionStore {
         value.timeZone = TimeZone.autoupdatingCurrent
         return value
     }()
+    private let weatherSnapshotStore: WeatherSnapshotStoreProtocol
 
     private let templates: [IndoorMissionTemplate] = [
         .init(
@@ -119,6 +120,12 @@ final class IndoorMissionStore {
             streakEligible: true
         )
     ]
+
+    /// 실내 미션 저장소를 생성합니다.
+    /// - Parameter weatherSnapshotStore: 홈/맵과 공유하는 최신 날씨 스냅샷 저장소입니다.
+    init(weatherSnapshotStore: WeatherSnapshotStoreProtocol = WeatherSnapshotStore.shared) {
+        self.weatherSnapshotStore = weatherSnapshotStore
+    }
 
     func buildBoard(now: Date) -> IndoorMissionBoard {
         buildBoard(now: now, context: nil)
@@ -794,6 +801,16 @@ final class IndoorMissionStore {
         if let env = ProcessInfo.processInfo.environment["WEATHER_RISK_LEVEL"],
            let level = IndoorWeatherRiskLevel(rawValue: env.lowercased()) {
             return (level, .environment)
+        }
+        if let snapshot = weatherSnapshotStore.loadSnapshot(),
+           let level = IndoorWeatherRiskLevel(rawValue: snapshot.level.rawValue) {
+            let now = Date().timeIntervalSince1970
+            let age = now - snapshot.observedAt
+            if age <= 7200 {
+                return (level, .snapshot)
+            }
+            let conservative = level == .clear ? IndoorWeatherRiskLevel.caution : level
+            return (conservative, .fallback)
         }
         if let raw = UserDefaults.standard.string(forKey: DefaultsKey.weatherRiskOverride),
            let level = IndoorWeatherRiskLevel(rawValue: raw.lowercased()) {

--- a/dogArea/Source/Domain/Weather/Models/WeatherSnapshot.swift
+++ b/dogArea/Source/Domain/Weather/Models/WeatherSnapshot.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum WeatherRiskLevelValue: String, CaseIterable, Codable {
+    case clear
+    case caution
+    case bad
+    case severe
+}
+
+enum WeatherSnapshotDataSource: String, Codable, Equatable {
+    case live
+    case fallback
+    case unavailable
+}
+
+struct WeatherObservationLocationReference: Codable, Equatable {
+    let latitude: Double
+    let longitude: Double
+}
+
+struct WeatherSnapshot: Codable, Equatable {
+    let level: WeatherRiskLevelValue
+    let observedAt: TimeInterval
+    let weatherSource: WeatherSnapshotDataSource
+    let airQualitySource: WeatherSnapshotDataSource
+    let location: WeatherObservationLocationReference
+    let temperatureC: Double
+    let apparentTemperatureC: Double
+    let relativeHumidityPercent: Double
+    let isPrecipitating: Bool
+    let precipitationMMPerHour: Double
+    let windMps: Double
+    let pm2_5: Double?
+    let pm10: Double?
+
+    /// 공기질 세부 지표가 하나라도 존재하는지 반환합니다.
+    /// - Returns: PM2.5 또는 PM10 값이 있으면 `true`입니다.
+    var hasAirQualityMeasurements: Bool {
+        pm2_5 != nil || pm10 != nil
+    }
+}
+
+protocol WeatherSnapshotProviding {
+    /// 좌표 기준 현재 날씨 스냅샷을 조회합니다.
+    /// - Parameters:
+    ///   - latitude: 조회 기준 위도입니다.
+    ///   - longitude: 조회 기준 경도입니다.
+    /// - Returns: 홈/맵/미션이 공통으로 사용할 현재 날씨 스냅샷입니다.
+    func fetchSnapshot(latitude: Double, longitude: Double) async throws -> WeatherSnapshot
+}
+
+extension WeatherSnapshotProviding {
+    /// 기존 risk-only 호출 경로와의 호환을 위해 날씨 스냅샷을 그대로 반환합니다.
+    /// - Parameters:
+    ///   - latitude: 조회 기준 위도입니다.
+    ///   - longitude: 조회 기준 경도입니다.
+    /// - Returns: 위험도와 원시 수치가 모두 담긴 날씨 스냅샷입니다.
+    func fetchRisk(latitude: Double, longitude: Double) async throws -> WeatherRiskSnapshot {
+        try await fetchSnapshot(latitude: latitude, longitude: longitude)
+    }
+}
+
+typealias WeatherRiskProviding = WeatherSnapshotProviding
+typealias WeatherRiskSnapshot = WeatherSnapshot

--- a/dogArea/Source/Domain/Weather/Services/OpenMeteoWeatherSnapshotProvider.swift
+++ b/dogArea/Source/Domain/Weather/Services/OpenMeteoWeatherSnapshotProvider.swift
@@ -1,0 +1,262 @@
+import Foundation
+
+final class OpenMeteoWeatherSnapshotProvider: WeatherSnapshotProviding {
+    private struct ForecastResponse: Decodable {
+        struct Current: Decodable {
+            let time: String
+            let temperature2M: Double
+            let apparentTemperature: Double
+            let relativeHumidity2M: Double
+            let precipitation: Double
+            let windSpeed10M: Double
+
+            enum CodingKeys: String, CodingKey {
+                case time
+                case temperature2M = "temperature_2m"
+                case apparentTemperature = "apparent_temperature"
+                case relativeHumidity2M = "relative_humidity_2m"
+                case precipitation
+                case windSpeed10M = "wind_speed_10m"
+            }
+        }
+
+        let current: Current
+    }
+
+    private struct AirQualityResponse: Decodable {
+        struct Current: Decodable {
+            let pm10: Double?
+            let pm25: Double?
+
+            enum CodingKeys: String, CodingKey {
+                case pm10
+                case pm25 = "pm2_5"
+            }
+        }
+
+        let current: Current
+    }
+
+    private let session: URLSession
+    private let requestTimeout: TimeInterval
+
+    /// Open-Meteo 기반 상세 날씨 스냅샷 공급자를 생성합니다.
+    /// - Parameters:
+    ///   - session: HTTP 요청에 사용할 URLSession입니다.
+    ///   - requestTimeout: 단건 요청 타임아웃(초)입니다.
+    init(session: URLSession = .shared, requestTimeout: TimeInterval = 6.0) {
+        self.session = session
+        self.requestTimeout = requestTimeout
+    }
+
+    /// 좌표 기준 현재 날씨 스냅샷을 조회합니다.
+    /// - Parameters:
+    ///   - latitude: 조회 기준 위도입니다.
+    ///   - longitude: 조회 기준 경도입니다.
+    /// - Returns: 홈/맵/미션 공용 상세 날씨 스냅샷입니다.
+    func fetchSnapshot(latitude: Double, longitude: Double) async throws -> WeatherSnapshot {
+        async let forecastResponse = fetchForecast(latitude: latitude, longitude: longitude)
+        async let airQualityResponse = fetchAirQuality(latitude: latitude, longitude: longitude)
+
+        let forecast = try await forecastResponse
+        let airQuality = await airQualityResponse
+        let observedAt = Self.parseObservedAt(forecast.current.time)
+        let level = Self.score(
+            precipitationMMPerHour: forecast.current.precipitation,
+            temperatureC: forecast.current.temperature2M,
+            windMps: forecast.current.windSpeed10M
+        )
+
+        return WeatherSnapshot(
+            level: level,
+            observedAt: observedAt,
+            weatherSource: .live,
+            airQualitySource: airQuality == nil ? .unavailable : .live,
+            location: WeatherObservationLocationReference(
+                latitude: latitude,
+                longitude: longitude
+            ),
+            temperatureC: forecast.current.temperature2M,
+            apparentTemperatureC: forecast.current.apparentTemperature,
+            relativeHumidityPercent: forecast.current.relativeHumidity2M,
+            isPrecipitating: forecast.current.precipitation > 0,
+            precipitationMMPerHour: forecast.current.precipitation,
+            windMps: forecast.current.windSpeed10M,
+            pm2_5: airQuality?.current.pm25,
+            pm10: airQuality?.current.pm10
+        )
+    }
+
+    /// 예보 API에서 현재 기상 수치를 조회합니다.
+    /// - Parameters:
+    ///   - latitude: 조회 기준 위도입니다.
+    ///   - longitude: 조회 기준 경도입니다.
+    /// - Returns: 위험도 계산과 홈 상세 카드에 필요한 기상 응답입니다.
+    private func fetchForecast(latitude: Double, longitude: Double) async throws -> ForecastResponse {
+        let url = try makeForecastURL(latitude: latitude, longitude: longitude)
+        let data = try await requestData(url: url)
+        return try JSONDecoder().decode(ForecastResponse.self, from: data)
+    }
+
+    /// 공기질 API에서 PM 지표를 조회합니다.
+    /// - Parameters:
+    ///   - latitude: 조회 기준 위도입니다.
+    ///   - longitude: 조회 기준 경도입니다.
+    /// - Returns: PM 지표 응답이며, 공급자가 실패하면 `nil`을 반환합니다.
+    private func fetchAirQuality(latitude: Double, longitude: Double) async -> AirQualityResponse? {
+        do {
+            let url = try makeAirQualityURL(latitude: latitude, longitude: longitude)
+            let data = try await requestData(url: url)
+            return try JSONDecoder().decode(AirQualityResponse.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Open-Meteo 예보 엔드포인트 URL을 생성합니다.
+    /// - Parameters:
+    ///   - latitude: 요청 위도입니다.
+    ///   - longitude: 요청 경도입니다.
+    /// - Returns: 상세 날씨 조회용 URL입니다.
+    private func makeForecastURL(latitude: Double, longitude: Double) throws -> URL {
+        var components = URLComponents(string: "https://api.open-meteo.com/v1/forecast")
+        components?.queryItems = [
+            .init(name: "latitude", value: String(latitude)),
+            .init(name: "longitude", value: String(longitude)),
+            .init(name: "current", value: "temperature_2m,apparent_temperature,relative_humidity_2m,precipitation,wind_speed_10m"),
+            .init(name: "wind_speed_unit", value: "ms"),
+            .init(name: "timezone", value: "auto")
+        ]
+        guard let url = components?.url else {
+            throw URLError(.badURL)
+        }
+        return url
+    }
+
+    /// Open-Meteo 공기질 엔드포인트 URL을 생성합니다.
+    /// - Parameters:
+    ///   - latitude: 요청 위도입니다.
+    ///   - longitude: 요청 경도입니다.
+    /// - Returns: 공기질 조회용 URL입니다.
+    private func makeAirQualityURL(latitude: Double, longitude: Double) throws -> URL {
+        var components = URLComponents(string: "https://air-quality-api.open-meteo.com/v1/air-quality")
+        components?.queryItems = [
+            .init(name: "latitude", value: String(latitude)),
+            .init(name: "longitude", value: String(longitude)),
+            .init(name: "current", value: "pm10,pm2_5"),
+            .init(name: "timezone", value: "auto")
+        ]
+        guard let url = components?.url else {
+            throw URLError(.badURL)
+        }
+        return url
+    }
+
+    /// 네트워크 응답 데이터를 조회하고 타임아웃/연결 유실에 한해 1회 재시도합니다.
+    /// - Parameter url: 조회 대상 URL입니다.
+    /// - Returns: 성공적으로 수신한 원시 응답 데이터입니다.
+    private func requestData(url: URL) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = requestTimeout
+
+        var lastError: Error?
+        for attempt in 0...1 {
+            do {
+                let (data, response) = try await session.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse,
+                   (200..<300).contains(httpResponse.statusCode) == false {
+                    throw URLError(.badServerResponse)
+                }
+                return data
+            } catch {
+                lastError = error
+                let urlError = error as? URLError
+                let shouldRetry = attempt == 0 && (urlError?.code == .timedOut || urlError?.code == .networkConnectionLost)
+                guard shouldRetry else { throw error }
+                try? await Task.sleep(nanoseconds: 350_000_000)
+            }
+        }
+
+        throw lastError ?? URLError(.cannotParseResponse)
+    }
+
+    /// Open-Meteo 시각 문자열을 epoch seconds로 변환합니다.
+    /// - Parameter value: Open-Meteo `current.time` 문자열입니다.
+    /// - Returns: 파싱된 epoch seconds이며, 실패 시 현재 시각을 반환합니다.
+    private static func parseObservedAt(_ value: String) -> TimeInterval {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+        if let date = isoFormatter.date(from: value) {
+            return date.timeIntervalSince1970
+        }
+        let fallbackFormatter = DateFormatter()
+        fallbackFormatter.locale = Locale(identifier: "en_US_POSIX")
+        fallbackFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        fallbackFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm"
+        if let date = fallbackFormatter.date(from: value) {
+            return date.timeIntervalSince1970
+        }
+        return Date().timeIntervalSince1970
+    }
+
+    /// 강수/기온/풍속 지표를 종합해 최종 날씨 위험도를 계산합니다.
+    /// - Parameters:
+    ///   - precipitationMMPerHour: 시간당 강수량(mm/h)입니다.
+    ///   - temperatureC: 기온(섭씨)입니다.
+    ///   - windMps: 풍속(m/s)입니다.
+    /// - Returns: 지표별 최대 위험도 규칙으로 계산된 최종 위험도입니다.
+    private static func score(
+        precipitationMMPerHour: Double,
+        temperatureC: Double,
+        windMps: Double
+    ) -> WeatherRiskLevelValue {
+        let precipitationRisk = riskForPrecipitation(precipitationMMPerHour)
+        let temperatureRisk = riskForTemperature(temperatureC)
+        let windRisk = riskForWind(windMps)
+        return [precipitationRisk, temperatureRisk, windRisk]
+            .max(by: { $0.severityRank < $1.severityRank }) ?? .clear
+    }
+
+    /// 강수량 임계값 기반 위험도를 계산합니다.
+    /// - Parameter value: 시간당 강수량(mm/h)입니다.
+    /// - Returns: 강수량 기준 위험도입니다.
+    private static func riskForPrecipitation(_ value: Double) -> WeatherRiskLevelValue {
+        if value >= 12 { return .severe }
+        if value >= 6 { return .bad }
+        if value >= 1 { return .caution }
+        return .clear
+    }
+
+    /// 기온 임계값 기반 위험도를 계산합니다.
+    /// - Parameter value: 섭씨 기온입니다.
+    /// - Returns: 기온 기준 위험도입니다.
+    private static func riskForTemperature(_ value: Double) -> WeatherRiskLevelValue {
+        if value >= 33 || value <= -8 { return .severe }
+        if value >= 30 || value <= -3 { return .bad }
+        if value >= 28 || value <= 0 { return .caution }
+        return .clear
+    }
+
+    /// 풍속 임계값 기반 위험도를 계산합니다.
+    /// - Parameter value: 풍속(m/s)입니다.
+    /// - Returns: 풍속 기준 위험도입니다.
+    private static func riskForWind(_ value: Double) -> WeatherRiskLevelValue {
+        if value >= 14 { return .severe }
+        if value >= 10 { return .bad }
+        if value >= 6 { return .caution }
+        return .clear
+    }
+}
+
+private extension WeatherRiskLevelValue {
+    var severityRank: Int {
+        switch self {
+        case .clear: return 0
+        case .caution: return 1
+        case .bad: return 2
+        case .severe: return 3
+        }
+    }
+}
+
+typealias OpenMeteoWeatherRiskProvider = OpenMeteoWeatherSnapshotProvider

--- a/dogArea/Source/Domain/Weather/Stores/WeatherSnapshotStore.swift
+++ b/dogArea/Source/Domain/Weather/Stores/WeatherSnapshotStore.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+protocol WeatherSnapshotStoreProtocol {
+    /// 최신 날씨 스냅샷을 로컬 캐시에 저장합니다.
+    /// - Parameter snapshot: 홈/맵/미션이 공통으로 사용할 최신 날씨 스냅샷입니다.
+    func save(_ snapshot: WeatherSnapshot)
+
+    /// 최신 날씨 스냅샷을 조회합니다.
+    /// - Returns: 저장된 스냅샷이며, 없거나 파싱 실패 시 `nil`입니다.
+    func loadSnapshot() -> WeatherSnapshot?
+
+    /// 최대 허용 나이 안에 있는 최신 날씨 스냅샷을 조회합니다.
+    /// - Parameter maxAge: 관측 시각 기준 허용 최대 나이(초)입니다.
+    /// - Returns: 유효한 최신 스냅샷이며, 없거나 만료됐으면 `nil`입니다.
+    func loadFreshSnapshot(maxAge: TimeInterval) -> WeatherSnapshot?
+
+    /// 저장된 날씨 스냅샷을 삭제합니다.
+    func clear()
+}
+
+final class WeatherSnapshotStore: WeatherSnapshotStoreProtocol {
+    static let shared = WeatherSnapshotStore()
+
+    private enum Key {
+        static let latestSnapshot = "weather.snapshot.latest.v1"
+    }
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private let stateQueue = DispatchQueue(label: "com.th.dogArea.weather-snapshot-store.state")
+
+    /// UserDefaults 기반 날씨 스냅샷 저장소를 생성합니다.
+    /// - Parameter defaults: 스냅샷을 저장할 UserDefaults 인스턴스입니다.
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// 최신 날씨 스냅샷을 로컬 캐시에 저장합니다.
+    /// - Parameter snapshot: 홈/맵/미션이 공통으로 사용할 최신 날씨 스냅샷입니다.
+    func save(_ snapshot: WeatherSnapshot) {
+        stateQueue.sync {
+            guard let data = try? encoder.encode(snapshot) else { return }
+            defaults.set(data, forKey: Key.latestSnapshot)
+        }
+    }
+
+    /// 최신 날씨 스냅샷을 조회합니다.
+    /// - Returns: 저장된 스냅샷이며, 없거나 파싱 실패 시 `nil`입니다.
+    func loadSnapshot() -> WeatherSnapshot? {
+        stateQueue.sync {
+            guard let data = defaults.data(forKey: Key.latestSnapshot) else { return nil }
+            return try? decoder.decode(WeatherSnapshot.self, from: data)
+        }
+    }
+
+    /// 최대 허용 나이 안에 있는 최신 날씨 스냅샷을 조회합니다.
+    /// - Parameter maxAge: 관측 시각 기준 허용 최대 나이(초)입니다.
+    /// - Returns: 유효한 최신 스냅샷이며, 없거나 만료됐으면 `nil`입니다.
+    func loadFreshSnapshot(maxAge: TimeInterval) -> WeatherSnapshot? {
+        guard let snapshot = loadSnapshot() else { return nil }
+        let age = Date().timeIntervalSince1970 - snapshot.observedAt
+        guard age <= maxAge else { return nil }
+        return snapshot
+    }
+
+    /// 저장된 날씨 스냅샷을 삭제합니다.
+    func clear() {
+        stateQueue.sync {
+            defaults.removeObject(forKey: Key.latestSnapshot)
+        }
+    }
+}

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -20,6 +20,7 @@ final class HomeViewModel: ObservableObject {
     @Published var weatherFeedbackRemainingCount: Int = 2
     @Published var weatherFeedbackResultMessage: String? = nil
     @Published var weatherMissionStatusSummary: WeatherMissionStatusSummary = .empty
+    @Published var latestWeatherSnapshot: WeatherSnapshot? = nil
     @Published var indoorMissionPresentation: HomeIndoorMissionBoardPresentation = .empty
     @Published var weatherShieldDailySummary: WeatherShieldDailySummary? = nil
     @Published var seasonCatchupBuffStatusMessage: String? = nil
@@ -57,6 +58,7 @@ final class HomeViewModel: ObservableObject {
     let areaAggregationService: HomeAreaAggregationServicing
     let weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding
     let indoorMissionPresentationService: HomeIndoorMissionPresenting
+    let weatherSnapshotStore: WeatherSnapshotStoreProtocol
     let areaMilestoneDetector: AreaMilestoneDetecting
     let areaMilestoneNotificationScheduler: AreaMilestoneNotificationScheduling
     let seasonMotionStore = SeasonMotionStore()
@@ -123,6 +125,7 @@ final class HomeViewModel: ObservableObject {
         areaAggregationService: HomeAreaAggregationServicing = HomeAreaAggregationService(),
         weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding = HomeWeatherMissionStatusBuilder(),
         indoorMissionPresentationService: HomeIndoorMissionPresenting = HomeIndoorMissionPresentationService(),
+        weatherSnapshotStore: WeatherSnapshotStoreProtocol = WeatherSnapshotStore.shared,
         areaMilestoneDetector: AreaMilestoneDetecting = AreaMilestoneDetector(),
         areaMilestoneNotificationScheduler: AreaMilestoneNotificationScheduling = LocalAreaMilestoneNotificationScheduler()
     ) {
@@ -134,6 +137,7 @@ final class HomeViewModel: ObservableObject {
         self.areaAggregationService = areaAggregationService
         self.weatherMissionStatusBuilder = weatherMissionStatusBuilder
         self.indoorMissionPresentationService = indoorMissionPresentationService
+        self.weatherSnapshotStore = weatherSnapshotStore
         self.areaMilestoneDetector = areaMilestoneDetector
         self.areaMilestoneNotificationScheduler = areaMilestoneNotificationScheduler
         self.questReminderScheduler = LocalQuestReminderScheduler()

--- a/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+IndoorMissionFlow.swift
+++ b/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+IndoorMissionFlow.swift
@@ -22,6 +22,7 @@ extension HomeViewModel {
         if applyIndoorMissionUITestScenarioIfNeeded(now: now) {
             return
         }
+        refreshWeatherSnapshot()
         let missionContext = makeIndoorMissionPetContext(reference: now)
         indoorMissionBoard = indoorMissionStore.buildBoard(now: now, context: missionContext)
         questAlternativeActionSuggestion = makeQuestAlternativeActionSuggestion(for: indoorMissionBoard)

--- a/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+SessionLifecycle.swift
+++ b/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+SessionLifecycle.swift
@@ -30,6 +30,12 @@ extension HomeViewModel {
         refreshAreaReferenceCatalogs()
         refreshGuestDataUpgradeReport()
         refreshIndoorMissions()
+        refreshWeatherSnapshot()
+    }
+
+    /// 공용 날씨 스냅샷 저장소에서 최신 값을 읽어 홈 상태에 반영합니다.
+    func refreshWeatherSnapshot() {
+        latestWeatherSnapshot = weatherSnapshotStore.loadSnapshot()
     }
 
     func refreshAreaReferenceCatalogs() {

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -15,186 +15,6 @@ import WatchConnectivity
 import UIKit
 #endif
 
-enum WeatherRiskLevelValue: String, CaseIterable {
-    case clear
-    case caution
-    case bad
-    case severe
-}
-
-struct WeatherRiskSnapshot: Equatable {
-    let level: WeatherRiskLevelValue
-    let observedAt: TimeInterval
-}
-
-protocol WeatherRiskProviding {
-    /// 주어진 좌표의 현재 날씨를 조회해 위험도 레벨을 산출합니다.
-    /// - Parameters:
-    ///   - latitude: 조회 대상 위도입니다.
-    ///   - longitude: 조회 대상 경도입니다.
-    /// - Returns: 위험도 레벨과 관측 시각을 담은 스냅샷입니다.
-    func fetchRisk(latitude: Double, longitude: Double) async throws -> WeatherRiskSnapshot
-}
-
-final class OpenMeteoWeatherRiskProvider: WeatherRiskProviding {
-    private struct OpenMeteoResponse: Decodable {
-        struct Current: Decodable {
-            let time: String
-            let temperature2M: Double
-            let precipitation: Double
-            let windSpeed10M: Double
-
-            enum CodingKeys: String, CodingKey {
-                case time
-                case temperature2M = "temperature_2m"
-                case precipitation
-                case windSpeed10M = "wind_speed_10m"
-            }
-        }
-
-        let current: Current
-    }
-
-    private let session: URLSession
-    private let requestTimeout: TimeInterval
-
-    /// Open-Meteo 기반 날씨 위험도 조회기를 생성합니다.
-    /// - Parameters:
-    ///   - session: HTTP 요청에 사용할 URLSession입니다.
-    ///   - requestTimeout: 단건 요청 타임아웃(초)입니다.
-    init(session: URLSession = .shared, requestTimeout: TimeInterval = 6.0) {
-        self.session = session
-        self.requestTimeout = requestTimeout
-    }
-
-    /// 주어진 좌표의 현재 날씨를 조회해 위험도 레벨을 산출합니다.
-    /// - Parameters:
-    ///   - latitude: 조회 대상 위도입니다.
-    ///   - longitude: 조회 대상 경도입니다.
-    /// - Returns: 위험도 레벨과 관측 시각을 담은 스냅샷입니다.
-    func fetchRisk(latitude: Double, longitude: Double) async throws -> WeatherRiskSnapshot {
-        var components = URLComponents(string: "https://api.open-meteo.com/v1/forecast")
-        components?.queryItems = [
-            .init(name: "latitude", value: String(latitude)),
-            .init(name: "longitude", value: String(longitude)),
-            .init(name: "current", value: "temperature_2m,precipitation,wind_speed_10m"),
-            .init(name: "wind_speed_unit", value: "ms"),
-            .init(name: "timezone", value: "auto")
-        ]
-        guard let url = components?.url else {
-            throw URLError(.badURL)
-        }
-
-        var request = URLRequest(url: url)
-        request.timeoutInterval = requestTimeout
-
-        var decoded: OpenMeteoResponse?
-        var lastError: Error?
-        for attempt in 0...1 {
-            do {
-                let (data, _) = try await session.data(for: request)
-                decoded = try JSONDecoder().decode(OpenMeteoResponse.self, from: data)
-                break
-            } catch {
-                lastError = error
-                let urlError = error as? URLError
-                let shouldRetry = attempt == 0 && (urlError?.code == .timedOut || urlError?.code == .networkConnectionLost)
-                guard shouldRetry else { throw error }
-                try? await Task.sleep(nanoseconds: 350_000_000)
-            }
-        }
-
-        guard let decoded else {
-            throw lastError ?? URLError(.cannotParseResponse)
-        }
-        let observedAt = Self.parseObservedAt(decoded.current.time)
-        let risk = Self.score(
-            precipitationMMPerHour: decoded.current.precipitation,
-            temperatureC: decoded.current.temperature2M,
-            windMps: decoded.current.windSpeed10M
-        )
-        return WeatherRiskSnapshot(level: risk, observedAt: observedAt)
-    }
-
-    /// Open-Meteo 시각 문자열을 epoch seconds로 변환합니다.
-    /// - Parameter value: Open-Meteo `current.time` 문자열입니다.
-    /// - Returns: 파싱된 epoch seconds이며, 실패 시 현재 시각을 반환합니다.
-    private static func parseObservedAt(_ value: String) -> TimeInterval {
-        let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime]
-        if let date = isoFormatter.date(from: value) {
-            return date.timeIntervalSince1970
-        }
-        let fallbackFormatter = DateFormatter()
-        fallbackFormatter.locale = Locale(identifier: "en_US_POSIX")
-        fallbackFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        fallbackFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm"
-        if let date = fallbackFormatter.date(from: value) {
-            return date.timeIntervalSince1970
-        }
-        return Date().timeIntervalSince1970
-    }
-
-    /// 강수/기온/풍속 지표를 종합해 최종 날씨 위험도를 계산합니다.
-    /// - Parameters:
-    ///   - precipitationMMPerHour: 시간당 강수량(mm/h)입니다.
-    ///   - temperatureC: 기온(섭씨)입니다.
-    ///   - windMps: 풍속(m/s)입니다.
-    /// - Returns: 지표별 최대 위험도 규칙으로 계산된 최종 위험도입니다.
-    private static func score(
-        precipitationMMPerHour: Double,
-        temperatureC: Double,
-        windMps: Double
-    ) -> WeatherRiskLevelValue {
-        let precipitationRisk = riskForPrecipitation(precipitationMMPerHour)
-        let temperatureRisk = riskForTemperature(temperatureC)
-        let windRisk = riskForWind(windMps)
-        return [precipitationRisk, temperatureRisk, windRisk]
-            .max(by: { $0.severityRank < $1.severityRank }) ?? .clear
-    }
-
-    /// 강수량 임계값 기반 위험도를 계산합니다.
-    /// - Parameter value: 시간당 강수량(mm/h)입니다.
-    /// - Returns: 강수량 기준 위험도입니다.
-    private static func riskForPrecipitation(_ value: Double) -> WeatherRiskLevelValue {
-        if value >= 12 { return .severe }
-        if value >= 6 { return .bad }
-        if value >= 1 { return .caution }
-        return .clear
-    }
-
-    /// 기온 임계값 기반 위험도를 계산합니다.
-    /// - Parameter value: 섭씨 기온입니다.
-    /// - Returns: 기온 기준 위험도입니다.
-    private static func riskForTemperature(_ value: Double) -> WeatherRiskLevelValue {
-        if value >= 33 || value <= -8 { return .severe }
-        if value >= 30 || value <= -3 { return .bad }
-        if value >= 28 || value <= 0 { return .caution }
-        return .clear
-    }
-
-    /// 풍속 임계값 기반 위험도를 계산합니다.
-    /// - Parameter value: 풍속(m/s)입니다.
-    /// - Returns: 풍속 기준 위험도입니다.
-    private static func riskForWind(_ value: Double) -> WeatherRiskLevelValue {
-        if value >= 14 { return .severe }
-        if value >= 10 { return .bad }
-        if value >= 6 { return .caution }
-        return .clear
-    }
-}
-
-private extension WeatherRiskLevelValue {
-    var severityRank: Int {
-        switch self {
-        case .clear: return 0
-        case .caution: return 1
-        case .bad: return 2
-        case .severe: return 3
-        }
-    }
-}
-
 #if DEBUG
 private enum MapCoreLocationCallTracer {
     private static let lock = NSLock()
@@ -669,7 +489,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     let userSessionStore: UserSessionStoreProtocol
     private let authSessionStore: AuthSessionStoreProtocol
     let preferenceStore: MapPreferenceStoreProtocol
-    private let weatherRiskProvider: WeatherRiskProviding
+    private let weatherSnapshotProvider: WeatherSnapshotProviding
+    private let weatherSnapshotStore: WeatherSnapshotStoreProtocol
     private let areaCalculationService: MapAreaCalculationServicing
     private let clusterAnnotationService: MapClusterAnnotationServicing
     let widgetSnapshotStore: WalkWidgetSnapshotStoring
@@ -777,7 +598,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         userSessionStore: UserSessionStoreProtocol = DefaultUserSessionStore.shared,
         authSessionStore: AuthSessionStoreProtocol = DefaultAuthSessionStore.shared,
         preferenceStore: MapPreferenceStoreProtocol = DefaultMapPreferenceStore.shared,
-        weatherRiskProvider: WeatherRiskProviding = OpenMeteoWeatherRiskProvider(),
+        weatherSnapshotProvider: WeatherSnapshotProviding = OpenMeteoWeatherSnapshotProvider(),
+        weatherSnapshotStore: WeatherSnapshotStoreProtocol = WeatherSnapshotStore.shared,
         areaCalculationService: MapAreaCalculationServicing = MapAreaCalculationService(),
         clusterAnnotationService: MapClusterAnnotationServicing = MapClusterAnnotationService(),
         widgetSnapshotStore: WalkWidgetSnapshotStoring = DefaultWalkWidgetSnapshotStore.shared,
@@ -789,7 +611,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.userSessionStore = userSessionStore
         self.authSessionStore = authSessionStore
         self.preferenceStore = preferenceStore
-        self.weatherRiskProvider = weatherRiskProvider
+        self.weatherSnapshotProvider = weatherSnapshotProvider
+        self.weatherSnapshotStore = weatherSnapshotStore
         self.areaCalculationService = areaCalculationService
         self.clusterAnnotationService = clusterAnnotationService
         self.widgetSnapshotStore = widgetSnapshotStore
@@ -3444,6 +3267,15 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
            let fromEnv = WeatherOverlayRiskLevel(rawValue: env.lowercased()) {
             return (fromEnv, false)
         }
+        if let snapshot = weatherSnapshotStore.loadSnapshot(),
+           let fromSnapshot = WeatherOverlayRiskLevel(rawValue: snapshot.level.rawValue) {
+            let age = now.timeIntervalSince1970 - snapshot.observedAt
+            if age <= weatherRiskCacheTTL {
+                return (fromSnapshot, false)
+            }
+            let conservativeRisk: WeatherOverlayRiskLevel = fromSnapshot == .clear ? .caution : fromSnapshot
+            return (conservativeRisk, true)
+        }
         if let raw = preferenceStore.string(forKey: weatherRiskOverrideKey),
            let fromDefaults = WeatherOverlayRiskLevel(rawValue: raw.lowercased()) {
             guard let observedAt = storedWeatherRiskObservedAt() else {
@@ -3496,7 +3328,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         weatherFetchTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let snapshot = try await weatherRiskProvider.fetchRisk(
+                let snapshot = try await weatherSnapshotProvider.fetchSnapshot(
                     latitude: latitude,
                     longitude: longitude
                 )
@@ -3518,6 +3350,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     /// - Parameter snapshot: 공급자에서 계산된 날씨 위험도 스냅샷입니다.
     private func applyWeatherRiskSnapshot(_ snapshot: WeatherRiskSnapshot) {
         let next = WeatherOverlayRiskLevel(rawValue: snapshot.level.rawValue) ?? .clear
+        weatherSnapshotStore.save(snapshot)
         preferenceStore.set(next.rawValue, forKey: weatherRiskOverrideKey)
         preferenceStore.set(String(snapshot.observedAt), forKey: weatherRiskObservedAtKey)
         refreshWeatherOverlayRisk()

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -82,6 +82,7 @@ swift scripts/territory_status_widget_unit_check.swift
 swift scripts/hotspot_widget_privacy_unit_check.swift
 swift scripts/season_policy_stage1_unit_check.swift
 swift scripts/weather_risk_policy_stage1_unit_check.swift
+swift scripts/weather_snapshot_provider_unit_check.swift
 swift scripts/weather_stage2_engine_unit_check.swift
 swift scripts/weather_ux_stage3_unit_check.swift
 swift scripts/weather_feedback_loop_unit_check.swift

--- a/scripts/weather_snapshot_provider_unit_check.swift
+++ b/scripts/weather_snapshot_provider_unit_check.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let snapshotModel = load("dogArea/Source/Domain/Weather/Models/WeatherSnapshot.swift")
+let provider = load("dogArea/Source/Domain/Weather/Services/OpenMeteoWeatherSnapshotProvider.swift")
+let store = load("dogArea/Source/Domain/Weather/Stores/WeatherSnapshotStore.swift")
+let homeViewModel = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let homeLifecycle = load("dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+SessionLifecycle.swift")
+let indoorMissionStore = load("dogArea/Source/Domain/Home/Stores/IndoorMissionStore.swift")
+let homeMissionModels = load("dogArea/Source/Domain/Home/Models/HomeMissionModels.swift")
+let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
+let doc = load("docs/weather-snapshot-provider-v1.md")
+let readme = load("README.md")
+
+[
+    "let temperatureC: Double",
+    "let apparentTemperatureC: Double",
+    "let relativeHumidityPercent: Double",
+    "let isPrecipitating: Bool",
+    "let precipitationMMPerHour: Double",
+    "let windMps: Double",
+    "let pm2_5: Double?",
+    "let pm10: Double?",
+    "enum WeatherSnapshotDataSource"
+].forEach { needle in
+    assertTrue(snapshotModel.contains(needle), "weather snapshot model should contain \(needle)")
+}
+
+assertTrue(provider.contains("https://api.open-meteo.com/v1/forecast"), "provider should use forecast endpoint")
+assertTrue(provider.contains("temperature_2m,apparent_temperature,relative_humidity_2m,precipitation,wind_speed_10m"), "provider should request detailed current weather fields")
+assertTrue(provider.contains("https://air-quality-api.open-meteo.com/v1/air-quality"), "provider should use air quality endpoint")
+assertTrue(provider.contains("current: \"pm10,pm2_5\"") || provider.contains("value: \"pm10,pm2_5\""), "provider should request PM fields")
+assertTrue(store.contains("weather.snapshot.latest.v1"), "weather snapshot store should persist shared snapshot")
+assertTrue(homeViewModel.contains("@Published var latestWeatherSnapshot: WeatherSnapshot? = nil"), "home view model should expose latest weather snapshot")
+assertTrue(homeViewModel.contains("let weatherSnapshotStore: WeatherSnapshotStoreProtocol"), "home view model should receive weather snapshot store")
+assertTrue(homeLifecycle.contains("refreshWeatherSnapshot()"), "home lifecycle should refresh weather snapshot state")
+assertTrue(indoorMissionStore.contains("weatherSnapshotStore.loadSnapshot()"), "indoor mission store should consult shared weather snapshot")
+assertTrue(homeMissionModels.contains("case snapshot"), "indoor weather source should represent shared snapshot source")
+assertTrue(mapViewModel.contains("weatherSnapshotStore.save(snapshot)"), "map view model should persist shared weather snapshot")
+
+assertTrue(doc.contains("`pm2_5`, `pm10`은 optional 필드"), "weather snapshot doc should define PM optional policy")
+assertTrue(doc.contains("core weather 필드가 누락되면 provider 요청은 실패"), "weather snapshot doc should define core field failure policy")
+assertTrue(doc.contains("`2h`를 초과하면 `clear`로 강등하지 않고 최소 `caution`"), "weather snapshot doc should define stale conservative fallback policy")
+
+assertTrue(readme.contains("docs/weather-snapshot-provider-v1.md"), "README should index weather snapshot provider doc")
+
+print("PASS: weather snapshot provider unit checks")


### PR DESCRIPTION
## Summary
- add a shared weather snapshot domain model, provider, and store for map/home/mission flows
- preserve existing weather risk compatibility while expanding detailed weather fields and fallback policy
- document the contract and add static validation to ios_pr_check

## Validation
- swift scripts/weather_snapshot_provider_unit_check.swift
- swift scripts/weather_risk_policy_stage1_unit_check.swift
- swift scripts/weather_ux_stage3_unit_check.swift
- swift scripts/indoor_weather_mission_unit_check.swift
- DOGAREA_DERIVED_DATA_PATH=.build/codex-457-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #457