### PR TITLE
fix: preserve walk list tab selected icon fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - Backend scheduler 운영 기준 v1: `docs/backend-scheduler-ops-standard-v1.md`
 - Backend realtime/moderation retention policy v1: `docs/backend-realtime-moderation-retention-policy-v1.md`
 - Widget summary RPC 공통 응답 모델 v1: `docs/widget-summary-rpc-common-response-model-v1.md`
+- TabBar SF Symbol fallback policy v1: `docs/tabbar-sf-symbol-fallback-policy-v1.md`
 - UX copy guideline v1: `docs/ux-copy-guideline-v1.md`
 - Auth mail resend state machine v1: `docs/auth-mail-resend-state-machine-v1.md`
 - Auth CAPTCHA insertion & fallback UX v1: `docs/auth-captcha-insertion-fallback-ux-v1.md`

--- a/docs/tabbar-sf-symbol-fallback-policy-v1.md
+++ b/docs/tabbar-sf-symbol-fallback-policy-v1.md
@@ -1,0 +1,31 @@
+# TabBar SF Symbol Fallback Policy v1
+
+## 목적
+
+커스텀 탭바에서 선택 상태 아이콘을 `"\(base).fill"` 규칙으로 자동 생성하지 않습니다.
+
+SF Symbol은 base 이름에 대응하는 fill variant가 항상 존재하지 않기 때문입니다. `list.bullet`처럼 fill variant가 없는 심볼은 선택 상태에서 아이콘이 비거나 사라질 수 있습니다.
+
+## 규칙
+
+1. 각 탭은 `defaultSymbolName`과 `selectedSymbolName`을 명시합니다.
+2. 선택 심볼은 런타임에서 실제 유효성을 확인합니다.
+3. `selectedSymbolName`이 현재 OS에서 유효하지 않으면 `defaultSymbolName`으로 fallback합니다.
+4. 선택 피드백의 기본 우선순위는 다음과 같습니다.
+   - 유효한 selected symbol
+   - 동일 레이아웃 frame 유지
+   - 기존 색상 강조 유지
+
+## 현재 적용
+
+- 홈: `house` -> `house.fill`
+- 산책 목록: `list.bullet` -> `list.bullet.circle.fill`
+- 라이벌: `person.2` -> `person.2.fill`
+- 설정: `gearshape` -> `gearshape.fill`
+- 지도 중앙 버튼: 기존 별도 로직 유지
+
+## 구현 원칙
+
+- 새 탭을 추가할 때는 먼저 explicit selected symbol을 넣습니다.
+- `".fill"` 문자열 결합은 금지합니다.
+- 탭 레이아웃/크기/frame은 심볼 교체 여부와 무관하게 고정합니다.

