### PR TITLE
feat: add watch walk end summary flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - Watch action feedback UX v1: `docs/watch-action-feedback-ux-v1.md`
 - Watch selected pet context UX v1: `docs/watch-selected-pet-context-ux-v1.md`
 - Watch offline queue sync UX v1: `docs/watch-offline-queue-sync-ux-v1.md`
+- Watch walk end summary UX v1: `docs/watch-walk-end-summary-ux-v1.md`
 - Walk widget pet context policy v1: `docs/walk-widget-pet-context-policy-v1.md`
 - Territory widget goal deeplink v1: `docs/territory-widget-goal-deeplink-v1.md`
 - Territory widget next goal summary v1: `docs/territory-widget-next-goal-summary-v1.md`

--- a/docs/watch-walk-end-summary-ux-v1.md
+++ b/docs/watch-walk-end-summary-ux-v1.md
@@ -1,0 +1,77 @@
+# Watch Walk End Summary UX v1
+
+Issue: #523
+
+## 목적
+watch에서도 산책 종료 의사결정을 iPhone과 같은 의미로 정리하고, 종료 직후 최소 요약을 손목에서 바로 확인할 수 있게 한다.
+
+## 결정
+- watch 종료 플로우는 `저장하고 종료 / 계속 걷기 / 기록 폐기` 3액션을 제공한다.
+- `계속 걷기`는 로컬 상태만 유지하고 서버/앱 상태를 변경하지 않는다.
+- `저장하고 종료`는 기존 iPhone `endWalk` 저장 정책을 그대로 사용한다.
+- `기록 폐기`는 기존 iPhone `discardCurrentWalk` 의미를 그대로 사용한다.
+- watch는 저장 정책이나 점수 정책을 새로 정의하지 않는다.
+
+## 종료 시트 정보 밀도
+watch 종료 sheet에서는 아래 4개만 보여준다.
+- 시간
+- 넓이
+- 포인트 수
+- 반려견 이름
+
+제외 항목:
+- 퀘스트 상세 변화
+- 영역 비교군 상세 변화
+- 랭크/보상 상세
+
+이 정보는 손목 위 정보 밀도를 넘기므로 iPhone 후속 확인으로 넘긴다.
+
+## 종료 직후 요약
+종료/폐기 반영이 완료되면 watch는 완료 요약 sheet를 자동으로 한 번 표시한다.
+
+표시 항목:
+- 결과 타이틀
+  - `저장하고 종료했어요`
+  - `기록을 폐기했어요`
+- 시간
+- 넓이
+- 포인트 수
+- 반려견 이름
+- 후속 안내 한 줄
+
+## 정합성 원칙
+- iPhone과 의미가 다른 종료 결과를 만들지 않는다.
+- watch는 `endWalk` / `discardWalk` action만 보낸다.
+- 실제 저장/폐기 판단은 iPhone `MapViewModel`이 수행한다.
+- watch summary는 iPhone이 action 직전 스냅샷한 payload를 application context로 다시 내려준 결과만 사용한다.
+
+## 오프라인 fallback
+- 오프라인일 때 `저장하고 종료` 또는 `기록 폐기`를 누르면 요청은 queue에 저장한다.
+- 이 시점에는 최종 요약을 먼저 보여주지 않는다.
+- 연결 복구 후 iPhone이 action을 반영하고 `watch_completion_summary`를 내려주면 그때 완료 요약을 보여준다.
+- 사용자는 queue status card에서 `다시 동기화`를 눌러 reachability가 돌아온 뒤 수동 재전송을 유도할 수 있다.
+
+## 구현 메모
+- watch main button은 즉시 종료하지 않고 종료 decision sheet를 연다.
+- iPhone application context 필드:
+  - `point_count`
+  - `watch_completion_summary`
+- `watch_completion_summary` payload 필드:
+  - `action_id`
+  - `result`
+  - `title`
+  - `detail`
+  - `pet_name`
+  - `elapsed_time`
+  - `area`
+  - `point_count`
+  - `generated_at`
+  - `follow_up_note`
+
+## 검증 포인트
+- watch 종료 버튼 탭 시 3액션 sheet가 열린다.
+- `계속 걷기`는 산책 상태를 유지한다.
+- `저장하고 종료`는 iPhone 기존 저장 의미와 동일하다.
+- `기록 폐기`는 iPhone 기존 폐기 의미와 동일하다.
+- 오프라인에서는 종료 요청이 queue로 들어가고 요약은 반영 후 표시된다.
+- 완료 요약은 같은 `action_id`로 한 번만 자동 표시된다.

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -239,6 +239,10 @@
 		DAB314D22B3C1D78000357C7 /* WatchOfflineQueueStatusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314D12B3C1D78000357C7 /* WatchOfflineQueueStatusState.swift */; };
 		DAB314D42B3C1D79000357C7 /* WatchOfflineQueueStatusCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314D32B3C1D79000357C7 /* WatchOfflineQueueStatusCardView.swift */; };
 		DAB314D62B3C1D7A000357C7 /* WatchOfflineQueueStatusSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314D52B3C1D7A000357C7 /* WatchOfflineQueueStatusSheetView.swift */; };
