### PR TITLE
feat: add watch sync recovery indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - Watch action feedback UX v1: `docs/watch-action-feedback-ux-v1.md`
 - Watch selected pet context UX v1: `docs/watch-selected-pet-context-ux-v1.md`
 - Watch offline queue sync UX v1: `docs/watch-offline-queue-sync-ux-v1.md`
+- Watch sync recovery UX v1: `docs/watch-sync-recovery-ux-v1.md`
 - Watch walk end summary UX v1: `docs/watch-walk-end-summary-ux-v1.md`
 - Walk widget pet context policy v1: `docs/walk-widget-pet-context-policy-v1.md`
 - Territory widget goal deeplink v1: `docs/territory-widget-goal-deeplink-v1.md`

--- a/docs/watch-sync-recovery-ux-v1.md
+++ b/docs/watch-sync-recovery-ux-v1.md
@@ -1,0 +1,115 @@
+# Watch Sync Recovery UX v1
+
+Issue: #524
+
+## 목표
+- watch 사용자가 "상태가 어긋난 것 같다"는 느낌을 제품 안에서 바로 이해하게 한다.
+- 자동 동기화는 기본값으로 유지하고, 수동 동기화는 recovery 용도로만 보수적으로 제공한다.
+- `WCSession` 계약을 바꾸지 않고도 회복 경로와 피드백을 명확하게 만든다.
+
+## out-of-sync 징후 기준
+watch는 아래 신호를 조합해 `WatchSyncRecoveryState`를 만든다.
+
+- `iPhone 연결 끊김`
+  - `isReachable == false`
+- `마지막 동기화 오래됨`
+  - `lastSyncAt` 기준 `60초` 이상 새 application context가 없음
+- `초기 동기화 전`
+  - `lastSyncAt == nil`
+- `큐 장기 적재`
+  - `oldestQueuedAt` 기준 `90초` 이상 대기
+- `ACK 아직 없음`
+  - pending queue가 남아 있는데 `lastAckAt == nil` 또는 ACK 상태가 여전히 대기
+
+이 징후들은 카드와 상세 시트에서 공통으로 쓰는 `signals` 배열로 노출한다.
+
+## recovery 상태 기계
+수동 recovery는 아래 4단계만 가진다.
+
+- `idle`
+  - 특별한 recovery가 진행 중이 아님
+- `processing`
+  - 사용자가 수동 동기화를 눌렀고, 최신 ACK/application context를 기다리는 중
+- `waiting`
+  - 수동 동기화 이후 `8초` 안에 최신 응답이 오지 않음
+  - 또는 진행 중 reachability가 끊김
+- `recovered`
+  - 수동 recovery 요청 시각 이후의 `lastSyncAt` 또는 `lastAckAt` 갱신을 확인함
+
+`processing` 또는 `waiting` 이후 실제 동기화 확인이 되면 `recovered`로 전환하고, 성공 배너 노출 후 잠시 뒤 `idle`로 되돌린다.
+
+## 수동 동기화 역할
+결정: `수동 동기화`는 유지한다. 다만 **자동 동기화를 대체하지 않는 recovery action**으로 제한한다.
+
+- 온라인(`reachable == true`)
+  - pending queue flush 시도
+  - `syncState` 즉시 전송
+  - recovery phase를 `processing`으로 전환
+- 오프라인(`reachable == false`)
+  - 새 `syncState`를 queue에 쌓지 않음
+  - `연결 후 다시 동기화` 안내만 보여줌
+
+즉, write 성격 액션은 여전히 queue가 책임지고, `syncState`는 상태 확인용 recovery action으로만 남긴다.
+
+## guard 기준
+- 수동 동기화 연타 방지 cooldown: `15초`
+- recovery 응답 grace window: `8초`
+- cooldown 중 버튼 상태:
+  - 제목: `잠시 후 다시`
+  - 버튼 비활성
+  - 남은 시간 문구 노출
+
+이 guard는 "사용자에게 아무것도 못 하게 막기"보다 "불필요한 반복 확인을 줄이는 것"이 목적이다.
+
+## 카드/시트 표면 규칙
+메인 카드와 상세 시트는 아래 문맥을 공유한다.
+
+- headline
+  - `동기화 정상`
+  - `상태 확인 필요`
+  - `다시 확인 중`
+  - `응답 대기 중`
+  - `동기화 확인됨`
+- signals
+  - 짧은 badge/chip 형태로 노출
+- CTA
+  - `지금 다시 동기화`
+  - `상태 다시 확인`
+  - `연결 후 다시 동기화`
+  - `잠시 후 다시`
+  - `다시 확인 중`
+
+상세 시트에는 아래 추가 정보가 들어간다.
+
+- `회복 상태`
+- `마지막 동기화`
+- `마지막 ACK`
+- `마지막 ACK 시각`
+- `어긋남 징후`
+- `중복 전송 안내`
+- `다음 행동`
+
+## 성공/실패/대기 피드백
+- 수동 동기화 직후
+  - processing banner
+  - headline: `다시 확인 중`
+- grace window 초과
+  - warning banner
+  - headline: `응답 대기 중`
+- 최신 sync/ACK 확인
+  - success banner
+  - headline: `동기화 확인됨`
+
+이번 단계에서는 별도 실패 terminal state를 추가하지 않는다. watch는 서버 직접 통신을 하지 않으므로, 실패보다는 `waiting`과 `unreachable` 문맥으로 보수적으로 안내한다.
+
+## 금지 범위 확인
+- `WCSession` message / application context 계약 전면 변경 없음
+- 서버와의 직접 통신 추가 없음
+- `syncState`를 write queue의 새로운 canonical action으로 승격하지 않음
+
+## 검증 기준
+- watch 메인 카드에서 out-of-sync 징후가 칩으로 보인다.
+- 상세 시트에 `어긋남 징후`와 `회복 상태`가 노출된다.
+- 수동 동기화 이후 `processing -> waiting/recovered` 전이가 가능하다.
+- cooldown 동안 반복 탭이 막힌다.
+- 오프라인에서는 수동 동기화가 새 queue spam을 만들지 않는다.

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		DAB314DA2B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314D92B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift */; };
 		DAB314DC2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314DB2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift */; };
 		DAB314DE2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314DD2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift */; };
+		DAB314E22B3C1D7F000357C7 /* WatchSyncRecoveryPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB314E12B3C1D7F000357C7 /* WatchSyncRecoveryPresentation.swift */; };
 		DAC19F0E2B0AE5AC002FE2E8 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC19F0D2B0AE5AC002FE2E8 /* ImagePicker.swift */; };
 		DAC19F102B0AF661002FE2E8 /* TitleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC19F0F2B0AF661002FE2E8 /* TitleTextView.swift */; };
 		DAC19F132B0AFCAC002FE2E8 /* UserdefaultSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC19F122B0AFCAC002FE2E8 /* UserdefaultSetting.swift */; };
