### PR TITLE
refactor: unify home refresh entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - 체감 날씨 피드백 루프 v1: `docs/weather-feedback-loop-v1.md`
 - 날씨 리스크 모델/Provider 정책 v1: `docs/weather-risk-provider-policy-v1.md`
 - 날씨 snapshot/provider 확장 v1: `docs/weather-snapshot-provider-v1.md`
+- 홈 refresh entrypoint 정리 v1: `docs/home-refresh-entrypoint-v1.md`
 - 날씨 치환/스트릭 보호 서버 엔진 v1: `docs/weather-replacement-shield-engine-v1.md`
 - 날씨 연동 UX/fallback/접근성 v1: `docs/weather-ux-fallback-accessibility-v1.md`
 - 퀘스트 Stage1 템플릿/난이도 정책 v1: `docs/quest-stage1-template-difficulty-policy-v1.md`

--- a/docs/home-refresh-entrypoint-v1.md
+++ b/docs/home-refresh-entrypoint-v1.md
@@ -1,0 +1,29 @@
+# Home Refresh Entrypoint v1
+
+## 목적
+
+홈 화면의 refresh 진입점을 trigger 기준으로 정리해서 같은 이벤트에서 `refreshIndoorMissions`, `syncSeasonScoreWithWalkSessions`, `refreshSeasonMotion`이 중복 실행되는 구조를 줄입니다.
+
+## Trigger Matrix
+
+| Trigger | Before entrypoint | Before expensive calls | After entrypoint | After expensive calls | 비고 |
+| --- | --- | --- | --- | --- | --- |
+| 홈 최초 진입 | `HomeViewModel.init -> fetchData` + `HomeView.onAppear -> fetchData` | `refreshIndoorMissions` / `syncSeasonScoreWithWalkSessions` / `refreshSeasonMotion` 각 4회 | `HomeViewModel.performInitialRefresh` | 세 계산 각 1회 | 첫 `onAppear`는 애니메이션/가시성 state만 동기화 |
+| 홈 재노출(탭 복귀) | `HomeView.onAppear -> fetchData` | 세 계산 각 2회 | `HomeView.refreshForVisibleReentry` | 세 계산 각 1회 | 화면 재노출 시 full refresh 1회만 수행 |
+| 앱 복귀(홈 visible) | 전용 진입점 없음 | 0회 또는 화면 재구성에 간접 의존 | `scenePhase == .active -> refreshForAppResumeIfNeeded` | 세 계산 각 1회 | launch 직후 첫 active 이벤트는 skip |
+| 당겨서 새로고침 | `fetchData` | 세 계산 각 2회 | `fetchData -> executeRefresh(.manualRefresh)` | 세 계산 각 1회 | 카드 결과는 동일 |
+| pet 전환(home source) | `selectPet -> applySelectedPetStatistics` + `selectedPetDidChange` sink | 세 계산 각 2회 | `selectPet -> refreshForSelectedPetChange` + sink ignore `home` source | 세 계산 각 1회 | 외부 source pet 전환은 여전히 1회 refresh |
+
+## After 구조
+
+1. 저장소 재조회 여부는 `HomeRefreshTrigger`가 결정합니다.
+2. `applySelectedPetStatistics(refreshDerivedContent: false)`로 집계만 먼저 계산합니다.
+3. 실내 미션/시즌/날씨 파생 상태는 `refreshIndoorMissions(now:)` 한 번으로 모읍니다.
+4. 앱 복귀와 홈 재노출은 서로 다른 trigger로 나누되, launch 직후 duplicate refresh는 막습니다.
+5. `selectedPetDidChangeNotification`는 `source == "home"`이면 자기 반사 refresh를 건너뜁니다.
+
+## 유지한 사용자 계약
+
+- 홈 카드 구성/문구/상태 결과는 유지합니다.
+- 시즌/날씨/실내 미션 계산 순서는 `refreshIndoorMissions(now:)` 내부 계약을 그대로 사용합니다.
+- time boundary 변경 시에도 타임존 메시지와 집계 결과는 유지합니다.

--- a/dogArea/Views/HomeView/HomeView.swift
+++ b/dogArea/Views/HomeView/HomeView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+    @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject var authFlow: AuthFlowCoordinator
     @StateObject var viewModel = HomeViewModel()
     @State private var animatedQuestProgress: [String: Double] = [:]
