### PR TITLE
refactor: cache home mission pet context snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - 날씨 리스크 모델/Provider 정책 v1: `docs/weather-risk-provider-policy-v1.md`
 - 날씨 snapshot/provider 확장 v1: `docs/weather-snapshot-provider-v1.md`
 - 홈 refresh entrypoint 정리 v1: `docs/home-refresh-entrypoint-v1.md`
+- 홈 미션 pet context snapshot v1: `docs/home-mission-pet-context-snapshot-v1.md`
 - 날씨 치환/스트릭 보호 서버 엔진 v1: `docs/weather-replacement-shield-engine-v1.md`
 - 날씨 연동 UX/fallback/접근성 v1: `docs/weather-ux-fallback-accessibility-v1.md`
 - 퀘스트 Stage1 템플릿/난이도 정책 v1: `docs/quest-stage1-template-difficulty-policy-v1.md`

--- a/docs/home-mission-pet-context-snapshot-v1.md
+++ b/docs/home-mission-pet-context-snapshot-v1.md
@@ -1,0 +1,66 @@
+# Home Mission Pet Context Snapshot v1
+
+## 목적
+
+홈 `refreshIndoorMissions(now:)`가 같은 입력으로 반복 호출될 때, 실내 미션 반려견 컨텍스트 집계(`최근 14일 일평균 산책 시간`, `최근 28일 주평균 산책 횟수`)를 매번 다시 `filter/reduce`하지 않도록 snapshot/cache 계약을 명시합니다.
+
+## 명시적 입력
+
+실내 미션 pet context 집계의 입력은 아래 3가지입니다.
+
+1. `polygonList`
+   - 이미 선택 반려견/전체 보기 정책이 반영된 홈 polygon 목록
+2. `selectedPetId`
+   - 현재 선택 반려견 식별자
+3. `reference`
+   - 최근 14일/28일 경계 계산의 기준 시각
+
+`petName`, `ageYears`는 집계 입력이 아니라 최종 프레젠테이션 합성 입력입니다. 따라서 집계 snapshot은 재사용하되, 최종 `IndoorMissionPetContext` 조립 시점에는 항상 현재 `selectedPet` 표시 정보를 다시 읽습니다.
+
+## Snapshot 계약
+
+- `HomeIndoorMissionPetContextSnapshotService`는 `polygonList`의 order-independent fingerprint를 생성합니다.
+- `applySelectedPetStatistics(...)`는 새 `polygonList`가 만들어질 때만 fingerprint를 갱신합니다.
+- fingerprint가 이전과 같으면 기존 snapshot을 보존합니다.
+- `refreshIndoorMissions(now:)`는 아래 조건을 모두 만족할 때만 snapshot을 재사용합니다.
+  - fingerprint 동일
+  - `selectedPetId` 동일
+  - `reference >= computedAt`
+  - `reference <= validThrough` 또는 `validThrough == nil`
+
+## Stale 허용 범위와 갱신 조건
+
+이 snapshot은 TTL 고정값이 아니라, **결과가 실제로 바뀔 수 있는 가장 이른 시간 경계**를 `validThrough`로 저장합니다.
+
+- 최근 14일 평균에 포함된 polygon은 `createdAt + 14d`까지 결과에 영향이 있습니다.
+- 최근 28일 주평균 횟수에 포함된 polygon은 `createdAt + 28d`까지 결과에 영향이 있습니다.
+- `validThrough`는 위 두 경계 중 가장 이른 시각입니다.
+- 포함된 polygon이 하나도 없으면 시간 경계로 인한 만료가 없으므로 `validThrough == nil`입니다.
+
+즉 stale 허용 범위는 다음과 같습니다.
+
+- 같은 `polygonList` / `selectedPetId`에서
+- `reference`가 `computedAt ... validThrough` 구간 안에 있으면
+- 기존 14일/28일 계산 결과를 그대로 재사용합니다.
+
+`reference`가 `validThrough`를 **초과하는 순간**에만 재집계합니다. 경계 시각과 정확히 같은 경우(`reference == validThrough`)는 기존 `>= cutoff` 규칙과 동일하게 재사용 가능합니다.
+
+## 결과 동일성
+
+기존 계산식은 유지합니다.
+
+- `recentDailyMinutes = recent14DayWalkingMinutes / 14`
+- `averageWeeklyWalkCount = recent28DayPolygonCount / 4`
+- window membership 기준도 동일하게 `createdAt >= cutoff`를 유지합니다.
+
+따라서 난이도 정책, 쉬운 날 규칙, 카드 문구/내용은 변경하지 않습니다.
+
+## 비용 비교
+
+| 상황 | Before | After |
+| --- | --- | --- |
+| `refreshIndoorMissions(now:)` 1회 cache miss | `polygonList.filter` 2회 + `reduce` 1회 | 동일 |
+| 같은 입력으로 `refreshIndoorMissions(now:)` 재호출 | 호출마다 `filter` 2회 + `reduce` 1회 반복 | `canReuseSnapshot` O(1) 판정 후 `filter/reduce` 0회 |
+| `polygonList` 재구성 | 별도 입력 추적 없음 | fingerprint 1회 재계산 후 변경 시에만 snapshot 무효화 |
+
+정리하면, 같은 홈 입력에서 반복 refresh가 들어와도 집계 본연의 비용은 첫 cache miss 1회로 제한됩니다.

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		A50000010000000000000006 /* SettingViewModel+ProductSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50000010000000000000016 /* SettingViewModel+ProductSurface.swift */; };
 		A45200010000000000000001 /* SettingsEditableImageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45200010000000000000011 /* SettingsEditableImageButton.swift */; };
 		A45300010000000000000001 /* HomeIndoorMissionPresentationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45300010000000000000011 /* HomeIndoorMissionPresentationService.swift */; };
