### PR TITLE
fix: elevate map stop alert above controls and tab bar

### DIFF
--- a/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift
@@ -56,9 +56,13 @@ struct MapAlertSubView: View {
         )
       }
       return AnyView(
-        alertView
-          .transition(.opacity.combined(with: .scale(scale: 0.96)))
-          .accessibilityIdentifier("map.alert.host")
+        ZStack {
+          alertView
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea()
+        .transition(.opacity.combined(with: .scale(scale: 0.96)))
+        .accessibilityIdentifier("map.alert.host")
       )
     }
     else {

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -37,7 +37,7 @@ struct MapView : View{
     }
     
     var body : some View {
-        var composed = AnyView(mapContent)
+        var composed = AnyView(rootContent)
         composed = AnyView(composed.onAppear {
             viewModel.activateMapRuntimeServices()
             viewModel.reloadSelectedPetContext()
@@ -130,6 +130,20 @@ struct MapView : View{
         return composed
     }
 
+    private var rootContent: some View {
+        ZStack {
+            mapContent
+                .allowsHitTesting(!isCriticalModalPresented)
+                .accessibilityHidden(isCriticalModalPresented)
+
+            if isCriticalModalPresented {
+                MapAlertSubView(viewModel: viewModel, myAlert: myAlert)
+                    .zIndex(10)
+            }
+        }
+        .appTabBarVisibility(resolvedTabBarVisibility)
+    }
+
     private var mapContent: some View {
         GeometryReader { proxy in
             ZStack {
@@ -143,7 +157,6 @@ struct MapView : View{
                         .easeInOut(duration: viewModel.weatherOverlayAnimationDuration),
                         value: viewModel.weatherOverlayRiskLevel
                     )
-                MapAlertSubView(viewModel: viewModel, myAlert: myAlert)
             }
             .overlay(alignment: .top) {
                 MapTopChromeView(
@@ -162,10 +175,24 @@ struct MapView : View{
                 )
             }
             .overlay(alignment: .bottom) {
-                mapBottomControlOverlay
+                if shouldShowBottomControls {
+                    mapBottomControlOverlay
+                }
             }
             .appTabBarContentPadding(extra: 8)
         }
+    }
+
+    private var isCriticalModalPresented: Bool {
+        myAlert.isAlert
+    }
+
+    private var shouldShowBottomControls: Bool {
+        !isCriticalModalPresented && !endWalkingViewPresented
+    }
+
+    private var resolvedTabBarVisibility: AppTabBarVisibility {
+        (isCriticalModalPresented || endWalkingViewPresented) ? .hidden : .automatic
     }
 
     private var statusOverlayView: some View {

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -1529,6 +1529,13 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
 
     private func pauseWalkForAuthorizationDowngrade() {
         guard isWalking else { return }
+        if Self.shouldForceWalkingStateForUITest() {
+            walkStatusMessage = "UI 테스트 강제 산책 상태를 유지합니다."
+            syncWatchContext(force: true)
+            syncWalkWidgetSnapshot(force: true)
+            syncWalkLiveActivity(force: true)
+            return
+        }
         timerStop()
         persistActiveWalkSession(force: true)
         prepareRecoverableSessionIfNeeded()

--- a/dogAreaUITests/FeatureRegressionUITests.swift
+++ b/dogAreaUITests/FeatureRegressionUITests.swift
@@ -65,6 +65,8 @@ final class FeatureRegressionUITests: XCTestCase {
         let primaryAlertAction = screenElement(identifier: "customAlert.action.primary", in: app)
         let secondaryAlertAction = screenElement(identifier: "customAlert.action.secondary", in: app)
         let destructiveAlertAction = screenElement(identifier: "customAlert.action.destructive", in: app)
+        let bottomControls = screenElement(identifier: "map.bottomControls", in: app)
+        let activeTabBarButton = app.buttons["tab.2"]
 
         let alertPresented = waitUntilExists(alertSurface, timeout: 4)
             || waitUntilExists(alertHost, timeout: 1)
@@ -77,9 +79,13 @@ final class FeatureRegressionUITests: XCTestCase {
         XCTAssertEqual(primaryAlertAction.label, "저장 후 종료", "주 행동 버튼 문구가 의도와 다릅니다.")
         XCTAssertEqual(secondaryAlertAction.label, "계속 걷기", "보조 행동 버튼 문구가 의도와 다릅니다.")
         XCTAssertEqual(destructiveAlertAction.label, "기록 폐기", "파괴적 행동 버튼 문구가 의도와 다릅니다.")
+        XCTAssertTrue(waitUntilGone(activeTabBarButton, timeout: 2), "종료 알럿 표시 중에는 전역 탭바가 숨겨져야 합니다.")
+        XCTAssertTrue(waitUntilGone(bottomControls, timeout: 2), "종료 알럿 표시 중에는 하단 control overlay가 숨겨져야 합니다.")
 
         secondaryAlertAction.tap()
         XCTAssertTrue(waitUntilGone(alertSurface, timeout: 3), "계속 걷기 탭 후 알럿이 닫히지 않았습니다.")
+        XCTAssertTrue(waitUntilExists(activeTabBarButton, timeout: 3), "종료 알럿 해제 후 전역 탭바가 다시 보여야 합니다.")
+        XCTAssertTrue(waitUntilExists(bottomControls, timeout: 3), "종료 알럿 해제 후 하단 control overlay가 다시 보여야 합니다.")
     }
 
     /// 산책 목록 탭의 핵심 콘텐츠 진입점이 하단 탭바에 가려지지 않는지 검증합니다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -147,6 +147,7 @@ swift scripts/walk_return_to_origin_suggestion_unit_check.swift
 swift scripts/map_area_calculation_service_unit_check.swift
 swift scripts/map_chrome_hierarchy_unit_check.swift
 swift scripts/map_custom_alert_redesign_unit_check.swift
+swift scripts/map_stop_alert_modal_layering_unit_check.swift
 swift scripts/map_bottom_controls_hit_testing_unit_check.swift
 swift scripts/map_log_unreachable_cleanup_unit_check.swift
 swift scripts/map_append_walk_point_discardable_unit_check.swift

--- a/scripts/map_stop_alert_modal_layering_unit_check.swift
+++ b/scripts/map_stop_alert_modal_layering_unit_check.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Aborts the script when a required condition is not satisfied.
+/// - Parameters:
+///   - condition: Boolean result that must evaluate to `true`.
+///   - message: Failure message printed to stderr when the condition fails.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let repositoryRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// Loads a UTF-8 text file from the repository root.
+/// - Parameter relativePath: Repository-relative path to read.
+/// - Returns: File contents decoded as UTF-8 text.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: repositoryRoot.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let mapView = load("dogArea/Views/MapView/MapView.swift")
+let mapAlertHost = load("dogArea/Views/MapView/MapSubViews/MapAlertSubView.swift")
+let featureRegression = load("dogAreaUITests/FeatureRegressionUITests.swift")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(
+    mapView.contains("private var rootContent: some View"),
+    "MapView should introduce a root-level content host for critical map modals"
+)
+assertTrue(
+    mapView.contains(".allowsHitTesting(!isCriticalModalPresented)"),
+    "MapView should block background interaction while the stop alert is presented"
+)
+assertTrue(
+    mapView.contains(".accessibilityHidden(isCriticalModalPresented)"),
+    "MapView should hide the background accessibility tree while the stop alert is presented"
+)
+assertTrue(
+    mapView.contains("MapAlertSubView(viewModel: viewModel, myAlert: myAlert)") &&
+    mapView.contains(".appTabBarVisibility(resolvedTabBarVisibility)"),
+    "MapView should own the critical alert host and declaratively control tab bar visibility"
+)
+assertTrue(
+    mapView.contains("if shouldShowBottomControls {") &&
+    mapView.contains("!isCriticalModalPresented && !endWalkingViewPresented"),
+    "MapView should suppress bottom controls while alert/sheet transitions are active"
+)
+assertTrue(
+    mapAlertHost.contains(".frame(maxWidth: .infinity, maxHeight: .infinity)") &&
+    mapAlertHost.contains(".ignoresSafeArea()"),
+    "Map alert host should occupy the full screen modal layer"
+)
+assertTrue(
+    featureRegression.contains("waitUntilGone(activeTabBarButton, timeout: 2)") &&
+    featureRegression.contains("waitUntilGone(bottomControls, timeout: 2)"),
+    "feature regression should verify that tab bar and bottom controls disappear during the stop alert"
+)
+assertTrue(
+    iosPRCheck.contains("swift scripts/map_stop_alert_modal_layering_unit_check.swift"),
+    "ios_pr_check should run the map stop alert modal layering unit check"
+)
+
+print("PASS: map stop alert modal layering unit checks")


### PR DESCRIPTION
## Summary
- move the map stop alert host to the MapView root layer so it owns modal presentation above map chrome
- hide the app tab bar and bottom controls while the stop alert or end-walk sheet is active
- stabilize the forced walking UI test path and add a regression check for the modal layering contract

## Testing
- swift scripts/map_stop_alert_modal_layering_unit_check.swift
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -derivedDataPath .build/codex-527-build -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapStopAlertPresentsClearActionHierarchy test\n- DOGAREA_DERIVED_DATA_PATH=.build/codex-527-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh\n\nCloses #527