@@ -31,6 +32,8 @@ struct HomeView: View {
     @State private var homeScrollOffsetY: CGFloat = 0
     @State private var isSeasonDetailPresented: Bool = false
     @State private var isTerritoryGoalPresented: Bool = false
+    @State private var hasAppearedOnce: Bool = false
+    @State private var isHomeVisible: Bool = false
 
     private var isQuestMotionReduced: Bool {
         accessibilityReduceMotion
@@ -136,13 +139,25 @@ struct HomeView: View {
                     viewModel.fetchData()
                 }
                 .onAppear{
-                    viewModel.reloadUserInfo()
-                    viewModel.fetchData()
+                    isHomeVisible = true
+                    if hasAppearedOnce {
+                        viewModel.refreshForVisibleReentry()
+                    } else {
+                        hasAppearedOnce = true
+                    }
                     seasonAnimatedProgress = viewModel.seasonMotionSummary.progress
                     if viewModel.seasonMotionSummary.weatherShieldActive {
                         startSeasonShieldRingAnimationIfNeeded()
                     }
-                }.onChange(of: viewModel.aggregationStatusMessage) { _, newValue in
+                }
+                .onDisappear {
+                    isHomeVisible = false
+                }
+                .onChange(of: scenePhase) { _, newPhase in
+                    guard newPhase == .active, isHomeVisible else { return }
+                    viewModel.refreshForAppResumeIfNeeded()
+                }
+                .onChange(of: viewModel.aggregationStatusMessage) { _, newValue in
                 guard newValue != nil else { return }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
                     viewModel.clearAggregationStatusMessage()

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -69,6 +69,7 @@ final class HomeViewModel: ObservableObject {
     var featuredGoalAreas: [AreaMeter] = []
     var areaMilestoneQueue: [AreaMilestoneEvent] = []
     var areaReferenceTask: Task<Void, Never>? = nil
+    var hasSkippedInitialActiveSceneRefresh: Bool = false
 
     var pets: [PetInfo] {
         userInfo?.pet.filter(\.isActive) ?? []
@@ -153,7 +154,7 @@ final class HomeViewModel: ObservableObject {
         bindQuestProgressNotifications()
         reloadUserInfo()
         reloadSeasonCatchupBuffStatus()
-        fetchData()
+        performInitialRefresh()
         Task { [weak self] in
             await self?.syncQuestReminderOnLaunch()
         }

--- a/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+AreaProgress.swift
+++ b/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+AreaProgress.swift
@@ -4,7 +4,16 @@ import UIKit
 #endif
 
 extension HomeViewModel {
-    func applySelectedPetStatistics(shouldUpdateMeter: Bool = false) {
+    /// 선택된 반려견/표시 범위 기준으로 홈 집계 상태를 재계산합니다.
+    /// - Parameters:
+    ///   - shouldUpdateMeter: 누적 영역 기준이 바뀌었을 때 현재 영역 마일스톤을 영속화할지 여부입니다.
+    ///   - refreshDerivedContent: 집계 후 실내 미션·시즌·날씨 파생 상태를 즉시 새로고칠지 여부입니다.
+    ///   - reference: 일자 경계/주간 통계 계산에 사용할 기준 시각입니다.
+    func applySelectedPetStatistics(
+        shouldUpdateMeter: Bool = false,
+        refreshDerivedContent: Bool = true,
+        reference: Date = Date()
+    ) {
         polygonList = areaAggregationService.filteredPolygons(
             from: allPolygons,
             selectedPetId: selectedPet?.petId,
@@ -16,8 +25,10 @@ extension HomeViewModel {
             totalArea: totalArea,
             selectedPetNameWithYi: selectedPetNameWithYi
         )
-        boundarySplitContribution = makeDayBoundarySplitContribution(reference: Date())
-        refreshIndoorMissions()
+        boundarySplitContribution = makeDayBoundarySplitContribution(reference: reference)
+        if refreshDerivedContent {
+            refreshIndoorMissions(now: reference)
+        }
         evaluateAreaMilestones()
         if shouldUpdateMeter {
             updateCurrentMeter()

--- a/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+SessionLifecycle.swift
+++ b/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+SessionLifecycle.swift
@@ -15,21 +15,129 @@ private enum HomeCatchupStatusFormatter {
     }()
 }
 
+private enum HomeRefreshTrigger: String {
+    case initialLoad
+    case visibleReentry
+    case manualRefresh
+    case appResume
+    case petSelection
+    case timeBoundaryChange
+
+    var reloadPersistedWalkData: Bool {
+        switch self {
+        case .initialLoad, .visibleReentry, .manualRefresh, .appResume:
+            return true
+        case .petSelection, .timeBoundaryChange:
+            return false
+        }
+    }
+
+    var refreshAreaReferences: Bool {
+        switch self {
+        case .initialLoad, .visibleReentry, .manualRefresh, .appResume:
+            return true
+        case .petSelection, .timeBoundaryChange:
+            return false
+        }
+    }
+
+    var refreshGuestUpgradeReport: Bool {
+        switch self {
+        case .initialLoad, .visibleReentry, .manualRefresh, .appResume:
+            return true
+        case .petSelection, .timeBoundaryChange:
+            return false
+        }
+    }
+
+    var shouldUpdateMeter: Bool {
+        switch self {
+        case .initialLoad, .visibleReentry, .manualRefresh, .appResume:
+            return true
+        case .petSelection, .timeBoundaryChange:
+            return false
+        }
+    }
+
+    var shouldReloadAreaList: Bool {
+        switch self {
+        case .initialLoad, .visibleReentry, .manualRefresh, .appResume:
+            return true
+        case .petSelection, .timeBoundaryChange:
+            return false
+        }
+    }
+}
+
 extension HomeViewModel {
     func localizedCopy(ko: String, en: String) -> String {
         let languageCode = Locale.preferredLanguages.first?.lowercased() ?? "ko"
         return languageCode.hasPrefix("en") ? en : ko
     }
 
-    func fetchData() {
+    /// 홈 화면 최초 구성 시 필요한 저장 상태와 파생 UI를 중복 없이 적재합니다.
+    /// - Parameter now: 초기 집계와 시간 경계 계산에 사용할 기준 시각입니다.
+    func performInitialRefresh(now: Date = Date()) {
+        executeRefresh(trigger: .initialLoad, now: now)
+    }
+
+    /// 사용자가 명시적으로 새로고침했을 때 홈 데이터를 다시 집계합니다.
+    /// - Parameter now: 새로고침 기준 시각입니다.
+    func fetchData(now: Date = Date()) {
+        executeRefresh(trigger: .manualRefresh, now: now)
+    }
+
+    /// 홈 탭이 다시 화면에 나타났을 때 필요한 새로고침을 수행합니다.
+    /// - Parameter now: 재진입 시각 기준입니다.
+    func refreshForVisibleReentry(now: Date = Date()) {
+        executeRefresh(trigger: .visibleReentry, now: now)
+    }
+
+    /// 포그라운드 복귀 시 홈이 보이는 상태라면 1회성 초기 active 이벤트를 제외하고 데이터를 다시 집계합니다.
+    /// - Parameter now: 앱 복귀 기준 시각입니다.
+    func refreshForAppResumeIfNeeded(now: Date = Date()) {
+        if hasSkippedInitialActiveSceneRefresh == false {
+            hasSkippedInitialActiveSceneRefresh = true
+            return
+        }
+        executeRefresh(trigger: .appResume, now: now)
+    }
+
+    /// 반려견 선택이 바뀌었을 때 선택 컨텍스트에 영향을 받는 홈 상태만 다시 계산합니다.
+    /// - Parameter now: pet 전환 기준 시각입니다.
+    func refreshForSelectedPetChange(now: Date = Date()) {
+        executeRefresh(trigger: .petSelection, now: now)
+    }
+
+    /// 홈 refresh trigger별로 저장소 재조회와 파생 상태 계산 순서를 조정합니다.
+    /// - Parameters:
+    ///   - trigger: 이번 새로고침을 유발한 홈 이벤트 종류입니다.
+    ///   - now: 집계/미션/시즌 계산에 공통으로 사용할 기준 시각입니다.
+    private func executeRefresh(trigger: HomeRefreshTrigger, now: Date = Date()) {
         reloadUserInfo()
-        reloadSeasonCatchupBuffStatus()
-        allPolygons = walkRepository.fetchPolygons()
-        applySelectedPetStatistics(shouldUpdateMeter: true)
-        myAreaList = walkRepository.fetchAreas()
-        refreshAreaReferenceCatalogs()
-        refreshGuestDataUpgradeReport()
-        refreshIndoorMissions()
+        reloadSeasonCatchupBuffStatus(now: now)
+
+        if trigger.reloadPersistedWalkData {
+            allPolygons = walkRepository.fetchPolygons()
+        }
+
+        applySelectedPetStatistics(
+            shouldUpdateMeter: trigger.shouldUpdateMeter,
+            refreshDerivedContent: false,
+            reference: now
+        )
+
+        if trigger.shouldReloadAreaList {
+            myAreaList = walkRepository.fetchAreas()
+        }
+        if trigger.refreshAreaReferences {
+            refreshAreaReferenceCatalogs()
+        }
+        if trigger.refreshGuestUpgradeReport {
+            refreshGuestDataUpgradeReport()
+        }
+
+        refreshIndoorMissions(now: now)
     }
 
     /// 공용 날씨 스냅샷 저장소에서 최신 값을 읽어 홈 상태에 반영합니다.
@@ -81,8 +189,7 @@ extension HomeViewModel {
         guard pets.contains(where: { $0.petId == petId }) else { return }
         isShowingAllRecordsOverride = false
         userSessionStore.setSelectedPetId(petId, source: "home")
-        reloadUserInfo()
-        applySelectedPetStatistics()
+        refreshForSelectedPetChange()
     }
 
     func showAllRecordsTemporarily() {
@@ -166,11 +273,12 @@ extension HomeViewModel {
     func bindSelectedPetSync() {
         eventCenter.publisher(for: UserdefaultSetting.selectedPetDidChangeNotification, object: nil)
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] notification in
                 guard let self else { return }
+                let source = notification.userInfo?["source"] as? String
+                guard source != "home" else { return }
                 self.isShowingAllRecordsOverride = false
-                self.reloadUserInfo()
-                self.applySelectedPetStatistics()
+                self.refreshForSelectedPetChange()
             }
             .store(in: &cancellables)
     }
@@ -201,8 +309,7 @@ extension HomeViewModel {
         let didTimeZoneChange = newTimeZoneIdentifier != aggregationTimeZoneIdentifier
 
         aggregationTimeZoneIdentifier = newTimeZoneIdentifier
-        applySelectedPetStatistics()
-        refreshIndoorMissions()
+        executeRefresh(trigger: .timeBoundaryChange, now: Date())
 
         guard didTimeZoneChange || name == .NSSystemTimeZoneDidChange else { return }
         aggregationStatusMessage = "타임존이 변경되어 통계를 현재 시간대 기준으로 다시 계산했어요."

--- a/scripts/home_refresh_entrypoint_unit_check.swift
+++ b/scripts/home_refresh_entrypoint_unit_check.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let homeView = load("dogArea/Views/HomeView/HomeView.swift")
+let homeViewModel = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let homeLifecycle = load("dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+SessionLifecycle.swift")
+let areaProgress = load("dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+AreaProgress.swift")
+let doc = load("docs/home-refresh-entrypoint-v1.md")
+let readme = load("README.md")
+
+assertTrue(homeLifecycle.contains("private enum HomeRefreshTrigger"), "home lifecycle should define a refresh trigger model")
+assertTrue(homeLifecycle.contains("func performInitialRefresh"), "home lifecycle should expose an initial refresh entrypoint")
+assertTrue(homeLifecycle.contains("func refreshForVisibleReentry"), "home lifecycle should expose a visible reentry refresh entrypoint")
+assertTrue(homeLifecycle.contains("func refreshForAppResumeIfNeeded"), "home lifecycle should expose an app resume refresh entrypoint")
+assertTrue(homeLifecycle.contains("func refreshForSelectedPetChange"), "home lifecycle should expose a pet selection refresh entrypoint")
+assertTrue(homeLifecycle.contains("applySelectedPetStatistics(\n            shouldUpdateMeter: trigger.shouldUpdateMeter,\n            refreshDerivedContent: false,"), "refresh coordinator should disable duplicate derived refresh during aggregation")
+assertTrue(homeLifecycle.contains("guard source != \"home\" else { return }"), "home-selected pet notifications should ignore self-originated events")
+assertTrue(homeLifecycle.contains("executeRefresh(trigger: .timeBoundaryChange"), "time boundary changes should reuse the shared refresh coordinator")
+
+assertTrue(areaProgress.contains("refreshDerivedContent: Bool = true"), "area progress aggregation should support opt-out of derived refresh")
+assertTrue(areaProgress.contains("if refreshDerivedContent {"), "area progress aggregation should guard derived refresh execution")
+
+assertTrue(homeView.contains("@Environment(\\.scenePhase) private var scenePhase"), "home view should observe scene phase for app resume refresh")
+assertTrue(homeView.contains("viewModel.refreshForVisibleReentry()"), "home view should refresh through visible reentry entrypoint")
+assertTrue(homeView.contains("viewModel.refreshForAppResumeIfNeeded()"), "home view should refresh through app resume entrypoint")
+assertTrue(homeView.contains(".onDisappear {"), "home view should track visibility around appearance changes")
+assertTrue(homeViewModel.contains("performInitialRefresh()"), "home view model init should use the dedicated initial refresh entrypoint")
+
+[
+    "홈 최초 진입",
+    "홈 재노출(탭 복귀)",
+    "앱 복귀(홈 visible)",
+    "당겨서 새로고침",
+    "pet 전환(home source)",
+    "각 4회",
+    "각 2회",
+    "각 1회"
+].forEach { needle in
+    assertTrue(doc.contains(needle), "home refresh doc should include \(needle)")
+}
+
+assertTrue(readme.contains("docs/home-refresh-entrypoint-v1.md"), "README should index the home refresh entrypoint doc")
+
+print("PASS: home refresh entrypoint unit checks")

--- a/scripts/home_viewmodel_state_aggregation_split_unit_check.swift
+++ b/scripts/home_viewmodel_state_aggregation_split_unit_check.swift
@@ -26,11 +26,11 @@ let aggregationService = load("dogArea/Source/Domain/Home/Services/HomeAreaAggre
 assertTrue(!mainFile.contains("enum QuestMotionEventType"), "HomeViewModel should no longer inline quest motion presentation types")
 assertTrue(!mainFile.contains("struct WeatherMissionStatusSummary"), "HomeViewModel should no longer inline weather presentation summary types")
 assertTrue(mainFile.contains("let areaAggregationService: HomeAreaAggregationServicing"), "HomeViewModel should inject area aggregation service")
-assertTrue(!mainFile.contains("func fetchData()"), "HomeViewModel main file should not own session lifecycle functions")
+assertTrue(!mainFile.contains("func fetchData("), "HomeViewModel main file should not own session lifecycle functions")
 assertTrue(!mainFile.contains("func applySelectedPetStatistics"), "HomeViewModel main file should not own aggregation functions")
 assertTrue(!mainFile.contains("func refreshIndoorMissions"), "HomeViewModel main file should not own indoor mission flow functions")
 
-assertTrue(sessionLifecycle.contains("func fetchData()"), "session lifecycle support should own fetchData")
+assertTrue(sessionLifecycle.contains("func fetchData(now: Date = Date())"), "session lifecycle support should own fetchData")
 assertTrue(sessionLifecycle.contains("func refreshAreaReferenceCatalogs()"), "session lifecycle support should own area reference refresh")
 assertTrue(sessionLifecycle.contains("func bindSelectedPetSync()"), "session lifecycle support should own selected pet sync binding")
 

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -83,6 +83,7 @@ swift scripts/hotspot_widget_privacy_unit_check.swift
 swift scripts/season_policy_stage1_unit_check.swift
 swift scripts/weather_risk_policy_stage1_unit_check.swift
 swift scripts/weather_snapshot_provider_unit_check.swift
+swift scripts/home_refresh_entrypoint_unit_check.swift
 swift scripts/weather_stage2_engine_unit_check.swift
 swift scripts/weather_ux_stage3_unit_check.swift
 swift scripts/weather_feedback_loop_unit_check.swift


### PR DESCRIPTION
## Summary
- unify home refresh entrypoints around trigger-based orchestration
- remove duplicate indoor mission/season/weather recalculation on initial load, manual refresh, and pet switching
- document before/after refresh call counts for the main home triggers

## Testing
- swift scripts/home_refresh_entrypoint_unit_check.swift
- swift scripts/weather_snapshot_provider_unit_check.swift
- swift scripts/home_viewmodel_state_aggregation_split_unit_check.swift
- DOGAREA_DERIVED_DATA_PATH=.build/codex-505-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -derivedDataPath .build/codex-505-ui -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_HomeWeatherDetailCardShowsRawSnapshotMetrics -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_HomeMissionLifecycleSeparatesCompletedMissionState test-without-building

Closes #505