### PR TITLE
[Map/Performance] active walk route·mark 파생 snapshot/cache 도입

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - 체감 날씨 피드백 루프 v1: `docs/weather-feedback-loop-v1.md`
 - 날씨 리스크 모델/Provider 정책 v1: `docs/weather-risk-provider-policy-v1.md`
 - 날씨 snapshot/provider 확장 v1: `docs/weather-snapshot-provider-v1.md`
+- 맵 route/mark snapshot cache v1: `docs/map-walk-point-snapshot-cache-v1.md`
 - 홈 refresh entrypoint 정리 v1: `docs/home-refresh-entrypoint-v1.md`
 - 홈 미션 pet context snapshot v1: `docs/home-mission-pet-context-snapshot-v1.md`
 - 날씨 치환/스트릭 보호 서버 엔진 v1: `docs/weather-replacement-shield-engine-v1.md`

--- a/docs/map-walk-point-snapshot-cache-v1.md
+++ b/docs/map-walk-point-snapshot-cache-v1.md
@@ -1,0 +1,35 @@
+#502 Map Walk Point Snapshot Cache
+
+## 배경
+- `MapSubView`는 같은 render 안에서 `routeCoordinates(for: viewModel.polygon)`를 `count` 확인과 실제 `MapPolyline` 그리기에 각각 호출했습니다.
+- 같은 분기에서 `markLocations(for: viewModel.polygon)`도 별도로 호출해, 동일한 `polygon.locations`를 다시 순회했습니다.
+- 활성 산책 세션도 route/mark 파생값을 route용과 mark용으로 나눠 각각 다시 계산할 수 있는 구조였습니다.
+
+## 변경
+- `MapWalkPointSnapshot` 모델을 추가해 route 좌표와 mark 포인트를 같은 snapshot으로 묶었습니다.
+- `MapWalkPointSnapshotService`를 도입해 `Polygon`별 route/mark 파생값을 캐시합니다.
+- append-only 경로에서는 마지막 포인트만 반영해 active walk snapshot을 갱신합니다.
+- `MapSubView`는 `activeWalkPointSnapshot`, `walkPointSnapshot(for:)`를 한 번만 읽고 같은 render 안에서 재사용합니다.
+
+## Before
+- 단일 polygon 상세 분기에서 같은 `polygon.locations` 기준 호출이 최소 `3회`였습니다.
+  - `routeCoordinates(...).count`
+  - `routeCoordinates(...)`
+  - `markLocations(...)`
+- 각 호출은 내부적으로 `filter/map`를 다시 수행했습니다.
+
+## After
+- 단일 polygon 상세 분기에서 route/mark 파생 계산은 snapshot 생성 `1회`로 정리됩니다.
+- active walk append-only 경로는 기존 snapshot에 마지막 포인트만 추가합니다.
+- 동일 render 안에서는 route 개수 판정, polyline 그리기, mark annotation 반복이 같은 snapshot을 재사용합니다.
+
+## 유지 조건
+- route 좌표 순서 유지
+- mark 포인트 개수와 표시 순서 유지
+- polyline/annotation 시각 정책 유지
+- 산책 중 포인트 추가 시 즉시 반영 유지
+
+## 회귀 방지 포인트
+- `MapSubView`에서 같은 polygon에 대해 `routeCoordinates(for:)` / `markLocations(for:)`를 중복 호출하지 말 것
+- route/mark 파생은 `MapWalkPointSnapshotServicing`을 경유해 공유할 것
+- append-only 최적화는 결과 변경이 없는 경우에만 적용할 것

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -177,6 +177,8 @@
 		DA3F9BA32AE0F14F0048550C /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9B2AE0F14F0048550C /* MapView.swift */; };
 		DA3F9BA42AE0F14F0048550C /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9C2AE0F14F0048550C /* MapViewModel.swift */; };
 		DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9D2AE0F14F0048550C /* MapModel.swift */; };
+		A50200010000000000000001 /* MapWalkPointSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50200010000000000000011 /* MapWalkPointSnapshot.swift */; };
+		A50200010000000000000002 /* MapWalkPointSnapshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50200010000000000000012 /* MapWalkPointSnapshotService.swift */; };
 		DA3F9BA62AE0F14F0048550C /* WalkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */; };
 		DA3F9BAE2AE0F2410048550C /* ViewUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */; };
 		A45000010000000000000011 /* MapChromeSurfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45000010000000000000001 /* MapChromeSurfaceStyle.swift */; };
