### PR TITLE
feat: unify widget state CTA taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - 근처 사용자 익명 핫스팟 명세 v1: `docs/nearby-anonymous-hotspot-v1.md`
 - 핫스팟 위젯 프라이버시 매핑 v1: `docs/hotspot-widget-privacy-mapping-v1.md`
 - 핫스팟 위젯 반경 preset v1: `docs/hotspot-widget-radius-preset-v1.md`
+- Widget state CTA taxonomy v1: `docs/widget-state-cta-taxonomy-v1.md`
 - Widget Lock Screen accessory family plan v1: `docs/widget-lock-screen-accessory-family-plan-v1.md`
 - Walk widget action state model v1: `docs/walk-widget-action-state-model-v1.md`
 - Walk widget pet context policy v1: `docs/walk-widget-pet-context-policy-v1.md`

--- a/docs/widget-state-cta-taxonomy-v1.md
+++ b/docs/widget-state-cta-taxonomy-v1.md
@@ -1,0 +1,54 @@
+# Widget state CTA taxonomy v1
+
+## Scope
+- Territory widget
+- Hotspot widget
+- Quest/Rival widget
+- 대상 상태: `guest`, `empty`, `offline`, `syncDelayed`
+
+## Taxonomy
+- `guest`
+  - 의미: 인증이 없어 위젯 핵심 데이터를 보여줄 수 없음
+  - 역할: 로그인 유도
+- `empty`
+  - 의미: 계정/표면은 유효하지만 아직 첫 행동 데이터가 없음
+  - 역할: 첫 행동 유도
+- `offline`
+  - 의미: 마지막 성공 스냅샷을 보여주고 있음
+  - 역할: 복구 대기 안내
+- `syncDelayed`
+  - 의미: 최신 상태 반영이 늦어지고 있음
+  - 역할: 앱 재진입 최신화 유도
+
+## CTA rules
+- `guest`
+  - badge: `로그인 필요`
+  - CTA: `앱에서 로그인`
+- `empty`
+  - badge: `첫 행동`
+  - CTA pattern: `앱에서 ... 시작`
+- `offline`
+  - badge: `오프라인`
+  - CTA: `연결 복구 대기 중`
+- `syncDelayed`
+  - badge: `지연`
+  - CTA: `앱에서 최신 상태 확인`
+
+## Copy rules
+- badge는 짧게 2~4음절 수준으로 유지
+- headline은 현재 상태를 바로 이해시키는 한 문장으로 제한
+- detail은 왜 이 상태인지와 다음 행동을 함께 설명
+- CTA는 명령형 한 줄로 유지
+- 접근성 라벨/힌트는 CTA title과 분리해 상태 이유를 보강
+
+## Surface specializations
+- Territory empty: `앱에서 첫 산책 시작`
+- Hotspot empty: `앱에서 익명 공유 시작`
+- Quest/Rival empty: `앱에서 퀘스트 시작`
+- Hotspot은 반경 preset 문맥을 detail에 유지
+- Quest/Rival은 `offline` / `syncDelayed`에서 보상/순위 CTA보다 복구 CTA를 우선
+
+## Accessibility
+- CTA label은 짧은 사용자 문구를 그대로 읽음
+- CTA hint는 왜 앱으로 가야 하는지 설명
+- 상태 badge와 CTA는 서로 다른 의미를 갖도록 중복 단어를 줄임

--- a/dogAreaWidgetExtension/Shared/WidgetPresentationSupport.swift
+++ b/dogAreaWidgetExtension/Shared/WidgetPresentationSupport.swift
@@ -14,6 +14,207 @@ struct WidgetStatusBadge: View {
     }
 }
 