+		DAB314D82B3C1D7B000357C7 /* WatchWalkCompletionSummaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314D72B3C1D7B000357C7 /* WatchWalkCompletionSummaryState.swift */; };
+		DAB314DA2B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314D92B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift */; };
+		DAB314DC2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314DB2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift */; };
+		DAB314DE2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314DD2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift */; };
 		DAC19F0E2B0AE5AC002FE2E8 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC19F0D2B0AE5AC002FE2E8 /* ImagePicker.swift */; };
 		DAC19F102B0AF661002FE2E8 /* TitleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC19F0F2B0AF661002FE2E8 /* TitleTextView.swift */; };
 		DAC19F132B0AFCAC002FE2E8 /* UserdefaultSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC19F122B0AFCAC002FE2E8 /* UserdefaultSetting.swift */; };
@@ -579,6 +583,10 @@
 		DAB314D12B3C1D78000357C7 /* WatchOfflineQueueStatusState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchOfflineQueueStatusState.swift; sourceTree = "<group>"; };
 		DAB314D32B3C1D79000357C7 /* WatchOfflineQueueStatusCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchOfflineQueueStatusCardView.swift; sourceTree = "<group>"; };
 		DAB314D52B3C1D7A000357C7 /* WatchOfflineQueueStatusSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchOfflineQueueStatusSheetView.swift; sourceTree = "<group>"; };
+		DAB314D72B3C1D7B000357C7 /* WatchWalkCompletionSummaryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWalkCompletionSummaryState.swift; sourceTree = "<group>"; };
+		DAB314D92B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWalkSummaryMetricGridView.swift; sourceTree = "<group>"; };
+		DAB314DB2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWalkEndDecisionSheetView.swift; sourceTree = "<group>"; };
+		DAB314DD2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWalkCompletionSummarySheetView.swift; sourceTree = "<group>"; };
 		DAC19F0D2B0AE5AC002FE2E8 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		DAC19F0F2B0AF661002FE2E8 /* TitleTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleTextView.swift; sourceTree = "<group>"; };
 		DAC19F122B0AFCAC002FE2E8 /* UserdefaultSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserdefaultSetting.swift; sourceTree = "<group>"; };
@@ -1286,6 +1294,10 @@
 				DAB314D12B3C1D78000357C7 /* WatchOfflineQueueStatusState.swift */,
 				DAB314D32B3C1D79000357C7 /* WatchOfflineQueueStatusCardView.swift */,
 				DAB314D52B3C1D7A000357C7 /* WatchOfflineQueueStatusSheetView.swift */,
+				DAB314D72B3C1D7B000357C7 /* WatchWalkCompletionSummaryState.swift */,
+				DAB314D92B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift */,
+				DAB314DB2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift */,
+				DAB314DD2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift */,
 				DAB314B52B3C1B4B000357C7 /* Assets.xcassets */,
 				DAB314B72B3C1B4B000357C7 /* Preview Content */,
 			);
@@ -1995,6 +2007,10 @@
 				DAB314D22B3C1D78000357C7 /* WatchOfflineQueueStatusState.swift in Sources */,
 				DAB314D42B3C1D79000357C7 /* WatchOfflineQueueStatusCardView.swift in Sources */,
 				DAB314D62B3C1D7A000357C7 /* WatchOfflineQueueStatusSheetView.swift in Sources */,
+				DAB314D82B3C1D7B000357C7 /* WatchWalkCompletionSummaryState.swift in Sources */,
+				DAB314DA2B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift in Sources */,
+				DAB314DC2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift in Sources */,
+				DAB314DE2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -389,6 +389,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     let maxProcessedWatchActions = 500
     var lastWatchContextSyncAt: Date = .distantPast
     var lastAppliedWatchActionId: String = ""
+    var lastWatchCompletionSummaryPayload: [String: Any]? = nil
     var lastAppliedWidgetActionId: String = ""
     let processedWatchActionStorageKey = "watch.processedActionIds"
     private let activeWalkSessionStorageKey = "walk.activeSession.v1"
@@ -511,7 +512,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         case startWalk
         case addPoint
         case endWalk
+        case discardWalk
         case syncState
+    }
+
+    enum WatchCompletionSummaryResult: String {
+        case saved
+        case discarded
     }
 
     struct WatchActionEnvelope {
@@ -919,6 +926,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         }
         else {
             clearActiveWalkSession()
+            lastWatchCompletionSummaryPayload = nil
             self.reloadSelectedPetContext()
             startLocationUpdatesIfAuthorized()
             setTrackingMode()

--- a/dogArea/Views/MapView/MapViewModelSupport/MapViewModel+WatchConnectivitySupport.swift
+++ b/dogArea/Views/MapView/MapViewModelSupport/MapViewModel+WatchConnectivitySupport.swift
@@ -18,11 +18,12 @@ extension MapViewModel {
             "isWalking": isWalking,
             "time": time,
             "area": calculateArea(),
+            "point_count": polygon.locations.count,
             "last_sync_at": now.timeIntervalSince1970,
             "watch_status": watchSyncStatusText,
             "last_action_id_applied": lastAppliedWatchActionId,
             "selected_pet_context": makeWatchSelectedPetContextPayload(lastSyncAt: now.timeIntervalSince1970)
-        ]
+        ].merging(makeWatchCompletionSummaryContext()) { _, new in new }
         try? watchSession.updateApplicationContext(context)
     }
 