@@ -587,6 +588,7 @@
 		DAB314D92B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWalkSummaryMetricGridView.swift; sourceTree = "<group>"; };
 		DAB314DB2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWalkEndDecisionSheetView.swift; sourceTree = "<group>"; };
 		DAB314DD2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWalkCompletionSummarySheetView.swift; sourceTree = "<group>"; };
+		DAB314E12B3C1D7F000357C7 /* WatchSyncRecoveryPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSyncRecoveryPresentation.swift; sourceTree = "<group>"; };
 		DAC19F0D2B0AE5AC002FE2E8 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		DAC19F0F2B0AF661002FE2E8 /* TitleTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleTextView.swift; sourceTree = "<group>"; };
 		DAC19F122B0AFCAC002FE2E8 /* UserdefaultSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserdefaultSetting.swift; sourceTree = "<group>"; };
@@ -1298,6 +1300,7 @@
 				DAB314D92B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift */,
 				DAB314DB2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift */,
 				DAB314DD2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift */,
+				DAB314E12B3C1D7F000357C7 /* WatchSyncRecoveryPresentation.swift */,
 				DAB314B52B3C1B4B000357C7 /* Assets.xcassets */,
 				DAB314B72B3C1B4B000357C7 /* Preview Content */,
 			);
@@ -2011,6 +2014,7 @@
 				DAB314DA2B3C1D7C000357C7 /* WatchWalkSummaryMetricGridView.swift in Sources */,
 				DAB314DC2B3C1D7D000357C7 /* WatchWalkEndDecisionSheetView.swift in Sources */,
 				DAB314DE2B3C1D7E000357C7 /* WatchWalkCompletionSummarySheetView.swift in Sources */,