+enum WidgetStateTaxonomy: String, CaseIterable {
+    case guest = "guest"
+    case empty = "empty"
+    case offline = "offline"
+    case syncDelayed = "sync_delayed"
+}
+
+enum WidgetStateSurfaceContext: Equatable {
+    case territory
+    case hotspot(radiusPreset: HotspotWidgetRadiusPreset)
+    case questRival
+}
+
+struct WidgetStateCTAContent: Equatable {
+    let title: String
+    let systemImage: String
+    let accessibilityLabel: String
+    let accessibilityHint: String
+}
+
+struct WidgetStatePresentationContent {
+    let badgeTitle: String
+    let badgeColor: Color
+    let headline: String
+    let detail: String
+    let cta: WidgetStateCTAContent
+}
+
+enum WidgetStatePresentationGuide {
+    /// 위젯 공통 상태 taxonomy와 표면 종류에 맞는 카피/CTA 구성을 반환합니다.
+    /// - Parameters:
+    ///   - taxonomy: 위젯 상태 taxonomy입니다.
+    ///   - surface: 카피를 적용할 위젯 표면 종류입니다.
+    ///   - fallbackMessage: 서버/스냅샷이 제공한 상태 설명이 있으면 우선 반영할 보조 문구입니다.
+    /// - Returns: 상태 배지, 설명, CTA가 정리된 공통 프레젠테이션 값입니다.
+    static func presentation(
+        for taxonomy: WidgetStateTaxonomy,
+        surface: WidgetStateSurfaceContext,
+        fallbackMessage: String? = nil
+    ) -> WidgetStatePresentationContent {
+        let resolvedFallback = fallbackMessage?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch taxonomy {
+        case .guest:
+            switch surface {
+            case .territory:
+                return .init(
+                    badgeTitle: "로그인 필요",
+                    badgeColor: .orange.opacity(0.20),
+                    headline: "영역 현황을 보려면 로그인해 주세요",
+                    detail: "오늘/주간 지표와 다음 목표를 위젯에서 이어서 볼 수 있어요.",
+                    cta: signInCTA(surfaceName: "영역 현황")
+                )
+            case let .hotspot(radiusPreset):
+                return .init(
+                    badgeTitle: "로그인 필요",
+                    badgeColor: .orange.opacity(0.20),
+                    headline: "\(radiusPreset.shortLabel) 핫스팟을 보려면 로그인해 주세요",
+                    detail: "익명 핫스팟 단계는 로그인 후 활성화됩니다.",
+                    cta: signInCTA(surfaceName: "익명 핫스팟")
+                )
+            case .questRival:
+                return .init(
+                    badgeTitle: "로그인 필요",
+                    badgeColor: .orange.opacity(0.20),
+                    headline: "퀘스트/라이벌을 보려면 로그인해 주세요",
+                    detail: "오늘의 퀘스트 진행률과 라이벌 순위를 위젯에서 이어서 확인할 수 있어요.",
+                    cta: signInCTA(surfaceName: "퀘스트/라이벌")
+                )
+            }
+        case .empty:
+            switch surface {
+            case .territory:
+                return .init(
+                    badgeTitle: "첫 행동",
+                    badgeColor: .blue.opacity(0.18),
+                    headline: "첫 산책을 시작해 보세요",
+                    detail: resolvedFallback ?? "첫 타일을 점령하면 다음 목표와 남은 면적을 바로 보여드릴게요.",
+                    cta: firstActionCTA(
+                        title: "앱에서 첫 산책 시작",
+                        systemImage: "figure.walk",
+                        accessibilityLabel: "앱에서 첫 산책 시작",
+                        accessibilityHint: "앱으로 이동해 첫 타일 점령을 시작합니다."
+                    )
+                )
+            case .hotspot:
+                return .init(
+                    badgeTitle: "첫 행동",
+                    badgeColor: .blue.opacity(0.18),
+                    headline: "익명 공유를 시작해 보세요",
+                    detail: resolvedFallback ?? "공유가 시작되면 주변 익명 신호 단계가 위젯에 표시됩니다.",
+                    cta: firstActionCTA(
+                        title: "앱에서 익명 공유 시작",
+                        systemImage: "antenna.radiowaves.left.and.right",
+                        accessibilityLabel: "앱에서 익명 공유 시작",
+                        accessibilityHint: "앱으로 이동해 익명 위치 공유를 시작합니다."
+                    )
+                )
+            case .questRival:
+                return .init(
+                    badgeTitle: "첫 행동",
+                    badgeColor: .blue.opacity(0.18),
+                    headline: "오늘의 퀘스트를 시작해 보세요",
+                    detail: resolvedFallback ?? "첫 행동이 기록되면 진행률과 라이벌 순위를 바로 보여드릴게요.",
+                    cta: firstActionCTA(
+                        title: "앱에서 퀘스트 시작",
+                        systemImage: "list.bullet.rectangle.portrait",
+                        accessibilityLabel: "앱에서 퀘스트 시작",
+                        accessibilityHint: "앱으로 이동해 오늘의 퀘스트를 확인합니다."
+                    )
+                )
+            }
+        case .offline:
+            return .init(
+                badgeTitle: "오프라인",
+                badgeColor: .orange.opacity(0.20),
+                headline: "마지막 동기화 내용을 보여주고 있어요",
+                detail: resolvedFallback ?? "연결이 복구되면 위젯이 자동으로 최신 상태로 돌아옵니다.",
+                cta: waitRecoveryCTA()
+            )
+        case .syncDelayed:
+            return .init(
+                badgeTitle: "지연",
+                badgeColor: .red.opacity(0.18),
+                headline: "최신 상태 반영이 늦어지고 있어요",
+                detail: resolvedFallback ?? "앱을 열어 최신 상태를 다시 불러와 주세요.",
+                cta: refreshInAppCTA()
+            )
+        }
+    }
+
+    /// 로그인 유도 상태에서 사용할 공통 CTA를 생성합니다.
+    /// - Parameter surfaceName: 로그인 후 확인할 위젯 표면 이름입니다.
+    /// - Returns: 로그인 유도용 CTA 문구와 접근성 메타데이터입니다.
+    private static func signInCTA(surfaceName: String) -> WidgetStateCTAContent {
+        .init(
+            title: "앱에서 로그인",
+            systemImage: "person.crop.circle.badge.checkmark",
+            accessibilityLabel: "앱에서 로그인",
+            accessibilityHint: "\(surfaceName) 위젯을 쓰려면 로그인해야 합니다."
+        )
+    }
+
+    /// 첫 행동 유도 상태에서 사용할 공통 CTA를 생성합니다.
+    /// - Parameters:
+    ///   - title: 사용자에게 노출할 CTA 제목입니다.
+    ///   - systemImage: CTA에 함께 표시할 SF Symbol 이름입니다.
+    ///   - accessibilityLabel: 접근성에 읽힐 CTA 라벨입니다.
+    ///   - accessibilityHint: 접근성 힌트입니다.
+    /// - Returns: 첫 행동 유도용 CTA 문구와 접근성 메타데이터입니다.
+    private static func firstActionCTA(
+        title: String,
+        systemImage: String,
+        accessibilityLabel: String,
+        accessibilityHint: String
+    ) -> WidgetStateCTAContent {
+        .init(
+            title: title,
+            systemImage: systemImage,
+            accessibilityLabel: accessibilityLabel,
+            accessibilityHint: accessibilityHint
+        )
+    }
+
+    /// 오프라인 복구 대기 상태에서 사용할 공통 CTA를 생성합니다.
+    /// - Returns: 연결 복구 대기 상태를 설명하는 CTA 문구와 접근성 메타데이터입니다.
+    private static func waitRecoveryCTA() -> WidgetStateCTAContent {
+        .init(
+            title: "연결 복구 대기 중",
+            systemImage: "wifi.slash",
+            accessibilityLabel: "연결 복구 대기 중",
+            accessibilityHint: "네트워크가 복구되면 위젯이 자동으로 다시 갱신됩니다."
+        )
+    }
+
+    /// 최신화 지연 상태에서 사용할 공통 CTA를 생성합니다.
+    /// - Returns: 앱 재진입 최신화 유도용 CTA 문구와 접근성 메타데이터입니다.
+    private static func refreshInAppCTA() -> WidgetStateCTAContent {
+        .init(
+            title: "앱에서 최신 상태 확인",
+            systemImage: "arrow.clockwise",
+            accessibilityLabel: "앱에서 최신 상태 확인",
+            accessibilityHint: "앱으로 이동해 최신 상태를 다시 불러옵니다."
+        )
+    }
+}
+
+struct WidgetStateCTAView: View {
+    let cta: WidgetStateCTAContent
+    var tint: Color = .orange
+
+    var body: some View {
+        Label(cta.title, systemImage: cta.systemImage)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(tint)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(cta.accessibilityLabel)
+            .accessibilityHint(cta.accessibilityHint)
+    }
+}
+
 enum WidgetFormatting {
     /// 경과 시간을 `HH:MM:SS` 형식으로 변환합니다.
     /// - Parameter elapsedSeconds: 변환할 경과 시간(초)입니다.

--- a/dogAreaWidgetExtension/Widgets/HotspotStatusWidget.swift
+++ b/dogAreaWidgetExtension/Widgets/HotspotStatusWidget.swift
@@ -150,47 +150,48 @@ struct HotspotStatusWidgetEntryView: View {
     }
 
     private var guestContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        let guide = WidgetStatePresentationGuide.presentation(
+            for: .guest,
+            surface: .hotspot(radiusPreset: currentPreset)
+        )
+        return VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 8) {
-                WidgetStatusBadge(title: "비회원", color: .orange.opacity(0.2))
+                WidgetStatusBadge(title: guide.badgeTitle, color: guide.badgeColor)
                 Spacer(minLength: 0)
                 presetBadge(currentPreset)
             }