@@ -56,11 +57,12 @@ extension MapViewModel {
             "isWalking": self.isWalking,
             "time": self.time,
             "area": self.polygon.walkingArea,
+            "point_count": self.polygon.locations.count,
             "last_sync_at": now.timeIntervalSince1970,
             "watch_status": self.watchSyncStatusText,
             "last_action_id_applied": self.lastAppliedWatchActionId,
             "selected_pet_context": self.makeWatchSelectedPetContextPayload(lastSyncAt: now.timeIntervalSince1970)
-        ]
+        ].merging(self.makeWatchCompletionSummaryContext()) { _, new in new }
 
         do {
             try watchSession.updateApplicationContext(context)
@@ -102,6 +104,56 @@ extension MapViewModel {
             payload["pet_id"] = petId
         }
         return payload
+    }
+
+    /// 마지막 watch 종료/폐기 결과가 있으면 application context에 포함할 완료 요약 payload를 구성합니다.
+    /// - Returns: 완료 요약이 있으면 `watch_completion_summary` 딕셔너리를 담은 context 조각을 반환합니다.
+    private func makeWatchCompletionSummaryContext() -> [String: Any] {
+        guard let payload = lastWatchCompletionSummaryPayload else { return [:] }
+        return ["watch_completion_summary": payload]
+    }
+
+    /// watch가 요청한 종료/폐기 직전 현재 산책 상태를 완료 요약 payload로 스냅샷합니다.
+    /// - Parameters:
+    ///   - actionId: 완료 요약을 특정 watch 액션과 연결하기 위한 action id입니다.
+    ///   - result: 저장 완료인지 기록 폐기인지 나타내는 요약 결과 타입입니다.
+    private func captureWatchCompletionSummary(
+        actionId: String,
+        result: WatchCompletionSummaryResult
+    ) {
+        let pointCount = polygon.locations.count
+        let areaValue = calculateArea()
+        let petName = currentWalkingPetName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? selectedPetName
+            : currentWalkingPetName
+        let detail: String
+        let followUpNote: String
+
+        switch result {
+        case .saved:
+            if pointCount > 2 {
+                detail = "이번 산책 기록을 저장하고 손목에서 바로 마무리했어요."
+            } else {
+                detail = "포인트가 적어 간단히 마감했어요."
+            }
+            followUpNote = "퀘스트와 영역 반영 상세는 iPhone 앱에서 이어서 확인할 수 있어요."
+        case .discarded:
+            detail = "이번 산책 기록은 저장하지 않고 폐기했어요."
+            followUpNote = "새 산책을 시작하면 다시 기록을 쌓을 수 있어요."
+        }
+
+        lastWatchCompletionSummaryPayload = [
+            "action_id": actionId,
+            "result": result.rawValue,
+            "title": result == .saved ? "저장하고 종료했어요" : "기록을 폐기했어요",
+            "detail": detail,
+            "pet_name": petName,
+            "elapsed_time": time,
+            "area": areaValue,
+            "point_count": pointCount,
+            "generated_at": Date().timeIntervalSince1970,
+            "follow_up_note": followUpNote
+        ]
     }
 
     /// 워치 컨텍스트 업데이트 가능 상태를 확인하고 사용 가능한 세션을 반환합니다.