+				DAB314E22B3C1D7F000357C7 /* WatchSyncRecoveryPresentation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dogAreaWatch Watch App/ContentsViewModel.swift
+++ b/dogAreaWatch Watch App/ContentsViewModel.swift
@@ -89,15 +89,26 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
     private var pendingActions: [WatchActionDTO] = []
     private let session = WCSession.default
     private let hapticService: WatchActionHapticServicing
+    private let syncRecoveryService: WatchSyncRecoveryPresenting
+    private let manualSyncCooldownInterval: TimeInterval = 15
+    private let manualSyncResponseGraceInterval: TimeInterval = 8
     @Published private var executionStates: [WatchActionType: WatchActionExecutionState] = [:]
     private var cooldownDeadlines: [WatchActionType: Date] = [:]
     private var actionTypeByActionId: [String: WatchActionType] = [:]
     private var resetWorkItems: [WatchActionType: DispatchWorkItem] = [:]
     private var lastCompletedActionId: String = ""
     private var lastPresentedCompletionSummaryActionId: String = ""
+    private var manualSyncRecoveryPhase: WatchManualSyncRecoveryPhase = .idle
+    private var nextManualSyncAllowedAt: TimeInterval?
+    private var manualSyncResponseWorkItem: DispatchWorkItem?
+    private var manualSyncCooldownRefreshWorkItem: DispatchWorkItem?
 
-    init(hapticService: WatchActionHapticServicing = DefaultWatchActionHapticService()) {
+    init(
+        hapticService: WatchActionHapticServicing = DefaultWatchActionHapticService(),
+        syncRecoveryService: WatchSyncRecoveryPresenting = DefaultWatchSyncRecoveryPresentationService()
+    ) {
         self.hapticService = hapticService
+        self.syncRecoveryService = syncRecoveryService
         super.init()
         loadPendingActions()
         loadAckSnapshot()
@@ -263,6 +274,7 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
     /// 사용자가 큐 상태 화면에서 수동 재동기화를 요청했을 때 reachability에 맞춰 처리합니다.
     /// 오프라인이면 새 sync action을 큐에 쌓지 않고, 온라인일 때만 queue flush와 상태 재확인을 수행합니다.
     func handleManualQueueResync() {
+        let now = Date().timeIntervalSince1970
         guard session.activationState == .activated, session.isReachable else {
             presentBanner(
                 title: "연결 대기 중",
@@ -273,6 +285,22 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
             return
         }
 
+        if let nextManualSyncAllowedAt, nextManualSyncAllowedAt > now {
+            presentBanner(
+                title: "잠시 후 다시",
+                detail: queueStatus.syncRecovery.cooldownRemainingText ?? "연속 재시도를 막기 위해 잠시 대기해 주세요.",
+                tone: .warning,
+                playsHaptic: false
+            )
+            refreshQueueStatus()
+            return
+        }
+
+        manualSyncRecoveryPhase = .processing(requestedAt: now)
+        nextManualSyncAllowedAt = now + manualSyncCooldownInterval
+        scheduleManualSyncResponseTimeout(requestedAt: now)
+        scheduleManualSyncCooldownRefresh(deadline: now + manualSyncCooldownInterval)
+
         presentBanner(
             title: pendingActions.isEmpty ? "상태 다시 확인" : "큐 다시 동기화",
             detail: pendingActions.isEmpty
@@ -281,6 +309,7 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
             tone: .processing,
             playsHaptic: false
         )
+        refreshQueueStatus()
         flushPendingActions()
         sendAction(.syncState)
     }
@@ -441,11 +470,88 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
     private func refreshQueueStatus() {
         queueStatus = .make(
             pendingActions: pendingActions,
+            lastSyncAt: lastSyncAt > 0 ? lastSyncAt : nil,
             lastAckStatus: lastAckStatus,
             lastAckActionId: lastAckActionId,
             lastAckAt: lastAckAt,
-            isReachable: isReachable
+            isReachable: isReachable,
+            syncRecoveryService: syncRecoveryService,
+            manualSyncPhase: manualSyncRecoveryPhase,
+            nextManualSyncAllowedAt: nextManualSyncAllowedAt
         )
+    }
+
+    /// 수동 동기화 요청 후 지정 시간 안에 ACK 또는 최신 context가 오지 않으면 `응답 대기` 상태로 전환합니다.
+    /// - Parameter requestedAt: 사용자가 수동 동기화를 누른 시각입니다.
+    private func scheduleManualSyncResponseTimeout(requestedAt: TimeInterval) {
+        manualSyncResponseWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard case .processing(let activeRequestedAt) = self.manualSyncRecoveryPhase,
+                  activeRequestedAt == requestedAt else {
+                return
+            }
+            self.manualSyncRecoveryPhase = .waiting(requestedAt: requestedAt)
+            self.refreshQueueStatus()
+            self.presentBanner(
+                title: "응답 대기 중",
+                detail: "아직 최신 ACK가 없어 자동 회복을 조금 더 기다리는 중입니다.",
+                tone: .warning,
+                playsHaptic: false
+            )
+        }
+        manualSyncResponseWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + manualSyncResponseGraceInterval,
+            execute: workItem
+        )
+    }
+
+    /// 수동 동기화 cooldown이 끝나는 시점에 카드/시트 상태를 다시 계산합니다.
+    /// - Parameter deadline: 다음 수동 동기화를 허용할 절대 시각입니다.
+    private func scheduleManualSyncCooldownRefresh(deadline: TimeInterval) {
+        manualSyncCooldownRefreshWorkItem?.cancel()
+        let interval = max(deadline - Date().timeIntervalSince1970, 0)
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.refreshQueueStatus()
+        }
+        manualSyncCooldownRefreshWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval, execute: workItem)
+    }
+
+    /// 수동 동기화 이후 최신 sync/ACK 시각이 갱신되면 recovery 상태를 완료로 전환합니다.
+    /// - Parameter syncTimestamp: recovery 완료를 판단할 최신 동기화 기준 시각입니다.
+    private func completeManualSyncRecoveryIfNeeded(syncTimestamp: TimeInterval) {
+        guard syncTimestamp > 0 else { return }
+        switch manualSyncRecoveryPhase {
+        case .processing(let requestedAt), .waiting(let requestedAt):
+            guard syncTimestamp >= requestedAt else { return }
+            manualSyncResponseWorkItem?.cancel()
+            manualSyncResponseWorkItem = nil
+            manualSyncRecoveryPhase = .recovered(recoveredAt: Date().timeIntervalSince1970)
+            refreshQueueStatus()
+            presentBanner(
+                title: "동기화 확인 완료",
+                detail: "watch와 iPhone 상태를 다시 맞췄어요.",
+                tone: .success
+            )
+            resetManualSyncRecoveryPhaseAfterDelay()
+        case .idle, .recovered:
+            break
+        }
+    }
+
+    /// 성공 배너가 지나가면 수동 recovery 상태를 기본값으로 되돌립니다.
+    private func resetManualSyncRecoveryPhaseAfterDelay() {
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            if case .recovered = self.manualSyncRecoveryPhase {
+                self.manualSyncRecoveryPhase = .idle
+                self.refreshQueueStatus()
+            }
+        }
+        manualSyncResponseWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4, execute: workItem)
     }
 
     /// 마지막 ACK 상태와 시각을 갱신하고 영속화합니다.
@@ -520,6 +626,9 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
             } else {
                 self.refreshQueueStatus()
             }
+            self.completeManualSyncRecoveryIfNeeded(
+                syncTimestamp: max(self.lastSyncAt, self.lastAckAt ?? 0)
+            )
         }
     }
 
@@ -550,6 +659,7 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
                 actionId: actionId,
                 ackAt: syncedAt
             )
+            self.completeManualSyncRecoveryIfNeeded(syncTimestamp: syncedAt)
 
             let actionType = self.actionTypeByActionId[actionId]
                 ?? actionName.flatMap(WatchActionType.init(rawValue:))
@@ -691,8 +801,13 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
             return
         }
         DispatchQueue.main.async { [weak self] in
-            self?.isReachable = session.isReachable
-            self?.refreshQueueStatus()
+            guard let self else { return }
+            self.isReachable = session.isReachable
+            if session.isReachable == false,
+               case .processing(let requestedAt) = self.manualSyncRecoveryPhase {
+                self.manualSyncRecoveryPhase = .waiting(requestedAt: requestedAt)
+            }
+            self.refreshQueueStatus()
         }
         applyContext(session.receivedApplicationContext)
         if session.isReachable {
@@ -703,10 +818,15 @@ final class ContentsViewModel: NSObject, ObservableObject, WCSessionDelegate {
 
     func sessionReachabilityDidChange(_ session: WCSession) {
         DispatchQueue.main.async { [weak self] in
-            self?.isReachable = session.isReachable
-            self?.refreshQueueStatus()
+            guard let self else { return }
+            self.isReachable = session.isReachable
+            if session.isReachable == false,
+               case .processing(let requestedAt) = self.manualSyncRecoveryPhase {
+                self.manualSyncRecoveryPhase = .waiting(requestedAt: requestedAt)
+            }
+            self.refreshQueueStatus()
             if session.isReachable == false {
-                self?.presentBanner(
+                self.presentBanner(
                     title: "오프라인 전환",
                     detail: "지금 누르는 액션은 큐에 저장했다가 연결되면 자동 전송합니다.",
                     tone: .warning,

--- a/dogAreaWatch Watch App/WatchOfflineQueueStatusCardView.swift
+++ b/dogAreaWatch Watch App/WatchOfflineQueueStatusCardView.swift
@@ -39,11 +39,25 @@ struct WatchOfflineQueueStatusCardView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(3)
 
+            if queueStatus.syncRecovery.signals.isEmpty == false {
+                HStack(spacing: 6) {
+                    ForEach(Array(queueStatus.syncRecovery.signals.prefix(2)), id: \.self) { signal in
+                        infoChip(title: signal.title, tone: signal.tone)
+                    }
+                }
+            }
+
             HStack(spacing: 8) {
                 infoChip(
                     title: "큐 \(queueStatus.pendingCount)건",
                     tone: queueStatus.pendingCount > 0 ? .warning : .neutral
                 )
+                if let lastSyncAt = queueStatus.lastSyncAt, lastSyncAt > 0 {
+                    infoChip(
+                        title: "동기화 \(formattedTimestamp(lastSyncAt))",
+                        tone: .neutral
+                    )
+                }
                 infoChip(
                     title: "ACK \(queueStatus.lastAckStatus)",
                     tone: .neutral
@@ -74,7 +88,7 @@ struct WatchOfflineQueueStatusCardView: View {
                             .padding(.vertical, 6)
                     }
                     .buttonStyle(.borderedProminent)
-                    .tint(queueStatus.isManualSyncHighlighted ? .orange : .blue)
+                    .tint(queueStatus.manualSyncButtonTone.tintColor)
                     .disabled(queueStatus.isManualSyncEnabled == false)
                 }
             }
@@ -83,7 +97,18 @@ struct WatchOfflineQueueStatusCardView: View {
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .fill(queueStatus.summaryTone.backgroundColor)
-        )
+            )
+    }
+
+    /// watch 카드용 짧은 시각 문자열을 포맷합니다.
+    /// - Parameter timestamp: 초 단위 Unix timestamp입니다.
+    /// - Returns: 값이 없으면 `없음`, 있으면 `HH:mm:ss` 형식 문자열입니다.
+    private func formattedTimestamp(_ timestamp: TimeInterval?) -> String {
+        guard let timestamp, timestamp > 0 else { return "없음" }
+        let date = Date(timeIntervalSince1970: timestamp)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
     }
 
     /// 큐 상태 카드 안에서 짧은 상태 배지를 렌더링합니다.

--- a/dogAreaWatch Watch App/WatchOfflineQueueStatusSheetView.swift
+++ b/dogAreaWatch Watch App/WatchOfflineQueueStatusSheetView.swift
@@ -16,6 +16,7 @@ struct WatchOfflineQueueStatusSheetView: View {
             VStack(alignment: .leading, spacing: 12) {
                 headerSection
                 statusSection
+                syncSignalSection
                 queuedActionSection
                 guidanceSection
             }
@@ -25,7 +26,7 @@ struct WatchOfflineQueueStatusSheetView: View {
 
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("오프라인 큐 상태")
+            Text("동기화 상태")
                 .font(.headline.weight(.semibold))
             Text(queueStatus.summaryDetail)
                 .font(.caption2)
@@ -36,6 +37,8 @@ struct WatchOfflineQueueStatusSheetView: View {
 
     private var statusSection: some View {
         VStack(alignment: .leading, spacing: 8) {
+            detailRow(label: "회복 상태", value: queueStatus.syncRecovery.headline)
+            detailRow(label: "마지막 동기화", value: formattedTimestamp(queueStatus.lastSyncAt))
             detailRow(label: "대기 건수", value: "\(queueStatus.pendingCount)건")
             detailRow(label: "마지막 큐 적재", value: formattedTimestamp(queueStatus.lastQueuedAt))
             detailRow(label: "가장 오래된 요청", value: formattedTimestamp(queueStatus.oldestQueuedAt))
@@ -51,6 +54,37 @@ struct WatchOfflineQueueStatusSheetView: View {
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.orange)
                     .lineLimit(4)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.white.opacity(0.08))
+        )
+    }
+
+    private var syncSignalSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("어긋남 징후")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if queueStatus.syncRecovery.signals.isEmpty {
+                Text("지금은 특별한 어긋남 징후가 없어요.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(queueStatus.syncRecovery.signals, id: \.self) { signal in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(signal.title)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(signal.tone.tintColor)
+                        Text(signal.detail)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(3)
+                    }
+                }
             }
         }
         .padding(10)
@@ -110,6 +144,13 @@ struct WatchOfflineQueueStatusSheetView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(4)
 
+            if let cooldownRemainingText = queueStatus.syncRecovery.cooldownRemainingText {
+                Text(cooldownRemainingText)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.orange)
+                    .lineLimit(2)
+            }
+
             if queueStatus.shouldOfferManualSync {
                 Button(action: onManualSync) {
                     Label(queueStatus.manualSyncButtonTitle, systemImage: "arrow.clockwise")
@@ -118,7 +159,7 @@ struct WatchOfflineQueueStatusSheetView: View {
                         .padding(.vertical, 6)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(queueStatus.isManualSyncHighlighted ? .orange : .blue)
+                .tint(queueStatus.manualSyncButtonTone.tintColor)
                 .disabled(queueStatus.isManualSyncEnabled == false)
             }
         }

--- a/dogAreaWatch Watch App/WatchOfflineQueueStatusState.swift
+++ b/dogAreaWatch Watch App/WatchOfflineQueueStatusState.swift
@@ -12,14 +12,19 @@ struct WatchOfflineQueueStatusState: Equatable {
     let queuedActionTitles: [String]
     let lastQueuedAt: TimeInterval?
     let oldestQueuedAt: TimeInterval?
+    let lastSyncAt: TimeInterval?
     let lastAckStatus: String
     let lastAckActionId: String
     let lastAckAt: TimeInterval?
     let isReachable: Bool
+    let syncRecovery: WatchSyncRecoveryState
 
     private let staleThreshold: TimeInterval = 90
 
     var summaryTone: WatchActionFeedbackTone {
+        if syncRecovery.isOutOfSyncLikely {
+            return syncRecovery.headlineTone
+        }
         if pendingCount == 0 {
             return isReachable ? .success : .neutral
         }
@@ -30,6 +35,9 @@ struct WatchOfflineQueueStatusState: Equatable {
     }
 
     var summaryTitle: String {
+        if syncRecovery.isOutOfSyncLikely {
+            return syncRecovery.headline
+        }
         if pendingCount == 0 {
             return "큐가 비어 있어요"
         }
@@ -37,6 +45,9 @@ struct WatchOfflineQueueStatusState: Equatable {
     }
 
     var summaryDetail: String {
+        if syncRecovery.isOutOfSyncLikely {
+            return syncRecovery.detail
+        }
         if pendingCount == 0 {
             return isReachable ? "지금은 바로 전송 가능한 상태예요." : "오프라인이면 새 요청을 큐에 안전하게 저장해요."
         }
@@ -51,6 +62,12 @@ struct WatchOfflineQueueStatusState: Equatable {
     }
 
     var nextActionText: String {
+        if syncRecovery.cooldownRemainingText != nil {
+            return syncRecovery.cooldownRemainingText!
+        }
+        if syncRecovery.isOutOfSyncLikely {
+            return syncRecovery.detail
+        }
         if pendingCount == 0 {
             return "지금은 추가 행동이 필요하지 않아요."
         }
@@ -65,6 +82,13 @@ struct WatchOfflineQueueStatusState: Equatable {
     }
 
     var warningText: String? {
+        if let cooldownRemainingText = syncRecovery.cooldownRemainingText {
+            return cooldownRemainingText
+        }
+        if syncRecovery.isOutOfSyncLikely,
+           let firstWarning = syncRecovery.signals.first(where: { $0.tone == .warning }) {
+            return firstWarning.detail
+        }
         guard pendingCount > 0 else { return nil }
         guard isStale else { return nil }
         return isReachable
@@ -82,18 +106,19 @@ struct WatchOfflineQueueStatusState: Equatable {
     }
 
     var isManualSyncEnabled: Bool {
-        isReachable
+        syncRecovery.isManualSyncEnabled
     }
 
     var manualSyncButtonTitle: String {
-        if isReachable {
-            return pendingCount > 0 ? "지금 다시 동기화" : "상태 다시 확인"
-        }
-        return "연결 후 다시 동기화"
+        syncRecovery.manualSyncButtonTitle
     }
 
     var isManualSyncHighlighted: Bool {
-        pendingCount > 0 && isReachable
+        syncRecovery.isManualSyncHighlighted
+    }
+
+    var manualSyncButtonTone: WatchActionFeedbackTone {
+        syncRecovery.manualSyncButtonTone
     }
 
     var isStale: Bool {
@@ -107,27 +132,39 @@ struct WatchOfflineQueueStatusState: Equatable {
     static func empty(isReachable: Bool) -> WatchOfflineQueueStatusState {
         make(
             pendingActions: [],
+            lastSyncAt: nil,
             lastAckStatus: "대기",
             lastAckActionId: "",
             lastAckAt: nil,
-            isReachable: isReachable
+            isReachable: isReachable,
+            syncRecoveryService: DefaultWatchSyncRecoveryPresentationService(),
+            manualSyncPhase: .idle,
+            nextManualSyncAllowedAt: nil
         )
     }
 
     /// pending queue, ACK, reachability 정보를 화면용 큐 상태 모델로 변환합니다.
     /// - Parameters:
     ///   - pendingActions: 아직 iPhone에 전달되지 않은 watch 액션 queue입니다.
+    ///   - lastSyncAt: 가장 최근 application context 동기화 시각입니다.
     ///   - lastAckStatus: 마지막 ACK 상태 요약 문자열입니다.
     ///   - lastAckActionId: 마지막 ACK에 대응한 action id입니다.
     ///   - lastAckAt: 마지막 ACK를 받은 시각입니다.
     ///   - isReachable: 현재 iPhone과 즉시 통신 가능한 상태인지 여부입니다.
+    ///   - syncRecoveryService: sync recovery 프레젠테이션 상태를 계산할 서비스입니다.
+    ///   - manualSyncPhase: 현재 수동 동기화 recovery 단계입니다.
+    ///   - nextManualSyncAllowedAt: 다시 수동 동기화를 허용할 다음 시각입니다.
     /// - Returns: 카드와 시트가 공통으로 사용할 큐 상태 모델입니다.
     static func make(
         pendingActions: [WatchActionDTO],
+        lastSyncAt: TimeInterval?,
         lastAckStatus: String,
         lastAckActionId: String,
         lastAckAt: TimeInterval?,
-        isReachable: Bool
+        isReachable: Bool,
+        syncRecoveryService: WatchSyncRecoveryPresenting,
+        manualSyncPhase: WatchManualSyncRecoveryPhase,
+        nextManualSyncAllowedAt: TimeInterval?
     ) -> WatchOfflineQueueStatusState {
         let queuedActionTitles = pendingActions
             .map(\.displayTitle)
@@ -137,15 +174,29 @@ struct WatchOfflineQueueStatusState: Equatable {
                 }
             }
         let sentTimes = pendingActions.map(\.sentAt)
+        let now = Date().timeIntervalSince1970
+        let syncRecovery = syncRecoveryService.makeState(
+            pendingCount: pendingActions.count,
+            oldestQueuedAt: sentTimes.min(),
+            lastSyncAt: lastSyncAt,
+            lastAckAt: lastAckAt,
+            lastAckStatus: lastAckStatus,
+            isReachable: isReachable,
+            manualSyncPhase: manualSyncPhase,
+            nextManualSyncAllowedAt: nextManualSyncAllowedAt,
+            now: now
+        )
         return WatchOfflineQueueStatusState(
             pendingCount: pendingActions.count,
             queuedActionTitles: queuedActionTitles,
             lastQueuedAt: sentTimes.max(),
             oldestQueuedAt: sentTimes.min(),
+            lastSyncAt: lastSyncAt,
             lastAckStatus: lastAckStatus,
             lastAckActionId: lastAckActionId,
             lastAckAt: lastAckAt,
-            isReachable: isReachable
+            isReachable: isReachable,
+            syncRecovery: syncRecovery
         )
     }
 }

--- a/dogAreaWatch Watch App/WatchSyncRecoveryPresentation.swift
+++ b/dogAreaWatch Watch App/WatchSyncRecoveryPresentation.swift
@@ -1,0 +1,369 @@
+//
+//  WatchSyncRecoveryPresentation.swift
+//  dogAreaWatch Watch App
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+
+enum WatchManualSyncRecoveryPhase: Equatable {
+    case idle
+    case processing(requestedAt: TimeInterval)
+    case waiting(requestedAt: TimeInterval)
+    case recovered(recoveredAt: TimeInterval)
+}
+
+struct WatchSyncRecoverySignal: Equatable, Hashable {
+    let title: String
+    let detail: String
+    let tone: WatchActionFeedbackTone
+}
+
+struct WatchSyncRecoveryState: Equatable {
+    let headline: String
+    let headlineTone: WatchActionFeedbackTone
+    let detail: String
+    let signals: [WatchSyncRecoverySignal]
+    let manualSyncButtonTitle: String
+    let manualSyncButtonTone: WatchActionFeedbackTone
+    let isManualSyncEnabled: Bool
+    let isManualSyncHighlighted: Bool
+    let cooldownRemainingText: String?
+    let isOutOfSyncLikely: Bool
+}
+
+protocol WatchSyncRecoveryPresenting {
+    /// queue, ACK, reachability, 수동 확인 상태를 종합해 watch 동기화 회복 프레젠테이션 상태를 계산합니다.
+    /// - Parameters:
+    ///   - pendingCount: 현재 큐에 남아 있는 action 개수입니다.
+    ///   - oldestQueuedAt: 가장 오래된 queued action의 전송 시각입니다.
+    ///   - lastSyncAt: iPhone application context 기준 마지막 동기화 시각입니다.
+    ///   - lastAckAt: 마지막 ACK를 받은 시각입니다.
+    ///   - lastAckStatus: 마지막 ACK 상태 문자열입니다.
+    ///   - isReachable: 현재 iPhone과 즉시 통신 가능한지 여부입니다.
+    ///   - manualSyncPhase: 수동 동기화 recovery 상태 단계입니다.
+    ///   - nextManualSyncAllowedAt: 다시 수동 동기화를 허용할 다음 시각입니다.
+    ///   - now: 기준이 되는 현재 시각입니다.
+    /// - Returns: watch 카드/상세 시트가 공통으로 사용할 sync recovery 상태입니다.
+    func makeState(
+        pendingCount: Int,
+        oldestQueuedAt: TimeInterval?,
+        lastSyncAt: TimeInterval?,
+        lastAckAt: TimeInterval?,
+        lastAckStatus: String,
+        isReachable: Bool,
+        manualSyncPhase: WatchManualSyncRecoveryPhase,
+        nextManualSyncAllowedAt: TimeInterval?,
+        now: TimeInterval
+    ) -> WatchSyncRecoveryState
+}
+
+struct DefaultWatchSyncRecoveryPresentationService: WatchSyncRecoveryPresenting {
+    private let staleSyncThreshold: TimeInterval = 60
+    private let staleQueueThreshold: TimeInterval = 90
+
+    /// queue/ACK/reachability 상태를 기반으로 watch sync recovery 프레젠테이션 스냅샷을 생성합니다.
+    /// - Parameters:
+    ///   - pendingCount: 현재 큐에 남아 있는 action 개수입니다.
+    ///   - oldestQueuedAt: 가장 오래된 queued action의 전송 시각입니다.
+    ///   - lastSyncAt: iPhone application context 기준 마지막 동기화 시각입니다.
+    ///   - lastAckAt: 마지막 ACK를 받은 시각입니다.
+    ///   - lastAckStatus: 마지막 ACK 상태 문자열입니다.
+    ///   - isReachable: 현재 iPhone과 즉시 통신 가능한지 여부입니다.
+    ///   - manualSyncPhase: 수동 동기화 recovery 상태 단계입니다.
+    ///   - nextManualSyncAllowedAt: 다시 수동 동기화를 허용할 다음 시각입니다.
+    ///   - now: 기준이 되는 현재 시각입니다.
+    /// - Returns: watch 카드/상세 시트가 공통으로 사용할 sync recovery 상태입니다.
+    func makeState(
+        pendingCount: Int,
+        oldestQueuedAt: TimeInterval?,
+        lastSyncAt: TimeInterval?,
+        lastAckAt: TimeInterval?,
+        lastAckStatus: String,
+        isReachable: Bool,
+        manualSyncPhase: WatchManualSyncRecoveryPhase,
+        nextManualSyncAllowedAt: TimeInterval?,
+        now: TimeInterval
+    ) -> WatchSyncRecoveryState {
+        let signals = makeSignals(
+            pendingCount: pendingCount,
+            oldestQueuedAt: oldestQueuedAt,
+            lastSyncAt: lastSyncAt,
+            lastAckAt: lastAckAt,
+            lastAckStatus: lastAckStatus,
+            isReachable: isReachable,
+            manualSyncPhase: manualSyncPhase,
+            now: now
+        )
+        let cooldownRemainingText = makeCooldownRemainingText(
+            nextManualSyncAllowedAt: nextManualSyncAllowedAt,
+            now: now
+        )
+        let hasSyncRisk = signals.contains { $0.tone == .warning || $0.tone == .failure }
+
+        let summary = makeSummary(
+            pendingCount: pendingCount,
+            isReachable: isReachable,
+            manualSyncPhase: manualSyncPhase,
+            signals: signals,
+            hasSyncRisk: hasSyncRisk
+        )
+        let manualSyncPresentation = makeManualSyncPresentation(
+            pendingCount: pendingCount,
+            isReachable: isReachable,
+            manualSyncPhase: manualSyncPhase,
+            hasSyncRisk: hasSyncRisk,
+            cooldownRemainingText: cooldownRemainingText
+        )
+
+        return WatchSyncRecoveryState(
+            headline: summary.headline,
+            headlineTone: summary.headlineTone,
+            detail: summary.detail,
+            signals: signals,
+            manualSyncButtonTitle: manualSyncPresentation.title,
+            manualSyncButtonTone: manualSyncPresentation.tone,
+            isManualSyncEnabled: manualSyncPresentation.isEnabled,
+            isManualSyncHighlighted: manualSyncPresentation.isHighlighted,
+            cooldownRemainingText: cooldownRemainingText,
+            isOutOfSyncLikely: hasSyncRisk || manualSyncPhase.isActiveRecovery
+        )
+    }
+
+    /// 현재 sync/queue/recovery 조건에서 사용자에게 노출할 out-of-sync 징후 목록을 생성합니다.
+    /// - Parameters:
+    ///   - pendingCount: 현재 큐에 남아 있는 action 개수입니다.
+    ///   - oldestQueuedAt: 가장 오래된 queued action의 전송 시각입니다.
+    ///   - lastSyncAt: 마지막 application context 동기화 시각입니다.
+    ///   - lastAckAt: 마지막 ACK 시각입니다.
+    ///   - lastAckStatus: 마지막 ACK 상태 문자열입니다.
+    ///   - isReachable: 현재 iPhone과 즉시 통신 가능한지 여부입니다.
+    ///   - manualSyncPhase: 수동 동기화 recovery 상태 단계입니다.
+    ///   - now: 기준이 되는 현재 시각입니다.
+    /// - Returns: 카드/시트에서 보여줄 sync 징후 목록입니다.
+    private func makeSignals(
+        pendingCount: Int,
+        oldestQueuedAt: TimeInterval?,
+        lastSyncAt: TimeInterval?,
+        lastAckAt: TimeInterval?,
+        lastAckStatus: String,
+        isReachable: Bool,
+        manualSyncPhase: WatchManualSyncRecoveryPhase,
+        now: TimeInterval
+    ) -> [WatchSyncRecoverySignal] {
+        var signals: [WatchSyncRecoverySignal] = []
+
+        if isReachable == false {
+            signals.append(
+                WatchSyncRecoverySignal(
+                    title: "iPhone 연결 끊김",
+                    detail: "연결이 돌아오면 자동 동기화가 다시 시작됩니다.",
+                    tone: .warning
+                )
+            )
+        }
+
+        if let lastSyncAt, lastSyncAt > 0 {
+            if now - lastSyncAt >= staleSyncThreshold {
+                signals.append(
+                    WatchSyncRecoverySignal(
+                        title: "마지막 동기화 오래됨",
+                        detail: "최근 상태 수신이 늦어져 현재 상태를 다시 확인할 필요가 있습니다.",
+                        tone: .warning
+                    )
+                )
+            }
+        } else {
+            signals.append(
+                WatchSyncRecoverySignal(
+                    title: "초기 동기화 전",
+                    detail: "아직 iPhone의 최신 상태를 한 번도 받지 못했습니다.",
+                    tone: .neutral
+                )
+            )
+        }
+
+        if pendingCount > 0,
+           let oldestQueuedAt,
+           now - oldestQueuedAt >= staleQueueThreshold {
+            signals.append(
+                WatchSyncRecoverySignal(
+                    title: "큐 장기 적재",
+                    detail: "90초 이상 처리되지 않은 요청이 남아 있어 직접 상태 확인이 필요합니다.",
+                    tone: .warning
+                )
+            )
+        }
+
+        if pendingCount > 0, lastAckAt == nil || lastAckStatus == "대기" {
+            signals.append(
+                WatchSyncRecoverySignal(
+                    title: "ACK 아직 없음",
+                    detail: "보낸 요청에 대한 최신 ACK를 아직 받지 못했습니다.",
+                    tone: .warning
+                )
+            )
+        }
+
+        switch manualSyncPhase {
+        case .idle:
+            break
+        case .processing:
+            signals.insert(
+                WatchSyncRecoverySignal(
+                    title: "수동 확인 진행 중",
+                    detail: "사용자가 요청한 다시 동기화에 대한 최신 상태를 확인 중입니다.",
+                    tone: .processing
+                ),
+                at: 0
+            )
+        case .waiting:
+            signals.insert(
+                WatchSyncRecoverySignal(
+                    title: "응답 대기 중",
+                    detail: "연결 또는 ACK 응답이 늦어져 자동 회복을 조금 더 기다리는 중입니다.",
+                    tone: .warning
+                ),
+                at: 0
+            )
+        case .recovered:
+            signals.insert(
+                WatchSyncRecoverySignal(
+                    title: "동기화 확인됨",
+                    detail: "가장 최근 다시 동기화 요청 이후 상태를 다시 맞췄습니다.",
+                    tone: .success
+                ),
+                at: 0
+            )
+        }
+
+        return signals
+    }
+
+    /// 현재 조건에서 카드 헤드라인과 설명을 결정합니다.
+    /// - Parameters:
+    ///   - pendingCount: 현재 큐에 남아 있는 action 개수입니다.
+    ///   - isReachable: 현재 iPhone과 즉시 통신 가능한지 여부입니다.
+    ///   - manualSyncPhase: 수동 동기화 recovery 상태 단계입니다.
+    ///   - signals: 현재 감지된 sync 징후 목록입니다.
+    ///   - hasSyncRisk: 사용자가 이해해야 할 out-of-sync 위험이 있는지 여부입니다.
+    /// - Returns: 카드/시트 헤더에 표시할 제목, 톤, 설명입니다.
+    private func makeSummary(
+        pendingCount: Int,
+        isReachable: Bool,
+        manualSyncPhase: WatchManualSyncRecoveryPhase,
+        signals: [WatchSyncRecoverySignal],
+        hasSyncRisk: Bool
+    ) -> (headline: String, headlineTone: WatchActionFeedbackTone, detail: String) {
+        switch manualSyncPhase {
+        case .processing:
+            return (
+                "다시 확인 중",
+                .processing,
+                "iPhone의 최신 ACK와 상태를 기다리는 중이에요."
+            )
+        case .waiting:
+            return (
+                "응답 대기 중",
+                .warning,
+                isReachable
+                    ? "연결은 살아 있지만 최신 응답이 늦어지고 있어요."
+                    : "연결이 돌아오면 자동 동기화가 다시 시도됩니다."
+            )
+        case .recovered:
+            return (
+                "동기화 확인됨",
+                .success,
+                "watch와 iPhone 상태를 다시 맞췄어요."
+            )
+        case .idle:
+            break
+        }
+
+        if hasSyncRisk {
+            return (
+                "상태 확인 필요",
+                .warning,
+                signals.first?.detail ?? "최신 상태를 다시 확인해 주세요."
+            )
+        }
+
+        if pendingCount == 0 {
+            return (
+                "동기화 정상",
+                isReachable ? .success : .neutral,
+                isReachable
+                    ? "watch와 iPhone 상태가 현재 잘 맞고 있어요."
+                    : "오프라인이지만 대기 중인 요청은 없습니다."
+            )
+        }
+
+        return (
+            "자동 동기화 대기",
+            isReachable ? .processing : .warning,
+            isReachable
+                ? "연결은 살아 있어 큐 재확인을 바로 시도할 수 있어요."
+                : "연결이 돌아오면 큐를 자동으로 다시 보냅니다."
+        )
+    }
+
+    /// 수동 동기화 CTA의 제목/강조/활성 상태를 계산합니다.
+    /// - Parameters:
+    ///   - pendingCount: 현재 큐에 남아 있는 action 개수입니다.
+    ///   - isReachable: 현재 iPhone과 즉시 통신 가능한지 여부입니다.
+    ///   - manualSyncPhase: 수동 동기화 recovery 상태 단계입니다.
+    ///   - hasSyncRisk: 사용자가 이해해야 할 out-of-sync 위험이 있는지 여부입니다.
+    ///   - cooldownRemainingText: 다음 수동 확인까지 남은 시간 설명입니다.
+    /// - Returns: CTA 제목, 톤, 활성 상태, 강조 여부입니다.
+    private func makeManualSyncPresentation(
+        pendingCount: Int,
+        isReachable: Bool,
+        manualSyncPhase: WatchManualSyncRecoveryPhase,
+        hasSyncRisk: Bool,
+        cooldownRemainingText: String?
+    ) -> (title: String, tone: WatchActionFeedbackTone, isEnabled: Bool, isHighlighted: Bool) {
+        if case .processing = manualSyncPhase {
+            return ("다시 확인 중", .processing, false, false)
+        }
+
+        if cooldownRemainingText != nil {
+            return ("잠시 후 다시", .warning, false, false)
+        }
+
+        guard isReachable else {
+            return ("연결 후 다시 동기화", .warning, false, false)
+        }
+
+        if hasSyncRisk || pendingCount > 0 {
+            return ("지금 다시 동기화", .warning, true, true)
+        }
+
+        return ("상태 다시 확인", .neutral, true, false)
+    }
+
+    /// 수동 동기화 cooldown이 남아 있을 때 사용자용 문구를 만듭니다.
+    /// - Parameters:
+    ///   - nextManualSyncAllowedAt: 다음 수동 동기화 허용 시각입니다.
+    ///   - now: 기준이 되는 현재 시각입니다.
+    /// - Returns: 남은 시간이 있으면 사용자용 문자열, 없으면 `nil`입니다.
+    private func makeCooldownRemainingText(
+        nextManualSyncAllowedAt: TimeInterval?,
+        now: TimeInterval
+    ) -> String? {
+        guard let nextManualSyncAllowedAt, nextManualSyncAllowedAt > now else { return nil }
+        let seconds = Int(ceil(nextManualSyncAllowedAt - now))
+        return "\(max(seconds, 1))초 뒤 다시 확인할 수 있어요."
+    }
+}
+
+private extension WatchManualSyncRecoveryPhase {
+    var isActiveRecovery: Bool {
+        switch self {
+        case .idle:
+            return false
+        case .processing, .waiting, .recovered:
+            return true
+        }
+    }
+}

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -61,6 +61,7 @@ swift scripts/widget_lock_screen_accessory_plan_unit_check.swift
 swift scripts/watch_action_feedback_ux_unit_check.swift
 swift scripts/watch_selected_pet_context_ux_unit_check.swift
 swift scripts/watch_offline_queue_sync_ux_unit_check.swift
+swift scripts/watch_sync_recovery_ux_unit_check.swift
 swift scripts/watch_walk_end_summary_ux_unit_check.swift
 swift scripts/walk_live_activity_priority_unit_check.swift
 swift scripts/walk_widget_action_state_model_unit_check.swift

--- a/scripts/watch_offline_queue_sync_ux_unit_check.swift
+++ b/scripts/watch_offline_queue_sync_ux_unit_check.swift
@@ -45,7 +45,9 @@ assertTrue(statusState.contains("var warningText"), "queue state should expose s
 
 assertTrue(cardView.contains("큐 상태 보기"), "queue card should expose detail CTA")
 assertTrue(cardView.contains("manualSyncButtonTitle"), "queue card should reuse manual sync title policy")
-assertTrue(sheetView.contains("오프라인 큐 상태"), "queue sheet should explain offline queue state")
+assertTrue(sheetView.contains("동기화 상태"), "queue sheet should explain sync status")
+assertTrue(sheetView.contains("어긋남 징후"), "queue sheet should expose out-of-sync signals section")
+assertTrue(sheetView.contains("회복 상태"), "queue sheet should expose recovery headline row")
 assertTrue(sheetView.contains("중복 전송 안내"), "queue sheet should explain idempotency")
 assertTrue(sheetView.contains("다음 행동"), "queue sheet should define next action guidance")
 

--- a/scripts/watch_sync_recovery_ux_unit_check.swift
+++ b/scripts/watch_sync_recovery_ux_unit_check.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+func read(_ path: String) -> String {
+    (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+}
+
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = FileManager.default.currentDirectoryPath
+let readme = read(root + "/README.md")
+let doc = read(root + "/docs/watch-sync-recovery-ux-v1.md")
+let project = read(root + "/dogArea.xcodeproj/project.pbxproj")
+let viewModel = read(root + "/dogAreaWatch Watch App/ContentsViewModel.swift")
+let statusState = read(root + "/dogAreaWatch Watch App/WatchOfflineQueueStatusState.swift")
+let cardView = read(root + "/dogAreaWatch Watch App/WatchOfflineQueueStatusCardView.swift")
+let sheetView = read(root + "/dogAreaWatch Watch App/WatchOfflineQueueStatusSheetView.swift")
+let recoveryModel = read(root + "/dogAreaWatch Watch App/WatchSyncRecoveryPresentation.swift")
+let checkScript = read(root + "/scripts/ios_pr_check.sh")
+
+assertTrue(readme.contains("watch-sync-recovery-ux-v1.md"), "README should index watch sync recovery doc")
+assertTrue(doc.contains("Issue: #524"), "doc should mention issue #524")
+assertTrue(doc.contains("마지막 동기화 오래됨"), "doc should define stale sync signal")
+assertTrue(doc.contains("ACK 아직 없음"), "doc should define missing ACK signal")
+assertTrue(doc.contains("큐 장기 적재"), "doc should define stale queue signal")
+assertTrue(doc.contains("iPhone 연결 끊김"), "doc should define unreachable signal")
+assertTrue(doc.contains("15초"), "doc should define manual sync cooldown")
+assertTrue(doc.contains("8초"), "doc should define grace window")
+assertTrue(doc.contains("WCSession"), "doc should confirm transport contract is preserved")
+
+assertTrue(recoveryModel.contains("enum WatchManualSyncRecoveryPhase"), "watch target should define manual sync recovery phase")
+assertTrue(recoveryModel.contains("struct WatchSyncRecoveryState"), "watch target should define sync recovery state")
+assertTrue(recoveryModel.contains("protocol WatchSyncRecoveryPresenting"), "watch target should define sync recovery presentation protocol")
+assertTrue(recoveryModel.contains("수동 확인 진행 중"), "recovery model should expose processing signal copy")
+assertTrue(recoveryModel.contains("응답 대기 중"), "recovery model should expose waiting signal copy")
+assertTrue(recoveryModel.contains("동기화 확인됨"), "recovery model should expose recovered signal copy")
+assertTrue(recoveryModel.contains("잠시 후 다시"), "recovery model should expose cooldown CTA copy")
+
+assertTrue(viewModel.contains("manualSyncCooldownInterval: TimeInterval = 15"), "view model should define manual sync cooldown interval")
+assertTrue(viewModel.contains("manualSyncResponseGraceInterval: TimeInterval = 8"), "view model should define manual sync grace interval")
+assertTrue(viewModel.contains("manualSyncRecoveryPhase = .processing"), "manual sync should enter processing phase")
+assertTrue(viewModel.contains("manualSyncRecoveryPhase = .waiting"), "manual sync should enter waiting phase")
+assertTrue(viewModel.contains("manualSyncRecoveryPhase = .recovered"), "manual sync should enter recovered phase")
+assertTrue(viewModel.contains("scheduleManualSyncResponseTimeout"), "view model should schedule response timeout")
+assertTrue(viewModel.contains("scheduleManualSyncCooldownRefresh"), "view model should schedule cooldown refresh")
+assertTrue(viewModel.contains("completeManualSyncRecoveryIfNeeded"), "view model should complete recovery on fresh sync")
+
+assertTrue(statusState.contains("let syncRecovery: WatchSyncRecoveryState"), "queue state should embed sync recovery snapshot")
+assertTrue(statusState.contains("manualSyncButtonTone"), "queue state should expose recovery button tone")
+assertTrue(statusState.contains("syncRecoveryService: WatchSyncRecoveryPresenting"), "queue state factory should depend on recovery presenter")
+
+assertTrue(cardView.contains("syncRecovery.signals"), "queue card should render sync recovery signals")
+assertTrue(sheetView.contains("어긋남 징후"), "queue sheet should expose sync signal section")
+assertTrue(sheetView.contains("회복 상태"), "queue sheet should expose recovery status row")
+assertTrue(sheetView.contains("syncRecovery.cooldownRemainingText"), "queue sheet should render cooldown guidance")
+
+assertTrue(project.contains("WatchSyncRecoveryPresentation.swift"), "xcode project should include watch sync recovery file")
+assertTrue(checkScript.contains("swift scripts/watch_sync_recovery_ux_unit_check.swift"), "ios_pr_check should run sync recovery unit check")
+
+print("PASS: watch sync recovery UX unit checks")


### PR DESCRIPTION
## Summary
- add a watch sync recovery presentation model for out-of-sync signals and guarded manual recovery
- surface recovery state on the queue card and detail sheet without changing the WCSession contract
- document the recovery UX and add static checks for README/project/check wiring

## Testing
- swift scripts/watch_offline_queue_sync_ux_unit_check.swift
- swift scripts/watch_sync_recovery_ux_unit_check.swift
- xcodebuild -project dogArea.xcodeproj -scheme 'dogAreaWatch Watch App' -configuration Debug -destination 'generic/platform=watchOS Simulator' CODE_SIGNING_ALLOWED=NO build\n- DOGAREA_DERIVED_DATA_PATH=.build/codex-524-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh\n\nCloses #524