@@ -548,6 +550,8 @@
 		DA3F9B9B2AE0F14F0048550C /* MapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		DA3F9B9C2AE0F14F0048550C /* MapViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		DA3F9B9D2AE0F14F0048550C /* MapModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapModel.swift; sourceTree = "<group>"; };
+		A50200010000000000000011 /* MapWalkPointSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapWalkPointSnapshot.swift; sourceTree = "<group>"; };
+		A50200010000000000000012 /* MapWalkPointSnapshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapWalkPointSnapshotService.swift; sourceTree = "<group>"; };
 		DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalkListView.swift; sourceTree = "<group>"; };
 		DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewUtility.swift; sourceTree = "<group>"; };
 		A45000010000000000000001 /* MapChromeSurfaceStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapChromeSurfaceStyle.swift; sourceTree = "<group>"; };
@@ -1502,6 +1506,7 @@
 			isa = PBXGroup;
 			children = (
 				DA3F9B9D2AE0F14F0048550C /* MapModel.swift */,
+				A50200010000000000000011 /* MapWalkPointSnapshot.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1511,6 +1516,7 @@
 			children = (
 				DAE148A01420000000000001 /* MapAreaCalculationService.swift */,
 				DAE147B01420000000000001 /* MapClusterAnnotationService.swift */,
+				A50200010000000000000012 /* MapWalkPointSnapshotService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1889,7 +1895,9 @@
 				A50700010000000000000004 /* SupabaseAuthMailActionService.swift in Sources */,
 				A37800010000000000000001 /* AppTabScaffold.swift in Sources */,
 				DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */,
+				A50200010000000000000001 /* MapWalkPointSnapshot.swift in Sources */,
 				DAE148A11420000000000001 /* MapAreaCalculationService.swift in Sources */,
+				A50200010000000000000002 /* MapWalkPointSnapshotService.swift in Sources */,
 				DAE147B11420000000000001 /* MapClusterAnnotationService.swift in Sources */,
 				A37600010000000000000021 /* ProfileEditorDraft.swift in Sources */,
 				A37600010000000000000022 /* SettingsPetManagementService.swift in Sources */,

--- a/dogArea/Source/Domain/Map/Models/MapWalkPointSnapshot.swift
+++ b/dogArea/Source/Domain/Map/Models/MapWalkPointSnapshot.swift
@@ -1,0 +1,20 @@
+//
+//  MapWalkPointSnapshot.swift
+//  dogArea
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+import CoreLocation
+
+struct MapWalkPointSnapshot {
+    let polygonID: UUID
+    let sourcePointCount: Int
+    let routeCoordinates: [CLLocationCoordinate2D]
+    let markLocations: [Location]
+
+    var hasRenderableRoute: Bool {
+        routeCoordinates.count > 1
+    }
+}

--- a/dogArea/Source/Domain/Map/Services/MapWalkPointSnapshotService.swift
+++ b/dogArea/Source/Domain/Map/Services/MapWalkPointSnapshotService.swift
@@ -1,0 +1,154 @@
+//
+//  MapWalkPointSnapshotService.swift
+//  dogArea
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+import CoreLocation
+
+protocol MapWalkPointSnapshotServicing {
+    /// 주어진 폴리곤의 route/mark 파생값 snapshot을 반환합니다.
+    /// - Parameter polygon: route/mark 파생값을 계산할 산책 폴리곤입니다.
+    /// - Returns: route 좌표, mark 포인트, 렌더링 판정에 필요한 메타데이터를 담은 snapshot입니다.
+    func snapshot(for polygon: Polygon) -> MapWalkPointSnapshot
+}
+
+final class MapWalkPointSnapshotService: MapWalkPointSnapshotServicing {
+    private struct CachedSnapshot {
+        let pointIDs: [UUID]
+        let snapshot: MapWalkPointSnapshot
+    }
+
+    private let lock = NSLock()
+    private var snapshotsByPolygonID: [UUID: CachedSnapshot] = [:]
+    private let maxCachedPolygonCount = 96
+
+    /// 주어진 폴리곤의 route/mark 파생값 snapshot을 반환합니다.
+    /// - Parameter polygon: route/mark 파생값을 계산할 산책 폴리곤입니다.
+    /// - Returns: route 좌표, mark 포인트, 렌더링 판정에 필요한 메타데이터를 담은 snapshot입니다.
+    func snapshot(for polygon: Polygon) -> MapWalkPointSnapshot {
+        let pointIDs = polygon.locations.map(\.id)
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let cached = snapshotsByPolygonID[polygon.id] {
+            if cached.pointIDs == pointIDs {
+                return cached.snapshot
+            }
+
+            if let appended = appendedSnapshotIfPossible(
+                for: polygon,
+                pointIDs: pointIDs,
+                cached: cached
+            ) {
+                snapshotsByPolygonID[polygon.id] = appended
+                trimCacheIfNeeded(retaining: polygon.id)
+                return appended.snapshot
+            }
+        }
+
+        let rebuilt = makeCachedSnapshot(for: polygon, pointIDs: pointIDs)
+        snapshotsByPolygonID[polygon.id] = rebuilt
+        trimCacheIfNeeded(retaining: polygon.id)
+        return rebuilt.snapshot
+    }
+
+    /// append-only 업데이트인지 확인하고, 가능하면 기존 snapshot에 마지막 포인트만 반영합니다.
+    /// - Parameters:
+    ///   - polygon: 최신 포인트 배열을 가진 폴리곤입니다.
+    ///   - pointIDs: 최신 포인트 ID 배열입니다.
+    ///   - cached: 기존에 저장된 snapshot입니다.
+    /// - Returns: append-only 경로가 유효하면 마지막 포인트만 반영된 새 캐시, 아니면 `nil`입니다.
+    private func appendedSnapshotIfPossible(
+        for polygon: Polygon,
+        pointIDs: [UUID],
+        cached: CachedSnapshot
+    ) -> CachedSnapshot? {
+        guard pointIDs.count == cached.pointIDs.count + 1 else { return nil }
+        guard pointIDs.starts(with: cached.pointIDs) else { return nil }
+        guard let appendedPoint = polygon.locations.last else { return nil }
+
+        var routeCoordinates = cached.snapshot.routeCoordinates
+        var markLocations = cached.snapshot.markLocations
+
+        switch appendedPoint.pointRole {
+        case .route:
+            routeCoordinates.append(appendedPoint.coordinate)
+        case .mark:
+            markLocations.append(appendedPoint)
+        }
+
+        return CachedSnapshot(
+            pointIDs: pointIDs,
+            snapshot: MapWalkPointSnapshot(
+                polygonID: polygon.id,
+                sourcePointCount: polygon.locations.count,
+                routeCoordinates: routeCoordinates,
+                markLocations: markLocations
+            )
+        )
+    }
+
+    /// 캐시에 저장할 snapshot을 포인트 원본에서 새로 생성합니다.
+    /// - Parameters:
+    ///   - polygon: snapshot을 생성할 폴리곤입니다.
+    ///   - pointIDs: 캐시 비교에 사용할 포인트 ID 배열입니다.
+    /// - Returns: ID 시그니처와 계산된 snapshot을 함께 담은 캐시 엔트리입니다.
+    private func makeCachedSnapshot(
+        for polygon: Polygon,
+        pointIDs: [UUID]
+    ) -> CachedSnapshot {
+        CachedSnapshot(
+            pointIDs: pointIDs,
+            snapshot: buildSnapshot(
+                polygonID: polygon.id,
+                points: polygon.locations
+            )
+        )
+    }
+
+    /// 포인트 원본을 한 번만 순회하며 route 좌표와 mark 포인트를 동시에 분리합니다.
+    /// - Parameters:
+    ///   - polygonID: snapshot 대상 폴리곤 ID입니다.
+    ///   - points: route/mark 역할이 섞여 있는 원본 포인트 배열입니다.
+    /// - Returns: route 좌표와 mark 포인트가 분리된 snapshot입니다.
+    private func buildSnapshot(
+        polygonID: UUID,
+        points: [Location]
+    ) -> MapWalkPointSnapshot {
+        var routeCoordinates: [CLLocationCoordinate2D] = []
+        var markLocations: [Location] = []
+        routeCoordinates.reserveCapacity(points.count)
+        markLocations.reserveCapacity(points.count)
+
+        for point in points {
+            switch point.pointRole {
+            case .route:
+                routeCoordinates.append(point.coordinate)
+            case .mark:
+                markLocations.append(point)
+            }
+        }
+
+        return MapWalkPointSnapshot(
+            polygonID: polygonID,
+            sourcePointCount: points.count,
+            routeCoordinates: routeCoordinates,
+            markLocations: markLocations
+        )
+    }
+
+    /// 캐시 엔트리가 과도하게 쌓이면 현재 폴리곤 snapshot만 남기고 정리합니다.
+    /// - Parameter polygonID: 즉시 다시 사용할 가능성이 높은 현재 폴리곤 ID입니다.
+    private func trimCacheIfNeeded(retaining polygonID: UUID) {
+        guard snapshotsByPolygonID.count > maxCachedPolygonCount else { return }
+        let retained = snapshotsByPolygonID[polygonID]
+        snapshotsByPolygonID.removeAll(keepingCapacity: true)
+        if let retained {
+            snapshotsByPolygonID[polygonID] = retained
+        }
+    }
+}

--- a/dogArea/Views/MapView/MapSubViews/MapSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapSubView.swift
@@ -16,10 +16,12 @@ struct MapSubView: View {
 
     var body: some View {
         MapRenderBudgetProbe.recordMapSubViewBodyEvaluationIfNeeded()
+        let activeWalkSnapshot = viewModel.activeWalkPointSnapshot
+        let selectedPolygonSnapshot = viewModel.walkPointSnapshot(for: viewModel.polygon)
 
         return Map(position: $viewModel.cameraPosition, interactionModes: .all) {
-            if viewModel.isWalking, viewModel.activeWalkRouteCoordinates.count > 1 {
-                MapPolyline(coordinates: viewModel.activeWalkRouteCoordinates)
+            if viewModel.isWalking, activeWalkSnapshot.hasRenderableRoute {
+                MapPolyline(coordinates: activeWalkSnapshot.routeCoordinates)
                     .stroke(routeStrokeColor, style: routeStrokeStyle)
             }
             ForEach(viewModel.activeCaptureRipples()) { ripple in
@@ -68,11 +70,11 @@ struct MapSubView: View {
             }
             if let walkArea = viewModel.polygon.polygon {
                 if viewModel.showOnlyOne {
-                    if viewModel.routeCoordinates(for: viewModel.polygon).count > 1 {
-                        MapPolyline(coordinates: viewModel.routeCoordinates(for: viewModel.polygon))
+                    if selectedPolygonSnapshot.hasRenderableRoute {
+                        MapPolyline(coordinates: selectedPolygonSnapshot.routeCoordinates)
                             .stroke(routeStrokeColor, style: routeStrokeStyle)
                     }
-                    ForEach(viewModel.markLocations(for: viewModel.polygon)) { location in
+                    ForEach(selectedPolygonSnapshot.markLocations) { location in
                         Annotation("", coordinate: location.coordinate) {
                             PositionMarkerView()
                         }
@@ -130,11 +132,11 @@ struct MapSubView: View {
                     }
                 }
             } else {
-                if viewModel.isWalking == false, viewModel.activeWalkRouteCoordinates.count > 1 {
-                    MapPolyline(coordinates: viewModel.activeWalkRouteCoordinates)
+                if viewModel.isWalking == false, activeWalkSnapshot.hasRenderableRoute {
+                    MapPolyline(coordinates: activeWalkSnapshot.routeCoordinates)
                         .stroke(routeStrokeColor, style: routeStrokeStyle)
                 }
-                ForEach(viewModel.activeWalkMarkLocations) { location in
+                ForEach(activeWalkSnapshot.markLocations) { location in
                     Annotation("", coordinate: location.coordinate) {
                         PositionMarkerView()
                             .onTapGesture {

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -497,6 +497,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let weatherSnapshotProvider: WeatherSnapshotProviding
     private let weatherSnapshotStore: WeatherSnapshotStoreProtocol
     private let areaCalculationService: MapAreaCalculationServicing
+    private let walkPointSnapshotService: MapWalkPointSnapshotServicing
     private let clusterAnnotationService: MapClusterAnnotationServicing
     let widgetSnapshotStore: WalkWidgetSnapshotStoring
     let liveActivityService: WalkLiveActivityServicing
@@ -608,6 +609,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         weatherSnapshotProvider: WeatherSnapshotProviding = OpenMeteoWeatherSnapshotProvider(),
         weatherSnapshotStore: WeatherSnapshotStoreProtocol = WeatherSnapshotStore.shared,
         areaCalculationService: MapAreaCalculationServicing = MapAreaCalculationService(),
+        walkPointSnapshotService: MapWalkPointSnapshotServicing = MapWalkPointSnapshotService(),
         clusterAnnotationService: MapClusterAnnotationServicing = MapClusterAnnotationService(),
         widgetSnapshotStore: WalkWidgetSnapshotStoring = DefaultWalkWidgetSnapshotStore.shared,
         liveActivityService: WalkLiveActivityServicing = WalkLiveActivityService(),
@@ -621,6 +623,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.weatherSnapshotProvider = weatherSnapshotProvider
         self.weatherSnapshotStore = weatherSnapshotStore
         self.areaCalculationService = areaCalculationService
+        self.walkPointSnapshotService = walkPointSnapshotService
         self.clusterAnnotationService = clusterAnnotationService
         self.widgetSnapshotStore = widgetSnapshotStore
         self.liveActivityService = liveActivityService
@@ -3519,37 +3522,40 @@ extension MapViewModel {
         polygon.walkingArea = summary.finalAreaM2
     }
 
-    /// 지정 세션 포인트에서 route 역할 좌표만 추출합니다.
-    /// - Parameter points: route 좌표를 추출할 원본 포인트 배열입니다.
-    /// - Returns: route 포인트만 순서대로 변환한 좌표 배열입니다.
-    private func routeCoordinates(from points: [Location]) -> [CLLocationCoordinate2D] {
-        points
-            .filter { $0.pointRole == .route }
-            .map(\.coordinate)
+    /// 현재 세션의 route/mark 파생 snapshot입니다.
+    var activeWalkPointSnapshot: MapWalkPointSnapshot {
+        walkPointSnapshotService.snapshot(for: polygon)
     }
 
     /// 현재 세션의 route 좌표 배열입니다.
     var activeWalkRouteCoordinates: [CLLocationCoordinate2D] {
-        routeCoordinates(from: polygon.locations)
+        activeWalkPointSnapshot.routeCoordinates
     }
 
     /// 현재 세션의 mark 포인트 배열입니다.
     var activeWalkMarkLocations: [Location] {
-        polygon.locations.filter { $0.pointRole == .mark }
+        activeWalkPointSnapshot.markLocations
+    }
+
+    /// 특정 폴리곤 세션의 route/mark 파생 snapshot을 반환합니다.
+    /// - Parameter polygon: 조회 대상 산책 폴리곤입니다.
+    /// - Returns: 해당 세션의 route 좌표와 mark 포인트를 함께 담은 snapshot입니다.
+    func walkPointSnapshot(for polygon: Polygon) -> MapWalkPointSnapshot {
+        walkPointSnapshotService.snapshot(for: polygon)
     }
 
     /// 특정 폴리곤 세션의 route 좌표 배열을 반환합니다.
     /// - Parameter polygon: 조회 대상 산책 폴리곤입니다.
     /// - Returns: 해당 세션의 route 포인트를 좌표로 변환한 배열입니다.
     func routeCoordinates(for polygon: Polygon) -> [CLLocationCoordinate2D] {
-        routeCoordinates(from: polygon.locations)
+        walkPointSnapshot(for: polygon).routeCoordinates
     }
 
     /// 특정 폴리곤 세션의 mark 포인트 배열을 반환합니다.
     /// - Parameter polygon: 조회 대상 산책 폴리곤입니다.
     /// - Returns: 해당 세션의 mark 역할 포인트 배열입니다.
     func markLocations(for polygon: Polygon) -> [Location] {
-        polygon.locations.filter { $0.pointRole == .mark }
+        walkPointSnapshot(for: polygon).markLocations
     }
 
     func calculateArea() -> Double {

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -29,6 +29,7 @@ swift scripts/userdefault_store_split_unit_check.swift
 swift scripts/userdefault_setting_second_split_unit_check.swift
 swift scripts/map_motion_pack_unit_check.swift
 swift scripts/map_walking_invalidation_reduction_unit_check.swift
+swift scripts/map_walk_point_snapshot_cache_unit_check.swift
 swift scripts/quest_motion_pack_unit_check.swift
 swift scripts/quest_stage1_policy_unit_check.swift
 swift scripts/quest_stage2_engine_unit_check.swift

--- a/scripts/map_walk_point_snapshot_cache_unit_check.swift
+++ b/scripts/map_walk_point_snapshot_cache_unit_check.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
+let mapSubView = load("dogArea/Views/MapView/MapSubViews/MapSubView.swift")
+let model = load("dogArea/Source/Domain/Map/Models/MapWalkPointSnapshot.swift")
+let service = load("dogArea/Source/Domain/Map/Services/MapWalkPointSnapshotService.swift")
+let doc = load("docs/map-walk-point-snapshot-cache-v1.md")
+let readme = load("README.md")
+
+assertTrue(model.contains("struct MapWalkPointSnapshot"), "snapshot model should exist")
+assertTrue(model.contains("let routeCoordinates"), "snapshot model should store route coordinates")
+assertTrue(model.contains("let markLocations"), "snapshot model should store mark locations")
+assertTrue(model.contains("var hasRenderableRoute"), "snapshot model should expose reusable route render state")
+
+assertTrue(service.contains("protocol MapWalkPointSnapshotServicing"), "service file should define a protocol-first contract")
+assertTrue(service.contains("final class MapWalkPointSnapshotService"), "service file should define the concrete snapshot service")
+assertTrue(service.contains("appendedSnapshotIfPossible"), "service should support append-only updates for active walks")
+assertTrue(service.contains("pointIDs.starts(with: cached.pointIDs)"), "service should detect append-only active walk updates")
+assertTrue(service.contains("buildSnapshot("), "service should rebuild snapshots from a single pass when cache reuse is not possible")
+
+assertTrue(mapViewModel.contains("private let walkPointSnapshotService: MapWalkPointSnapshotServicing"), "map view model should inject the walk point snapshot service")
+assertTrue(mapViewModel.contains("walkPointSnapshotService: MapWalkPointSnapshotServicing = MapWalkPointSnapshotService()"), "map view model init should default the walk point snapshot service")
+assertTrue(mapViewModel.contains("var activeWalkPointSnapshot: MapWalkPointSnapshot"), "map view model should expose the active walk snapshot")
+assertTrue(mapViewModel.contains("func walkPointSnapshot(for polygon: Polygon) -> MapWalkPointSnapshot"), "map view model should expose polygon snapshot access")
+
+assertTrue(mapSubView.contains("let activeWalkSnapshot = viewModel.activeWalkPointSnapshot"), "MapSubView should reuse a single active walk snapshot per render")
+assertTrue(mapSubView.contains("let selectedPolygonSnapshot = viewModel.walkPointSnapshot(for: viewModel.polygon)"), "MapSubView should reuse a single selected polygon snapshot per render")
+assertTrue(!mapSubView.contains("routeCoordinates(for: viewModel.polygon).count"), "MapSubView should not duplicate route coordinate extraction for count checks")
+
+assertTrue(doc.contains("#502"), "doc should reference issue #502")
+assertTrue(doc.contains("최소 `3회`"), "doc should record the before call count")
+assertTrue(doc.contains("snapshot 생성 `1회`"), "doc should record the after snapshot reuse count")
+assertTrue(readme.contains("docs/map-walk-point-snapshot-cache-v1.md"), "README should index the map walk point snapshot cache doc")
+
+print("PASS: map walk point snapshot cache unit checks")


### PR DESCRIPTION
## Summary
- add a protocol-first walk point snapshot/cache service for route and mark derivation
- reuse a single selected polygon snapshot and active walk snapshot in MapSubView
- document the before/after derivation count and add a static regression check

## Verification
- swift scripts/map_walk_point_snapshot_cache_unit_check.swift
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -derivedDataPath .build/codex-476-build -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapPrimaryActionIsNotObscuredByTabBar -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapAddPointControlRemainsHittableWhileWalking -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapWalkingRuntimeKeepsRootRenderCountBelowThreshold test

Closes #502