--- a/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
+++ b/dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift
@@ -7,15 +7,18 @@
 
 import Foundation
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct CustomTabBar: View {
     @Binding var selectedTab: Int
 
     private let sideItems: [TabVisualItem] = [
-        .init(id: 0, title: "홈", icon: "house"),
-        .init(id: 1, title: "산책 목록", icon: "list.bullet"),
-        .init(id: 3, title: "라이벌", icon: "person.2"),
-        .init(id: 4, title: "설정", icon: "gearshape")
+        .init(id: 0, title: "홈", defaultSymbolName: "house", selectedSymbolName: "house.fill"),
+        .init(id: 1, title: "산책 목록", defaultSymbolName: "list.bullet", selectedSymbolName: "list.bullet.circle.fill"),
+        .init(id: 3, title: "라이벌", defaultSymbolName: "person.2", selectedSymbolName: "person.2.fill"),
+        .init(id: 4, title: "설정", defaultSymbolName: "gearshape", selectedSymbolName: "gearshape.fill")
     ]
 
     var body: some View {
@@ -51,11 +54,12 @@ struct CustomTabBar: View {
     /// 일반 탭 아이템 버튼을 렌더링합니다.
     private func tabItemButton(for item: TabVisualItem) -> some View {
         let isSelected = selectedTab == item.id
+        let resolvedSymbolName = item.resolvedSymbolName(isSelected: isSelected)
         return Button {
             selectedTab = item.id
         } label: {
             VStack(spacing: 4) {
-                Image(systemName: isSelected ? "\(item.icon).fill" : item.icon)
+                Image(systemName: resolvedSymbolName)
                     .font(.system(size: 19, weight: .semibold))
                     .frame(width: 28, height: 22)
                     .foregroundStyle(
@@ -63,6 +67,7 @@ struct CustomTabBar: View {
                         ? Color.appDynamicHex(light: 0xF59E0B, dark: 0xEAB308)
                         : Color.appDynamicHex(light: 0x94A3B8, dark: 0x64748B)
                     )
+                    .accessibilityHidden(true)
                 Text(item.title)
                     .font(.appScaledFont(for: .SemiBold, size: 11, relativeTo: .caption))
                     .foregroundStyle(
@@ -80,6 +85,7 @@ struct CustomTabBar: View {
         .contentShape(Rectangle())
         .accessibilityIdentifier("tab.\(item.id)")
         .accessibilityLabel(item.title)
+        .accessibilityValue(isSelected ? "selected:\(resolvedSymbolName)" : "default:\(resolvedSymbolName)")
     }
 
     /// 중앙 지도 액션을 강조한 탭 버튼입니다.
@@ -126,7 +132,29 @@ struct CustomTabBar: View {
 private struct TabVisualItem: Equatable {
     let id: Int
     let title: String
-    let icon: String
+    let defaultSymbolName: String
+    let selectedSymbolName: String
+
+    /// 현재 선택 상태에 맞는 SF Symbol 이름을 반환합니다.
+    /// - Parameter isSelected: 탭이 현재 선택 상태인지 여부입니다.
+    /// - Returns: 현재 상태에서 실제로 렌더링에 사용할 유효한 SF Symbol 이름입니다.
+    func resolvedSymbolName(isSelected: Bool) -> String {
+        guard isSelected else { return defaultSymbolName }
+        return Self.preferredSymbolName(primary: selectedSymbolName, fallback: defaultSymbolName)
+    }
+
+    /// 우선 사용할 심볼이 유효한지 확인하고, 실패하면 fallback 심볼을 반환합니다.
+    /// - Parameters:
+    ///   - primary: 선택 상태에서 우선 사용할 심볼 이름입니다.
+    ///   - fallback: 우선 심볼을 사용할 수 없을 때 대체할 기본 심볼 이름입니다.
+    /// - Returns: 현재 런타임에서 렌더링 가능한 안전한 SF Symbol 이름입니다.
+    private static func preferredSymbolName(primary: String, fallback: String) -> String {
+#if canImport(UIKit)
+        return UIImage(systemName: primary) == nil ? fallback : primary
+#else
+        return primary
+#endif
+    }
 }
 
 #Preview {

--- a/dogAreaUITests/FeatureRegressionUITests.swift
+++ b/dogAreaUITests/FeatureRegressionUITests.swift
@@ -112,6 +112,12 @@ final class FeatureRegressionUITests: XCTestCase {
         XCTAssertTrue(waitUntilExists(emptyCard, timeout: 2), "산책 목록 탭의 기본 비어 있음 상태를 찾지 못했습니다.")
     }
 
+    /// 산책 목록 탭을 선택해도 선택 아이콘이 유효한 SF Symbol로 유지되는지 검증합니다.
+    func testFeatureRegression_WalkListTabSelectedIconRemainsVisibleInBothStyles() throws {
+        try assertWalkListTabSelectedIconRemainsVisible(style: .light)
+        try assertWalkListTabSelectedIconRemainsVisible(style: .dark)
+    }
+
     /// 홈의 영역 목표 상세 진입 시 탭바가 숨겨지고 뒤로 복귀 시 다시 표시되는지 검증합니다.
     func testFeatureRegression_TerritoryGoalNavigationHidesAndRestoresTabBar() throws {
         let app = launchAppForFeatureRegression()
@@ -654,6 +660,25 @@ final class FeatureRegressionUITests: XCTestCase {
         app.launch()
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 12), "앱이 foreground 상태로 실행되지 않았습니다.")
         return app
+    }
+
+    /// 지정한 인터페이스 스타일에서 산책 목록 탭의 선택 아이콘 해상 상태를 검증합니다.
+    /// - Parameter style: 검증에 사용할 인터페이스 스타일입니다.
+    /// - Throws: XCTest assertion 실패 시 에러를 전파합니다.
+    private func assertWalkListTabSelectedIconRemainsVisible(style: InterfaceStyle) throws {
+        let app = launchAppForFeatureRegression(style: style)
+        let walkListTab = app.buttons["tab.1"]
+
+        XCTAssertTrue(waitUntilExists(walkListTab, timeout: 12), "산책 목록 탭 버튼(tab.1)을 찾지 못했습니다.")
+        XCTAssertTrue(openTab(index: 1, app: app), "산책 목록 탭 진입에 실패했습니다.")
+
+        let resolvedValue = walkListTab.value as? String
+        XCTAssertEqual(
+            resolvedValue,
+            "selected:list.bullet.circle.fill",
+            "산책 목록 탭 선택 상태에서 유효한 selected SF Symbol이 유지되어야 합니다."
+        )
+        XCTAssertTrue(walkListTab.isHittable, "산책 목록 탭 버튼이 선택 후에도 정상 hit-test 상태를 유지해야 합니다.")
     }
 
     /// 이메일/비밀번호를 입력해 로그인 버튼을 누르고 화면 복귀를 기다립니다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -136,6 +136,7 @@ swift scripts/feature_flag_refresh_throttle_unit_check.swift
 swift scripts/feature_flag_refresh_singleflight_unit_check.swift
 swift scripts/security_key_exposure_unit_check.swift
 swift scripts/map_home_viewmodel_boundary_unit_check.swift
+swift scripts/tabbar_symbol_fallback_unit_check.swift
 swift scripts/tabbar_safearea_regression_unit_check.swift
 swift scripts/root_view_supporting_type_split_unit_check.swift
 swift scripts/home_presentation_split_unit_check.swift

--- a/scripts/tabbar_symbol_fallback_unit_check.swift
+++ b/scripts/tabbar_symbol_fallback_unit_check.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// 조건이 거짓이면 에러를 출력하고 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 불리언 조건입니다.
+///   - message: 실패 시 출력할 메시지입니다.
+func assertTrue(_ condition: Bool, _ message: String) {
+    if condition == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+/// 저장소 루트 기준 상대 경로 파일을 UTF-8 문자열로 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let url = root.appendingPathComponent(relativePath)
+    let data = try! Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+}
+
+let tabBar = load("dogArea/Views/GlobalViews/BaseView/CustomTabBar.swift")
+let regressionTests = load("dogAreaUITests/FeatureRegressionUITests.swift")
+let policy = load("docs/tabbar-sf-symbol-fallback-policy-v1.md")
+let readme = load("README.md")
+
+assertTrue(
+    tabBar.contains("defaultSymbolName"),
+    "CustomTabBar should define explicit default symbol names per tab"
+)
+assertTrue(
+    tabBar.contains("selectedSymbolName"),
+    "CustomTabBar should define explicit selected symbol names per tab"
+)
+assertTrue(
+    tabBar.contains("list.bullet.circle.fill"),
+    "Walk list tab should provide an explicit selected SF Symbol"
+)
+assertTrue(
+    tabBar.contains("resolvedSymbolName(isSelected: isSelected)"),
+    "CustomTabBar should resolve tab symbols through an explicit resolver"
+)
+assertTrue(
+    !tabBar.contains("\\(item.icon).fill"),
+    "CustomTabBar should not compose selected symbol names via string fill suffix"
+)
+assertTrue(
+    tabBar.contains("UIImage(systemName: primary) == nil ? fallback : primary"),
+    "CustomTabBar should guard selected symbols with a runtime fallback rule"
+)
+assertTrue(
+    tabBar.contains(".accessibilityValue(isSelected ? \"selected:\\(resolvedSymbolName)\" : \"default:\\(resolvedSymbolName)\")"),
+    "CustomTabBar should expose resolved selected symbol state for regression testing"
+)
+assertTrue(
+    regressionTests.contains("testFeatureRegression_WalkListTabSelectedIconRemainsVisibleInBothStyles"),
+    "Feature regression tests should cover the walk list tab selected icon state"
+)
+assertTrue(
+    policy.contains("자동 생성하지 않습니다"),
+    "Policy doc should forbid automatic selected symbol composition"
+)
+assertTrue(
+    policy.contains(".fill") && policy.contains("문자열 결합은 금지합니다."),
+    "Policy doc should forbid automatic .fill composition"
+)
+assertTrue(
+    readme.contains("docs/tabbar-sf-symbol-fallback-policy-v1.md"),
+    "README should index the tab bar SF Symbol fallback policy"
+)
+
+print("PASS: tabbar symbol fallback unit checks")


### PR DESCRIPTION
## Summary
- replace implicit tab selected-symbol composition with explicit per-tab symbol mapping
- add runtime SF Symbol fallback resolution for selected/default states
- add policy docs and regression coverage for the walk list tab icon

## Verification
- swift scripts/tabbar_symbol_fallback_unit_check.swift
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -derivedDataPath .build/codex-528-build -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_WalkListTabSelectedIconRemainsVisibleInBothStyles test\n- DOGAREA_DERIVED_DATA_PATH=.build/codex-528-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh\n\nCloses #528