@@ -285,6 +337,7 @@ extension MapViewModel {
             guard self.isWalking == false else {
                 return .rejected(message: "이미 산책이 진행 중이에요. 현재 세션을 먼저 확인해 주세요.")
             }
+            self.lastWatchCompletionSummaryPayload = nil
             let petContext = self.applyRequestedWalkPetContextIfNeeded(
                 envelope.requestedContextId,
                 source: "watch_start_context"
@@ -315,8 +368,23 @@ extension MapViewModel {
             guard self.isWalking else {
                 return .rejected(message: "종료할 산책이 아직 없어요.")
             }
+            self.captureWatchCompletionSummary(
+                actionId: envelope.actionId,
+                result: .saved
+            )
             self.endWalk()
             self.latestWatchActionText = "워치 종료 반영 \(Self.statusTimeString(from: Date()))"
+            self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action.rawValue])
+        case .discardWalk:
+            guard self.isWalking else {
+                return .rejected(message: "폐기할 산책이 아직 없어요.")
+            }
+            self.captureWatchCompletionSummary(
+                actionId: envelope.actionId,
+                result: .discarded
+            )
+            self.discardCurrentWalk()
+            self.latestWatchActionText = "워치 폐기 반영 \(Self.statusTimeString(from: Date()))"
             self.metricTracker.track(.watchActionApplied, userKey: self.currentMetricUserId(), payload: ["action": action.rawValue])
         case .syncState:
             self.latestWatchActionText = "워치 상태 재동기화 \(Self.statusTimeString(from: Date()))"

--- a/dogAreaWatch Watch App/ContentView.swift
+++ b/dogAreaWatch Watch App/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ContentView: View {
     @StateObject private var viewModel = ContentsViewModel()
     @State private var isQueueStatusPresented = false
+    @State private var isWalkEndDecisionPresented = false
 
     var body: some View {
         ScrollView {
@@ -48,7 +49,7 @@ struct ContentView: View {
                         )
                         WatchActionButtonView(
                             presentation: viewModel.controlPresentation(for: .endWalk),
-                            action: { viewModel.handleActionTap(.endWalk) }
+                            action: { isWalkEndDecisionPresented = true }
                         )
                     } else {
                         WatchActionButtonView(
@@ -64,6 +65,42 @@ struct ContentView: View {
             WatchOfflineQueueStatusSheetView(
                 queueStatus: viewModel.queueStatus,
                 onManualSync: { viewModel.handleManualQueueResync() }
+            )
+        }
+        .sheet(isPresented: $isWalkEndDecisionPresented) {
+            WatchWalkEndDecisionSheetView(
+                elapsedTime: viewModel.walkingTime,
+                area: viewModel.walkingArea,
+                pointCount: viewModel.currentPointCount,
+                petName: viewModel.currentWalkingPetName,
+                isReachable: viewModel.isReachable,
+                onSaveAndEnd: {
+                    isWalkEndDecisionPresented = false
+                    viewModel.handleWalkEndDecision(.saveAndEnd)
+                },
+                onContinueWalking: {
+                    isWalkEndDecisionPresented = false
+                    viewModel.handleWalkEndDecision(.continueWalking)
+                },
+                onDiscard: {
+                    isWalkEndDecisionPresented = false
+                    viewModel.handleWalkEndDecision(.discardRecord)
+                }
+            )
+        }
+        .sheet(
+            item: Binding(
+                get: { viewModel.walkCompletionSummary },
+                set: { summary in
+                    if summary == nil {
+                        viewModel.dismissWalkCompletionSummary()
+                    }
+                }
+            )
+        ) { summary in
+            WatchWalkCompletionSummarySheetView(
+                summary: summary,
+                onDismiss: { viewModel.dismissWalkCompletionSummary() }
             )
         }
     }

--- a/dogAreaWatch Watch App/ContentsViewModel.swift
+++ b/dogAreaWatch Watch App/ContentsViewModel.swift
@@ -44,7 +44,14 @@ enum WatchActionType: String {
     case startWalk = "startWalk"
     case addPoint = "addPoint"
     case endWalk = "endWalk"
+    case discardWalk = "discardWalk"
     case syncState = "syncState"
+}
+
+enum WatchWalkEndDecision {
+    case saveAndEnd
+    case continueWalking
+    case discardRecord
 }
 
 private struct WatchAckSnapshot: Codable, Equatable {
@@ -57,6 +64,7 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
     @Published var isWalking = false
     @Published var walkingTime: TimeInterval = 0
     @Published var walkingArea: Double = 0
+    @Published var currentWalkPointCount: Int = 0
     @Published var isReachable = false
     @Published var lastSyncAt: TimeInterval = 0
     @Published var pendingActionCount: Int = 0
@@ -70,9 +78,11 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
         lastSyncAt: nil
     )
     @Published private(set) var queueStatus: WatchOfflineQueueStatusState = .empty(isReachable: false)
+    @Published private(set) var walkCompletionSummary: WatchWalkCompletionSummaryState?
 
     private let actionQueueStorageKey = "watch.pendingActions.v1"
     private let ackSnapshotStorageKey = "watch.lastAckSnapshot.v1"
+    private let presentedCompletionSummaryActionIdStorageKey = "watch.presentedCompletionSummaryActionId.v1"
     private let watchContractVersion = "watch.remote.v1"
     private let watchActionMessageType = "watch_action"
     private let watchAckMessageType = "watch_ack"
@@ -84,14 +94,24 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
     private var actionTypeByActionId: [String: WatchActionType] = [:]
     private var resetWorkItems: [WatchActionType: DispatchWorkItem] = [:]
     private var lastCompletedActionId: String = ""
+    private var lastPresentedCompletionSummaryActionId: String = ""
 
     init(hapticService: WatchActionHapticServicing = DefaultWatchActionHapticService()) {
         self.hapticService = hapticService
         super.init()
         loadPendingActions()
         loadAckSnapshot()
+        loadPresentedCompletionSummaryActionId()
         refreshQueueStatus()
         activateSession()
+    }
+
+    var currentPointCount: Int {
+        currentWalkPointCount
+    }
+
+    var currentWalkingPetName: String {
+        petContext.petName
     }
 
     /// 워치 액션 버튼이 현재 렌더링해야 할 프레젠테이션 상태를 계산합니다.
@@ -215,6 +235,29 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
             return
         }
         sendAction(action)
+    }
+
+    /// 종료 결정 sheet에서 선택한 액션을 watch transport 경로로 전달하거나 로컬 상태만 정리합니다.
+    /// - Parameter decision: 사용자가 종료 시트에서 선택한 의사결정입니다.
+    func handleWalkEndDecision(_ decision: WatchWalkEndDecision) {
+        switch decision {
+        case .saveAndEnd:
+            sendAction(.endWalk)
+        case .continueWalking:
+            presentBanner(
+                title: "산책 계속",
+                detail: "지금 산책을 그대로 이어서 기록합니다.",
+                tone: .neutral,
+                playsHaptic: false
+            )
+        case .discardRecord:
+            sendAction(.discardWalk)
+        }
+    }
+
+    /// 완료 요약 sheet를 닫고 현재 표시 중인 요약 상태를 초기화합니다.
+    func dismissWalkCompletionSummary() {
+        walkCompletionSummary = nil
     }
 
     /// 사용자가 큐 상태 화면에서 수동 재동기화를 요청했을 때 reachability에 맞춰 처리합니다.
@@ -341,11 +384,18 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
               let decoded = try? JSONDecoder().decode([WatchActionDTO].self, from: data) else {
             pendingActions = []
             pendingActionCount = 0
+            actionTypeByActionId = [:]
             refreshQueueStatus()
             return
         }
         pendingActions = decoded
         pendingActionCount = decoded.count
+        actionTypeByActionId = Dictionary(
+            uniqueKeysWithValues: decoded.compactMap { action in
+                guard let type = WatchActionType(rawValue: action.action) else { return nil }
+                return (action.actionId, type)
+            }
+        )
         refreshQueueStatus()
     }
 
@@ -366,6 +416,13 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
         lastAckStatus = decoded.status
         lastAckActionId = decoded.actionId
         lastAckAt = decoded.ackAt
+    }
+
+    /// 이전에 이미 표시한 완료 요약 action id를 복원해 중복 sheet 노출을 방지합니다.
+    private func loadPresentedCompletionSummaryActionId() {
+        lastPresentedCompletionSummaryActionId = UserDefaults.standard.string(
+            forKey: presentedCompletionSummaryActionIdStorageKey
+        ) ?? ""
     }
 
     /// 현재 마지막 ACK 상태를 UserDefaults에 영속화합니다.