-            Text("익명 핫스팟")
+            Text(guide.headline)
                 .font(.headline)
-            Text("\(currentPreset.shortLabel) 기준으로 지역 트렌드 단계를 확인할 수 있어요. 로그인 후 활성화됩니다.")
+            Text(guide.detail)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(3)
             Spacer(minLength: 2)
-            Text("앱에서 로그인")
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(.orange)
+            WidgetStateCTAView(cta: guide.cta)
         }
     }
 
     private var emptyContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        let guide = WidgetStatePresentationGuide.presentation(
+            for: .empty,
+            surface: .hotspot(radiusPreset: currentPreset),
+            fallbackMessage: entry.snapshot.message
+        )
+        return VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 8) {
-                WidgetStatusBadge(title: "신호 부족", color: .blue.opacity(0.18))
+                WidgetStatusBadge(title: guide.badgeTitle, color: guide.badgeColor)
                 Spacer(minLength: 0)
                 presetBadge(currentPreset)
             }
-            Text("주변 익명 신호를 수집 중입니다")
+            Text(guide.headline)
                 .font(.headline)
                 .lineLimit(2)
-            Text(currentPreset.widgetSummaryDetail)
+            Text(guide.detail)
                 .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-            Text(entry.snapshot.message)
-                .font(.caption2)
                 .foregroundStyle(.secondary)
                 .lineLimit(3)
             Spacer(minLength: 2)
