### PR TITLE
feat: add auth mail resend state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - Backend realtime/moderation retention policy v1: `docs/backend-realtime-moderation-retention-policy-v1.md`
 - Widget summary RPC 공통 응답 모델 v1: `docs/widget-summary-rpc-common-response-model-v1.md`
 - UX copy guideline v1: `docs/ux-copy-guideline-v1.md`
+- Auth mail resend state machine v1: `docs/auth-mail-resend-state-machine-v1.md`
 - Backend Edge auth policy v1: `docs/backend-edge-auth-policy-v1.md`
 - Backend Edge auth mode inventory v1: `docs/backend-edge-auth-mode-inventory-v1.md`
 - Backend upload-profile-image owner binding policy v1: `docs/backend-upload-profile-image-owner-binding-policy-v1.md`

--- a/docs/auth-mail-resend-state-machine-v1.md
+++ b/docs/auth-mail-resend-state-machine-v1.md
@@ -1,0 +1,155 @@
+# Auth Mail Resend State Machine v1
+
+## 목적
+
+회원가입 확인 메일, 비밀번호 재설정 메일, 이메일 변경 확인 메일을 같은 UX 축으로 다루되,
+액션 타입이 서로 다른 흐름을 잘못 막지 않도록 액션별 resend 상태 기계를 고정합니다.
+
+## 액션 키
+
+메일 액션 key는 아래 조합으로 분리합니다.
+
+- `actionType`
+  - `signup_confirmation`
+  - `password_reset`
+  - `email_change`
+- `recipient`
+  - 정규화한 대상 이메일
+- `context`
+  - 현재는 `signup_sheet`
+  - 같은 액션이라도 표면이 달라지면 별도 문맥으로 분리 가능
+
+예:
+
+- `signup_confirmation::hello@dogarea.test::signup_sheet`
+- `password_reset::hello@dogarea.test::reset_sheet`
+- `email_change::next@dogarea.test::settings_email_change`
+
+## 상태 모델
+
+필수 상태는 아래 6개입니다.
+
+- `idle`
+- `sending`
+- `sent`
+- `cooldown`
+- `rate_limited`
+- `failed`
+
+### 의미
+
+- `idle`: 지금 요청을 보낼 수 있음
+- `sending`: 동일 액션 중복 탭 금지
+- `sent`: 방금 서버 성공 응답을 받았고 성공 배너를 짧게 유지하는 구간
+- `cooldown`: 성공 직후 재전송을 잠시 막는 구간
+- `rate_limited`: `429` 또는 `Retry-After`로 서버가 명시적으로 막은 구간
+- `failed`: 네트워크/기타 실패. 다음 시도는 허용하지만 실패 문구를 남김
+
+## 상태 유지 범위
+
+- `sending`
+  - view-local only
+  - 화면 재진입 시 복원하지 않음
+- `failed`
+  - view-local only
+  - 사용자가 다시 시도하면 덮어씀
+- `sent / cooldown / rate_limited`
+  - `UserDefaults` snapshot으로 유지
+  - 시트 dismiss / reopen, 화면 이동 후 복귀에도 유지
+
+## Stale Tolerance / Refresh 규칙
+
+canonical source는 서버 응답입니다.
+
+앱은 서버 응답 이후 아래 snapshot만 로컬에 유지합니다.
+
+- `sentBannerUntil`
+- `nextAllowedAt`
+- `retryAfterSeconds`
+- `wasRateLimited`
+
+refresh rule:
+
+1. 현재 시각 `< sentBannerUntil` 이면 `sent`
+2. 현재 시각 `>= sentBannerUntil` 이고 `< nextAllowedAt` 이면
+   - `wasRateLimited == true` -> `rate_limited`
+   - 그 외 -> `cooldown`
+3. 현재 시각 `>= nextAllowedAt` 이면 snapshot 제거 후 `idle`
+
+## Retry-After 우선순위
+
+1. 서버 `Retry-After`
+2. 액션별 fallback cooldown
+
+현재 fallback 값:
+
+- signup confirmation: `60s`
+- password reset: `75s`
+- email change: `90s`
+
+## 현재 앱 적용 범위
+
+이번 사이클에서 실제 UI에 붙인 표면은 `signup_sheet` 입니다.
+
+- 초기 회원가입 성공 후 즉시 dismiss 하지 않음
+- 성공 카드에서 `프로필 입력 계속`과 `인증 메일 다시 보내기`를 함께 제공
+- cooldown/rate-limited 상태에서는 resend 버튼 disabled
+- 남은 시간 문구를 버튼과 카드 설명에 함께 표시
+
+reset / email change는 아직 표면이 없으므로,
+이번 사이클에서는 **상태 모델 / key 분리 / 저장소 계약**까지만 선반영합니다.
+
+## 사용자 문구 원칙
+
+- 내부 운영 용어 금지
+- `SMTP`, `Rate Limit`, `over_email_send_rate_limit` 노출 금지
+- 사용자 관점 행동만 안내
+
+예:
+
+- `요청이 많아 잠시 기다린 뒤 다시 보낼 수 있어요. 48초 후 다시 시도해주세요.`
+- `방금 메일을 보냈어요. 31초 후 다시 보낼 수 있어요.`
+
+## 관측성
+
+metric/log payload:
+
+- `action_type`
+- `surface`
+- `retry_after_seconds`
+- `duplicate_suppressed`
+
+metric event:
+
+- `auth_mail_action_succeeded`
+- `auth_mail_action_rate_limited`
+- `auth_mail_action_failed`
+- `auth_mail_action_suppressed`
+
+## QA 시나리오
+
+1. signup 성공
+- 성공 카드 노출
+- `프로필 입력 계속`으로 온보딩 진입 가능
+- resend 버튼이 바로 연속 탭되지 않음
+
+2. signup `429`
+- `Retry-After`가 있으면 그 초 단위가 우선 반영됨
+- 없으면 `60s` fallback 사용
+- 버튼 disabled + 남은 시간 노출
+
+3. 네트워크 실패
+- resend 상태는 `failed`
+- 사용자는 즉시 다시 시도 가능
+
+4. 중복 탭
+- `sending` 중 추가 탭 억제
+- metric/log에 `duplicate_suppressed=true`
+
+5. sheet dismiss / reopen
+- `sent / cooldown / rate_limited` snapshot 유지
+- 입력 이메일이 같으면 같은 상태가 다시 보임
+
+6. background 복귀
+- 현재 시각 기준으로 상태 재해석
+- `nextAllowedAt`이 지났으면 자동으로 `idle` 복귀

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -100,6 +100,11 @@
 		A45200010000000000000001 /* SettingsEditableImageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45200010000000000000011 /* SettingsEditableImageButton.swift */; };
 		A45300010000000000000001 /* HomeIndoorMissionPresentationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45300010000000000000011 /* HomeIndoorMissionPresentationService.swift */; };
 		A50600010000000000000001 /* HomeIndoorMissionPetContextSnapshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50600010000000000000011 /* HomeIndoorMissionPetContextSnapshotService.swift */; };
+		A50700010000000000000001 /* AuthMailActionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50700010000000000000011 /* AuthMailActionModels.swift */; };
+		A50700010000000000000002 /* AuthMailActionStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50700010000000000000012 /* AuthMailActionStateMachine.swift */; };
+		A50700010000000000000003 /* AuthMailActionStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50700010000000000000013 /* AuthMailActionStateStore.swift */; };
+		A50700010000000000000004 /* SupabaseAuthMailActionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50700010000000000000014 /* SupabaseAuthMailActionService.swift */; };
+		A50700010000000000000005 /* AuthMailActionStatusCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50700010000000000000015 /* AuthMailActionStatusCardView.swift */; };
 		A45600010000000000000001 /* HomeWeatherSnapshotPresentationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45600010000000000000011 /* HomeWeatherSnapshotPresentationService.swift */; };
 		A45600010000000000000002 /* HomeWeatherSnapshotCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45600010000000000000012 /* HomeWeatherSnapshotCardView.swift */; };
 		A45600010000000000000003 /* HomeWeatherSnapshotMetricTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45600010000000000000013 /* HomeWeatherSnapshotMetricTileView.swift */; };
@@ -436,6 +441,11 @@
 		A45200010000000000000011 /* SettingsEditableImageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsEditableImageButton.swift; sourceTree = "<group>"; };
 		A45300010000000000000011 /* HomeIndoorMissionPresentationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeIndoorMissionPresentationService.swift; sourceTree = "<group>"; };
 		A50600010000000000000011 /* HomeIndoorMissionPetContextSnapshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeIndoorMissionPetContextSnapshotService.swift; sourceTree = "<group>"; };
+		A50700010000000000000011 /* AuthMailActionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthMailActionModels.swift; sourceTree = "<group>"; };
+		A50700010000000000000012 /* AuthMailActionStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthMailActionStateMachine.swift; sourceTree = "<group>"; };
+		A50700010000000000000013 /* AuthMailActionStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthMailActionStateStore.swift; sourceTree = "<group>"; };
+		A50700010000000000000014 /* SupabaseAuthMailActionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseAuthMailActionService.swift; sourceTree = "<group>"; };
+		A50700010000000000000015 /* AuthMailActionStatusCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthMailActionStatusCardView.swift; sourceTree = "<group>"; };
 		A45600010000000000000011 /* HomeWeatherSnapshotPresentationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherSnapshotPresentationService.swift; sourceTree = "<group>"; };
 		A45600010000000000000012 /* HomeWeatherSnapshotCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherSnapshotCardView.swift; sourceTree = "<group>"; };
 		A45600010000000000000013 /* HomeWeatherSnapshotMetricTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherSnapshotMetricTileView.swift; sourceTree = "<group>"; };
@@ -787,6 +797,7 @@
 			isa = PBXGroup;
 			children = (
 				A37500010000000000000017 /* AuthUserInfo.swift */,
+				A50700010000000000000015 /* AuthMailActionStatusCardView.swift */,
 				A37500010000000000000018 /* EmailSignUpSheetView.swift */,
 				414CE261F0EB5ECCEED97F09 /* MemberUpgradeSheetView.swift */,
 				29F07A82B4C3550CACA2C6ED /* GuestDataUpgradePromptSheetView.swift */,
@@ -1004,6 +1015,7 @@
 				A41300010000000000000013 /* SupabasePresenceAndQuestServices.swift */,
 				A41300010000000000000014 /* SupabaseWidgetAndAreaServices.swift */,
 				A41300010000000000000015 /* SupabaseAuthAndAssetServices.swift */,
+				A50700010000000000000014 /* SupabaseAuthMailActionService.swift */,
 			);
 			path = Infrastructure/Supabase/Services;
 			sourceTree = "<group>";
@@ -1018,6 +1030,7 @@
 				A41500010000000000000015 /* AppPreferenceStores.swift */,
 				A41500010000000000000016 /* FeatureFlagStore.swift */,
 				A41500010000000000000017 /* AppMetricTracker.swift */,
+				A50700010000000000000013 /* AuthMailActionStateStore.swift */,
 				A41500010000000000000018 /* SyncOutboxStore.swift */,
 			);
 			path = UserDefaultsSupport;
@@ -1295,6 +1308,7 @@
 		DAF0A0014200000000000001 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				A50700010000000000000021 /* Auth */,
 				DAF0A0024200000000000001 /* Home */,
 				DAF0A0044200000000000001 /* Map */,
 				A37600010000000000000001 /* Profile */,
@@ -1302,6 +1316,31 @@
 				A45700010000000000000021 /* Weather */,
 			);
 			path = Domain;