@@ -404,6 +461,19 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
         refreshQueueStatus()
     }
 
+    /// iPhone이 전달한 완료 요약을 새 action id 기준으로 한 번만 표시합니다.
+    /// - Parameter context: iPhone 앱이 내려준 최신 application context입니다.
+    private func presentWalkCompletionSummaryIfNeeded(from context: [String: Any]) {
+        guard let summary = WatchWalkCompletionSummaryState.make(from: context) else { return }
+        guard summary.actionId != lastPresentedCompletionSummaryActionId else { return }
+        lastPresentedCompletionSummaryActionId = summary.actionId
+        UserDefaults.standard.set(
+            summary.actionId,
+            forKey: presentedCompletionSummaryActionIdStorageKey
+        )
+        walkCompletionSummary = summary
+    }
+
     /// pending queue를 가능한 transport 경로로 전달합니다.
     /// reachability가 없으면 queue를 유지하고 개수만 갱신합니다.
     private func flushPendingActions() {
@@ -432,12 +502,14 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
             self.isWalking = context["isWalking"] as? Bool ?? false
             self.walkingTime = context["time"] as? TimeInterval ?? 0
             self.walkingArea = context["area"] as? Double ?? 0
+            self.currentWalkPointCount = context["point_count"] as? Int ?? 0
             self.lastSyncAt = context["last_sync_at"] as? TimeInterval ?? 0
             self.petContext = WatchSelectedPetContextState.make(
                 from: context,
                 fallbackIsWalking: self.isWalking,
                 fallbackLastSyncAt: self.lastSyncAt
             )
+            self.presentWalkCompletionSummaryIfNeeded(from: context)
             if let appliedActionId = context["last_action_id_applied"] as? String, appliedActionId.isEmpty == false {
                 self.applyCompletedState(for: appliedActionId, statusText: context["watch_status"] as? String)
             }

--- a/dogAreaWatch Watch App/WatchActionFeedbackModels.swift
+++ b/dogAreaWatch Watch App/WatchActionFeedbackModels.swift
@@ -86,6 +86,8 @@ extension WatchActionType {
             return "영역 표시하기"
         case .endWalk:
             return "산책 종료"
+        case .discardWalk:
+            return "기록 폐기"
         case .syncState:
             return "상태 동기화"
         }
@@ -99,6 +101,8 @@ extension WatchActionType {
             return "영역 전송 중"
         case .endWalk:
             return "종료 요청 중"
+        case .discardWalk:
+            return "폐기 요청 중"
         case .syncState:
             return "동기화 요청 중"
         }
@@ -112,6 +116,8 @@ extension WatchActionType {
             return "영역 큐 저장"
         case .endWalk:
             return "종료 큐 저장"
+        case .discardWalk:
+            return "폐기 큐 저장"
         case .syncState:
             return "동기화 큐 저장"
         }
@@ -121,7 +127,7 @@ extension WatchActionType {
         switch self {
         case .endWalk:
             return "한 번 더 탭"
-        case .startWalk, .addPoint, .syncState:
+        case .startWalk, .addPoint, .discardWalk, .syncState:
             return baseTitle
         }
     }
@@ -134,6 +140,8 @@ extension WatchActionType {
             return "영역 중복 억제"
         case .endWalk:
             return "종료 대기 중"
+        case .discardWalk:
+            return "폐기 대기 중"
         case .syncState:
             return "동기화 대기 중"
         }
@@ -141,7 +149,7 @@ extension WatchActionType {
 
     var cooldownInterval: TimeInterval {
         switch self {
-        case .startWalk, .endWalk:
+        case .startWalk, .endWalk, .discardWalk:
             return 2.0
         case .addPoint:
             return 1.2
@@ -154,14 +162,14 @@ extension WatchActionType {
         switch self {
         case .endWalk:
             return 3.0
-        case .startWalk, .addPoint, .syncState:
+        case .startWalk, .addPoint, .discardWalk, .syncState:
             return 0.0
         }
     }
 
     var blocksWhileQueued: Bool {
         switch self {
-        case .startWalk, .endWalk:
+        case .startWalk, .endWalk, .discardWalk:
             return true
         case .addPoint, .syncState:
             return false
@@ -175,7 +183,9 @@ extension WatchActionType {
         case .addPoint:
             return "현재 위치를 1회 기록해요"
         case .endWalk:
-            return "오조작 방지를 위해 한 번 더 확인해요"
+            return "저장·계속·폐기 중에서 선택해요"
+        case .discardWalk:
+            return "이번 산책 기록을 저장하지 않아요"
         case .syncState:
             return "최신 상태를 다시 요청해요"
         }

--- a/dogAreaWatch Watch App/WatchWalkCompletionSummarySheetView.swift
+++ b/dogAreaWatch Watch App/WatchWalkCompletionSummarySheetView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct WatchWalkCompletionSummarySheetView: View {
+    let summary: WatchWalkCompletionSummaryState
+    let onDismiss: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Label(summary.title, systemImage: summary.tone.symbolName)
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(summary.tone.tintColor)
+                    Text(summary.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                WatchWalkSummaryMetricGridView(
+                    elapsedTime: summary.elapsedTime,
+                    area: summary.area,
+                    pointCount: summary.pointCount,
+                    petName: summary.petName
+                )
+
+                Text(summary.followUpNote)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button("확인") {
+                    onDismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .frame(maxWidth: .infinity)
+            }
+            .padding()
+        }
+    }
+}

--- a/dogAreaWatch Watch App/WatchWalkCompletionSummaryState.swift
+++ b/dogAreaWatch Watch App/WatchWalkCompletionSummaryState.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+enum WatchWalkCompletionResult: String, Equatable {
+    case saved
+    case discarded
+}
+
+struct WatchWalkCompletionSummaryState: Equatable, Identifiable {
+    let actionId: String
+    let result: WatchWalkCompletionResult
+    let title: String
+    let detail: String
+    let petName: String
+    let elapsedTime: TimeInterval
+    let area: Double
+    let pointCount: Int
+    let generatedAt: TimeInterval?
+    let followUpNote: String
+
+    var id: String {
+        actionId
+    }
+
+    var tone: WatchActionFeedbackTone {
+        switch result {
+        case .saved:
+            return .success
+        case .discarded:
+            return .warning
+        }
+    }
+
+    /// iPhone application context에 담긴 완료 요약 payload를 watch 전용 상태로 변환합니다.
+    /// - Parameter context: iPhone 앱이 전달한 최신 WatchConnectivity application context입니다.
+    /// - Returns: 표시 가능한 완료 요약이 있으면 상태를 반환하고, 없으면 `nil`을 반환합니다.
+    static func make(from context: [String: Any]) -> WatchWalkCompletionSummaryState? {
+        guard let payload = context["watch_completion_summary"] as? [String: Any],
+              let actionId = (payload["action_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              actionId.isEmpty == false,
+              let rawResult = payload["result"] as? String,
+              let result = WatchWalkCompletionResult(rawValue: rawResult) else {
+            return nil
+        }
+
+        let title = ((payload["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap {
+            $0.isEmpty ? nil : $0
+        } ?? result.defaultTitle
+        let detail = ((payload["detail"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap {
+            $0.isEmpty ? nil : $0
+        } ?? result.defaultDetail
+        let petName = ((payload["pet_name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap {
+            $0.isEmpty ? nil : $0
+        } ?? "반려견"
+        let followUpNote = ((payload["follow_up_note"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap {
+            $0.isEmpty ? nil : $0
+        } ?? result.defaultFollowUpNote
+
+        return WatchWalkCompletionSummaryState(
+            actionId: actionId,
+            result: result,
+            title: title,
+            detail: detail,
+            petName: petName,
+            elapsedTime: (payload["elapsed_time"] as? TimeInterval) ?? 0,
+            area: (payload["area"] as? Double) ?? 0,
+            pointCount: (payload["point_count"] as? Int) ?? 0,
+            generatedAt: payload["generated_at"] as? TimeInterval,
+            followUpNote: followUpNote
+        )
+    }
+}
+
+private extension WatchWalkCompletionResult {
+    var defaultTitle: String {
+        switch self {
+        case .saved:
+            return "저장하고 종료했어요"
+        case .discarded:
+            return "기록을 폐기했어요"
+        }
+    }
+
+    var defaultDetail: String {
+        switch self {
+        case .saved:
+            return "이번 산책을 손목에서 바로 마무리했어요."
+        case .discarded:
+            return "이번 산책 기록은 저장하지 않았어요."
+        }
+    }
+
+    var defaultFollowUpNote: String {
+        switch self {
+        case .saved:
+            return "퀘스트와 영역 반영 상세는 iPhone 앱에서 이어서 확인할 수 있어요."
+        case .discarded:
+            return "새 산책을 시작하면 다시 기록을 쌓을 수 있어요."
+        }
+    }
+}

--- a/dogAreaWatch Watch App/WatchWalkEndDecisionSheetView.swift
+++ b/dogAreaWatch Watch App/WatchWalkEndDecisionSheetView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct WatchWalkEndDecisionSheetView: View {
+    let elapsedTime: TimeInterval
+    let area: Double
+    let pointCount: Int
+    let petName: String
+    let isReachable: Bool
+    let onSaveAndEnd: () -> Void
+    let onContinueWalking: () -> Void
+    let onDiscard: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("산책을 마칠까요?")
+                        .font(.headline.weight(.semibold))
+                    Text(headerDetail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                WatchWalkSummaryMetricGridView(
+                    elapsedTime: elapsedTime,
+                    area: area,
+                    pointCount: pointCount,
+                    petName: petName
+                )
+
+                VStack(spacing: 8) {
+                    WatchActionButtonView(
+                        presentation: WatchActionControlPresentation(
+                            title: "저장하고 종료",
+                            detail: isReachable
+                                ? "현재 기록을 저장하고 산책을 마칩니다"
+                                : "오프라인 큐에 넣고 연결 후 저장합니다",
+                            tone: .success,
+                            isDisabled: false,
+                            showsProgress: false
+                        ),
+                        action: onSaveAndEnd
+                    )
+                    WatchActionButtonView(
+                        presentation: WatchActionControlPresentation(
+                            title: "계속 걷기",
+                            detail: "산책 상태를 그대로 유지합니다",
+                            tone: .neutral,
+                            isDisabled: false,
+                            showsProgress: false
+                        ),
+                        action: onContinueWalking
+                    )
+                    WatchActionButtonView(
+                        presentation: WatchActionControlPresentation(
+                            title: "기록 폐기",
+                            detail: isReachable
+                                ? "이번 산책 기록을 저장하지 않고 삭제합니다"
+                                : "연결 후 폐기 요청을 보낼 때까지 현재 상태를 유지합니다",
+                            tone: .warning,
+                            isDisabled: false,
+                            showsProgress: false
+                        ),
+                        action: onDiscard
+                    )
+                }
+            }
+            .padding()
+        }
+    }
+
+    private var headerDetail: String {
+        if isReachable {
+            return "손목에서 바로 저장·계속·폐기를 고를 수 있어요."
+        }
+        return "지금은 오프라인이라 선택한 종료 요청을 큐에 저장하고, 반영 후 요약을 다시 보여줘요."
+    }
+}

--- a/dogAreaWatch Watch App/WatchWalkSummaryMetricGridView.swift
+++ b/dogAreaWatch Watch App/WatchWalkSummaryMetricGridView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct WatchWalkSummaryMetricGridView: View {
+    let elapsedTime: TimeInterval
+    let area: Double
+    let pointCount: Int
+    let petName: String
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                metricTile(title: "시간", value: formattedTime(elapsedTime))
+                metricTile(title: "넓이", value: formattedArea(area))
+            }
+            HStack(spacing: 8) {
+                metricTile(title: "포인트", value: "\(pointCount)개")
+                metricTile(title: "반려견", value: petName)
+            }
+        }
+    }
+
+    /// watch 요약 메트릭 한 칸을 렌더링합니다.
+    /// - Parameters:
+    ///   - title: 메트릭의 짧은 제목입니다.
+    ///   - value: watch 폭에 맞춰 포맷된 값 문자열입니다.
+    /// - Returns: 제목과 값을 함께 보여주는 요약 타일 뷰입니다.
+    private func metricTile(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.callout.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.white.opacity(0.08))
+        )
+    }
+
+    /// 누적 산책 시간을 watch 요약용 문자열로 변환합니다.
+    /// - Parameter elapsedTime: 초 단위 누적 산책 시간입니다.
+    /// - Returns: `mm:ss` 또는 `hh:mm:ss` 형태의 문자열입니다.
+    private func formattedTime(_ elapsedTime: TimeInterval) -> String {
+        let hours = Int(elapsedTime) / 3600
+        let minutes = (Int(elapsedTime) % 3600) / 60
+        let seconds = Int(elapsedTime) % 60
+        if hours == 0 {
+            return String(format: "%02d:%02d", minutes, seconds)
+        }
+        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+
+    /// 누적 영역 값을 watch 요약용 면적 문자열로 변환합니다.
+    /// - Parameter area: 제곱미터 단위 누적 영역 값입니다.
+    /// - Returns: watch 폭에 맞춘 축약 면적 문자열입니다.
+    private func formattedArea(_ area: Double) -> String {
+        if area >= 1_000_000 {
+            return String(format: "%.2fkm²", area / 1_000_000)
+        }
+        if area >= 10_000 {
+            return String(format: "%.2f만㎡", area / 10_000)
+        }
+        return String(format: "%.1f㎡", area)
+    }
+}

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -61,6 +61,7 @@ swift scripts/widget_lock_screen_accessory_plan_unit_check.swift
 swift scripts/watch_action_feedback_ux_unit_check.swift
 swift scripts/watch_selected_pet_context_ux_unit_check.swift
 swift scripts/watch_offline_queue_sync_ux_unit_check.swift
+swift scripts/watch_walk_end_summary_ux_unit_check.swift
 swift scripts/walk_live_activity_priority_unit_check.swift
 swift scripts/walk_widget_action_state_model_unit_check.swift
 swift scripts/walk_widget_pet_context_policy_unit_check.swift

--- a/scripts/watch_walk_end_summary_ux_unit_check.swift
+++ b/scripts/watch_walk_end_summary_ux_unit_check.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+func read(_ path: String) -> String {
+    (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+}
+
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = FileManager.default.currentDirectoryPath
+let readme = read(root + "/README.md")
+let doc = read(root + "/docs/watch-walk-end-summary-ux-v1.md")
+let contentView = read(root + "/dogAreaWatch Watch App/ContentView.swift")
+let watchViewModel = read(root + "/dogAreaWatch Watch App/ContentsViewModel.swift")
+let endSheet = read(root + "/dogAreaWatch Watch App/WatchWalkEndDecisionSheetView.swift")
+let summaryState = read(root + "/dogAreaWatch Watch App/WatchWalkCompletionSummaryState.swift")
+let summarySheet = read(root + "/dogAreaWatch Watch App/WatchWalkCompletionSummarySheetView.swift")
+let summaryGrid = read(root + "/dogAreaWatch Watch App/WatchWalkSummaryMetricGridView.swift")
+let iphoneMapModel = read(root + "/dogArea/Views/MapView/MapViewModel.swift")
+let iphoneWatchSupport = read(root + "/dogArea/Views/MapView/MapViewModelSupport/MapViewModel+WatchConnectivitySupport.swift")
+let prCheck = read(root + "/scripts/ios_pr_check.sh")
+
+assertTrue(readme.contains("watch-walk-end-summary-ux-v1.md"), "README should index watch walk end summary doc")
+assertTrue(doc.contains("#523"), "doc should mention issue #523")
+assertTrue(doc.contains("저장하고 종료 / 계속 걷기 / 기록 폐기"), "doc should define three-action end flow")
+assertTrue(doc.contains("watch_completion_summary"), "doc should define watch completion summary payload")
+assertTrue(doc.contains("오프라인"), "doc should define offline fallback")
+
+assertTrue(contentView.contains("WatchWalkEndDecisionSheetView"), "watch content should present end decision sheet")
+assertTrue(contentView.contains("WatchWalkCompletionSummarySheetView"), "watch content should present completion summary sheet")
+assertTrue(contentView.contains("isWalkEndDecisionPresented"), "watch content should manage end decision presentation state")
+
+assertTrue(watchViewModel.contains("case discardWalk = \"discardWalk\""), "watch action type should include discardWalk")
+assertTrue(watchViewModel.contains("enum WatchWalkEndDecision"), "watch view model should define end decision enum")
+assertTrue(watchViewModel.contains("func handleWalkEndDecision"), "watch view model should handle end decision actions")
+assertTrue(watchViewModel.contains("walkCompletionSummary"), "watch view model should publish completion summary")
+assertTrue(watchViewModel.contains("presentWalkCompletionSummaryIfNeeded"), "watch view model should gate summary presentation")
+assertTrue(watchViewModel.contains("presentedCompletionSummaryActionIdStorageKey"), "watch view model should persist presented summary action id")
+
+assertTrue(endSheet.contains("저장하고 종료"), "end decision sheet should expose save action")
+assertTrue(endSheet.contains("계속 걷기"), "end decision sheet should expose continue action")
+assertTrue(endSheet.contains("기록 폐기"), "end decision sheet should expose discard action")
+assertTrue(summaryState.contains("struct WatchWalkCompletionSummaryState"), "watch target should define completion summary state")
+assertTrue(summaryState.contains("watch_completion_summary"), "summary state should parse watch completion payload")
+assertTrue(summarySheet.contains("summary.followUpNote"), "completion summary sheet should render follow-up note")
+assertTrue(summaryGrid.contains("포인트"), "summary metric grid should render point count")
+assertTrue(summaryGrid.contains("반려견"), "summary metric grid should render pet name")
+
+assertTrue(iphoneMapModel.contains("case discardWalk"), "iphone map model should parse discard watch action")
+assertTrue(iphoneMapModel.contains("enum WatchCompletionSummaryResult"), "iphone map model should define completion summary result")
+assertTrue(iphoneWatchSupport.contains("point_count"), "iphone watch context should include point count")
+assertTrue(iphoneWatchSupport.contains("watch_completion_summary"), "iphone watch context should include completion summary payload")
+assertTrue(iphoneWatchSupport.contains("captureWatchCompletionSummary"), "iphone watch support should capture completion summary before ending")
+assertTrue(iphoneWatchSupport.contains("self.discardCurrentWalk()"), "iphone watch support should route discard action to existing discard flow")
+
+assertTrue(prCheck.contains("swift scripts/watch_walk_end_summary_ux_unit_check.swift"), "ios_pr_check should run watch walk end summary unit check")
+
+print("PASS: watch walk end summary UX unit checks")


### PR DESCRIPTION
## Summary
- add a 3-action watch walk end decision sheet and completion summary flow
- sync watch completion summary payload from iPhone canonical walk actions
- document and statically verify the watch walk end summary UX

## Testing
- swift scripts/watch_walk_end_summary_ux_unit_check.swift
- swift scripts/watch_action_feedback_ux_unit_check.swift
- swift scripts/watch_remote_contract_unit_check.swift
- xcodebuild -project dogArea.xcodeproj -scheme 'dogAreaWatch Watch App' -configuration Debug -destination 'generic/platform=watchOS Simulator' CODE_SIGNING_ALLOWED=NO build\n- DOGAREA_DERIVED_DATA_PATH=.build/codex-523-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh\n\nCloses #523