-            Text(updatedAtText)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+            WidgetStateCTAView(cta: guide.cta, tint: .blue)
         }
     }
 
@@ -198,7 +199,7 @@ struct HotspotStatusWidgetEntryView: View {
         let summary = entry.snapshot.summary ?? .zero(radiusPreset: entry.snapshot.radiusPreset)
         return VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 8) {
-                WidgetStatusBadge(title: signalTitle(summary.signalLevel), color: signalColor(summary.signalLevel))
+                WidgetStatusBadge(title: statusBadgeTitle(summary), color: statusBadgeColor(summary))
                 Spacer(minLength: 0)
                 presetBadge(summary.radiusPreset)
             }
@@ -209,12 +210,42 @@ struct HotspotStatusWidgetEntryView: View {
                 mediumBody(summary: summary)
             }
 
-            if entry.snapshot.status != .memberReady {
+            if let guide = nonReadyStateGuide {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(guide.detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                    WidgetStateCTAView(
+                        cta: guide.cta,
+                        tint: entry.snapshot.status == .syncDelayed ? .red : .orange
+                    )
+                }
+            } else if entry.snapshot.status == .privacyGuarded {
                 Text(entry.snapshot.message)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
+        }
+    }
+
+    private var nonReadyStateGuide: WidgetStatePresentationContent? {
+        switch entry.snapshot.status {
+        case .offlineCached:
+            return WidgetStatePresentationGuide.presentation(
+                for: .offline,
+                surface: .hotspot(radiusPreset: currentPreset),
+                fallbackMessage: entry.snapshot.message
+            )
+        case .syncDelayed:
+            return WidgetStatePresentationGuide.presentation(
+                for: .syncDelayed,
+                surface: .hotspot(radiusPreset: currentPreset),
+                fallbackMessage: entry.snapshot.message
+            )
+        case .guestLocked, .emptyData, .memberReady, .privacyGuarded:
+            return nil
         }
     }
 
@@ -370,6 +401,32 @@ struct HotspotStatusWidgetEntryView: View {
         case .none:
             return .blue.opacity(0.16)
         }
+    }
+
+    /// 현재 스냅샷 상태와 신호 단계에 맞는 배지 제목을 반환합니다.
+    /// - Parameter summary: 익명 핫스팟 요약 스냅샷입니다.
+    /// - Returns: 상태 우선 규칙이 반영된 배지 제목입니다.
+    private func statusBadgeTitle(_ summary: HotspotWidgetSummarySnapshot) -> String {
+        if let guide = nonReadyStateGuide {
+            return guide.badgeTitle
+        }
+        if entry.snapshot.status == .privacyGuarded {
+            return "보호 중"
+        }
+        return signalTitle(summary.signalLevel)
+    }
+
+    /// 현재 스냅샷 상태와 신호 단계에 맞는 배지 색상을 반환합니다.
+    /// - Parameter summary: 익명 핫스팟 요약 스냅샷입니다.
+    /// - Returns: 상태 우선 규칙이 반영된 배지 색상입니다.
+    private func statusBadgeColor(_ summary: HotspotWidgetSummarySnapshot) -> Color {
+        if let guide = nonReadyStateGuide {
+            return guide.badgeColor
+        }
+        if entry.snapshot.status == .privacyGuarded {
+            return .blue.opacity(0.18)
+        }
+        return signalColor(summary.signalLevel)
     }
 
     /// 프라이버시 가드 상태를 설명하는 보조 문구를 생성합니다.