+			sourceTree = "<group>";
+		};
+		A50700010000000000000021 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				A50700010000000000000022 /* Models */,
+				A50700010000000000000023 /* Services */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		A50700010000000000000022 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A50700010000000000000011 /* AuthMailActionModels.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		A50700010000000000000023 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				A50700010000000000000012 /* AuthMailActionStateMachine.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		DAF0A0024200000000000001 /* Home */ = {
@@ -1747,6 +1786,7 @@
 				A41300010000000000000023 /* SupabasePresenceAndQuestServices.swift in Sources */,
 				A41300010000000000000024 /* SupabaseWidgetAndAreaServices.swift in Sources */,
 				A41300010000000000000025 /* SupabaseAuthAndAssetServices.swift in Sources */,
+				A50700010000000000000004 /* SupabaseAuthMailActionService.swift in Sources */,
 				A37800010000000000000001 /* AppTabScaffold.swift in Sources */,
 				DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */,
 				DAE148A11420000000000001 /* MapAreaCalculationService.swift in Sources */,
@@ -1757,12 +1797,15 @@
 				A50000010000000000000002 /* SettingsProductSurfaceService.swift in Sources */,
 				DA4513832AFB25C2007AD69B /* PositionMarkerView.swift in Sources */,
 				DA8BB9F22B02FE3A00E350C4 /* HomeViewModel.swift in Sources */,
+				A50700010000000000000001 /* AuthMailActionModels.swift in Sources */,
+				A50700010000000000000002 /* AuthMailActionStateMachine.swift in Sources */,
 				A37500010000000000000021 /* HomeMissionModels.swift in Sources */,
 				A37500010000000000000022 /* IndoorMissionStore.swift in Sources */,
 				A37500010000000000000023 /* SeasonMotionStore.swift in Sources */,
 				A45700010000000000000001 /* WeatherSnapshot.swift in Sources */,
 				A45700010000000000000002 /* OpenMeteoWeatherSnapshotProvider.swift in Sources */,
 				A45700010000000000000003 /* WeatherSnapshotStore.swift in Sources */,
+				A50700010000000000000003 /* AuthMailActionStateStore.swift in Sources */,
 				DAE147A11420000000000001 /* HomeWeeklyStatisticsService.swift in Sources */,
 				DAE147A31420000000000001 /* HomeWeatherMissionStatusBuilder.swift in Sources */,
 				A45300010000000000000001 /* HomeIndoorMissionPresentationService.swift in Sources */,
@@ -1786,6 +1829,7 @@
 				DA390A752AFE1AFC00BACF2B /* SimpleMessageView.swift in Sources */,
 				DAC19F2C2B0B43BB002FE2E8 /* SignInView.swift in Sources */,
 				A37500010000000000000027 /* AuthUserInfo.swift in Sources */,
+				A50700010000000000000005 /* AuthMailActionStatusCardView.swift in Sources */,
 				A37500010000000000000028 /* EmailSignUpSheetView.swift in Sources */,
 				A37600010000000000000023 /* ProfileEditorCards.swift in Sources */,
 				A37600010000000000000025 /* ProfileEditorImageSection.swift in Sources */,

--- a/dogArea/Source/Domain/Auth/Models/AuthMailActionModels.swift
+++ b/dogArea/Source/Domain/Auth/Models/AuthMailActionModels.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+enum AuthMailActionType: String, Codable, CaseIterable {
+    case signupConfirmation = "signup_confirmation"
+    case passwordReset = "password_reset"
+    case emailChange = "email_change"
+
+    var analyticsKey: String {
+        rawValue
+    }
+
+    var fallbackCooldownSeconds: Int {
+        switch self {
+        case .signupConfirmation:
+            return 60
+        case .passwordReset:
+            return 75
+        case .emailChange:
+            return 90
+        }
+    }
+
+    var resendButtonTitle: String {
+        switch self {
+        case .signupConfirmation:
+            return "인증 메일 다시 보내기"
+        case .passwordReset:
+            return "재설정 메일 다시 보내기"
+        case .emailChange:
+            return "변경 확인 메일 다시 보내기"
+        }
+    }
+
+    var sendingButtonTitle: String {
+        switch self {
+        case .signupConfirmation:
+            return "인증 메일 보내는 중..."
+        case .passwordReset:
+            return "재설정 메일 보내는 중..."
+        case .emailChange:
+            return "변경 확인 메일 보내는 중..."
+        }
+    }
+
+    /// 액션 타입에 맞는 발송 성공 제목을 반환합니다.
+    /// - Returns: 사용자에게 노출할 성공 상태 제목입니다.
+    func successTitle() -> String {
+        switch self {
+        case .signupConfirmation:
+            return "인증 메일을 보냈어요"
+        case .passwordReset:
+            return "재설정 메일을 보냈어요"
+        case .emailChange:
+            return "변경 확인 메일을 보냈어요"
+        }
+    }
+
+    /// 액션 타입과 수신 이메일에 맞는 성공 안내 문구를 반환합니다.
+    /// - Parameter email: 사용자가 확인할 메일함의 대상 이메일입니다.
+    /// - Returns: 발송 성공 후 사용자에게 보여줄 설명 문구입니다.
+    func successDescription(for email: String) -> String {
+        switch self {
+        case .signupConfirmation:
+            return "\(email) 메일함을 확인한 뒤 프로필 입력을 계속하세요."
+        case .passwordReset:
+            return "\(email) 메일함에서 비밀번호 재설정 링크를 확인하세요."
+        case .emailChange:
+            return "\(email) 메일함에서 이메일 변경 확인 링크를 확인하세요."
+        }
+    }
+
+    /// 액션 타입에 맞는 기본 실패 문구를 반환합니다.
+    /// - Returns: 구체적인 서버 메시지가 없을 때 사용할 사용자 안내 문구입니다.
+    func defaultFailureMessage() -> String {
+        switch self {
+        case .signupConfirmation:
+            return "인증 메일을 보내지 못했습니다. 네트워크를 확인하고 다시 시도해주세요."
+        case .passwordReset:
+            return "재설정 메일을 보내지 못했습니다. 네트워크를 확인하고 다시 시도해주세요."
+        case .emailChange:
+            return "변경 확인 메일을 보내지 못했습니다. 잠시 후 다시 시도해주세요."
+        }
+    }
+}
+
+struct AuthMailActionKey: Hashable, Codable {
+    let actionType: AuthMailActionType
+    let recipient: String
+    let context: String?
+
+    /// 액션 타입/수신자/부가 문맥을 정규화해 고유 키를 생성합니다.
+    /// - Parameters:
+    ///   - actionType: 메일 상태를 분리할 액션 타입입니다.
+    ///   - recipient: 메일을 받는 정규화 대상 이메일입니다.
+    ///   - context: 같은 액션 안에서도 세부 흐름을 분리하고 싶을 때 사용하는 선택 문맥입니다.
+    init(actionType: AuthMailActionType, recipient: String, context: String? = nil) {
+        self.actionType = actionType
+        self.recipient = recipient.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedContext = context?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        self.context = normalizedContext?.isEmpty == true ? nil : normalizedContext
+    }
+
+    var storageKey: String {
+        if let context, context.isEmpty == false {
+            return "\(actionType.rawValue)::\(recipient)::\(context)"
+        }
+        return "\(actionType.rawValue)::\(recipient)"
+    }
+}
+
+enum AuthMailResendState: Equatable {
+    case idle
+    case sending
+    case sent(remainingSeconds: Int)
+    case cooldown(remainingSeconds: Int)
+    case rateLimited(remainingSeconds: Int)
+    case failed(message: String)
+
+    var remainingSeconds: Int? {
+        switch self {
+        case .sent(let remainingSeconds), .cooldown(let remainingSeconds), .rateLimited(let remainingSeconds):
+            return remainingSeconds
+        case .idle, .sending, .failed:
+            return nil
+        }
+    }
+
+    var isRequestAllowed: Bool {
+        switch self {
+        case .idle, .failed:
+            return true
+        case .sending, .sent, .cooldown, .rateLimited:
+            return false
+        }
+    }
+
+    /// 현재 상태에 맞는 버튼 타이틀을 반환합니다.
+    /// - Parameter actionType: 버튼 문구를 정할 메일 액션 타입입니다.
+    /// - Returns: 사용자가 탭할 버튼의 상태별 제목입니다.
+    func buttonTitle(for actionType: AuthMailActionType) -> String {
+        switch self {
+        case .idle, .failed:
+            return actionType.resendButtonTitle
+        case .sending:
+            return actionType.sendingButtonTitle
+        case .sent(let remainingSeconds), .cooldown(let remainingSeconds), .rateLimited(let remainingSeconds):
+            return "\(remainingSeconds)초 후 다시 보내기"
+        }
+    }
+
+    /// 현재 상태에 맞는 사용자 설명 문구를 반환합니다.
+    /// - Parameters:
+    ///   - actionType: 설명 문구를 정할 메일 액션 타입입니다.
+    ///   - email: 안내 대상 이메일입니다.
+    /// - Returns: 상태 카드나 보조 문구에 표시할 사용자 설명입니다.
+    func message(for actionType: AuthMailActionType, email: String) -> String? {
+        switch self {
+        case .idle:
+            return nil
+        case .sending:
+            return "응답을 기다리는 중이에요. 잠시만 기다려주세요."
+        case .sent:
+            return actionType.successDescription(for: email)
+        case .cooldown(let remainingSeconds):
+            return "방금 메일을 보냈어요. \(remainingSeconds)초 후 다시 보낼 수 있어요."
+        case .rateLimited(let remainingSeconds):
+            return "요청이 많아 잠시 기다린 뒤 다시 보낼 수 있어요. \(remainingSeconds)초 후 다시 시도해주세요."
+        case .failed(let message):
+            return message
+        }
+    }
+}
+
+struct AuthMailResendSnapshot: Codable, Equatable {
+    let actionType: AuthMailActionType
+    let recipient: String
+    let context: String?
+    let sentBannerUntil: TimeInterval
+    let nextAllowedAt: TimeInterval
+    let retryAfterSeconds: Int?
+    let lastUpdatedAt: TimeInterval
+    let wasRateLimited: Bool
+}

--- a/dogArea/Source/Domain/Auth/Services/AuthMailActionStateMachine.swift
+++ b/dogArea/Source/Domain/Auth/Services/AuthMailActionStateMachine.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+protocol AuthMailActionStateStoring {
+    /// 지정한 메일 액션 키에 해당하는 persisted snapshot을 조회합니다.
+    /// - Parameter key: 조회할 메일 액션 고유 키입니다.
+    /// - Returns: 저장된 snapshot이 있으면 해당 값을 반환하고, 없으면 `nil`을 반환합니다.
+    func snapshot(for key: AuthMailActionKey) -> AuthMailResendSnapshot?
+
+    /// 지정한 메일 액션 키에 대한 persisted snapshot을 저장합니다.
+    /// - Parameters:
+    ///   - snapshot: 저장할 메일 액션 상태 snapshot입니다.
+    ///   - key: snapshot을 연결할 메일 액션 고유 키입니다.
+    func save(_ snapshot: AuthMailResendSnapshot, for key: AuthMailActionKey)
+
+    /// 지정한 메일 액션 키에 연결된 persisted snapshot을 제거합니다.
+    /// - Parameter key: 제거할 메일 액션 고유 키입니다.
+    func removeSnapshot(for key: AuthMailActionKey)
+}
+
+protocol AuthMailActionStateManaging {
+    /// persisted snapshot을 해석해 현재 시각 기준의 resend 상태를 반환합니다.
+    /// - Parameters:
+    ///   - key: 해석할 메일 액션 고유 키입니다.
+    ///   - now: 상태 해석 기준 시각입니다.
+    /// - Returns: 현재 시각 기준으로 계산된 resend 상태입니다.
+    func state(for key: AuthMailActionKey, now: Date) -> AuthMailResendState
+
+    /// 현재 상태가 실제 요청 전송을 허용하는지 판정합니다.
+    /// - Parameters:
+    ///   - key: 요청 전송 여부를 확인할 메일 액션 고유 키입니다.
+    ///   - now: 판정 기준 시각입니다.
+    /// - Returns: 현재 메일 액션 요청을 전송해도 되면 `true`, 아니면 `false`입니다.
+    func canSend(for key: AuthMailActionKey, now: Date) -> Bool
+
+    /// 서버 성공 응답을 기준으로 sent/cooldown snapshot을 기록합니다.
+    /// - Parameters:
+    ///   - key: 성공 상태를 기록할 메일 액션 고유 키입니다.
+    ///   - now: 성공 처리 기준 시각입니다.
+    ///   - fallbackCooldownSeconds: `Retry-After`가 없을 때 적용할 보수적 쿨다운 초 단위 값입니다.
+    /// - Returns: 성공 직후 사용자에게 노출할 resend 상태입니다.
+    @discardableResult
+    func recordSuccess(
+        for key: AuthMailActionKey,
+        now: Date,
+        fallbackCooldownSeconds: Int
+    ) -> AuthMailResendState
+
+    /// 429/Retry-After 응답을 기준으로 rate-limited snapshot을 기록합니다.
+    /// - Parameters:
+    ///   - key: 제한 상태를 기록할 메일 액션 고유 키입니다.
+    ///   - retryAfterSeconds: 서버가 준 재시도 대기 시간입니다.
+    ///   - now: 제한 처리 기준 시각입니다.
+    ///   - fallbackCooldownSeconds: 헤더가 없을 때 사용할 보수적 fallback 초 단위 값입니다.
+    /// - Returns: 제한 응답 직후 사용자에게 노출할 resend 상태입니다.
+    @discardableResult
+    func recordRateLimited(
+        for key: AuthMailActionKey,
+        retryAfterSeconds: Int?,
+        now: Date,
+        fallbackCooldownSeconds: Int
+    ) -> AuthMailResendState
+}
+
+final class AuthMailActionStateMachine: AuthMailActionStateManaging {
+    private let store: AuthMailActionStateStoring
+    private let sentBannerSeconds: Int
+
+    /// persisted snapshot 저장소를 주입해 메일 resend 상태 기계를 초기화합니다.
+    /// - Parameters:
+    ///   - store: 액션별 cooldown/rate-limit snapshot 저장소입니다.
+    ///   - sentBannerSeconds: 성공 직후 `sent` 상태를 유지할 초 단위 시간입니다.
+    init(
+        store: AuthMailActionStateStoring = AuthMailActionStateStore(),
+        sentBannerSeconds: Int = 8
+    ) {
+        self.store = store
+        self.sentBannerSeconds = sentBannerSeconds
+    }
+
+    func state(for key: AuthMailActionKey, now: Date = Date()) -> AuthMailResendState {
+        guard let snapshot = store.snapshot(for: key) else {
+            return .idle
+        }
+
+        let nowSeconds = now.timeIntervalSince1970
+        if nowSeconds >= snapshot.nextAllowedAt {
+            store.removeSnapshot(for: key)
+            return .idle
+        }
+
+        let remainingSeconds = max(Int(ceil(snapshot.nextAllowedAt - nowSeconds)), 1)
+        if nowSeconds < snapshot.sentBannerUntil, snapshot.wasRateLimited == false {
+            return .sent(remainingSeconds: remainingSeconds)
+        }
+        if snapshot.wasRateLimited {
+            return .rateLimited(remainingSeconds: remainingSeconds)
+        }
+        return .cooldown(remainingSeconds: remainingSeconds)
+    }
+
+    func canSend(for key: AuthMailActionKey, now: Date = Date()) -> Bool {
+        state(for: key, now: now).isRequestAllowed
+    }
+
+    @discardableResult
+    func recordSuccess(
+        for key: AuthMailActionKey,
+        now: Date = Date(),
+        fallbackCooldownSeconds: Int
+    ) -> AuthMailResendState {
+        let snapshot = AuthMailResendSnapshot(
+            actionType: key.actionType,
+            recipient: key.recipient,
+            context: key.context,
+            sentBannerUntil: now.addingTimeInterval(TimeInterval(sentBannerSeconds)).timeIntervalSince1970,
+            nextAllowedAt: now.addingTimeInterval(TimeInterval(fallbackCooldownSeconds)).timeIntervalSince1970,
+            retryAfterSeconds: nil,
+            lastUpdatedAt: now.timeIntervalSince1970,
+            wasRateLimited: false
+        )
+        store.save(snapshot, for: key)
+        return .sent(remainingSeconds: max(fallbackCooldownSeconds, 1))
+    }
+
+    @discardableResult
+    func recordRateLimited(
+        for key: AuthMailActionKey,
+        retryAfterSeconds: Int?,
+        now: Date = Date(),
+        fallbackCooldownSeconds: Int
+    ) -> AuthMailResendState {
+        let resolvedCooldownSeconds = max(retryAfterSeconds ?? fallbackCooldownSeconds, 1)
+        let snapshot = AuthMailResendSnapshot(
+            actionType: key.actionType,
+            recipient: key.recipient,
+            context: key.context,
+            sentBannerUntil: now.timeIntervalSince1970,
+            nextAllowedAt: now.addingTimeInterval(TimeInterval(resolvedCooldownSeconds)).timeIntervalSince1970,
+            retryAfterSeconds: retryAfterSeconds,
+            lastUpdatedAt: now.timeIntervalSince1970,
+            wasRateLimited: true
+        )
+        store.save(snapshot, for: key)
+        return .rateLimited(remainingSeconds: resolvedCooldownSeconds)
+    }
+}

--- a/dogArea/Source/Infrastructure/Supabase/Services/SupabaseAuthAndAssetServices.swift
+++ b/dogArea/Source/Infrastructure/Supabase/Services/SupabaseAuthAndAssetServices.swift
@@ -47,7 +47,7 @@ enum SupabaseAuthError: LocalizedError {
             }()
             switch errorCode {
             case "over_email_send_rate_limit":
-                return "Supabase 이메일 발송 한도를 초과했습니다.\(retryText) 잠시 후 재시도하거나 SMTP/Rate Limit 설정을 확인해주세요."
+                return "메일 요청이 많아 잠시 뒤 다시 시도할 수 있어요.\(retryText)"
             default:
                 if let message, message.isEmpty == false {
                     return "요청이 너무 많아 인증이 제한되었습니다: \(message)\(retryText)"

--- a/dogArea/Source/Infrastructure/Supabase/Services/SupabaseAuthMailActionService.swift
+++ b/dogArea/Source/Infrastructure/Supabase/Services/SupabaseAuthMailActionService.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+enum AuthMailDispatchRequest: Equatable {
+    case signupConfirmation(email: String)
+    case passwordReset(email: String)
+    case emailChange(email: String)
+
+    var actionType: AuthMailActionType {
+        switch self {
+        case .signupConfirmation:
+            return .signupConfirmation
+        case .passwordReset:
+            return .passwordReset
+        case .emailChange:
+            return .emailChange
+        }
+    }
+
+    var normalizedEmail: String {
+        switch self {
+        case .signupConfirmation(let email), .passwordReset(let email), .emailChange(let email):
+            return email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+    }
+
+    var endpoint: SupabaseEndpoint {
+        switch self {
+        case .signupConfirmation, .emailChange:
+            return .auth(path: "resend")
+        case .passwordReset:
+            return .auth(path: "recover")
+        }
+    }
+
+    var payload: [String: String] {
+        switch self {
+        case .signupConfirmation(let email):
+            return [
+                "type": "signup",
+                "email": email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            ]
+        case .passwordReset(let email):
+            return [
+                "email": email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            ]
+        case .emailChange(let email):
+            return [
+                "type": "email_change",
+                "email": email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            ]
+        }
+    }
+}
+
+protocol AuthMailActionDispatching {
+    /// 메일 액션 요청을 서버로 전송합니다.
+    /// - Parameter request: 발송할 메일 액션 요청입니다.
+    func send(_ request: AuthMailDispatchRequest) async throws
+}
+
+final class SupabaseAuthMailActionService: AuthMailActionDispatching {
+    private let session: URLSession
+    private let configLoader: () -> SupabaseRuntimeConfig?
+
+    /// Supabase Auth 메일 액션 디스패처를 초기화합니다.
+    /// - Parameters:
+    ///   - session: HTTP 요청에 사용할 URLSession입니다.
+    ///   - configLoader: 런타임 Supabase 설정을 읽어오는 클로저입니다.
+    init(
+        session: URLSession = .shared,
+        configLoader: @escaping () -> SupabaseRuntimeConfig? = { SupabaseRuntimeConfig.load() }
+    ) {
+        self.session = session
+        self.configLoader = configLoader
+    }
+
+    func send(_ request: AuthMailDispatchRequest) async throws {
+        guard let config = configLoader() else {
+            throw SupabaseAuthError.notConfigured
+        }
+
+        let url = request.endpoint.resolveURL(baseURL: config.baseURL)
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = HTTPMethod.post.rawValue
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue(config.anonKey, forHTTPHeaderField: "apikey")
+        urlRequest.setValue("Bearer \(config.anonKey)", forHTTPHeaderField: "Authorization")
+        urlRequest.httpBody = try JSONEncoder().encode(request.payload)
+
+        #if DEBUG
+        print("[AuthMail] -> action=\(request.actionType.analyticsKey) endpoint=\(url.absoluteString) email=\(request.normalizedEmail)")
+        #endif
+        let startedAt = Date()
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: urlRequest)
+        } catch {
+            #if DEBUG
+            let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+            print("[AuthMail] xx action=\(request.actionType.analyticsKey) elapsed=\(elapsedMs)ms error=\(error.localizedDescription)")
+            #endif
+            throw SupabaseAuthError.requestFailed(request.actionType.defaultFailureMessage())
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SupabaseAuthError.responseDecodeFailed
+        }
+
+        let statusCode = httpResponse.statusCode
+        let errorPayload = decodeLooseAuthErrorPayload(from: data)
+        let errorCode = errorPayload.errorCode ?? httpResponse.value(forHTTPHeaderField: "x-sb-error-code")
+        let retryAfterSeconds = retryAfterSeconds(from: httpResponse)
+
+        #if DEBUG
+        let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+        let bodyPreview = String(decoding: data.prefix(180), as: UTF8.self)
+        print("[AuthMail] <- action=\(request.actionType.analyticsKey) status=\(statusCode) elapsed=\(elapsedMs)ms errorCode=\(errorCode ?? "none") retryAfter=\(retryAfterSeconds.map(String.init) ?? "none") body=\(bodyPreview)")
+        #endif
+
+        guard (200..<300).contains(statusCode) else {
+            if statusCode == 429 {
+                throw SupabaseAuthError.rateLimited(
+                    message: normalizedRateLimitMessage(for: request),
+                    errorCode: errorCode,
+                    retryAfterSeconds: retryAfterSeconds
+                )
+            }
+            throw SupabaseAuthError.requestFailed(
+                normalizedFailureMessage(for: request, upstreamMessage: errorPayload.message)
+            )
+        }
+    }
+
+    /// 서버가 제공한 원본 오류와 액션 타입을 바탕으로 사용자용 실패 문구를 정규화합니다.
+    /// - Parameters:
+    ///   - request: 실패한 메일 액션 요청입니다.
+    ///   - upstreamMessage: 서버 응답에서 추출한 원본 오류 메시지입니다.
+    /// - Returns: 내부 운영 용어를 제거한 사용자용 실패 안내 문구입니다.
+    private func normalizedFailureMessage(
+        for request: AuthMailDispatchRequest,
+        upstreamMessage: String?
+    ) -> String {
+        let trimmedMessage = upstreamMessage?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedMessage, trimmedMessage.isEmpty == false,
+           trimmedMessage.contains("SMTP") == false,
+           trimmedMessage.contains("Rate Limit") == false {
+            return trimmedMessage
+        }
+        return request.actionType.defaultFailureMessage()
+    }
+
+    /// 429 응답을 메일 액션별 사용자 안내 문구로 정규화합니다.
+    /// - Parameter request: rate-limit이 발생한 메일 액션 요청입니다.
+    /// - Returns: 사용자에게 보여줄 보수적 429 안내 문구입니다.
+    private func normalizedRateLimitMessage(for request: AuthMailDispatchRequest) -> String {
+        switch request.actionType {
+        case .signupConfirmation:
+            return "인증 메일 요청이 많아 잠시 뒤 다시 보낼 수 있어요."
+        case .passwordReset:
+            return "재설정 메일 요청이 많아 잠시 뒤 다시 보낼 수 있어요."
+        case .emailChange:
+            return "변경 확인 메일 요청이 많아 잠시 뒤 다시 보낼 수 있어요."
+        }
+    }
+
+    /// Auth 오류 응답을 느슨하게 디코딩해 메시지와 오류 코드를 추출합니다.
+    /// - Parameter data: 서버가 반환한 응답 바디 데이터입니다.
+    /// - Returns: 메시지와 오류 코드의 느슨한 파싱 결과입니다.
+    private func decodeLooseAuthErrorPayload(from data: Data) -> (message: String?, errorCode: String?) {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return (nil, nil)
+        }
+        let message = (object["error_description"] as? String)
+            ?? (object["message"] as? String)
+            ?? (object["msg"] as? String)
+            ?? (object["error"] as? String)
+        let errorCode = object["error_code"] as? String
+        return (message, errorCode)
+    }
+
+    /// HTTP 응답에서 `Retry-After` 헤더를 초 단위 값으로 해석합니다.
+    /// - Parameter response: Supabase Auth HTTP 응답 객체입니다.
+    /// - Returns: 유효한 `Retry-After` 값이 있으면 초 단위 정수를, 없으면 `nil`을 반환합니다.
+    private func retryAfterSeconds(from response: HTTPURLResponse) -> Int? {
+        guard let rawValue = response.value(forHTTPHeaderField: "Retry-After")?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              rawValue.isEmpty == false,
+              let seconds = Int(rawValue),
+              seconds >= 0 else {
+            return nil
+        }
+        return seconds
+    }
+}

--- a/dogArea/Source/UserDefaultsSupport/AppMetricTracker.swift
+++ b/dogArea/Source/UserDefaultsSupport/AppMetricTracker.swift
@@ -3,6 +3,10 @@ import Foundation
 enum AppMetricEvent: String {
     case walkSaveSuccess = "walk_save_success"
     case walkSaveFailed = "walk_save_failed"
+    case authMailActionSucceeded = "auth_mail_action_succeeded"
+    case authMailActionRateLimited = "auth_mail_action_rate_limited"
+    case authMailActionFailed = "auth_mail_action_failed"
+    case authMailActionSuppressed = "auth_mail_action_suppressed"
     case watchActionReceived = "watch_action_received"
     case watchActionProcessed = "watch_action_processed"
     case watchActionApplied = "watch_action_applied"

--- a/dogArea/Source/UserDefaultsSupport/AuthMailActionStateStore.swift
+++ b/dogArea/Source/UserDefaultsSupport/AuthMailActionStateStore.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+final class AuthMailActionStateStore: AuthMailActionStateStoring {
+    private let defaults: UserDefaults
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let namespace: String
+
+    /// 메일 resend snapshot을 UserDefaults에 저장하는 구현을 초기화합니다.
+    /// - Parameters:
+    ///   - defaults: snapshot persistence에 사용할 UserDefaults 저장소입니다.
+    ///   - encoder: snapshot 인코딩에 사용할 JSON 인코더입니다.
+    ///   - decoder: snapshot 디코딩에 사용할 JSON 디코더입니다.
+    ///   - namespace: 액션별 저장 키 앞에 붙일 네임스페이스 접두사입니다.
+    init(
+        defaults: UserDefaults = .standard,
+        encoder: JSONEncoder = JSONEncoder(),
+        decoder: JSONDecoder = JSONDecoder(),
+        namespace: String = "auth.mail.resend.snapshot.v1"
+    ) {
+        self.defaults = defaults
+        self.encoder = encoder
+        self.decoder = decoder
+        self.namespace = namespace
+    }
+
+    func snapshot(for key: AuthMailActionKey) -> AuthMailResendSnapshot? {
+        guard let data = defaults.data(forKey: storageKey(for: key)) else {
+            return nil
+        }
+        return try? decoder.decode(AuthMailResendSnapshot.self, from: data)
+    }
+
+    func save(_ snapshot: AuthMailResendSnapshot, for key: AuthMailActionKey) {
+        guard let data = try? encoder.encode(snapshot) else { return }
+        defaults.set(data, forKey: storageKey(for: key))
+    }
+
+    func removeSnapshot(for key: AuthMailActionKey) {
+        defaults.removeObject(forKey: storageKey(for: key))
+    }
+
+    /// 네임스페이스와 액션 키를 결합해 저장소 키를 생성합니다.
+    /// - Parameter key: 저장/조회/삭제에 사용할 메일 액션 고유 키입니다.
+    /// - Returns: UserDefaults에 실제로 사용할 문자열 키입니다.
+    private func storageKey(for key: AuthMailActionKey) -> String {
+        "\(namespace).\(key.storageKey)"
+    }
+}

--- a/dogArea/Views/SigningView/Components/AuthMailActionStatusCardView.swift
+++ b/dogArea/Views/SigningView/Components/AuthMailActionStatusCardView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct AuthMailActionStatusCardView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let actionType: AuthMailActionType
+    let email: String
+    let state: AuthMailResendState
+    let messageOverride: String?
+    let resendAccessibilityIdentifier: String
+    let continueAccessibilityIdentifier: String?
+    let onResend: () -> Void
+    let onContinue: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Circle()
+                    .fill(statusTint.opacity(0.16))
+                    .frame(width: 38, height: 38)
+                    .overlay {
+                        Image(systemName: statusIconName)
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(statusTint)
+                    }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(statusTitle)
+                        .font(.appFont(for: .SemiBold, size: 16))
+                        .foregroundStyle(Color.appColor(type: .appTextBlack, scheme: colorScheme))
+                    if let message = messageOverride ?? state.message(for: actionType, email: email) {
+                        Text(message)
+                            .font(.appFont(for: .Regular, size: 12))
+                            .foregroundStyle(Color.appTextDarkGray)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button(state.buttonTitle(for: actionType)) {
+                    onResend()
+                }
+                .buttonStyle(AppFilledButtonStyle(role: state.isRequestAllowed ? .primary : .neutral, fillsWidth: false))
+                .disabled(state.isRequestAllowed == false)
+                .accessibilityIdentifier(resendAccessibilityIdentifier)
+
+                if let onContinue, let continueAccessibilityIdentifier {
+                    Button("프로필 입력 계속") {
+                        onContinue()
+                    }
+                    .buttonStyle(AppFilledButtonStyle(role: .neutral, fillsWidth: false))
+                    .accessibilityIdentifier(continueAccessibilityIdentifier)
+                }
+            }
+        }
+        .appCardSurface()
+    }
+
+    private var statusTitle: String {
+        switch state {
+        case .idle, .sending, .sent, .cooldown, .rateLimited:
+            return actionType.successTitle()
+        case .failed:
+            return "다시 확인이 필요해요"
+        }
+    }
+
+    private var statusTint: Color {
+        switch state {
+        case .failed:
+            return Color.appRed
+        case .rateLimited:
+            return Color.appYellow
+        case .idle, .sending, .sent, .cooldown:
+            return Color.appGreen
+        }
+    }
+
+    private var statusIconName: String {
+        switch state {
+        case .failed:
+            return "exclamationmark.circle.fill"
+        case .rateLimited:
+            return "clock.badge.exclamationmark"
+        case .idle, .sending, .sent, .cooldown:
+            return "envelope.badge.fill"
+        }
+    }
+}