+		A50600010000000000000001 /* HomeIndoorMissionPetContextSnapshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50600010000000000000011 /* HomeIndoorMissionPetContextSnapshotService.swift */; };
 		A45600010000000000000001 /* HomeWeatherSnapshotPresentationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45600010000000000000011 /* HomeWeatherSnapshotPresentationService.swift */; };
 		A45600010000000000000002 /* HomeWeatherSnapshotCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45600010000000000000012 /* HomeWeatherSnapshotCardView.swift */; };
 		A45600010000000000000003 /* HomeWeatherSnapshotMetricTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45600010000000000000013 /* HomeWeatherSnapshotMetricTileView.swift */; };
@@ -434,6 +435,7 @@
 		A50000010000000000000016 /* SettingViewModel+ProductSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingViewModel+ProductSurface.swift"; sourceTree = "<group>"; };
 		A45200010000000000000011 /* SettingsEditableImageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsEditableImageButton.swift; sourceTree = "<group>"; };
 		A45300010000000000000011 /* HomeIndoorMissionPresentationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeIndoorMissionPresentationService.swift; sourceTree = "<group>"; };
+		A50600010000000000000011 /* HomeIndoorMissionPetContextSnapshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeIndoorMissionPetContextSnapshotService.swift; sourceTree = "<group>"; };
 		A45600010000000000000011 /* HomeWeatherSnapshotPresentationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherSnapshotPresentationService.swift; sourceTree = "<group>"; };
 		A45600010000000000000012 /* HomeWeatherSnapshotCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherSnapshotCardView.swift; sourceTree = "<group>"; };
 		A45600010000000000000013 /* HomeWeatherSnapshotMetricTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherSnapshotMetricTileView.swift; sourceTree = "<group>"; };
@@ -1320,6 +1322,7 @@
 				DAE147A01420000000000001 /* HomeWeeklyStatisticsService.swift */,
 				DAE147A21420000000000001 /* HomeWeatherMissionStatusBuilder.swift */,
 				A45300010000000000000011 /* HomeIndoorMissionPresentationService.swift */,
+				A50600010000000000000011 /* HomeIndoorMissionPetContextSnapshotService.swift */,
 				A45600010000000000000011 /* HomeWeatherSnapshotPresentationService.swift */,
 				D55F514F099289DA27BC2654 /* HomeAreaAggregationService.swift */,
 			);
@@ -1763,6 +1766,7 @@
 				DAE147A11420000000000001 /* HomeWeeklyStatisticsService.swift in Sources */,
 				DAE147A31420000000000001 /* HomeWeatherMissionStatusBuilder.swift in Sources */,
 				A45300010000000000000001 /* HomeIndoorMissionPresentationService.swift in Sources */,
+				A50600010000000000000001 /* HomeIndoorMissionPetContextSnapshotService.swift in Sources */,
 				DAED25022AFA1D430044715A /* SplashView.swift in Sources */,
 				DA99F9E62AFA4F3E00B1483F /* Color.swift in Sources */,
 				DA3F9BD32AE0FF8A0048550C /* RootView.swift in Sources */,

--- a/dogArea/Source/Domain/Home/Services/HomeIndoorMissionPetContextSnapshotService.swift
+++ b/dogArea/Source/Domain/Home/Services/HomeIndoorMissionPetContextSnapshotService.swift
@@ -1,0 +1,178 @@
+import Foundation
+import CryptoKit
+
+/// 홈 실내 미션 반려견 컨텍스트 집계의 재사용 가능 snapshot을 계산하는 계약입니다.
+protocol HomeIndoorMissionPetContextSnapshotServicing {
+    /// 현재 홈 집계에 반영된 polygon 목록의 변경 여부를 추적할 fingerprint를 생성합니다.
+    /// - Parameter polygons: 선택 반려견/전체 보기 정책이 반영된 홈 산책 polygon 목록입니다.
+    /// - Returns: 순서 변화에 영향받지 않는 polygon 입력 fingerprint입니다.
+    func makePolygonFingerprint(from polygons: [Polygon]) -> HomeIndoorMissionPetContextPolygonFingerprint
+
+    /// 저장된 snapshot이 이번 요청 입력에 그대로 재사용 가능한지 판단합니다.
+    /// - Parameters:
+    ///   - snapshot: 이전 계산에서 보관 중인 집계 snapshot입니다.
+    ///   - polygonFingerprint: 현재 홈 polygon 목록의 fingerprint입니다.
+    ///   - selectedPetId: 현재 선택된 반려견 식별자입니다. 선택되지 않았으면 `nil`입니다.
+    ///   - reference: 이번 실내 미션 계산의 기준 시각입니다.
+    /// - Returns: 입력이 동일하고 snapshot의 시간 유효 구간 안이면 `true`입니다.
+    func canReuseSnapshot(
+        _ snapshot: HomeIndoorMissionPetContextAggregationSnapshot?,
+        polygonFingerprint: HomeIndoorMissionPetContextPolygonFingerprint,
+        selectedPetId: String?,
+        reference: Date
+    ) -> Bool
+
+    /// 최근 14일/28일 산책 집계를 계산해 재사용 가능한 snapshot으로 반환합니다.
+    /// - Parameters:
+    ///   - polygons: 선택 반려견/전체 보기 정책이 반영된 홈 산책 polygon 목록입니다.
+    ///   - polygonFingerprint: 현재 홈 polygon 목록의 fingerprint입니다.
+    ///   - selectedPetId: 현재 선택된 반려견 식별자입니다. 선택되지 않았으면 `nil`입니다.
+    ///   - reference: 이번 실내 미션 계산의 기준 시각입니다.
+    /// - Returns: 다음 시간 경계까지 재사용 가능한 pet context 집계 snapshot입니다.
+    func makeAggregationSnapshot(
+        polygons: [Polygon],
+        polygonFingerprint: HomeIndoorMissionPetContextPolygonFingerprint,
+        selectedPetId: String?,
+        reference: Date
+    ) -> HomeIndoorMissionPetContextAggregationSnapshot
+}
+
+/// 홈 실내 미션 pet context 집계 입력이 실제로 바뀌었는지 추적하는 fingerprint입니다.
+struct HomeIndoorMissionPetContextPolygonFingerprint: Equatable {
+    let digestHex: String
+    let polygonCount: Int
+}
+
+/// 홈 실내 미션 pet context의 재사용 가능한 집계 snapshot입니다.
+struct HomeIndoorMissionPetContextAggregationSnapshot: Equatable {
+    let polygonFingerprint: HomeIndoorMissionPetContextPolygonFingerprint
+    let selectedPetId: String?
+    let computedAt: TimeInterval
+    let validThrough: TimeInterval?
+    let recentDailyMinutes: Double
+    let averageWeeklyWalkCount: Double
+}
+
+final class HomeIndoorMissionPetContextSnapshotService: HomeIndoorMissionPetContextSnapshotServicing {
+    private let fourteenDayWindow: TimeInterval
+    private let twentyEightDayWindow: TimeInterval
+
+    /// 최근 산책 집계 snapshot 서비스의 기간 정책을 생성합니다.
+    /// - Parameters:
+    ///   - fourteenDayWindow: 최근 일일 평균 산책 시간을 계산할 lookback 길이(초)입니다.
+    ///   - twentyEightDayWindow: 최근 주간 평균 산책 횟수를 계산할 lookback 길이(초)입니다.
+    init(
+        fourteenDayWindow: TimeInterval = 14 * 24 * 3600,
+        twentyEightDayWindow: TimeInterval = 28 * 24 * 3600
+    ) {
+        self.fourteenDayWindow = fourteenDayWindow
+        self.twentyEightDayWindow = twentyEightDayWindow
+    }
+
+    /// 현재 홈 집계에 반영된 polygon 목록의 변경 여부를 추적할 fingerprint를 생성합니다.
+    /// - Parameter polygons: 선택 반려견/전체 보기 정책이 반영된 홈 산책 polygon 목록입니다.
+    /// - Returns: 순서 변화에 영향받지 않는 polygon 입력 fingerprint입니다.
+    func makePolygonFingerprint(from polygons: [Polygon]) -> HomeIndoorMissionPetContextPolygonFingerprint {
+        HomeIndoorMissionPetContextPolygonFingerprint(
+            digestHex: makeDigestHex(from: polygons),
+            polygonCount: polygons.count
+        )
+    }
+
+    /// 저장된 snapshot이 이번 요청 입력에 그대로 재사용 가능한지 판단합니다.
+    /// - Parameters:
+    ///   - snapshot: 이전 계산에서 보관 중인 집계 snapshot입니다.
+    ///   - polygonFingerprint: 현재 홈 polygon 목록의 fingerprint입니다.
+    ///   - selectedPetId: 현재 선택된 반려견 식별자입니다. 선택되지 않았으면 `nil`입니다.
+    ///   - reference: 이번 실내 미션 계산의 기준 시각입니다.
+    /// - Returns: 입력이 동일하고 snapshot의 시간 유효 구간 안이면 `true`입니다.
+    func canReuseSnapshot(
+        _ snapshot: HomeIndoorMissionPetContextAggregationSnapshot?,
+        polygonFingerprint: HomeIndoorMissionPetContextPolygonFingerprint,
+        selectedPetId: String?,
+        reference: Date
+    ) -> Bool {
+        guard let snapshot else { return false }
+        guard snapshot.polygonFingerprint == polygonFingerprint else { return false }
+        guard snapshot.selectedPetId == selectedPetId else { return false }
+
+        let referenceTimestamp = reference.timeIntervalSince1970
+        guard referenceTimestamp >= snapshot.computedAt else { return false }
+        guard let validThrough = snapshot.validThrough else { return true }
+        return referenceTimestamp <= validThrough
+    }
+
+    /// 최근 14일/28일 산책 집계를 계산해 재사용 가능한 snapshot으로 반환합니다.
+    /// - Parameters:
+    ///   - polygons: 선택 반려견/전체 보기 정책이 반영된 홈 산책 polygon 목록입니다.
+    ///   - polygonFingerprint: 현재 홈 polygon 목록의 fingerprint입니다.
+    ///   - selectedPetId: 현재 선택된 반려견 식별자입니다. 선택되지 않았으면 `nil`입니다.
+    ///   - reference: 이번 실내 미션 계산의 기준 시각입니다.
+    /// - Returns: 다음 시간 경계까지 재사용 가능한 pet context 집계 snapshot입니다.
+    func makeAggregationSnapshot(
+        polygons: [Polygon],
+        polygonFingerprint: HomeIndoorMissionPetContextPolygonFingerprint,
+        selectedPetId: String?,
+        reference: Date
+    ) -> HomeIndoorMissionPetContextAggregationSnapshot {
+        let referenceTimestamp = reference.timeIntervalSince1970
+        let recentCutoff = referenceTimestamp - fourteenDayWindow
+        let monthlyCutoff = referenceTimestamp - twentyEightDayWindow
+
+        let recentPolygons = polygons.filter { $0.createdAt >= recentCutoff }
+        let monthlyPolygons = polygons.filter { $0.createdAt >= monthlyCutoff }
+        let totalRecentMinutes = recentPolygons.reduce(0.0) { partial, polygon in
+            partial + max(0, polygon.walkingTime) / 60.0
+        }
+
+        return HomeIndoorMissionPetContextAggregationSnapshot(
+            polygonFingerprint: polygonFingerprint,
+            selectedPetId: selectedPetId,
+            computedAt: referenceTimestamp,
+            validThrough: makeNextInvalidationTimestamp(
+                recentPolygons: recentPolygons,
+                monthlyPolygons: monthlyPolygons
+            ),
+            recentDailyMinutes: totalRecentMinutes / 14.0,
+            averageWeeklyWalkCount: Double(monthlyPolygons.count) / 4.0
+        )
+    }
+
+    /// polygon 목록을 순서와 무관하게 식별하는 SHA256 digest를 계산합니다.
+    /// - Parameter polygons: 홈 실내 미션 집계에 사용 중인 polygon 목록입니다.
+    /// - Returns: 동일 membership이면 같은 값을 갖는 hex digest 문자열입니다.
+    private func makeDigestHex(from polygons: [Polygon]) -> String {
+        let raw = polygons
+            .map { polygon in
+                "\(polygon.id.uuidString.lowercased())|\(polygon.createdAt.bitPattern)|\(polygon.walkingTime.bitPattern)"
+            }
+            .sorted()
+            .joined(separator: "\n")
+        let digest = SHA256.hash(data: Data(raw.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// 현재 snapshot 결과가 바뀔 수 있는 가장 이른 시간 경계를 계산합니다.
+    /// - Parameters:
+    ///   - recentPolygons: 최근 14일 평균에 포함된 polygon 목록입니다.
+    ///   - monthlyPolygons: 최근 28일 평균에 포함된 polygon 목록입니다.
+    /// - Returns: 결과가 달라질 수 있는 가장 이른 시각이며, 더 이상 만료 이벤트가 없으면 `nil`입니다.
+    private func makeNextInvalidationTimestamp(
+        recentPolygons: [Polygon],
+        monthlyPolygons: [Polygon]
+    ) -> TimeInterval? {
+        let recentExpiry = recentPolygons.map { $0.createdAt + fourteenDayWindow }.min()
+        let monthlyExpiry = monthlyPolygons.map { $0.createdAt + twentyEightDayWindow }.min()
+
+        switch (recentExpiry, monthlyExpiry) {
+        case let (lhs?, rhs?):
+            return min(lhs, rhs)
+        case let (lhs?, nil):
+            return lhs
+        case let (nil, rhs?):
+            return rhs
+        case (nil, nil):
+            return nil
+        }
+    }
+}

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -60,6 +60,7 @@ final class HomeViewModel: ObservableObject {
     let weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding
     let weatherSnapshotPresentationService: HomeWeatherSnapshotPresenting
     let indoorMissionPresentationService: HomeIndoorMissionPresenting
+    let indoorMissionPetContextSnapshotService: HomeIndoorMissionPetContextSnapshotServicing
     let weatherSnapshotStore: WeatherSnapshotStoreProtocol
     let areaMilestoneDetector: AreaMilestoneDetecting
     let areaMilestoneNotificationScheduler: AreaMilestoneNotificationScheduling
@@ -70,6 +71,8 @@ final class HomeViewModel: ObservableObject {
     var areaMilestoneQueue: [AreaMilestoneEvent] = []
     var areaReferenceTask: Task<Void, Never>? = nil
     var hasSkippedInitialActiveSceneRefresh: Bool = false
+    var indoorMissionPetContextPolygonFingerprint: HomeIndoorMissionPetContextPolygonFingerprint? = nil
+    var indoorMissionPetContextAggregationSnapshot: HomeIndoorMissionPetContextAggregationSnapshot? = nil
 
     var pets: [PetInfo] {
         userInfo?.pet.filter(\.isActive) ?? []
@@ -129,6 +132,7 @@ final class HomeViewModel: ObservableObject {
         weatherMissionStatusBuilder: HomeWeatherMissionStatusBuilding = HomeWeatherMissionStatusBuilder(),
         weatherSnapshotPresentationService: HomeWeatherSnapshotPresenting = HomeWeatherSnapshotPresentationService(),
         indoorMissionPresentationService: HomeIndoorMissionPresenting = HomeIndoorMissionPresentationService(),
+        indoorMissionPetContextSnapshotService: HomeIndoorMissionPetContextSnapshotServicing = HomeIndoorMissionPetContextSnapshotService(),
         weatherSnapshotStore: WeatherSnapshotStoreProtocol = WeatherSnapshotStore.shared,
         areaMilestoneDetector: AreaMilestoneDetecting = AreaMilestoneDetector(),
         areaMilestoneNotificationScheduler: AreaMilestoneNotificationScheduling = LocalAreaMilestoneNotificationScheduler()
@@ -142,6 +146,7 @@ final class HomeViewModel: ObservableObject {
         self.weatherMissionStatusBuilder = weatherMissionStatusBuilder
         self.weatherSnapshotPresentationService = weatherSnapshotPresentationService
         self.indoorMissionPresentationService = indoorMissionPresentationService
+        self.indoorMissionPetContextSnapshotService = indoorMissionPetContextSnapshotService
         self.weatherSnapshotStore = weatherSnapshotStore
         self.areaMilestoneDetector = areaMilestoneDetector
         self.areaMilestoneNotificationScheduler = areaMilestoneNotificationScheduler

--- a/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+AreaProgress.swift
+++ b/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+AreaProgress.swift
@@ -19,6 +19,7 @@ extension HomeViewModel {
             selectedPetId: selectedPet?.petId,
             showsAllRecords: isShowingAllRecordsOverride
         )
+        updateIndoorMissionPetContextPolygonFingerprint(for: polygonList)
         totalArea = polygonList.map(\.walkingArea).reduce(0.0, +)
         totalTime = polygonList.map(\.walkingTime).reduce(0.0, +)
         myArea = areaAggregationService.makeCurrentArea(
@@ -33,6 +34,15 @@ extension HomeViewModel {
         if shouldUpdateMeter {
             updateCurrentMeter()
         }
+    }
+
+    /// 현재 홈에 노출 중인 polygon 목록으로 실내 미션 pet context 입력 fingerprint를 갱신합니다.
+    /// - Parameter polygons: 선택 반려견/전체 보기 정책이 반영된 홈 polygon 목록입니다.
+    func updateIndoorMissionPetContextPolygonFingerprint(for polygons: [Polygon]) {
+        let nextFingerprint = indoorMissionPetContextSnapshotService.makePolygonFingerprint(from: polygons)
+        guard indoorMissionPetContextPolygonFingerprint != nextFingerprint else { return }
+        indoorMissionPetContextPolygonFingerprint = nextFingerprint
+        indoorMissionPetContextAggregationSnapshot = nil
     }
 
     func refreshAreaList() {

--- a/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+IndoorMissionFlow.swift
+++ b/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+IndoorMissionFlow.swift
@@ -346,22 +346,57 @@ extension HomeViewModel {
     }
 
     func makeIndoorMissionPetContext(reference: Date) -> IndoorMissionPetContext {
-        let fourteenDaysAgo = reference.addingTimeInterval(-14 * 24 * 3600)
-        let twentyEightDaysAgo = reference.addingTimeInterval(-28 * 24 * 3600)
-        let recentPolygons = polygonList.filter { Date(timeIntervalSince1970: $0.createdAt) >= fourteenDaysAgo }
-        let monthlyPolygons = polygonList.filter { Date(timeIntervalSince1970: $0.createdAt) >= twentyEightDaysAgo }
-        let totalRecentMinutes = recentPolygons.reduce(0.0) { partial, polygon in
-            partial + max(0, polygon.walkingTime) / 60.0
-        }
-        let recentDailyMinutes = totalRecentMinutes / 14.0
-        let averageWeeklyWalkCount = Double(monthlyPolygons.count) / 4.0
+        let selectedPetId = normalizedIndoorMissionPetContextPetId()
+        let polygonFingerprint = indoorMissionPetContextPolygonFingerprint
+            ?? indoorMissionPetContextSnapshotService.makePolygonFingerprint(from: polygonList)
+        indoorMissionPetContextPolygonFingerprint = polygonFingerprint
 
-        return .init(
-            petId: selectedPet?.petId,
+        if indoorMissionPetContextSnapshotService.canReuseSnapshot(
+            indoorMissionPetContextAggregationSnapshot,
+            polygonFingerprint: polygonFingerprint,
+            selectedPetId: selectedPetId,
+            reference: reference
+        ) {
+            return makeIndoorMissionPetContext(
+                from: indoorMissionPetContextAggregationSnapshot,
+                selectedPetId: selectedPetId
+            )
+        }
+
+        let snapshot = indoorMissionPetContextSnapshotService.makeAggregationSnapshot(
+            polygons: polygonList,
+            polygonFingerprint: polygonFingerprint,
+            selectedPetId: selectedPetId,
+            reference: reference
+        )
+        indoorMissionPetContextAggregationSnapshot = snapshot
+        return makeIndoorMissionPetContext(from: snapshot, selectedPetId: selectedPetId)
+    }
+
+    /// 현재 선택 반려견 식별자를 실내 미션 pet context 입력 형식으로 정규화합니다.
+    /// - Returns: 비어 있지 않은 선택 반려견 식별자이며, 선택되지 않았으면 `nil`입니다.
+    func normalizedIndoorMissionPetContextPetId() -> String? {
+        guard let selectedPetId = selectedPet?.petId, selectedPetId.isEmpty == false else {
+            return nil
+        }
+        return selectedPetId
+    }
+
+    /// 집계 snapshot과 현재 선택 반려견 표시 정보를 조합해 최종 pet context를 생성합니다.
+    /// - Parameters:
+    ///   - snapshot: 최근 14일/28일 집계가 들어 있는 재사용 snapshot입니다.
+    ///   - selectedPetId: 현재 선택 반려견 식별자입니다. 선택되지 않았으면 `nil`입니다.
+    /// - Returns: 홈 실내 미션 난이도 계산에 전달할 최종 반려견 컨텍스트입니다.
+    func makeIndoorMissionPetContext(
+        from snapshot: HomeIndoorMissionPetContextAggregationSnapshot?,
+        selectedPetId: String?
+    ) -> IndoorMissionPetContext {
+        IndoorMissionPetContext(
+            petId: selectedPetId,
             petName: selectedPet?.petName ?? "강아지",
             ageYears: selectedPet?.ageYears,
-            recentDailyMinutes: recentDailyMinutes,
-            averageWeeklyWalkCount: averageWeeklyWalkCount
+            recentDailyMinutes: snapshot?.recentDailyMinutes ?? 0.0,
+            averageWeeklyWalkCount: snapshot?.averageWeeklyWalkCount ?? 0.0
         )
     }
 

--- a/scripts/home_mission_pet_context_snapshot_unit_check.swift
+++ b/scripts/home_mission_pet_context_snapshot_unit_check.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let homeViewModel = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let areaProgress = load("dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+AreaProgress.swift")
+let indoorMissionFlow = load("dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+IndoorMissionFlow.swift")
+let service = load("dogArea/Source/Domain/Home/Services/HomeIndoorMissionPetContextSnapshotService.swift")
+let doc = load("docs/home-mission-pet-context-snapshot-v1.md")
+let readme = load("README.md")
+
+assertTrue(homeViewModel.contains("let indoorMissionPetContextSnapshotService: HomeIndoorMissionPetContextSnapshotServicing"), "home view model should inject the pet context snapshot service")
+assertTrue(homeViewModel.contains("var indoorMissionPetContextPolygonFingerprint: HomeIndoorMissionPetContextPolygonFingerprint? = nil"), "home view model should store the polygon fingerprint cache state")
+assertTrue(homeViewModel.contains("var indoorMissionPetContextAggregationSnapshot: HomeIndoorMissionPetContextAggregationSnapshot? = nil"), "home view model should store the pet context aggregation snapshot")
+assertTrue(homeViewModel.contains("indoorMissionPetContextSnapshotService: HomeIndoorMissionPetContextSnapshotServicing = HomeIndoorMissionPetContextSnapshotService()"), "home view model init should default the pet context snapshot service")
+
+assertTrue(areaProgress.contains("updateIndoorMissionPetContextPolygonFingerprint(for: polygonList)"), "area progress should update the mission pet context fingerprint when polygonList changes")
+assertTrue(areaProgress.contains("indoorMissionPetContextAggregationSnapshot = nil"), "fingerprint changes should invalidate the cached snapshot")
+
+assertTrue(indoorMissionFlow.contains("indoorMissionPetContextSnapshotService.canReuseSnapshot("), "indoor mission flow should reuse snapshot only when inputs still match")
+assertTrue(indoorMissionFlow.contains("makeAggregationSnapshot("), "indoor mission flow should rebuild the aggregation snapshot on cache miss")
+assertTrue(indoorMissionFlow.contains("normalizedIndoorMissionPetContextPetId()"), "indoor mission flow should normalize selected pet id input")
+assertTrue(indoorMissionFlow.contains("return makeIndoorMissionPetContext(\n                from: indoorMissionPetContextAggregationSnapshot,\n                selectedPetId: selectedPetId\n            )") || indoorMissionFlow.contains("return makeIndoorMissionPetContext(from: snapshot, selectedPetId: selectedPetId)"), "indoor mission flow should compose the final context from the cached snapshot")
+
+assertTrue(service.contains("protocol HomeIndoorMissionPetContextSnapshotServicing"), "service file should define a protocol-first pet context snapshot contract")
+assertTrue(service.contains("struct HomeIndoorMissionPetContextPolygonFingerprint: Equatable"), "service file should define the polygon fingerprint model")
+assertTrue(service.contains("struct HomeIndoorMissionPetContextAggregationSnapshot: Equatable"), "service file should define the aggregation snapshot model")
+assertTrue(service.contains("makePolygonFingerprint(from polygons: [Polygon])"), "service file should expose polygon fingerprint generation")
+assertTrue(service.contains("canReuseSnapshot("), "service file should expose snapshot reuse validation")
+assertTrue(service.contains("makeAggregationSnapshot("), "service file should expose snapshot building")
+assertTrue(service.contains("createdAt + fourteenDayWindow"), "service file should compute the 14-day invalidation boundary")
+assertTrue(service.contains("createdAt + twentyEightDayWindow"), "service file should compute the 28-day invalidation boundary")
+assertTrue(service.contains("SHA256.hash"), "service file should use a stable digest for polygon fingerprinting")
+
+[
+    "명시적 입력",
+    "polygonList",
+    "selectedPetId",
+    "reference",
+    "validThrough",
+    "reference == validThrough",
+    "filter` 2회 + `reduce` 1회",
+    "`canReuseSnapshot` O(1)"
+].forEach { needle in
+    assertTrue(doc.contains(needle), "doc should describe \(needle)")
+}
+
+assertTrue(readme.contains("docs/home-mission-pet-context-snapshot-v1.md"), "README should index the home mission pet context snapshot doc")
+
+print("PASS: home mission pet context snapshot unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -84,6 +84,7 @@ swift scripts/season_policy_stage1_unit_check.swift
 swift scripts/weather_risk_policy_stage1_unit_check.swift
 swift scripts/weather_snapshot_provider_unit_check.swift
 swift scripts/home_refresh_entrypoint_unit_check.swift
+swift scripts/home_mission_pet_context_snapshot_unit_check.swift
 swift scripts/weather_stage2_engine_unit_check.swift
 swift scripts/weather_ux_stage3_unit_check.swift
 swift scripts/weather_feedback_loop_unit_check.swift


### PR DESCRIPTION
## Summary
- add a pet context aggregation snapshot service for indoor mission calculations
- reuse cached mission pet context unless polygons, selected pet, or reference window actually changes
- document refresh conditions, stale tolerance, and before/after cost comparison

## Validation
- swift scripts/home_mission_pet_context_snapshot_unit_check.swift
- swift scripts/home_refresh_entrypoint_unit_check.swift
- swift scripts/home_mission_lifecycle_ux_unit_check.swift
- DOGAREA_DERIVED_DATA_PATH=.build/codex-506-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -derivedDataPath .build/codex-506-build -destination 'id=6D292EBD-6651-4B84-836D-15D8FB55F6BA' CODE_SIGNING_ALLOWED=NO -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_HomeMissionLifecycleSeparatesCompletedMissionState test\n\nCloses #506