--- a/dogAreaWidgetExtension/Widgets/QuestRivalStatusWidget.swift
+++ b/dogAreaWidgetExtension/Widgets/QuestRivalStatusWidget.swift
@@ -61,37 +61,52 @@ struct QuestRivalStatusWidgetEntryView: View {
     }
 
     private var guestContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            WidgetStatusBadge(title: "비회원", color: .orange.opacity(0.2))
-            Text("퀘스트/라이벌 위젯")
+        let guide = WidgetStatePresentationGuide.presentation(
+            for: .guest,
+            surface: .questRival
+        )
+        return VStack(alignment: .leading, spacing: 8) {
+            WidgetStatusBadge(title: guide.badgeTitle, color: guide.badgeColor)
+            Text(guide.headline)
                 .font(.headline)
-            Text("로그인 후 오늘의 퀘스트 진행률과 라이벌 순위를 빠르게 확인할 수 있어요.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(3)
-            Spacer(minLength: 2)
-            Text("앱에서 로그인")
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(.orange)
-        }
-    }
-
-    private var emptyContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            WidgetStatusBadge(title: "준비 중", color: .blue.opacity(0.18))
-            Text("퀘스트 데이터를 준비 중입니다")
-                .font(.headline)
-                .lineLimit(2)
-            Text(entry.snapshot.message)
+            Text(guide.detail)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(3)
             Spacer(minLength: 2)
             Button(intent: OpenQuestDetailIntent()) {
-                Label("퀘스트 상세 보기", systemImage: "list.bullet.rectangle.portrait")
+                Label(guide.cta.title, systemImage: guide.cta.systemImage)
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
+            .accessibilityLabel(guide.cta.accessibilityLabel)
+            .accessibilityHint(guide.cta.accessibilityHint)
+        }
+    }
+
+    private var emptyContent: some View {
+        let guide = WidgetStatePresentationGuide.presentation(
+            for: .empty,
+            surface: .questRival,
+            fallbackMessage: entry.snapshot.message
+        )
+        return VStack(alignment: .leading, spacing: 8) {
+            WidgetStatusBadge(title: guide.badgeTitle, color: guide.badgeColor)
+            Text(guide.headline)
+                .font(.headline)
+                .lineLimit(2)
+            Text(guide.detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+            Spacer(minLength: 2)
+            Button(intent: OpenQuestDetailIntent()) {
+                Label(guide.cta.title, systemImage: guide.cta.systemImage)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel(guide.cta.accessibilityLabel)
+            .accessibilityHint(guide.cta.accessibilityHint)
         }
     }
 
@@ -113,10 +128,29 @@ struct QuestRivalStatusWidgetEntryView: View {
                 mediumBody(summary: summary)
             }
 
-            Text(entry.snapshot.message)
+            Text(actionStateGuide?.detail ?? entry.snapshot.message)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
+        }
+    }
+
+    private var actionStateGuide: WidgetStatePresentationContent? {
+        switch entry.snapshot.status {
+        case .offlineCached:
+            return WidgetStatePresentationGuide.presentation(
+                for: .offline,
+                surface: .questRival,
+                fallbackMessage: entry.snapshot.message
+            )
+        case .syncDelayed:
+            return WidgetStatePresentationGuide.presentation(
+                for: .syncDelayed,
+                surface: .questRival,
+                fallbackMessage: entry.snapshot.message
+            )
+        case .memberReady, .guestLocked, .emptyData, .claimInFlight, .claimFailed, .claimSucceeded:
+            return nil
         }
     }
 
@@ -215,7 +249,9 @@ struct QuestRivalStatusWidgetEntryView: View {
             return .openQuestDetail
         case .emptyData:
             return .openQuestDetail
-        case .offlineCached, .syncDelayed, .memberReady:
+        case .offlineCached, .syncDelayed:
+            return .openQuestRecovery
+        case .memberReady:
             if summary.questClaimable, summary.questInstanceId != nil {
                 return .claimQuestReward
             }
@@ -230,6 +266,9 @@ struct QuestRivalStatusWidgetEntryView: View {
     /// - Parameter summary: 퀘스트/라이벌 위젯 요약 스냅샷입니다.
     /// - Returns: 함께 노출할 보조 행동 종류가 있으면 반환하고, 없으면 `nil`을 반환합니다.
     private func secondaryActionKind(for summary: QuestRivalWidgetSummarySnapshot) -> WalkWidgetActionKind? {
+        if actionStateGuide != nil {
+            return nil
+        }
         switch primaryActionKind(for: summary) {
         case .claimQuestReward:
             return .openRivalTab
@@ -248,6 +287,9 @@ struct QuestRivalStatusWidgetEntryView: View {
     /// - Parameter summary: 퀘스트/라이벌 위젯 요약 스냅샷입니다.
     /// - Returns: 상태별로 달라지는 다음 행동 제목입니다.
     private func nextActionHeadline(_ summary: QuestRivalWidgetSummarySnapshot) -> String {
+        if let guide = actionStateGuide {
+            return guide.headline
+        }
         switch primaryActionKind(for: summary) {
         case .claimQuestReward:
             return "지금 보상 받을 수 있어요"
@@ -270,6 +312,9 @@ struct QuestRivalStatusWidgetEntryView: View {
     /// - Parameter summary: 퀘스트/라이벌 위젯 요약 스냅샷입니다.
     /// - Returns: 상태별 CTA와 복구 맥락을 설명하는 보조 문구입니다.
     private func nextActionCaption(_ summary: QuestRivalWidgetSummarySnapshot) -> String {
+        if let guide = actionStateGuide {
+            return guide.detail
+        }
         switch primaryActionKind(for: summary) {
         case .claimQuestReward:
             return "보상 \(summary.questRewardPoint)pt를 지금 수령할 수 있어요."
@@ -339,6 +384,9 @@ struct QuestRivalStatusWidgetEntryView: View {
     /// - Parameter kind: 렌더링할 CTA 종류입니다.
     /// - Returns: 버튼에 표시할 사용자 문구입니다.
     private func actionTitle(for kind: WalkWidgetActionKind) -> String {
+        if kind == .openQuestRecovery, let guide = actionStateGuide {
+            return guide.cta.title
+        }
         switch kind {
         case .claimQuestReward:
             return "보상 받기"
@@ -361,6 +409,9 @@ struct QuestRivalStatusWidgetEntryView: View {
     /// - Parameter kind: 렌더링할 CTA 종류입니다.
     /// - Returns: 버튼 라벨에 사용할 시스템 이미지 이름입니다.
     private func actionSymbolName(for kind: WalkWidgetActionKind) -> String {
+        if kind == .openQuestRecovery, let guide = actionStateGuide {
+            return guide.cta.systemImage
+        }
         switch kind {
         case .claimQuestReward:
             return "gift.fill"
@@ -501,6 +552,9 @@ struct QuestRivalStatusWidgetEntryView: View {
     }
 
     private var statusBadgeTitle: String {
+        if let guide = actionStateGuide {
+            return guide.badgeTitle
+        }
         switch entry.snapshot.status {
         case .memberReady:
             return "실시간"
@@ -522,6 +576,9 @@ struct QuestRivalStatusWidgetEntryView: View {
     }
 
     private var statusBadgeColor: Color {
+        if let guide = actionStateGuide {
+            return guide.badgeColor
+        }
         switch entry.snapshot.status {
         case .memberReady, .claimSucceeded:
             return .green.opacity(0.20)

--- a/dogAreaWidgetExtension/Widgets/TerritoryStatusWidget.swift
+++ b/dogAreaWidgetExtension/Widgets/TerritoryStatusWidget.swift
@@ -71,35 +71,39 @@ struct TerritoryStatusWidgetEntryView: View {
     }
 
     private var guestContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            WidgetStatusBadge(title: "비회원", color: .orange.opacity(0.2))
-            Text("영역 현황")
+        let guide = WidgetStatePresentationGuide.presentation(
+            for: .guest,
+            surface: .territory
+        )
+        return VStack(alignment: .leading, spacing: 8) {
+            WidgetStatusBadge(title: guide.badgeTitle, color: guide.badgeColor)
+            Text(guide.headline)
                 .font(.headline)
-            Text("로그인 후 오늘/주간 지표와 다음 목표를 위젯에서 볼 수 있어요.")
+            Text(guide.detail)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(3)
             Spacer(minLength: 2)
-            Text("앱에서 로그인")
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(.orange)
+            WidgetStateCTAView(cta: guide.cta)
         }
     }
 
     private var emptyContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            WidgetStatusBadge(title: "초기 안내", color: .blue.opacity(0.18))
-            Text("첫 타일 점령을 시작해보세요")
+        let guide = WidgetStatePresentationGuide.presentation(
+            for: .empty,
+            surface: .territory
+        )
+        return VStack(alignment: .leading, spacing: 8) {
+            WidgetStatusBadge(title: guide.badgeTitle, color: guide.badgeColor)
+            Text(guide.headline)
                 .font(.headline)
                 .lineLimit(2)
-            Text("첫 산책을 시작하면 다음 목표와 남은 면적을 함께 보여드릴게요.")
+            Text(guide.detail)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(3)
             Spacer(minLength: 2)
-            Text(updatedAtText)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+            WidgetStateCTAView(cta: guide.cta, tint: .blue)
         }
     }
 
@@ -120,12 +124,37 @@ struct TerritoryStatusWidgetEntryView: View {
                 mediumMetricContent
             }
 
-            if entry.snapshot.status != .memberReady {
-                Text(entry.snapshot.message)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
+            if let guide = nonReadyStateGuide {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(guide.detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                    WidgetStateCTAView(
+                        cta: guide.cta,
+                        tint: entry.snapshot.status == .syncDelayed ? .red : .orange
+                    )
+                }
             }
+        }
+    }
+
+    private var nonReadyStateGuide: WidgetStatePresentationContent? {
+        switch entry.snapshot.status {
+        case .offlineCached:
+            return WidgetStatePresentationGuide.presentation(
+                for: .offline,
+                surface: .territory,
+                fallbackMessage: entry.snapshot.message
+            )
+        case .syncDelayed:
+            return WidgetStatePresentationGuide.presentation(
+                for: .syncDelayed,
+                surface: .territory,
+                fallbackMessage: entry.snapshot.message
+            )
+        case .memberReady, .guestLocked, .emptyData:
+            return nil
         }
     }
 
@@ -284,32 +313,26 @@ struct TerritoryStatusWidgetEntryView: View {
     }
 
     private var statusBadgeText: String {
+        if let guide = nonReadyStateGuide {
+            return guide.badgeTitle
+        }
         switch entry.snapshot.status {
         case .memberReady:
             return "실시간"
-        case .offlineCached:
-            return "오프라인"
-        case .syncDelayed:
-            return "지연"
-        case .guestLocked:
-            return "비회원"
-        case .emptyData:
-            return "초기 안내"
+        case .offlineCached, .syncDelayed, .guestLocked, .emptyData:
+            return "실시간"
         }
     }
 
     private var statusBadgeColor: Color {
+        if let guide = nonReadyStateGuide {
+            return guide.badgeColor
+        }
         switch entry.snapshot.status {
         case .memberReady:
             return .green.opacity(0.2)
-        case .offlineCached:
-            return .orange.opacity(0.2)
-        case .syncDelayed:
-            return .red.opacity(0.18)
-        case .guestLocked:
-            return .orange.opacity(0.2)
-        case .emptyData:
-            return .blue.opacity(0.18)
+        case .offlineCached, .syncDelayed, .guestLocked, .emptyData:
+            return .green.opacity(0.2)
         }
     }
 

--- a/scripts/hotspot_widget_privacy_unit_check.swift
+++ b/scripts/hotspot_widget_privacy_unit_check.swift
@@ -71,7 +71,7 @@ assertTrue(widget.contains("struct HotspotStatusWidget"), "widget extension shou
 assertTrue(bundle.contains("HotspotStatusWidget()"), "widget bundle should register hotspot widget")
 assertTrue(widget.contains("signalDistributionSummary"), "widget should summarize distribution without raw counts")
 assertTrue(widget.contains("stageChip"), "widget should render stage chips")
-assertTrue(widget.contains("지역 트렌드 단계를 확인할 수 있어요"), "guest card should describe trend-only exposure")
+assertTrue(widget.contains("익명 핫스팟 단계는 로그인 후 활성화됩니다"), "guest card should describe gated trend-only exposure")
 assertTrue(widget.contains("개인 좌표/정밀 카운트는 제공하지 않습니다"), "widget policy footnote should mention no precise count exposure")
 assertTrue(widget.contains("k-익명 정책으로 백분위 단계만 제공됩니다"), "widget should include k-anon copy")
 assertTrue(!widget.contains("Text(\"높음 \\(summary.highCellCount)"), "widget should not expose raw stage counts on text")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -87,6 +87,7 @@ swift scripts/widget_extension_split_unit_check.swift
 swift scripts/territory_status_widget_unit_check.swift
 swift scripts/hotspot_widget_privacy_unit_check.swift
 swift scripts/hotspot_widget_radius_preset_unit_check.swift
+swift scripts/widget_state_cta_taxonomy_unit_check.swift
 swift scripts/season_policy_stage1_unit_check.swift
 swift scripts/weather_risk_policy_stage1_unit_check.swift
 swift scripts/weather_snapshot_provider_unit_check.swift

--- a/scripts/widget_state_cta_taxonomy_unit_check.swift
+++ b/scripts/widget_state_cta_taxonomy_unit_check.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+@discardableResult
+func require(_ condition: @autoclosure () -> Bool, _ message: String) -> Bool {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+    return true
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func read(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+        fputs("FAIL: unable to read \(relativePath)\n", stderr)
+        exit(1)
+    }
+    return content
+}
+
+let support = read("dogAreaWidgetExtension/Shared/WidgetPresentationSupport.swift")
+let territory = read("dogAreaWidgetExtension/Widgets/TerritoryStatusWidget.swift")
+let hotspot = read("dogAreaWidgetExtension/Widgets/HotspotStatusWidget.swift")
+let quest = read("dogAreaWidgetExtension/Widgets/QuestRivalStatusWidget.swift")
+let readme = read("README.md")
+let prCheck = read("scripts/ios_pr_check.sh")
+let doc = read("docs/widget-state-cta-taxonomy-v1.md")
+
+require(support.contains("enum WidgetStateTaxonomy"), "widget 상태 taxonomy enum이 없습니다.")
+require(support.contains("case guest"), "guest 상태 taxonomy가 없습니다.")
+require(support.contains("case empty"), "empty 상태 taxonomy가 없습니다.")
+require(support.contains("case offline"), "offline 상태 taxonomy가 없습니다.")
+require(support.contains("case syncDelayed"), "syncDelayed 상태 taxonomy가 없습니다.")
+require(support.contains("struct WidgetStateCTAContent"), "공통 CTA 모델이 없습니다.")
+require(support.contains("struct WidgetStatePresentationContent"), "공통 상태 프레젠테이션 모델이 없습니다.")
+require(support.contains("enum WidgetStatePresentationGuide"), "공통 상태 프레젠테이션 가이드가 없습니다.")
+require(support.contains("struct WidgetStateCTAView"), "공통 CTA 뷰가 없습니다.")
+
+require(territory.contains("WidgetStatePresentationGuide.presentation("), "Territory widget가 공통 상태 가이드를 사용하지 않습니다.")
+require(hotspot.contains("WidgetStatePresentationGuide.presentation("), "Hotspot widget가 공통 상태 가이드를 사용하지 않습니다.")
+require(quest.contains("WidgetStatePresentationGuide.presentation("), "Quest/Rival widget가 공통 상태 가이드를 사용하지 않습니다.")
+require(quest.contains("return .openQuestRecovery"), "Quest/Rival widget offline/delayed 복구 CTA 우선 경로가 없습니다.")
+
+require(doc.contains("## Taxonomy"), "문서에 taxonomy 섹션이 없습니다.")
+require(doc.contains("## CTA rules"), "문서에 CTA rules 섹션이 없습니다.")
+require(doc.contains("## Accessibility"), "문서에 Accessibility 섹션이 없습니다.")
+require(doc.contains("앱에서 로그인"), "문서에 guest CTA 기준이 없습니다.")
+require(doc.contains("연결 복구 대기 중"), "문서에 offline CTA 기준이 없습니다.")
+require(doc.contains("앱에서 최신 상태 확인"), "문서에 delayed CTA 기준이 없습니다.")
+
+require(readme.contains("docs/widget-state-cta-taxonomy-v1.md"), "README에 widget state CTA taxonomy 문서 링크가 없습니다.")
+require(prCheck.contains("widget_state_cta_taxonomy_unit_check.swift"), "ios_pr_check에 widget state CTA taxonomy 체크가 없습니다.")
+
+print("PASS: widget state CTA taxonomy unit checks")


### PR DESCRIPTION
## Summary
- add a shared widget state taxonomy and CTA presentation guide for guest, empty, offline, and sync-delayed states
- align territory, hotspot, and quest/rival widgets to the shared CTA system while preserving surface-specific behavior
- add docs and static checks for the widget CTA taxonomy

Closes #518