### PR TITLE
refactor: gate map heatmap recomputation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - 체감 날씨 피드백 루프 v1: `docs/weather-feedback-loop-v1.md`
 - 날씨 리스크 모델/Provider 정책 v1: `docs/weather-risk-provider-policy-v1.md`
 - 날씨 snapshot/provider 확장 v1: `docs/weather-snapshot-provider-v1.md`
+- 맵 heatmap trigger gating v1: `docs/map-heatmap-trigger-gating-v1.md`
 - 맵 route/mark snapshot cache v1: `docs/map-walk-point-snapshot-cache-v1.md`
 - 홈 refresh entrypoint 정리 v1: `docs/home-refresh-entrypoint-v1.md`
 - 홈 미션 pet context snapshot v1: `docs/home-mission-pet-context-snapshot-v1.md`

--- a/docs/map-heatmap-trigger-gating-v1.md
+++ b/docs/map-heatmap-trigger-gating-v1.md
@@ -1,0 +1,58 @@
+#503 Map Heatmap Trigger Gating
+
+## 배경
+- 변경 전 `MapViewModel.refreshHeatmap()`는 `HeatmapEngine.aggregate(...)`를 직접 호출했습니다.
+- `applyPolygonList()`, `applyFeatureFlags()`, `toggleHeatmapEnabled()` 경로가 모두 같은 함수로 들어가면서, 실제 입력 데이터가 그대로여도 전체 heatmap 재집계를 다시 수행할 수 있었습니다.
+- 특히 heatmap이 실제로 화면에 보이지 않는 상태(`산책 중`, `단일 영역 보기`, `feature off`, `사용자 toggle off`)에서도 `polygonList` 갱신이나 feature flag 재적용이 들어오면 전체 히스토리를 다시 훑는 구조였습니다.
+
+## 구조 변경
+- `MapHeatmapDatasetFingerprint` / `MapHeatmapAggregationSnapshot` 모델 추가
+- `MapHeatmapAggregationService`로 fingerprint 생성, snapshot 재사용 판정, background 집계 책임 분리
+- `MapViewModel`은 다음 책임만 유지
+  - heatmap이 실제로 보이는 상태인지 판단
+  - 현재 snapshot을 재사용할지 결정
+  - 최신 요청 결과만 화면에 적용
+- 집계 자체는 service 내부 `Task.detached(priority: .utility)`에서 수행해 메인 스레드 점유를 줄였습니다.
+
+## Trigger Gating 규칙
+- 재계산 허용 조건
+  - `feature flag on`
+  - `heatmapEnabled == true`
+  - `isWalking == false`
+  - `showOnlyOne == false`
+- 동일 입력 재사용 조건
+  - polygon/location fingerprint 동일
+  - 현재 시각이 `15분 bucket` 안
+- 숨김 상태에서는
+  - 진행 중 집계 task 취소
+  - `heatmapCells`만 비우고 snapshot은 유지
+  - 다시 노출될 때 fingerprint가 같으면 즉시 재사용
+
+## Before / After 근거
+
+### 호출 빈도 관점
+- Before
+  - `applyPolygonList()`가 호출될 때마다 전체 heatmap 집계 `1회`
+  - 같은 입력으로 `applyFeatureFlags()`가 이어지면 전체 heatmap 집계가 추가 `1회`
+  - 즉, heatmap이 실제로 화면에 보이지 않는 상태에서도 동일 입력 기준 최소 `2회` 재집계 경로가 존재했습니다.
+- After
+  - 동일 시나리오에서 heatmap이 숨김 상태면 전체 집계 `0회`
+  - heatmap이 보이는 상태라도 fingerprint와 15분 bucket이 같으면 추가 집계 `0회`
+  - 최초 1회 계산 후에는 snapshot 재사용만 수행합니다.
+
+### 메인 스레드 점유 관점
+- Before
+  - `MapViewModel.refreshHeatmap()`가 뷰모델 내부에서 즉시 `HeatmapEngine.aggregate(...)`를 실행했습니다.
+- After
+  - 실제 집계는 `MapHeatmapAggregationService` 내부 background task에서 수행됩니다.
+  - `MapViewModel`은 계산 완료 후 snapshot 적용만 메인 스레드에서 처리합니다.
+
+## 제품 의미 유지
+- heatmap score 계산식은 기존 `HeatmapEngine.aggregate(points:now:precision:)`를 그대로 사용합니다.
+- geohash precision도 기존과 같은 `7`을 유지합니다.
+- 15분 bucket은 decay half-life가 21일인 현재 heatmap 의미를 바꾸지 않는 범위에서 재계산 빈도만 줄이기 위한 정책입니다.
+
+## 회귀 방지 포인트
+- `MapViewModel`에서 `HeatmapEngine.aggregate(...)`를 직접 다시 호출하지 말 것
+- heatmap 표시 조건과 무관한 state 변경이 전체 집계를 일으키지 않도록 할 것
+- time-based freshness를 더 촘촘하게 조정할 필요가 생기면 bucket 정책만 service에서 수정할 것

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -179,6 +179,8 @@
 		DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9D2AE0F14F0048550C /* MapModel.swift */; };
 		A50200010000000000000001 /* MapWalkPointSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50200010000000000000011 /* MapWalkPointSnapshot.swift */; };
 		A50200010000000000000002 /* MapWalkPointSnapshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50200010000000000000012 /* MapWalkPointSnapshotService.swift */; };
+		A50300010000000000000001 /* MapHeatmapSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50300010000000000000011 /* MapHeatmapSnapshot.swift */; };
+		A50300010000000000000002 /* MapHeatmapAggregationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50300010000000000000012 /* MapHeatmapAggregationService.swift */; };
 		DA3F9BA62AE0F14F0048550C /* WalkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */; };
 		DA3F9BAE2AE0F2410048550C /* ViewUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */; };
 		A45000010000000000000011 /* MapChromeSurfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45000010000000000000001 /* MapChromeSurfaceStyle.swift */; };
@@ -552,6 +554,8 @@
 		DA3F9B9D2AE0F14F0048550C /* MapModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapModel.swift; sourceTree = "<group>"; };
 		A50200010000000000000011 /* MapWalkPointSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapWalkPointSnapshot.swift; sourceTree = "<group>"; };
 		A50200010000000000000012 /* MapWalkPointSnapshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapWalkPointSnapshotService.swift; sourceTree = "<group>"; };
+		A50300010000000000000011 /* MapHeatmapSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapHeatmapSnapshot.swift; sourceTree = "<group>"; };
+		A50300010000000000000012 /* MapHeatmapAggregationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapHeatmapAggregationService.swift; sourceTree = "<group>"; };
 		DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalkListView.swift; sourceTree = "<group>"; };
 		DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewUtility.swift; sourceTree = "<group>"; };
 		A45000010000000000000001 /* MapChromeSurfaceStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapChromeSurfaceStyle.swift; sourceTree = "<group>"; };
@@ -1506,6 +1510,7 @@
 			isa = PBXGroup;
 			children = (
 				DA3F9B9D2AE0F14F0048550C /* MapModel.swift */,
+				A50300010000000000000011 /* MapHeatmapSnapshot.swift */,
 				A50200010000000000000011 /* MapWalkPointSnapshot.swift */,
 			);
 			path = Models;
@@ -1515,6 +1520,7 @@
 			isa = PBXGroup;
 			children = (
 				DAE148A01420000000000001 /* MapAreaCalculationService.swift */,
+				A50300010000000000000012 /* MapHeatmapAggregationService.swift */,
 				DAE147B01420000000000001 /* MapClusterAnnotationService.swift */,
 				A50200010000000000000012 /* MapWalkPointSnapshotService.swift */,
 			);
@@ -1895,8 +1901,10 @@
 				A50700010000000000000004 /* SupabaseAuthMailActionService.swift in Sources */,
 				A37800010000000000000001 /* AppTabScaffold.swift in Sources */,
 				DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */,
+				A50300010000000000000001 /* MapHeatmapSnapshot.swift in Sources */,
 				A50200010000000000000001 /* MapWalkPointSnapshot.swift in Sources */,
 				DAE148A11420000000000001 /* MapAreaCalculationService.swift in Sources */,
+				A50300010000000000000002 /* MapHeatmapAggregationService.swift in Sources */,
 				A50200010000000000000002 /* MapWalkPointSnapshotService.swift in Sources */,
 				DAE147B11420000000000001 /* MapClusterAnnotationService.swift in Sources */,
 				A37600010000000000000021 /* ProfileEditorDraft.swift in Sources */,

--- a/dogArea/Source/Domain/Map/Models/MapHeatmapSnapshot.swift
+++ b/dogArea/Source/Domain/Map/Models/MapHeatmapSnapshot.swift
@@ -1,0 +1,24 @@
+//
+//  MapHeatmapSnapshot.swift
+//  dogArea
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+
+/// heatmap 입력 데이터셋이 실제로 바뀌었는지 추적하는 fingerprint입니다.
+struct MapHeatmapDatasetFingerprint: Equatable {
+    let digestHex: String
+    let polygonCount: Int
+    let pointCount: Int
+}
+
+/// 재사용 가능한 heatmap 집계 결과 snapshot입니다.
+struct MapHeatmapAggregationSnapshot: Equatable {
+    let datasetFingerprint: MapHeatmapDatasetFingerprint
+    let computedAt: TimeInterval
+    let validThrough: TimeInterval
+    let sourcePointCount: Int
+    let cells: [HeatmapCellDTO]
+}

--- a/dogArea/Source/Domain/Map/Services/MapHeatmapAggregationService.swift
+++ b/dogArea/Source/Domain/Map/Services/MapHeatmapAggregationService.swift
@@ -1,0 +1,170 @@
+//
+//  MapHeatmapAggregationService.swift
+//  dogArea
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+
+/// 지도 heatmap 집계 재사용과 비동기 계산을 담당하는 계약입니다.
+protocol MapHeatmapAggregationServicing {
+    /// 현재 polygon 목록의 heatmap 입력 변경 여부를 추적할 fingerprint를 생성합니다.
+    /// - Parameter polygons: heatmap 집계에 반영할 polygon 목록입니다.
+    /// - Returns: 동일한 입력이면 같은 값을 갖는 heatmap dataset fingerprint입니다.
+    func makeDatasetFingerprint(from polygons: [Polygon]) -> MapHeatmapDatasetFingerprint
+
+    /// 저장된 heatmap snapshot을 그대로 재사용할 수 있는지 판단합니다.
+    /// - Parameters:
+    ///   - snapshot: 이전 계산 결과로 보관 중인 snapshot입니다.
+    ///   - datasetFingerprint: 현재 polygon 목록의 fingerprint입니다.
+    ///   - reference: 이번 판단 기준 시각입니다.
+    /// - Returns: 입력과 시간 버킷이 모두 유효하면 `true`입니다.
+    func canReuseSnapshot(
+        _ snapshot: MapHeatmapAggregationSnapshot?,
+        datasetFingerprint: MapHeatmapDatasetFingerprint,
+        reference: Date
+    ) -> Bool
+
+    /// 현재 polygon 목록의 heatmap 셀을 background task에서 집계합니다.
+    /// - Parameters:
+    ///   - polygons: heatmap 집계에 사용할 polygon 목록입니다.
+    ///   - datasetFingerprint: 현재 polygon 목록의 fingerprint입니다.
+    ///   - reference: decay weight와 snapshot 유효 구간 계산에 사용할 기준 시각입니다.
+    /// - Returns: 재사용 가능한 heatmap 집계 snapshot입니다.
+    func makeAggregationSnapshot(
+        polygons: [Polygon],
+        datasetFingerprint: MapHeatmapDatasetFingerprint,
+        reference: Date
+    ) async -> MapHeatmapAggregationSnapshot
+}
+
+final class MapHeatmapAggregationService: MapHeatmapAggregationServicing {
+    private let refreshBucketInterval: TimeInterval
+    private let geohashPrecision: Int
+
+    /// heatmap 집계 서비스의 시간 버킷/정밀도 정책을 생성합니다.
+    /// - Parameters:
+    ///   - refreshBucketInterval: 동일 입력 재사용을 허용할 시간 버킷 길이(초)입니다.
+    ///   - geohashPrecision: heatmap bucket geohash 정밀도입니다.
+    init(
+        refreshBucketInterval: TimeInterval = 900,
+        geohashPrecision: Int = 7
+    ) {
+        self.refreshBucketInterval = refreshBucketInterval
+        self.geohashPrecision = geohashPrecision
+    }
+
+    /// 현재 polygon 목록의 heatmap 입력 변경 여부를 추적할 fingerprint를 생성합니다.
+    /// - Parameter polygons: heatmap 집계에 반영할 polygon 목록입니다.
+    /// - Returns: 동일한 입력이면 같은 값을 갖는 heatmap dataset fingerprint입니다.
+    func makeDatasetFingerprint(from polygons: [Polygon]) -> MapHeatmapDatasetFingerprint {
+        var hash: UInt64 = 0xcbf29ce484222325
+        let sortedPolygons = polygons.sorted { lhs, rhs in
+            lhs.id.uuidString < rhs.id.uuidString
+        }
+        var pointCount = 0
+
+        for polygon in sortedPolygons {
+            mix(value: polygon.id.uuidString.utf8, into: &hash)
+            mix(value: polygon.createdAt.bitPattern, into: &hash)
+            mix(value: UInt64(polygon.locations.count), into: &hash)
+
+            for point in polygon.locations {
+                pointCount += 1
+                mix(value: point.id.uuidString.utf8, into: &hash)
+                mix(value: point.createdAt.bitPattern, into: &hash)
+                mix(value: point.coordinate.latitude.bitPattern, into: &hash)
+                mix(value: point.coordinate.longitude.bitPattern, into: &hash)
+            }
+        }
+
+        return MapHeatmapDatasetFingerprint(
+            digestHex: String(format: "%016llx", hash),
+            polygonCount: polygons.count,
+            pointCount: pointCount
+        )
+    }
+
+    /// 저장된 heatmap snapshot을 그대로 재사용할 수 있는지 판단합니다.
+    /// - Parameters:
+    ///   - snapshot: 이전 계산 결과로 보관 중인 snapshot입니다.
+    ///   - datasetFingerprint: 현재 polygon 목록의 fingerprint입니다.
+    ///   - reference: 이번 판단 기준 시각입니다.
+    /// - Returns: 입력과 시간 버킷이 모두 유효하면 `true`입니다.
+    func canReuseSnapshot(
+        _ snapshot: MapHeatmapAggregationSnapshot?,
+        datasetFingerprint: MapHeatmapDatasetFingerprint,
+        reference: Date
+    ) -> Bool {
+        guard let snapshot else { return false }
+        guard snapshot.datasetFingerprint == datasetFingerprint else { return false }
+
+        let referenceTimestamp = reference.timeIntervalSince1970
+        guard referenceTimestamp >= snapshot.computedAt else { return false }
+        return referenceTimestamp <= snapshot.validThrough
+    }
+
+    /// 현재 polygon 목록의 heatmap 셀을 background task에서 집계합니다.
+    /// - Parameters:
+    ///   - polygons: heatmap 집계에 사용할 polygon 목록입니다.
+    ///   - datasetFingerprint: 현재 polygon 목록의 fingerprint입니다.
+    ///   - reference: decay weight와 snapshot 유효 구간 계산에 사용할 기준 시각입니다.
+    /// - Returns: 재사용 가능한 heatmap 집계 snapshot입니다.
+    func makeAggregationSnapshot(
+        polygons: [Polygon],
+        datasetFingerprint: MapHeatmapDatasetFingerprint,
+        reference: Date
+    ) async -> MapHeatmapAggregationSnapshot {
+        let points = polygons.flatMap(\.locations)
+        let computedAt = reference.timeIntervalSince1970
+        let validThrough = nextBucketBoundary(after: reference)
+        let geohashPrecision = self.geohashPrecision
+
+        return await Task.detached(priority: .utility) {
+            let cells = HeatmapEngine.aggregate(
+                points: points,
+                now: reference,
+                precision: geohashPrecision
+            )
+            return MapHeatmapAggregationSnapshot(
+                datasetFingerprint: datasetFingerprint,
+                computedAt: computedAt,
+                validThrough: validThrough,
+                sourcePointCount: points.count,
+                cells: cells
+            )
+        }.value
+    }
+
+    /// 기준 시각이 속한 재사용 버킷의 다음 경계를 계산합니다.
+    /// - Parameter reference: 이번 heatmap snapshot 기준 시각입니다.
+    /// - Returns: snapshot을 다시 계산해야 하는 다음 시간 경계입니다.
+    private func nextBucketBoundary(after reference: Date) -> TimeInterval {
+        let current = reference.timeIntervalSince1970
+        let bucket = max(60.0, refreshBucketInterval)
+        let bucketIndex = floor(current / bucket)
+        return (bucketIndex + 1.0) * bucket
+    }
+
+    /// FNV-1a 스타일 rolling hash에 문자열 바이트를 반영합니다.
+    /// - Parameters:
+    ///   - value: hash에 섞을 문자열 바이트 시퀀스입니다.
+    ///   - hash: 누적 중인 64-bit hash 값입니다.
+    private func mix<S: Sequence>(value: S, into hash: inout UInt64) where S.Element == UInt8 {
+        for byte in value {
+            hash ^= UInt64(byte)
+            hash &*= 1099511628211
+        }
+    }
+
+    /// FNV-1a 스타일 rolling hash에 64-bit 값을 반영합니다.
+    /// - Parameters:
+    ///   - value: hash에 섞을 64-bit 값입니다.
+    ///   - hash: 누적 중인 64-bit hash 값입니다.
+    private func mix(value: UInt64, into hash: inout UInt64) {
+        withUnsafeBytes(of: value.littleEndian) { bytes in
+            mix(value: bytes, into: &hash)
+        }
+    }
+}

--- a/dogArea/Views/MapView/MapSubViews/MapSubView.swift
+++ b/dogArea/Views/MapView/MapSubViews/MapSubView.swift
@@ -52,7 +52,7 @@ struct MapSubView: View {
                         .shadow(radius: 5)
                 }
             }
-            if !viewModel.isWalking && !viewModel.showOnlyOne && viewModel.isHeatmapFeatureAvailable && viewModel.heatmapEnabled {
+            if viewModel.isHeatmapVisibleInMapUI {
                 ForEach(viewModel.heatmapCells) { cell in
                     MapCircle(center: cell.centerCoordinate, radius: 75)
                         .foregroundStyle(

--- a/dogArea/Views/MapView/MapView.swift
+++ b/dogArea/Views/MapView/MapView.swift
@@ -164,7 +164,7 @@ struct MapView : View{
                     safeAreaTopInset: proxy.safeAreaInsets.top,
                     weatherStatusText: viewModel.weatherOverlayStatusText,
                     isWeatherFallbackActive: viewModel.weatherOverlayFallbackActive,
-                    heatmapSummaryText: (!viewModel.isWalking && viewModel.isHeatmapFeatureAvailable && viewModel.heatmapEnabled)
+                    heatmapSummaryText: viewModel.isHeatmapVisibleInMapUI
                         ? viewModel.seasonTileStatusSummaryText
                         : nil,
                     bannerContent: activeBanner.map { AnyView(topBannerView(for: $0)) },

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -317,6 +317,9 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             if self.isWalking {
                 self.showOnlyOne = true
             }
+            if oldValue != self.isWalking {
+                handleHeatmapVisibilityStateChanged()
+            }
             self.publishWatchState()
         }
     }
@@ -325,7 +328,12 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     var camera: MapCamera = .init(.init())
     @Published var cameraPosition = MapCameraPosition.automatic
     @Published var selectedMarker: Location? = nil
-    @Published var showOnlyOne: Bool = true
+    @Published var showOnlyOne: Bool = true {
+        didSet {
+            guard oldValue != showOnlyOne else { return }
+            handleHeatmapVisibilityStateChanged()
+        }
+    }
     @Published var heatmapEnabled: Bool = true
     @Published var heatmapCells: [HeatmapCellDTO] = []
     @Published var nearbyHotspotEnabled: Bool = true
@@ -371,7 +379,11 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     private let featureFlags = FeatureFlagStore.shared
     let metricTracker = AppMetricTracker.shared
     private let nearbyService = NearbyPresenceService()
+    private let heatmapAggregationService: MapHeatmapAggregationServicing
     private var nearbyTickTimer: Timer? = nil
+    private var heatmapAggregationSnapshot: MapHeatmapAggregationSnapshot?
+    private var heatmapRefreshTask: Task<Void, Never>?
+    private var latestHeatmapRefreshRequestID: UUID?
     private var lastPresenceSentAt: Date = .distantPast
     private var lastPresenceSentCoordinate: CLLocationCoordinate2D?
     private var lastPresenceSuccessfulAt: Date = .distantPast
@@ -609,6 +621,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         weatherSnapshotProvider: WeatherSnapshotProviding = OpenMeteoWeatherSnapshotProvider(),
         weatherSnapshotStore: WeatherSnapshotStoreProtocol = WeatherSnapshotStore.shared,
         areaCalculationService: MapAreaCalculationServicing = MapAreaCalculationService(),
+        heatmapAggregationService: MapHeatmapAggregationServicing = MapHeatmapAggregationService(),
         walkPointSnapshotService: MapWalkPointSnapshotServicing = MapWalkPointSnapshotService(),
         clusterAnnotationService: MapClusterAnnotationServicing = MapClusterAnnotationService(),
         widgetSnapshotStore: WalkWidgetSnapshotStoring = DefaultWalkWidgetSnapshotStore.shared,
@@ -623,6 +636,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.weatherSnapshotProvider = weatherSnapshotProvider
         self.weatherSnapshotStore = weatherSnapshotStore
         self.areaCalculationService = areaCalculationService
+        self.heatmapAggregationService = heatmapAggregationService
         self.walkPointSnapshotService = walkPointSnapshotService
         self.clusterAnnotationService = clusterAnnotationService
         self.widgetSnapshotStore = widgetSnapshotStore
@@ -683,6 +697,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     deinit {
         timer?.invalidate()
         nearbyTickTimer?.invalidate()
+        heatmapRefreshTask?.cancel()
         cancelAllCaptureRippleExpiryTasks()
         locationManager.stopUpdatingLocation()
         liveActivitySyncTask?.cancel()
@@ -2306,17 +2321,108 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.applyPolygonList(updated)
     }
 
-    func refreshHeatmap(now: Date = Date()) {
-        guard isHeatmapFeatureAvailable else {
-            self.heatmapCells = []
+    /// 현재 지도 표시 조건과 입력 fingerprint를 기준으로 heatmap을 재사용하거나 새로 계산합니다.
+    /// - Parameters:
+    ///   - now: decay weight와 시간 버킷 판단에 사용할 기준 시각입니다.
+    ///   - force: snapshot 재사용을 건너뛰고 새 집계를 강제할지 여부입니다.
+    func refreshHeatmap(now: Date = Date(), force: Bool = false) {
+        guard isHeatmapVisibleInMapUI else {
+            clearHeatmapPresentation(preserveSnapshot: true)
             return
         }
-        let points = self.polygonList.flatMap { $0.locations }
-        self.heatmapCells = HeatmapEngine.aggregate(points: points, now: now, precision: 7)
+
+        let datasetFingerprint = heatmapAggregationService.makeDatasetFingerprint(from: polygonList)
+        if force == false,
+           heatmapAggregationService.canReuseSnapshot(
+               heatmapAggregationSnapshot,
+               datasetFingerprint: datasetFingerprint,
+               reference: now
+           ),
+           let snapshot = heatmapAggregationSnapshot {
+            heatmapRefreshTask?.cancel()
+            heatmapRefreshTask = nil
+            latestHeatmapRefreshRequestID = nil
+            applyHeatmapSnapshot(snapshot)
+            return
+        }
+
+        heatmapRefreshTask?.cancel()
+        let requestID = UUID()
+        latestHeatmapRefreshRequestID = requestID
+        let polygons = polygonList
+        let service = heatmapAggregationService
+
+        heatmapRefreshTask = Task { [weak self] in
+            let snapshot = await service.makeAggregationSnapshot(
+                polygons: polygons,
+                datasetFingerprint: datasetFingerprint,
+                reference: now
+            )
+            guard Task.isCancelled == false else { return }
+            await MainActor.run { [weak self] in
+                self?.applyHeatmapSnapshot(snapshot, requestID: requestID)
+            }
+        }
+    }
+
+    /// heatmap이 실제로 화면에 보이는 상태인지 계산합니다.
+    /// - Returns: feature flag, 사용자 토글, 지도 모드가 모두 heatmap 표시를 허용하면 `true`입니다.
+    var isHeatmapVisibleInMapUI: Bool {
+        isHeatmapFeatureAvailable && heatmapEnabled && isWalking == false && showOnlyOne == false
     }
 
     var isHeatmapFeatureAvailable: Bool {
         featureFlags.isEnabled(.heatmapV1)
+    }
+
+    /// 산책 모드/단일 영역 모드 전환이 heatmap 표시 조건에 영향을 줄 때 표현 상태를 정리합니다.
+    private func handleHeatmapVisibilityStateChanged() {
+        if isHeatmapVisibleInMapUI {
+            refreshHeatmap()
+        } else {
+            clearHeatmapPresentation(preserveSnapshot: true)
+        }
+    }
+
+    /// 화면에서 heatmap을 감춰야 할 때 진행 중 계산을 취소하고 셀 표시 상태를 정리합니다.
+    /// - Parameter preserveSnapshot: 이후 재노출 시 snapshot 재사용을 위해 마지막 계산 결과를 유지할지 여부입니다.
+    private func clearHeatmapPresentation(preserveSnapshot: Bool) {
+        heatmapRefreshTask?.cancel()
+        heatmapRefreshTask = nil
+        latestHeatmapRefreshRequestID = nil
+        heatmapCells = []
+        if preserveSnapshot == false {
+            heatmapAggregationSnapshot = nil
+        }
+    }
+
+    /// background 집계 결과를 현재 지도 상태에 맞게 적용합니다.
+    /// - Parameters:
+    ///   - snapshot: service가 계산한 heatmap snapshot입니다.
+    ///   - requestID: 현재 적용 시도가 최신 요청인지 확인할 식별자입니다.
+    private func applyHeatmapSnapshot(
+        _ snapshot: MapHeatmapAggregationSnapshot,
+        requestID: UUID? = nil
+    ) {
+        if let requestID, latestHeatmapRefreshRequestID != requestID {
+            return
+        }
+
+        heatmapAggregationSnapshot = snapshot
+        heatmapRefreshTask = nil
+        latestHeatmapRefreshRequestID = nil
+
+        guard isHeatmapVisibleInMapUI else {
+            heatmapCells = []
+            return
+        }
+
+        let latestFingerprint = heatmapAggregationService.makeDatasetFingerprint(from: polygonList)
+        guard latestFingerprint == snapshot.datasetFingerprint else {
+            return
+        }
+
+        heatmapCells = snapshot.cells
     }
 
     var isCloudSyncAvailableForSession: Bool {
@@ -2690,7 +2796,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     func toggleHeatmapEnabled() {
         guard isHeatmapFeatureAvailable else {
             self.heatmapEnabled = false
-            self.heatmapCells = []
+            clearHeatmapPresentation(preserveSnapshot: false)
             return
         }
         self.heatmapEnabled.toggle()
@@ -2698,7 +2804,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         if self.heatmapEnabled {
             refreshHeatmap()
         } else {
-            self.heatmapCells = []
+            clearHeatmapPresentation(preserveSnapshot: true)
         }
     }
 
@@ -3302,7 +3408,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         if heatmapAllowed {
             self.refreshHeatmap()
         } else {
-            self.heatmapCells = []
+            clearHeatmapPresentation(preserveSnapshot: false)
         }
 
         if nearbyAllowedForSession == false {

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -29,6 +29,7 @@ swift scripts/userdefault_store_split_unit_check.swift
 swift scripts/userdefault_setting_second_split_unit_check.swift
 swift scripts/map_motion_pack_unit_check.swift
 swift scripts/map_walking_invalidation_reduction_unit_check.swift
+swift scripts/map_heatmap_trigger_gating_unit_check.swift
 swift scripts/map_walk_point_snapshot_cache_unit_check.swift
 swift scripts/quest_motion_pack_unit_check.swift
 swift scripts/quest_stage1_policy_unit_check.swift

--- a/scripts/map_heatmap_trigger_gating_unit_check.swift
+++ b/scripts/map_heatmap_trigger_gating_unit_check.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
+let mapSubView = load("dogArea/Views/MapView/MapSubViews/MapSubView.swift")
+let mapView = load("dogArea/Views/MapView/MapView.swift")
+let model = load("dogArea/Source/Domain/Map/Models/MapHeatmapSnapshot.swift")
+let service = load("dogArea/Source/Domain/Map/Services/MapHeatmapAggregationService.swift")
+let doc = load("docs/map-heatmap-trigger-gating-v1.md")
+let readme = load("README.md")
+let iosCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(model.contains("struct MapHeatmapDatasetFingerprint"), "heatmap dataset fingerprint model should exist")
+assertTrue(model.contains("struct MapHeatmapAggregationSnapshot"), "heatmap aggregation snapshot model should exist")
+assertTrue(service.contains("protocol MapHeatmapAggregationServicing"), "heatmap service should be protocol-first")
+assertTrue(service.contains("final class MapHeatmapAggregationService"), "heatmap service concrete type should exist")
+assertTrue(service.contains("Task.detached(priority: .utility)"), "heatmap aggregation should run off the main thread")
+assertTrue(service.contains("refreshBucketInterval: TimeInterval = 900"), "heatmap snapshot reuse should default to a 15 minute bucket")
+assertTrue(service.contains("func canReuseSnapshot"), "heatmap service should expose snapshot reuse gating")
+
+assertTrue(mapViewModel.contains("private let heatmapAggregationService: MapHeatmapAggregationServicing"), "MapViewModel should inject the heatmap aggregation service")
+assertTrue(mapViewModel.contains("private var heatmapAggregationSnapshot: MapHeatmapAggregationSnapshot?"), "MapViewModel should retain the latest heatmap snapshot")
+assertTrue(mapViewModel.contains("private var heatmapRefreshTask: Task<Void, Never>?"), "MapViewModel should track an async heatmap task")
+assertTrue(mapViewModel.contains("var isHeatmapVisibleInMapUI: Bool"), "MapViewModel should expose a single effective heatmap visibility rule")
+assertTrue(mapViewModel.contains("clearHeatmapPresentation(preserveSnapshot: true)"), "MapViewModel should clear only the presentation when heatmap is hidden")
+assertTrue(!mapViewModel.contains("self.heatmapCells = HeatmapEngine.aggregate"), "MapViewModel should no longer aggregate heatmap cells directly")
+
+assertTrue(mapSubView.contains("if viewModel.isHeatmapVisibleInMapUI"), "MapSubView should reuse the shared heatmap visibility rule")
+assertTrue(mapView.contains("heatmapSummaryText: viewModel.isHeatmapVisibleInMapUI"), "MapView top chrome should reuse the shared heatmap visibility rule")
+
+assertTrue(doc.contains("#503"), "performance report should reference issue #503")
+assertTrue(doc.contains("최소 `2회`"), "performance report should explain the before call frequency")
+assertTrue(doc.contains("전체 집계 `0회`"), "performance report should explain the hidden-state call reduction")
+assertTrue(doc.contains("15분 bucket"), "performance report should document the snapshot reuse bucket")
+
+assertTrue(readme.contains("docs/map-heatmap-trigger-gating-v1.md"), "README should index the heatmap trigger gating document")
+assertTrue(iosCheck.contains("swift scripts/map_heatmap_trigger_gating_unit_check.swift"), "ios_pr_check should run the heatmap trigger gating check")
+
+print("PASS: map heatmap trigger gating checks")


### PR DESCRIPTION
## Summary
- gate map heatmap recomputation behind shared visibility state and input fingerprints
- move heatmap aggregation into a background aggregation service with snapshot reuse
- add docs and regression checks for hidden-state and same-input recompute suppression

## Testing
- swift scripts/map_heatmap_trigger_gating_unit_check.swift
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -derivedDataPath .build/codex-503-build -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapPrimaryActionIsNotObscuredByTabBar -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapAddPointControlRemainsHittableWhileWalking -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapWalkingRuntimeKeepsRootRenderCountBelowThreshold test\n- DOGAREA_DERIVED_DATA_PATH=.build/codex-503-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh\n\nCloses #503