--- a/dogArea/Views/SigningView/Components/EmailSignUpSheetView.swift
+++ b/dogArea/Views/SigningView/Components/EmailSignUpSheetView.swift
@@ -60,6 +60,11 @@ struct EmailSignUpSheetView: View {
         }
     }
 
+    private enum SignUpSheetMode {
+        case form
+        case confirmation(outcome: AuthUseCaseOutcome, email: String)
+    }
+
     @Environment(\.dismiss) private var dismiss
     @FocusState private var focusedField: SignUpField?
 
@@ -67,15 +72,22 @@ struct EmailSignUpSheetView: View {
     @State private var password: String = ""
     @State private var confirmPassword: String = ""
     @State private var loading: Bool = false
+    @State private var isMailActionDispatching: Bool = false
     @State private var errorMessage: String? = nil
     @State private var emailValidationState: FieldValidationState = .idle
     @State private var passwordValidationState: FieldValidationState = .idle
     @State private var confirmPasswordValidationState: FieldValidationState = .idle
     @State private var lastValidatedEmail: String = ""
     @State private var emailValidationTask: Task<Void, Never>? = nil
+    @State private var signUpSheetMode: SignUpSheetMode = .form
+    @State private var signUpMailState: AuthMailResendState = .idle
+    @State private var mailActionTickerTask: Task<Void, Never>? = nil
 
     private let authUseCase: AuthUseCaseProtocol
     private let emailValidationService: SignUpEmailValidationServicing
+    private let authMailActionService: AuthMailActionDispatching
+    private let authMailStateMachine: AuthMailActionStateManaging
+    private let metricTracker: AppMetricTracker
     private let onOutcome: (AuthUseCaseOutcome) -> Void
     private let minimumPasswordLength: Int = 8
 
@@ -84,16 +96,55 @@ struct EmailSignUpSheetView: View {
     ///   - initialEmail: 로그인 화면에서 전달받은 초기 이메일 값입니다.
     ///   - authUseCase: 이메일 회원가입 요청을 수행할 인증 유즈케이스입니다.
     ///   - emailValidationService: 이메일 중복 확인 RPC 요청을 수행하는 검증 서비스입니다.
+    ///   - authMailActionService: 인증 메일 resend 요청을 수행하는 서비스입니다.
+    ///   - authMailStateMachine: 메일 resend state machine을 계산하는 서비스입니다.
+    ///   - metricTracker: 메일 액션 telemetry를 전송하는 metric 추적기입니다.
     ///   - onOutcome: 회원가입 성공 시 상위 화면으로 전달할 인증 결과 콜백입니다.
     init(
         initialEmail: String,
         authUseCase: AuthUseCaseProtocol,
         emailValidationService: SignUpEmailValidationServicing = SupabaseSignUpEmailValidationService(),
+        authMailActionService: AuthMailActionDispatching = SupabaseAuthMailActionService(),
+        authMailStateMachine: AuthMailActionStateManaging = AuthMailActionStateMachine(),
+        metricTracker: AppMetricTracker = .shared,
         onOutcome: @escaping (AuthUseCaseOutcome) -> Void
     ) {
-        self._email = State(initialValue: initialEmail)
+        let arguments = ProcessInfo.processInfo.arguments
+        let previewEmail: String?
+        if let previewIndex = arguments.firstIndex(of: "-UITest.SignUpMailPreviewEmail"),
+           arguments.indices.contains(previewIndex + 1) {
+            let rawPreviewEmail = arguments[previewIndex + 1]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            previewEmail = rawPreviewEmail.isEmpty ? nil : rawPreviewEmail
+        } else {
+            previewEmail = nil
+        }
+
+        let resolvedInitialEmail = previewEmail ?? initialEmail
+        self._email = State(initialValue: resolvedInitialEmail)
+        if let previewEmail {
+            self._signUpSheetMode = State(
+                initialValue: .confirmation(
+                    outcome: AuthUseCaseOutcome(
+                        identity: AuthenticatedUserIdentity(
+                            userId: "uitest-signup-preview",
+                            email: previewEmail
+                        ),
+                        displayNameHint: nil,
+                        requiresOnboarding: true
+                    ),
+                    email: previewEmail
+                )
+            )
+        } else {
+            self._signUpSheetMode = State(initialValue: .form)
+        }
         self.authUseCase = authUseCase
         self.emailValidationService = emailValidationService
+        self.authMailActionService = authMailActionService
+        self.authMailStateMachine = authMailStateMachine
+        self.metricTracker = metricTracker
         self.onOutcome = onOutcome
     }
 
@@ -102,98 +153,12 @@ struct EmailSignUpSheetView: View {
             VStack(spacing: 14) {
                 TitleTextView(title: "이메일 회원가입", subTitle: "가입 정보를 입력해주세요.")
 
-                VStack(spacing: 8) {
-                    TextField("이메일", text: $email)
-                        .keyboardType(.emailAddress)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled(true)
-                        .textContentType(.username)
-                        .submitLabel(.next)
-                        .focused($focusedField, equals: .email)
-                        .onSubmit {
-                            handleEmailSubmit()
-                        }
-                        .onChange(of: email) { _, _ in
-                            handleEmailInputChanged()
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 12)
-                        .background(Color.appSurface)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .stroke(emailValidationState.borderColor, lineWidth: 1.2)
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                        .accessibilityIdentifier("signup.email")
-                    if let message = emailValidationState.message {
-                        Text(message)
-                            .font(.appFont(for: .Regular, size: 11))
-                            .foregroundStyle(emailValidationState.messageColor)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-
-                    SecureField("비밀번호", text: $password)
-                        .textContentType(.newPassword)
-                        .submitLabel(.next)
-                        .focused($focusedField, equals: .password)
-                        .onSubmit {
-                            handlePasswordSubmit()
-                        }
-                        .onChange(of: password) { _, _ in
-                            handlePasswordInputChanged()
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 12)
-                        .background(Color.appSurface)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .stroke(passwordValidationState.borderColor, lineWidth: 1.2)
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                        .accessibilityIdentifier("signup.password")
-                    if let message = passwordValidationState.message {
-                        Text(message)
-                            .font(.appFont(for: .Regular, size: 11))
-                            .foregroundStyle(passwordValidationState.messageColor)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-
-                    SecureField("비밀번호 확인", text: $confirmPassword)
-                        .textContentType(.newPassword)
-                        .submitLabel(.done)
-                        .focused($focusedField, equals: .confirmPassword)
-                        .onSubmit {
-                            handleConfirmPasswordSubmit()
-                        }
-                        .onChange(of: confirmPassword) { _, _ in
-                            validatePasswordFields(triggerHaptic: false)
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 12)
-                        .background(Color.appSurface)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .stroke(confirmPasswordValidationState.borderColor, lineWidth: 1.2)
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                        .accessibilityIdentifier("signup.passwordConfirm")
-                    if let message = confirmPasswordValidationState.message {
-                        Text(message)
-                            .font(.appFont(for: .Regular, size: 11))
-                            .foregroundStyle(confirmPasswordValidationState.messageColor)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-
-                    Button("회원가입 계속") {
-                        submitSignUp()
-                    }
-                    .accessibilityIdentifier("signup.submit")
-                    .buttonStyle(AppFilledButtonStyle(role: .primary))
-                    .disabled(loading)
+                switch signUpSheetMode {
+                case .form:
+                    signUpFormContent
+                case .confirmation(_, let confirmedEmail):
+                    signUpConfirmationContent(email: confirmedEmail)
                 }
-                .padding(.horizontal, 20)
-                .appCardSurface()
-                .padding(.horizontal, 16)
 
                 if loading {
                     ProgressView("회원가입 처리 중...")
@@ -210,12 +175,22 @@ struct EmailSignUpSheetView: View {
                 Spacer()
             }
             .background(Color.appBackground)
-            .accessibilityIdentifier("screen.signup")
+            .overlay(alignment: .topLeading) {
+                Color.clear
+                    .frame(width: 2, height: 2)
+                    .allowsHitTesting(false)
+                    .accessibilityIdentifier("screen.signup")
+            }
+            .onAppear {
+                refreshSignUpMailState()
+                startMailActionTicker()
+            }
             .onChange(of: focusedField) { oldValue, newValue in
                 handleFocusTransition(from: oldValue, to: newValue)
             }
             .onDisappear {
                 emailValidationTask?.cancel()
+                mailActionTickerTask?.cancel()
             }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -230,7 +205,154 @@ struct EmailSignUpSheetView: View {
         }
     }
 
-    /// 이메일 회원가입을 실행하고 성공 시 상위 인증 플로우로 결과를 전달합니다.
+    private var signUpFormContent: some View {
+        VStack(spacing: 12) {
+            VStack(spacing: 8) {
+                TextField("이메일", text: $email)
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .textContentType(.username)
+                    .submitLabel(.next)
+                    .focused($focusedField, equals: .email)
+                    .onSubmit {
+                        handleEmailSubmit()
+                    }
+                    .onChange(of: email) { _, _ in
+                        handleEmailInputChanged()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 12)
+                    .background(Color.appSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(emailValidationState.borderColor, lineWidth: 1.2)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .accessibilityIdentifier("signup.email")
+                if let message = emailValidationState.message {
+                    Text(message)
+                        .font(.appFont(for: .Regular, size: 11))
+                        .foregroundStyle(emailValidationState.messageColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                SecureField("비밀번호", text: $password)
+                    .textContentType(.newPassword)
+                    .submitLabel(.next)
+                    .focused($focusedField, equals: .password)
+                    .onSubmit {
+                        handlePasswordSubmit()
+                    }
+                    .onChange(of: password) { _, _ in
+                        handlePasswordInputChanged()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 12)
+                    .background(Color.appSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(passwordValidationState.borderColor, lineWidth: 1.2)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .accessibilityIdentifier("signup.password")
+                if let message = passwordValidationState.message {
+                    Text(message)
+                        .font(.appFont(for: .Regular, size: 11))
+                        .foregroundStyle(passwordValidationState.messageColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                SecureField("비밀번호 확인", text: $confirmPassword)
+                    .textContentType(.newPassword)
+                    .submitLabel(.done)
+                    .focused($focusedField, equals: .confirmPassword)
+                    .onSubmit {
+                        handleConfirmPasswordSubmit()
+                    }
+                    .onChange(of: confirmPassword) { _, _ in
+                        validatePasswordFields(triggerHaptic: false)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 12)
+                    .background(Color.appSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(confirmPasswordValidationState.borderColor, lineWidth: 1.2)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .accessibilityIdentifier("signup.passwordConfirm")
+                if let message = confirmPasswordValidationState.message {
+                    Text(message)
+                        .font(.appFont(for: .Regular, size: 11))
+                        .foregroundStyle(confirmPasswordValidationState.messageColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                Button("회원가입 계속") {
+                    submitSignUp()
+                }
+                .accessibilityIdentifier("signup.submit")
+                .buttonStyle(AppFilledButtonStyle(role: .primary))
+                .disabled(loading || isMailActionDispatching)
+            }
+            .padding(.horizontal, 20)
+            .appCardSurface()
+            .padding(.horizontal, 16)
+
+            if shouldShowFormMailStatusCard, let email = activeMailActionEmail {
+                AuthMailActionStatusCardView(
+                    actionType: .signupConfirmation,
+                    email: email,
+                    state: signUpMailState,
+                    messageOverride: nil,
+                    resendAccessibilityIdentifier: "signup.mail.resend",
+                    continueAccessibilityIdentifier: nil,
+                    onResend: {
+                        resendSignupConfirmationMail()
+                    },
+                    onContinue: nil
+                )
+                .padding(.horizontal, 16)
+                .overlay(alignment: .topLeading) {
+                    Color.clear
+                        .frame(width: 2, height: 2)
+                        .allowsHitTesting(false)
+                        .accessibilityIdentifier("signup.mail.status")
+                }
+            }
+        }
+    }
+
+    /// 회원가입 성공 후 메일 resend 상태와 프로필 입력 진입 버튼을 구성합니다.
+    /// - Parameter email: 방금 인증 메일을 발송한 정규화 이메일입니다.
+    /// - Returns: 성공 직후 확인/재발송/계속 진행 UI를 포함한 확인 콘텐츠입니다.
+    @ViewBuilder
+    private func signUpConfirmationContent(email: String) -> some View {
+        AuthMailActionStatusCardView(
+            actionType: .signupConfirmation,
+            email: email,
+            state: signUpMailState,
+            messageOverride: confirmationMessageOverride(for: email),
+            resendAccessibilityIdentifier: "signup.mail.resend",
+            continueAccessibilityIdentifier: "signup.mail.continue",
+            onResend: {
+                resendSignupConfirmationMail()
+            },
+            onContinue: {
+                continueToProfileSetup()
+            }
+        )
+        .padding(.horizontal, 16)
+        .overlay(alignment: .topLeading) {
+            Color.clear
+                .frame(width: 2, height: 2)
+                .allowsHitTesting(false)
+                .accessibilityIdentifier("signup.mail.status")
+        }
+    }
+
+    /// 이메일 회원가입을 실행하고 성공 시 메일 확인 단계를 거쳐 상위 인증 플로우로 결과를 전달합니다.
     private func submitSignUp() {
         errorMessage = nil
 
@@ -248,12 +370,20 @@ struct EmailSignUpSheetView: View {
             return
         }
 
+        guard let actionKey = makeSignUpMailActionKey(for: normalizedEmail),
+              allowMailActionRequest(for: actionKey, surface: "signup_submit") else {
+            return
+        }
+
         loading = true
+        signUpMailState = .sending
+
         Task {
             let isEmailAvailable = await ensureEmailAvailabilityBeforeSubmit(email: normalizedEmail)
             guard isEmailAvailable else {
                 await MainActor.run {
                     loading = false
+                    refreshSignUpMailState()
                 }
                 return
             }
@@ -263,17 +393,73 @@ struct EmailSignUpSheetView: View {
                 )
                 await MainActor.run {
                     loading = false
-                    onOutcome(outcome)
-                    dismiss()
+                    signUpSheetMode = .confirmation(outcome: outcome, email: normalizedEmail)
+                    signUpMailState = authMailStateMachine.recordSuccess(
+                        for: actionKey,
+                        now: Date(),
+                        fallbackCooldownSeconds: actionKey.actionType.fallbackCooldownSeconds
+                    )
+                    trackAuthMailEvent(
+                        .authMailActionSucceeded,
+                        actionType: actionKey.actionType,
+                        surface: "signup_submit",
+                        retryAfterSeconds: nil,
+                        duplicateSuppressed: false
+                    )
+                    errorMessage = nil
                 }
             } catch {
                 await MainActor.run {
                     loading = false
-                    errorMessage = error.localizedDescription
-                    AppHapticFeedback.questFailed()
+                    handleMailActionFailure(error, for: actionKey, surface: "signup_submit")
                 }
             }
         }
+    }
+
+    /// 회원가입 확인 메일 resend 요청을 실행하고 상태 기계를 갱신합니다.
+    private func resendSignupConfirmationMail() {
+        guard let actionKey = activeMailActionKey else { return }
+        guard allowMailActionRequest(for: actionKey, surface: "signup_resend") else {
+            return
+        }
+
+        errorMessage = nil
+        isMailActionDispatching = true
+        signUpMailState = .sending
+
+        Task {
+            do {
+                try await authMailActionService.send(.signupConfirmation(email: actionKey.recipient))
+                await MainActor.run {
+                    isMailActionDispatching = false
+                    signUpMailState = authMailStateMachine.recordSuccess(
+                        for: actionKey,
+                        now: Date(),
+                        fallbackCooldownSeconds: actionKey.actionType.fallbackCooldownSeconds
+                    )
+                    trackAuthMailEvent(
+                        .authMailActionSucceeded,
+                        actionType: actionKey.actionType,
+                        surface: "signup_resend",
+                        retryAfterSeconds: nil,
+                        duplicateSuppressed: false
+                    )
+                }
+            } catch {
+                await MainActor.run {
+                    isMailActionDispatching = false
+                    handleMailActionFailure(error, for: actionKey, surface: "signup_resend")
+                }
+            }
+        }
+    }
+
+    /// 메일 확인 단계를 마친 뒤 상위 인증 플로우로 결과를 전달하고 시트를 닫습니다.
+    private func continueToProfileSetup() {
+        guard case let .confirmation(outcome, _) = signUpSheetMode else { return }
+        onOutcome(outcome)
+        dismiss()
     }
 
     /// 회원가입 입력값을 로컬에서 검증하고 실패 사유를 반환합니다.
@@ -310,14 +496,16 @@ struct EmailSignUpSheetView: View {
         return email.range(of: pattern, options: .regularExpression) != nil
     }
 
-    /// 이메일 입력값 변경 시 기존 서버 검증 상태를 초기화합니다.
+    /// 이메일 입력값 변경 시 기존 서버 검증 상태를 초기화하고 메일 resend 상태를 다시 계산합니다.
     private func handleEmailInputChanged() {
         lastValidatedEmail = ""
         emailValidationTask?.cancel()
         if case .idle = emailValidationState {
+            refreshSignUpMailState()
             return
         }
         emailValidationState = .idle
+        refreshSignUpMailState()
     }
 
     /// 비밀번호 입력값 변경 시 형식/확인값 검증 상태를 재계산합니다.
@@ -489,6 +677,249 @@ struct EmailSignUpSheetView: View {
         let hasLetter = password.range(of: #"[A-Za-z]"#, options: .regularExpression) != nil
         let hasNumber = password.range(of: #"[0-9]"#, options: .regularExpression) != nil
         return hasLetter && hasNumber
+    }
+
+    /// 현재 입력/확인 단계에 대응하는 메일 resend 상태를 다시 계산합니다.
+    private func refreshSignUpMailState() {
+        guard let actionKey = activeMailActionKey else {
+            if isMailActionDispatching == false {
+                signUpMailState = .idle
+            }
+            return
+        }
+        if let uiTestOverride = resolvedUITestMailStateOverride() {
+            signUpMailState = uiTestOverride
+            return
+        }
+        if isMailActionDispatching || loading {
+            return
+        }
+        signUpMailState = authMailStateMachine.state(for: actionKey, now: Date())
+    }
+
+    /// cooldown/rate-limit 카운트다운이 자연스럽게 줄어들도록 1초 주기 ticker를 시작합니다.
+    private func startMailActionTicker() {
+        mailActionTickerTask?.cancel()
+        mailActionTickerTask = Task {
+            while Task.isCancelled == false {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard Task.isCancelled == false else { return }
+                await MainActor.run {
+                    refreshSignUpMailState()
+                }
+            }
+        }
+    }
+
+    /// 메일 액션 요청이 현재 시점에 허용되는지 확인하고, 막힌 경우 사용자/metric/log 상태를 함께 갱신합니다.
+    /// - Parameters:
+    ///   - key: 전송 여부를 판정할 메일 액션 키입니다.
+    ///   - surface: 요청 진입 화면/버튼을 식별할 표면 이름입니다.
+    /// - Returns: 현재 요청을 보내도 되면 `true`, 아니면 `false`입니다.
+    private func allowMailActionRequest(for key: AuthMailActionKey, surface: String) -> Bool {
+        if loading || isMailActionDispatching {
+            trackAuthMailEvent(
+                .authMailActionSuppressed,
+                actionType: key.actionType,
+                surface: surface,
+                retryAfterSeconds: signUpMailState.remainingSeconds,
+                duplicateSuppressed: true
+            )
+            return false
+        }
+
+        if let uiTestOverride = resolvedUITestMailStateOverride() {
+            signUpMailState = uiTestOverride
+            if uiTestOverride.isRequestAllowed == false {
+                errorMessage = uiTestOverride.message(for: key.actionType, email: key.recipient)
+                    ?? "잠시 후 다시 시도해주세요."
+                return false
+            }
+        }
+
+        let resolvedState = authMailStateMachine.state(for: key, now: Date())
+        signUpMailState = resolvedState
+        guard resolvedState.isRequestAllowed else {
+            errorMessage = resolvedState.message(for: key.actionType, email: key.recipient)
+                ?? "잠시 후 다시 시도해주세요."
+            AppHapticFeedback.questFailed()
+            trackAuthMailEvent(
+                .authMailActionSuppressed,
+                actionType: key.actionType,
+                surface: surface,
+                retryAfterSeconds: resolvedState.remainingSeconds,
+                duplicateSuppressed: true
+            )
+            return false
+        }
+        return true
+    }
+
+    /// 서버 응답 오류를 resend 상태 기계와 사용자 문구로 변환합니다.
+    /// - Parameters:
+    ///   - error: 서버 또는 네트워크에서 발생한 오류입니다.
+    ///   - key: 상태를 갱신할 메일 액션 키입니다.
+    ///   - surface: 오류가 발생한 화면/버튼 진입점입니다.
+    private func handleMailActionFailure(
+        _ error: Error,
+        for key: AuthMailActionKey,
+        surface: String
+    ) {
+        if case let SupabaseAuthError.rateLimited(_, _, retryAfterSeconds) = error {
+            signUpMailState = authMailStateMachine.recordRateLimited(
+                for: key,
+                retryAfterSeconds: retryAfterSeconds,
+                now: Date(),
+                fallbackCooldownSeconds: key.actionType.fallbackCooldownSeconds
+            )
+            errorMessage = signUpMailState.message(for: key.actionType, email: key.recipient)
+            trackAuthMailEvent(
+                .authMailActionRateLimited,
+                actionType: key.actionType,
+                surface: surface,
+                retryAfterSeconds: retryAfterSeconds,
+                duplicateSuppressed: false
+            )
+        } else {
+            let failureMessage = normalizedMailActionFailureMessage(error, actionType: key.actionType)
+            signUpMailState = .failed(message: failureMessage)
+            errorMessage = failureMessage
+            trackAuthMailEvent(
+                .authMailActionFailed,
+                actionType: key.actionType,
+                surface: surface,
+                retryAfterSeconds: nil,
+                duplicateSuppressed: false
+            )
+        }
+        AppHapticFeedback.questFailed()
+    }
+
+    /// 현재 confirmation 단계에서 idle 상태가 되더라도 성공 안내 문구를 유지하기 위한 override를 생성합니다.
+    /// - Parameter email: confirmation 상태의 대상 이메일입니다.
+    /// - Returns: idle일 때만 유지할 성공 설명 문구이며, 그 외 상태면 `nil`입니다.
+    private func confirmationMessageOverride(for email: String) -> String? {
+        if case .idle = signUpMailState {
+            return AuthMailActionType.signupConfirmation.successDescription(for: email)
+        }
+        return nil
+    }
+
+    /// 현재 입력/confirmation 단계에 대응하는 메일 액션 고유 키를 생성합니다.
+    /// - Parameter email: 키 생성에 사용할 정규화 이메일입니다.
+    /// - Returns: 이메일이 비어 있지 않으면 signup confirmation 키를 반환합니다.
+    private func makeSignUpMailActionKey(for email: String) -> AuthMailActionKey? {
+        guard email.isEmpty == false else { return nil }
+        return AuthMailActionKey(
+            actionType: .signupConfirmation,
+            recipient: email,
+            context: "signup_sheet"
+        )
+    }
+
+    /// 현재 화면 상태에서 resend 상태를 계산해야 하는 대상 이메일을 반환합니다.
+    /// - Returns: confirmation 단계 이메일 또는 현재 입력 이메일의 정규화 값입니다.
+    private var activeMailActionEmail: String? {
+        switch signUpSheetMode {
+        case .form:
+            let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            return normalizedEmail.isEmpty ? nil : normalizedEmail
+        case .confirmation(_, let email):
+            return email
+        }
+    }
+
+    /// 현재 화면 상태에서 사용할 signup confirmation 메일 액션 키를 반환합니다.
+    private var activeMailActionKey: AuthMailActionKey? {
+        guard let activeMailActionEmail else { return nil }
+        return makeSignUpMailActionKey(for: activeMailActionEmail)
+    }
+
+    /// form 단계에서 상태 카드 노출이 필요한지 여부를 반환합니다.
+    private var shouldShowFormMailStatusCard: Bool {
+        guard case .form = signUpSheetMode else { return false }
+        guard activeMailActionEmail != nil else { return false }
+        if case .idle = signUpMailState {
+            return false
+        }
+        return true
+    }
+
+    /// 오류 객체를 사용자용 메일 액션 실패 문구로 정규화합니다.
+    /// - Parameters:
+    ///   - error: 정규화할 원본 오류입니다.
+    ///   - actionType: 사용자 문구를 결정할 메일 액션 타입입니다.
+    /// - Returns: 내부 운영 용어를 제거한 사용자용 실패 안내 문구입니다.
+    private func normalizedMailActionFailureMessage(_ error: Error, actionType: AuthMailActionType) -> String {
+        let description = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard description.isEmpty == false,
+              description.contains("SMTP") == false,
+              description.contains("Rate Limit") == false else {
+            return actionType.defaultFailureMessage()
+        }
+        return description
+    }
+
+    /// UI 테스트 런타임 인자로 signup 메일 상태를 강제로 주입해야 하는지 확인합니다.
+    /// - Returns: 테스트 인자가 유효하면 강제할 resend 상태를, 아니면 `nil`을 반환합니다.
+    private func resolvedUITestMailStateOverride() -> AuthMailResendState? {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard arguments.contains("-UITest.SignUpMailStateStub"),
+              activeMailActionEmail != nil,
+              let rawState = uiTestArgumentValue(after: "-UITest.SignUpMailStateStub") else {
+            return nil
+        }
+        let remainingSeconds = max(Int(uiTestArgumentValue(after: "-UITest.SignUpMailRemaining") ?? "48") ?? 48, 1)
+        switch rawState {
+        case "sent":
+            return .sent(remainingSeconds: remainingSeconds)
+        case "cooldown":
+            return .cooldown(remainingSeconds: remainingSeconds)
+        case "rate_limited":
+            return .rateLimited(remainingSeconds: remainingSeconds)
+        case "failed":
+            return .failed(message: "메일을 다시 보내지 못했습니다. 잠시 후 다시 시도해주세요.")
+        default:
+            return nil
+        }
+    }
+
+    /// 특정 UI 테스트 런타임 인자 뒤에 이어지는 값을 읽어옵니다.
+    /// - Parameter flag: 값을 읽고 싶은 런타임 인자 플래그입니다.
+    /// - Returns: 다음 위치에 값이 있으면 문자열을, 없으면 `nil`을 반환합니다.
+    private func uiTestArgumentValue(after flag: String) -> String? {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let index = arguments.firstIndex(of: flag),
+              arguments.indices.contains(index + 1) else {
+            return nil
+        }
+        return arguments[index + 1]
+    }
+
+    /// 메일 액션 결과를 metric/log 파이프라인으로 보냅니다.
+    /// - Parameters:
+    ///   - event: 기록할 메트릭 이벤트 타입입니다.
+    ///   - actionType: 메일 액션 종류입니다.
+    ///   - surface: 사용자가 요청을 발생시킨 화면/진입점입니다.
+    ///   - retryAfterSeconds: 서버 또는 상태기계가 계산한 남은 대기 시간입니다.
+    ///   - duplicateSuppressed: 중복 탭/중복 요청이 억제된 경우 `true`입니다.
+    private func trackAuthMailEvent(
+        _ event: AppMetricEvent,
+        actionType: AuthMailActionType,
+        surface: String,
+        retryAfterSeconds: Int?,
+        duplicateSuppressed: Bool
+    ) {
+        let payload: [String: String] = [
+            "action_type": actionType.analyticsKey,
+            "surface": surface,
+            "retry_after_seconds": retryAfterSeconds.map(String.init) ?? "none",
+            "duplicate_suppressed": duplicateSuppressed ? "true" : "false"
+        ]
+        metricTracker.track(event, payload: payload)
+        #if DEBUG
+        print("[AuthMailMetric] event=\(event.rawValue) action=\(actionType.analyticsKey) surface=\(surface) retryAfter=\(retryAfterSeconds.map(String.init) ?? "none") duplicateSuppressed=\(duplicateSuppressed)")
+        #endif
     }
 
     /// 이메일 필드 검증 상태를 갱신하고 필요 시 햅틱 피드백을 발생시킵니다.

--- a/dogArea/Views/SigningView/SignInView.swift
+++ b/dogArea/Views/SigningView/SignInView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct SignInView: View {
     /// Apple Developer 서명 준비 전까지 Apple 로그인 노출을 차단합니다.
     private let isAppleSignInTemporarilyDisabled: Bool
+    private let launchArguments = ProcessInfo.processInfo.arguments
 
     @State private var userId: AuthUserInfo? = nil
     @State private var path = NavigationPath()
@@ -46,130 +47,155 @@ struct SignInView: View {
     }
 
     var body: some View {
-        NavigationStack(path: $path) {
-            VStack(spacing: 14) {
-                TitleTextView(title: "로그인/회원가입", subTitle: "계정 정보가 필요해요!")
+        if shouldPresentUITestSignUpPreviewRoute {
+            EmailSignUpSheetView(
+                initialEmail: resolvedUITestSignUpPreviewEmail,
+                authUseCase: authUseCase,
+                onOutcome: applyAuthOutcome
+            )
+        } else {
+            NavigationStack(path: $path) {
+                VStack(spacing: 14) {
+                    TitleTextView(title: "로그인/회원가입", subTitle: "계정 정보가 필요해요!")
 
-                if isAppleSignInTemporarilyDisabled == false {
-                    AppleSigninButton(
-                        authUseCase: authUseCase,
-                        onOutcome: applyAuthOutcome,
-                        onError: { authErrorMessage = $0 }
-                    )
+                    if isAppleSignInTemporarilyDisabled == false {
+                        AppleSigninButton(
+                            authUseCase: authUseCase,
+                            onOutcome: applyAuthOutcome,
+                            onError: { authErrorMessage = $0 }
+                        )
 
-                    HStack {
-                        Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
-                        Text("또는 이메일")
-                            .font(.appFont(for: .Light, size: 12))
+                        HStack {
+                            Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
+                            Text("또는 이메일")
+                                .font(.appFont(for: .Light, size: 12))
+                                .foregroundStyle(Color.appTextDarkGray)
+                            Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
+                        }
+                        .padding(.horizontal, 20)
+                    } else {
+                        Text("Apple 로그인은 준비 중입니다. 현재 이메일 로그인/회원가입만 사용할 수 있어요.")
+                            .font(.appFont(for: .Regular, size: 12))
                             .foregroundStyle(Color.appTextDarkGray)
-                        Rectangle().fill(Color.appTextLightGray.opacity(0.5)).frame(height: 0.7)
+                            .padding(.horizontal, 20)
+                    }
+
+                    VStack(spacing: 8) {
+                        TextField("이메일", text: $email)
+                            .keyboardType(.emailAddress)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled(true)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 12)
+                            .background(Color.appSurface)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .stroke(Color.appTextLightGray.opacity(0.7), lineWidth: 1)
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .accessibilityIdentifier("signin.email")
+
+                        SecureField("비밀번호", text: $password)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 12)
+                            .background(Color.appSurface)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .stroke(Color.appTextLightGray.opacity(0.7), lineWidth: 1)
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .accessibilityIdentifier("signin.password")
+
+                        Button("이메일 로그인") {
+                            runEmailSignIn()
+                        }
+                        .accessibilityIdentifier("signin.login")
+                        .buttonStyle(AppFilledButtonStyle(role: .primary))
+                        .disabled(emailAuthLoading)
+
+                        Button("이메일 회원가입") {
+                            presentSignUpSheet()
+                        }
+                        .accessibilityIdentifier("signin.signup")
+                        .buttonStyle(.plain)
+                        .font(.appFont(for: .Regular, size: 14))
+                        .foregroundStyle(Color.appTextDarkGray)
+                        .frame(maxWidth: .infinity)
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
+                        .disabled(emailAuthLoading)
                     }
                     .padding(.horizontal, 20)
-                } else {
-                    Text("Apple 로그인은 준비 중입니다. 현재 이메일 로그인/회원가입만 사용할 수 있어요.")
-                        .font(.appFont(for: .Regular, size: 12))
-                        .foregroundStyle(Color.appTextDarkGray)
-                        .padding(.horizontal, 20)
-                }
+                    .appCardSurface()
+                    .padding(.horizontal, 16)
 
-                VStack(spacing: 8) {
-                    TextField("이메일", text: $email)
-                        .keyboardType(.emailAddress)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled(true)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 12)
-                        .background(Color.appSurface)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .stroke(Color.appTextLightGray.opacity(0.7), lineWidth: 1)
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                        .accessibilityIdentifier("signin.email")
-
-                    SecureField("비밀번호", text: $password)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 12)
-                        .background(Color.appSurface)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .stroke(Color.appTextLightGray.opacity(0.7), lineWidth: 1)
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                        .accessibilityIdentifier("signin.password")
-
-                    Button("이메일 로그인") {
-                        runEmailSignIn()
+                    if emailAuthLoading {
+                        ProgressView("이메일 인증 처리 중...")
+                            .font(.appFont(for: .Regular, size: 12))
                     }
-                    .accessibilityIdentifier("signin.login")
-                    .buttonStyle(AppFilledButtonStyle(role: .primary))
-                    .disabled(emailAuthLoading)
 
-                    Button("이메일 회원가입") {
-                        presentSignUpSheet()
+                    if let authErrorMessage, authErrorMessage.isEmpty == false {
+                        Text(authErrorMessage)
+                            .font(.appFont(for: .Regular, size: 12))
+                            .foregroundStyle(Color.appRed)
+                            .padding(.horizontal, 20)
                     }
-                    .accessibilityIdentifier("signin.signup")
-                    .buttonStyle(.plain)
-                    .font(.appFont(for: .Regular, size: 14))
-                    .foregroundStyle(Color.appTextDarkGray)
-                    .frame(maxWidth: .infinity)
-                    .frame(minHeight: 44)
-                    .contentShape(Rectangle())
-                    .disabled(emailAuthLoading)
-                }
-                .padding(.horizontal, 20)
-                .appCardSurface()
-                .padding(.horizontal, 16)
 
-                if emailAuthLoading {
-                    ProgressView("이메일 인증 처리 중...")
-                        .font(.appFont(for: .Regular, size: 12))
+                    Spacer()
                 }
-
-                if let authErrorMessage, authErrorMessage.isEmpty == false {
-                    Text(authErrorMessage)
-                        .font(.appFont(for: .Regular, size: 12))
-                        .foregroundStyle(Color.appRed)
-                        .padding(.horizontal, 20)
+                .navigationDestination(item: $userId, destination: { info in
+                    ProfileSettingsView(
+                        path: $path,
+                        viewModel: .init(info: info),
+                        onSignupCompleted: onAuthenticated
+                    )
+                })
+                .sheet(isPresented: $isSignUpSheetPresented) {
+                    EmailSignUpSheetView(
+                        initialEmail: email,
+                        authUseCase: authUseCase,
+                        onOutcome: applyAuthOutcome
+                    )
                 }
-
-                Spacer()
-            }
-            .navigationDestination(item: $userId, destination: { info in
-                ProfileSettingsView(
-                    path: $path,
-                    viewModel: .init(info: info),
-                    onSignupCompleted: onAuthenticated
-                )
-            })
-            .sheet(isPresented: $isSignUpSheetPresented) {
-                EmailSignUpSheetView(
-                    initialEmail: email,
-                    authUseCase: authUseCase,
-                    onOutcome: applyAuthOutcome
-                )
-            }
-            .frame(maxHeight: .infinity)
-            .background(Color.appBackground)
-            .overlay(alignment: .topLeading) {
-                Color.clear
-                    .frame(width: 2, height: 2)
-                    .allowsHitTesting(false)
-                    .accessibilityIdentifier("screen.signin")
-            }
-            .toolbar {
-                if allowDismiss {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button("나중에") {
-                            onDismiss()
+                .frame(maxHeight: .infinity)
+                .background(Color.appBackground)
+                .overlay(alignment: .topLeading) {
+                    Color.clear
+                        .frame(width: 2, height: 2)
+                        .allowsHitTesting(false)
+                        .accessibilityIdentifier("screen.signin")
+                }
+                .toolbar {
+                    if allowDismiss {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button("나중에") {
+                                onDismiss()
+                            }
+                            .font(.appFont(for: .Regular, size: 14))
+                            .tint(Color.appTextDarkGray)
+                            .accessibilityIdentifier("signin.dismiss")
                         }
-                        .font(.appFont(for: .Regular, size: 14))
-                        .tint(Color.appTextDarkGray)
-                        .accessibilityIdentifier("signin.dismiss")
                     }
                 }
             }
         }
+    }
+
+    /// 회원가입 메일 상태 회귀 테스트에서 시트 네비게이션 의존성을 제거할 직접 진입 라우트 활성 여부를 반환합니다.
+    private var shouldPresentUITestSignUpPreviewRoute: Bool {
+        launchArguments.contains("-UITest.SignUpMailPreviewRoute")
+    }
+
+    /// 회귀 테스트용 직접 회원가입 라우트에서 초기 메일 프리뷰에 사용할 이메일을 반환합니다.
+    private var resolvedUITestSignUpPreviewEmail: String {
+        guard let index = launchArguments.firstIndex(of: "-UITest.SignUpMailPreviewEmail"),
+              launchArguments.indices.contains(index + 1) else {
+            return email
+        }
+        let previewEmail = launchArguments[index + 1]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return previewEmail.isEmpty ? email : previewEmail
     }
 
     /// 이메일 로그인 요청을 실행하고 결과에 따라 인증 플로우를 분기합니다.

--- a/dogAreaUITests/FeatureRegressionUITests.swift
+++ b/dogAreaUITests/FeatureRegressionUITests.swift
@@ -229,6 +229,30 @@ final class FeatureRegressionUITests: XCTestCase {
         XCTAssertTrue(logoutButton.isHittable, "로그아웃 버튼이 탭 가능한 상태가 아닙니다.")
     }
 
+    /// 회원가입 시트가 rate-limited resend 상태를 유지하고 중복 resend 탭을 막는지 검증합니다.
+    func testFeatureRegression_SignUpMailRateLimitedStateDisablesResendAction() throws {
+        let app = launchAppForFeatureRegression(
+            extraArguments: [
+                "-UITest.SignUpMailPreviewRoute",
+                "-UITest.SignUpMailStateStub", "rate_limited",
+                "-UITest.SignUpMailRemaining", "48",
+                "-UITest.SignUpMailPreviewEmail", "rate-limited@dogarea.test"
+            ]
+        )
+
+        XCTAssertTrue(presentSignInFlowIfNeeded(app), "로그인 화면 진입에 실패했습니다.")
+
+        XCTAssertTrue(
+            waitUntilExists(screenElement(identifier: "screen.signup", in: app), timeout: 6),
+            "회원가입 시트가 열리지 않았습니다."
+        )
+
+        let resendButton = app.descendants(matching: .any).matching(identifier: "signup.mail.resend").firstMatch
+        XCTAssertTrue(waitUntilExists(resendButton, timeout: 4), "메일 resend 버튼을 찾지 못했습니다.")
+        XCTAssertFalse(resendButton.isEnabled, "rate-limited 상태에서 resend 버튼은 비활성화되어야 합니다.")
+        XCTAssertTrue(resendButton.label.contains("48초 후 다시"), "남은 시간 버튼 문구가 노출되지 않았습니다.")
+    }
+
     /// 설정 탭이 실제 앱 설정/법적 문서/지원/앱 정보 섹션을 모두 노출하는지 검증합니다.
     func testFeatureRegression_SettingsProductSectionsExposeOperationalEntries() throws {
         let app = launchAppForFeatureRegression()
@@ -828,7 +852,8 @@ final class FeatureRegressionUITests: XCTestCase {
     /// - Returns: 로그인 화면 또는 로그인 진입 버튼이 노출될 때까지 중간 단계를 처리한 경우 `true`를 반환합니다.
     @discardableResult
     private func presentSignInFlowIfNeeded(_ app: XCUIApplication) -> Bool {
-        if waitUntilExists(screenElement(identifier: "screen.signin", in: app), timeout: 1.2) {
+        if waitUntilExists(screenElement(identifier: "screen.signin", in: app), timeout: 1.2) ||
+            waitUntilExists(screenElement(identifier: "screen.signup", in: app), timeout: 1.2) {
             return true
         }
 
@@ -838,7 +863,8 @@ final class FeatureRegressionUITests: XCTestCase {
             usleep(300_000)
         }
 
-        if waitUntilExists(screenElement(identifier: "screen.signin", in: app), timeout: 1.2) {
+        if waitUntilExists(screenElement(identifier: "screen.signin", in: app), timeout: 1.2) ||
+            waitUntilExists(screenElement(identifier: "screen.signup", in: app), timeout: 1.2) {
             return true
         }
 
@@ -848,7 +874,30 @@ final class FeatureRegressionUITests: XCTestCase {
             usleep(300_000)
         }
 
-        return waitUntilExists(screenElement(identifier: "screen.signin", in: app), timeout: 2.5)
+        if waitUntilExists(screenElement(identifier: "screen.signin", in: app), timeout: 1.2) ||
+            waitUntilExists(screenElement(identifier: "screen.signup", in: app), timeout: 1.2) {
+            return true
+        }
+
+        let settingsTabButton = app.buttons["tab.4"]
+        if waitUntilExists(settingsTabButton, timeout: 2.5) {
+            settingsTabButton.tap()
+            usleep(300_000)
+
+            let settingsSignInButton = app.buttons["settings.open.signin"]
+            if waitUntilExists(settingsSignInButton, timeout: 2.5) {
+                settingsSignInButton.tap()
+                usleep(300_000)
+
+                if waitUntilExists(memberUpgradeSignInButton, timeout: 2.5) {
+                    memberUpgradeSignInButton.tap()
+                    usleep(300_000)
+                }
+            }
+        }
+
+        return waitUntilExists(screenElement(identifier: "screen.signin", in: app), timeout: 2.5) ||
+            waitUntilExists(screenElement(identifier: "screen.signup", in: app), timeout: 2.5)
     }
 
     /// 커스텀 탭 인덱스로 탭 전환을 시도합니다.

--- a/scripts/auth_mail_resend_state_machine_unit_check.swift
+++ b/scripts/auth_mail_resend_state_machine_unit_check.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+@inline(__always)
+/// 조건이 거짓이면 즉시 실패 종료합니다.
+/// - Parameters:
+///   - condition: 반드시 참이어야 하는 조건식입니다.
+///   - message: 실패 시 stderr에 출력할 설명입니다.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if condition == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 상대 경로의 텍스트 파일을 읽어 문자열로 반환합니다.
+/// - Parameter relativePath: 프로젝트 루트 기준 상대 경로입니다.
+/// - Returns: UTF-8 문자열로 디코딩한 파일 내용입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let models = load("dogArea/Source/Domain/Auth/Models/AuthMailActionModels.swift")
+let stateMachine = load("dogArea/Source/Domain/Auth/Services/AuthMailActionStateMachine.swift")
+let store = load("dogArea/Source/UserDefaultsSupport/AuthMailActionStateStore.swift")
+let authMailService = load("dogArea/Source/Infrastructure/Supabase/Services/SupabaseAuthMailActionService.swift")
+let signupView = load("dogArea/Views/SigningView/Components/EmailSignUpSheetView.swift")
+let signupCard = load("dogArea/Views/SigningView/Components/AuthMailActionStatusCardView.swift")
+let metrics = load("dogArea/Source/UserDefaultsSupport/AppMetricTracker.swift")
+let readme = load("README.md")
+let doc = load("docs/auth-mail-resend-state-machine-v1.md")
+
+assertTrue(models.contains("enum AuthMailActionType: String, Codable, CaseIterable"), "auth mail action type enum should exist")
+assertTrue(models.contains("case signupConfirmation") && models.contains("case passwordReset") && models.contains("case emailChange"), "all three auth mail action types should be defined")
+assertTrue(models.contains("enum AuthMailResendState: Equatable") && models.contains("case idle") && models.contains("case sending") && models.contains("case sent") && models.contains("case cooldown") && models.contains("case rateLimited") && models.contains("case failed"), "resend state machine should define idle/sending/sent/cooldown/rate_limited/failed")
+assertTrue(models.contains("struct AuthMailActionKey: Hashable, Codable"), "action key model should be defined")
+assertTrue(models.contains("var storageKey: String"), "action key should provide storageKey")
+
+assertTrue(stateMachine.contains("protocol AuthMailActionStateStoring"), "state store protocol should exist")
+assertTrue(stateMachine.contains("protocol AuthMailActionStateManaging"), "state machine protocol should exist")
+assertTrue(stateMachine.contains("final class AuthMailActionStateMachine"), "state machine implementation should exist")
+assertTrue(stateMachine.contains("func recordSuccess(") && stateMachine.contains("func recordRateLimited("), "state machine should record success and rate limits")
+assertTrue(stateMachine.contains("store.removeSnapshot(for: key)"), "expired snapshots should be removed")
+
+assertTrue(store.contains("final class AuthMailActionStateStore: AuthMailActionStateStoring"), "UserDefaults auth mail store should exist")
+assertTrue(store.contains("namespace: String = \"auth.mail.resend.snapshot.v1\""), "auth mail store should use dedicated namespace")
+
+assertTrue(authMailService.contains("enum AuthMailDispatchRequest: Equatable"), "mail dispatch request enum should exist")
+assertTrue(authMailService.contains("case signupConfirmation") && authMailService.contains("case passwordReset") && authMailService.contains("case emailChange"), "dispatch request should recognize signup/reset/email change")
+assertTrue(authMailService.contains(".auth(path: \"resend\")") && authMailService.contains(".auth(path: \"recover\")"), "mail dispatch service should define resend/recover endpoints")
+assertTrue(authMailService.contains("SupabaseAuthError.rateLimited"), "mail dispatch service should map 429 to SupabaseAuthError.rateLimited")
+
+assertTrue(signupView.contains("@State private var signUpSheetMode: SignUpSheetMode = .form"), "signup sheet should keep explicit form/confirmation mode")
+assertTrue(signupView.contains("@State private var signUpMailState: AuthMailResendState = .idle"), "signup sheet should keep auth mail resend state")
+assertTrue(signupView.contains("signUpConfirmationContent") && signupView.contains("continueToProfileSetup()"), "signup sheet should present a confirmation step before continuing")
+assertTrue(signupView.contains("resendSignupConfirmationMail()"), "signup sheet should expose explicit resend action")
+assertTrue(signupView.contains("allowMailActionRequest(for: actionKey, surface: \"signup_submit\")"), "signup submit should be guarded by resend state machine")
+assertTrue(signupView.contains("AuthMailActionStatusCardView(") && signupView.contains("signup.mail.resend"), "signup sheet should render auth mail status card with resend CTA")
+assertTrue(signupView.contains("-UITest.SignUpMailStateStub"), "signup sheet should support UI test override for mail states")
+
+assertTrue(signupCard.contains("struct AuthMailActionStatusCardView: View"), "signup auth mail status card view should exist")
+assertTrue(signupCard.contains("프로필 입력 계속"), "auth mail status card should support continue CTA")
+
+assertTrue(metrics.contains("case authMailActionSucceeded") && metrics.contains("case authMailActionRateLimited") && metrics.contains("case authMailActionFailed") && metrics.contains("case authMailActionSuppressed"), "metric tracker should include auth mail events")
+
+assertTrue(readme.contains("docs/auth-mail-resend-state-machine-v1.md"), "README should index auth mail resend doc")
+assertTrue(doc.contains("idle") && doc.contains("sending") && doc.contains("sent") && doc.contains("cooldown") && doc.contains("rate_limited") && doc.contains("failed"), "doc should describe full resend state machine")
+assertTrue(doc.contains("Retry-After") && doc.contains("fallback cooldown"), "doc should define retry-after precedence and fallback cooldown")
+assertTrue(doc.contains("sheet dismiss / reopen") && doc.contains("background 복귀"), "doc should define persistence and resume behavior")
+assertTrue(doc.contains("429") && doc.contains("네트워크 실패") && doc.contains("중복 탭"), "doc should include QA scenarios for 429/network/duplicate tap")
+
+print("PASS: auth mail resend state machine unit checks")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -103,6 +103,7 @@ swift scripts/auth_onboarding_session_consistency_unit_check.swift
 swift scripts/auth_signup_entry_ux_unit_check.swift
 swift scripts/auth_signup_validation_unit_check.swift
 swift scripts/auth_rate_limit_message_unit_check.swift
+swift scripts/auth_mail_resend_state_machine_unit_check.swift
 swift scripts/signin_metal_overlay_guard_unit_check.swift
 swift scripts/auth_overlay_widget_action_defer_unit_check.swift
 swift scripts/auth_reauth_session_downgrade_unit_check.swift


### PR DESCRIPTION
## Summary
- add auth mail resend state/domain model, persistence store, and Supabase dispatch service
- integrate signup confirmation resend UX with persisted cooldown/rate-limit state and status card
- add docs, static checks, and feature regression coverage for rate-limited resend state

## Test
- swift scripts/auth_mail_resend_state_machine_unit_check.swift
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -derivedDataPath .build/codex-507-build -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_SignUpMailRateLimitedStateDisablesResendAction test
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #507