### PR TITLE
refactor: gate hotspot cluster recomputation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - 날씨 snapshot/provider 확장 v1: `docs/weather-snapshot-provider-v1.md`
 - 맵 heatmap trigger gating v1: `docs/map-heatmap-trigger-gating-v1.md`
 - 맵 route/mark snapshot cache v1: `docs/map-walk-point-snapshot-cache-v1.md`
+- 맵 hotspot cluster trigger gating v1: `docs/map-hotspot-cluster-trigger-gating-v1.md`
 - 홈 refresh entrypoint 정리 v1: `docs/home-refresh-entrypoint-v1.md`
 - 홈 미션 pet context snapshot v1: `docs/home-mission-pet-context-snapshot-v1.md`
 - 날씨 치환/스트릭 보호 서버 엔진 v1: `docs/weather-replacement-shield-engine-v1.md`

--- a/docs/map-hotspot-cluster-trigger-gating-v1.md
+++ b/docs/map-hotspot-cluster-trigger-gating-v1.md
@@ -1,0 +1,65 @@
+#504 Map Hotspot Cluster Trigger Gating
+
+## 배경
+- 변경 전 `MapViewModel.refreshRenderableNearbyHotspots()`는 호출될 때마다 `clusterAnnotationService.renderHotspots(...)`를 직접 실행했습니다.
+- 이 경로는 두 군데에서 쉽게 다시 들어왔습니다.
+  - `recordCameraChange(...)`가 `cameraCacheMinUpdateInterval == 0.9초` heartbeat만으로 캐시를 갱신한 경우
+  - `nearbyHotspots`에 이전과 동일한 배열이 다시 대입된 경우
+- 결과적으로 카메라 거리/뷰포트/핫스팟 입력이 실질적으로 그대로여도 재버킷팅이 반복될 수 있었습니다.
+
+## 변경
+- `MapHotspotClusterDatasetFingerprint` / `MapHotspotClusterViewportFingerprint` / `MapHotspotClusterTuningFingerprint` 모델 추가
+- `MapHotspotClusterRenderingService`를 도입해
+  - dataset fingerprint 생성
+  - viewport bucket 양자화
+  - tuning fingerprint 고정
+  - snapshot 재사용 판정
+  - 실제 `renderHotspots(...)` 호출
+  책임을 분리했습니다.
+- `MapViewModel`은
+  - 현재 입력과 뷰포트를 해석
+  - snapshot 재사용 여부를 묻고
+  - 새 계산이 필요한 경우에만 결과를 publish
+  하도록 정리했습니다.
+
+## Trigger Gating 규칙
+- 재계산 허용 조건
+  - `nearby hotspot feature on`
+  - `nearbyHotspotEnabled == true`
+  - dataset fingerprint 변경
+  - viewport fingerprint 변경
+  - tuning fingerprint 변경
+- viewport fingerprint 구성
+  - camera distance `80m bucket`
+  - viewport radius 기반 center bucket
+  - center bucket은 `24m ... 240m` 범위에서 동적으로 계산
+- 동일 fingerprint면
+  - 기존 snapshot의 노드를 그대로 재사용
+  - `renderableNearbyHotspotNodes`를 다시 publish하지 않음
+
+## Before / After 근거
+
+### 재계산 횟수 관점
+- Before
+  - 카메라가 실제로 거의 그대로여도 `0.9초 heartbeat`만 지나면 hotspot cluster 재계산이 최소 `1회` 다시 발생할 수 있었습니다.
+  - 동일한 hotspot 입력 배열이 다시 들어와도 hotspot cluster 재계산이 최소 `1회` 다시 발생할 수 있었습니다.
+- After
+  - heartbeat만 발생하고 dataset/viewport/tuning fingerprint가 같으면 hotspot cluster 재계산 `0회`입니다.
+  - 동일 hotspot 입력이 다시 대입돼도 snapshot 재사용 경로로 묶여 hotspot cluster 재계산 `0회`입니다.
+
+### 화면 안정성 관점
+- Before
+  - 동일 결과라도 `renderableNearbyHotspotNodes`를 다시 assign해 publish할 수 있었습니다.
+- After
+  - 같은 snapshot이면 publish를 생략합니다.
+  - 따라서 flicker 없이 기존 노드 순서/그룹 의미를 그대로 유지합니다.
+
+## 제품 의미 유지
+- 실제 hotspot 노드 계산은 기존 `MapClusterAnnotationService.renderHotspots(...)`를 그대로 사용합니다.
+- 후보 cap, viewport radius, cluster distance threshold, cell ratio 규칙은 바꾸지 않았습니다.
+- 바뀐 것은 재계산을 시작하는 trigger gate뿐입니다.
+
+## 회귀 방지 포인트
+- `MapViewModel`에서 `clusterAnnotationService.renderHotspots(...)`를 직접 다시 호출하지 말 것
+- hotspot 재계산 조건은 dataset/viewport/tuning fingerprint를 통해서만 늘릴 것
+- 동일 snapshot에서는 노드를 다시 publish하지 말 것

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -181,6 +181,8 @@
 		A50200010000000000000002 /* MapWalkPointSnapshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50200010000000000000012 /* MapWalkPointSnapshotService.swift */; };
 		A50300010000000000000001 /* MapHeatmapSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50300010000000000000011 /* MapHeatmapSnapshot.swift */; };
 		A50300010000000000000002 /* MapHeatmapAggregationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50300010000000000000012 /* MapHeatmapAggregationService.swift */; };
+		A50400010000000000000001 /* MapHotspotClusterSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50400010000000000000011 /* MapHotspotClusterSnapshot.swift */; };
+		A50400010000000000000002 /* MapHotspotClusterRenderingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50400010000000000000012 /* MapHotspotClusterRenderingService.swift */; };
 		DA3F9BA62AE0F14F0048550C /* WalkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */; };
 		DA3F9BAE2AE0F2410048550C /* ViewUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */; };
 		A45000010000000000000011 /* MapChromeSurfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45000010000000000000001 /* MapChromeSurfaceStyle.swift */; };
@@ -556,6 +558,8 @@
 		A50200010000000000000012 /* MapWalkPointSnapshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapWalkPointSnapshotService.swift; sourceTree = "<group>"; };
 		A50300010000000000000011 /* MapHeatmapSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapHeatmapSnapshot.swift; sourceTree = "<group>"; };
 		A50300010000000000000012 /* MapHeatmapAggregationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapHeatmapAggregationService.swift; sourceTree = "<group>"; };
+		A50400010000000000000011 /* MapHotspotClusterSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapHotspotClusterSnapshot.swift; sourceTree = "<group>"; };
+		A50400010000000000000012 /* MapHotspotClusterRenderingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapHotspotClusterRenderingService.swift; sourceTree = "<group>"; };
 		DA3F9B9F2AE0F14F0048550C /* WalkListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalkListView.swift; sourceTree = "<group>"; };
 		DA3F9BAD2AE0F2410048550C /* ViewUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewUtility.swift; sourceTree = "<group>"; };
 		A45000010000000000000001 /* MapChromeSurfaceStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapChromeSurfaceStyle.swift; sourceTree = "<group>"; };
@@ -1511,6 +1515,7 @@
 			children = (
 				DA3F9B9D2AE0F14F0048550C /* MapModel.swift */,
 				A50300010000000000000011 /* MapHeatmapSnapshot.swift */,
+				A50400010000000000000011 /* MapHotspotClusterSnapshot.swift */,
 				A50200010000000000000011 /* MapWalkPointSnapshot.swift */,
 			);
 			path = Models;
@@ -1522,6 +1527,7 @@
 				DAE148A01420000000000001 /* MapAreaCalculationService.swift */,
 				A50300010000000000000012 /* MapHeatmapAggregationService.swift */,
 				DAE147B01420000000000001 /* MapClusterAnnotationService.swift */,
+				A50400010000000000000012 /* MapHotspotClusterRenderingService.swift */,
 				A50200010000000000000012 /* MapWalkPointSnapshotService.swift */,
 			);
 			path = Services;
@@ -1902,9 +1908,11 @@
 				A37800010000000000000001 /* AppTabScaffold.swift in Sources */,
 				DA3F9BA52AE0F14F0048550C /* MapModel.swift in Sources */,
 				A50300010000000000000001 /* MapHeatmapSnapshot.swift in Sources */,
+				A50400010000000000000001 /* MapHotspotClusterSnapshot.swift in Sources */,
 				A50200010000000000000001 /* MapWalkPointSnapshot.swift in Sources */,
 				DAE148A11420000000000001 /* MapAreaCalculationService.swift in Sources */,
 				A50300010000000000000002 /* MapHeatmapAggregationService.swift in Sources */,
+				A50400010000000000000002 /* MapHotspotClusterRenderingService.swift in Sources */,
 				A50200010000000000000002 /* MapWalkPointSnapshotService.swift in Sources */,
 				DAE147B11420000000000001 /* MapClusterAnnotationService.swift in Sources */,
 				A37600010000000000000021 /* ProfileEditorDraft.swift in Sources */,

--- a/dogArea/Source/Domain/Map/Models/MapHotspotClusterSnapshot.swift
+++ b/dogArea/Source/Domain/Map/Models/MapHotspotClusterSnapshot.swift
@@ -1,0 +1,43 @@
+//
+//  MapHotspotClusterSnapshot.swift
+//  dogArea
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+
+/// 핫스팟 원본 입력이 실제로 바뀌었는지 추적하는 dataset fingerprint입니다.
+struct MapHotspotClusterDatasetFingerprint: Equatable {
+    let digestHex: String
+    let hotspotCount: Int
+    let aggregatedCount: Int
+}
+
+/// 핫스팟 렌더링에 영향을 주는 뷰포트 버킷 fingerprint입니다.
+struct MapHotspotClusterViewportFingerprint: Equatable {
+    let latitudeBucketIndex: Int?
+    let longitudeBucketIndex: Int?
+    let distanceBucketMeters: Int
+    let viewportRadiusMeters: Int
+}
+
+/// 핫스팟 렌더링 정책 파라미터를 고정하는 tuning fingerprint입니다.
+struct MapHotspotClusterTuningFingerprint: Equatable {
+    let maxVisible: Int
+    let pageMultiplier: Int
+    let clusterDistanceThresholdMeters: Int
+    let distanceRatioPermille: Int
+    let minCellMeters: Int
+    let maxCellMeters: Int
+}
+
+/// 재사용 가능한 핫스팟 클러스터 렌더링 결과 snapshot입니다.
+struct MapHotspotClusterSnapshot {
+    let datasetFingerprint: MapHotspotClusterDatasetFingerprint
+    let viewportFingerprint: MapHotspotClusterViewportFingerprint
+    let tuningFingerprint: MapHotspotClusterTuningFingerprint
+    let sourceHotspotCount: Int
+    let renderedNodeCount: Int
+    let nodes: [NearbyHotspotRenderNode]
+}

--- a/dogArea/Source/Domain/Map/Services/MapHotspotClusterRenderingService.swift
+++ b/dogArea/Source/Domain/Map/Services/MapHotspotClusterRenderingService.swift
@@ -1,0 +1,319 @@
+//
+//  MapHotspotClusterRenderingService.swift
+//  dogArea
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+import CoreLocation
+
+/// 지도 핫스팟 클러스터 재계산을 dataset/viewport diff 기준으로 제한하는 계약입니다.
+protocol MapHotspotClusterRenderingServicing {
+    /// 현재 핫스팟 렌더링 입력 목록의 fingerprint를 생성합니다.
+    /// - Parameter hotspots: 시각 상태까지 반영된 핫스팟 렌더링 입력 목록입니다.
+    /// - Returns: 동일한 입력이면 같은 값을 갖는 dataset fingerprint입니다.
+    func makeDatasetFingerprint(
+        from hotspots: [NearbyHotspotRenderInput]
+    ) -> MapHotspotClusterDatasetFingerprint
+
+    /// 현재 카메라 상태를 핫스팟 렌더링용 뷰포트 fingerprint로 양자화합니다.
+    /// - Parameters:
+    ///   - viewportCenter: 현재 뷰포트 중심 좌표입니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    /// - Returns: 의미 있는 뷰포트 변화만 구분하는 fingerprint입니다.
+    func makeViewportFingerprint(
+        viewportCenter: CLLocationCoordinate2D?,
+        cameraDistance: Double
+    ) -> MapHotspotClusterViewportFingerprint
+
+    /// 렌더링 정책 파라미터를 fingerprint로 고정합니다.
+    /// - Parameters:
+    ///   - maxVisible: 최종 렌더링 최대 개수입니다.
+    ///   - pageMultiplier: 후보 풀 확장 배수입니다.
+    ///   - clusterDistanceThreshold: 클러스터 모드 전환 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 셀 거리 비율입니다.
+    ///   - minCellMeters: 셀 거리 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 거리 최대값(미터)입니다.
+    /// - Returns: 렌더링 정책이 바뀌었는지 비교할 tuning fingerprint입니다.
+    func makeTuningFingerprint(
+        maxVisible: Int,
+        pageMultiplier: Int,
+        clusterDistanceThreshold: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> MapHotspotClusterTuningFingerprint
+
+    /// 기존 snapshot을 그대로 재사용할 수 있는지 판단합니다.
+    /// - Parameters:
+    ///   - snapshot: 이전에 계산된 핫스팟 렌더링 snapshot입니다.
+    ///   - datasetFingerprint: 현재 입력 fingerprint입니다.
+    ///   - viewportFingerprint: 현재 뷰포트 fingerprint입니다.
+    ///   - tuningFingerprint: 현재 렌더링 정책 fingerprint입니다.
+    /// - Returns: 세 fingerprint가 모두 같으면 `true`입니다.
+    func canReuseSnapshot(
+        _ snapshot: MapHotspotClusterSnapshot?,
+        datasetFingerprint: MapHotspotClusterDatasetFingerprint,
+        viewportFingerprint: MapHotspotClusterViewportFingerprint,
+        tuningFingerprint: MapHotspotClusterTuningFingerprint
+    ) -> Bool
+
+    /// 현재 입력/뷰포트 기준의 핫스팟 렌더링 snapshot을 생성합니다.
+    /// - Parameters:
+    ///   - hotspots: 렌더링할 핫스팟 입력 목록입니다.
+    ///   - datasetFingerprint: 현재 입력 fingerprint입니다.
+    ///   - viewportFingerprint: 현재 뷰포트 fingerprint입니다.
+    ///   - tuningFingerprint: 현재 렌더링 정책 fingerprint입니다.
+    ///   - viewportCenter: 현재 뷰포트 중심 좌표입니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    ///   - maxVisible: 최종 렌더링 최대 개수입니다.
+    ///   - pageMultiplier: 후보 풀 확장 배수입니다.
+    ///   - clusterDistanceThreshold: 클러스터 모드 전환 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 셀 거리 비율입니다.
+    ///   - minCellMeters: 셀 거리 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 거리 최대값(미터)입니다.
+    /// - Returns: fingerprint와 최종 렌더링 노드를 함께 담은 snapshot입니다.
+    func makeRenderSnapshot(
+        hotspots: [NearbyHotspotRenderInput],
+        datasetFingerprint: MapHotspotClusterDatasetFingerprint,
+        viewportFingerprint: MapHotspotClusterViewportFingerprint,
+        tuningFingerprint: MapHotspotClusterTuningFingerprint,
+        viewportCenter: CLLocationCoordinate2D?,
+        cameraDistance: Double,
+        maxVisible: Int,
+        pageMultiplier: Int,
+        clusterDistanceThreshold: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> MapHotspotClusterSnapshot
+}
+
+final class MapHotspotClusterRenderingService: MapHotspotClusterRenderingServicing {
+    private let clusterAnnotationService: MapClusterAnnotationServicing
+
+    /// 핫스팟 렌더링 gating 서비스를 생성합니다.
+    /// - Parameter clusterAnnotationService: 실제 핫스팟 노드 계산에 사용할 클러스터 서비스입니다.
+    init(clusterAnnotationService: MapClusterAnnotationServicing = MapClusterAnnotationService()) {
+        self.clusterAnnotationService = clusterAnnotationService
+    }
+
+    /// 현재 핫스팟 렌더링 입력 목록의 fingerprint를 생성합니다.
+    /// - Parameter hotspots: 시각 상태까지 반영된 핫스팟 렌더링 입력 목록입니다.
+    /// - Returns: 동일한 입력이면 같은 값을 갖는 dataset fingerprint입니다.
+    func makeDatasetFingerprint(
+        from hotspots: [NearbyHotspotRenderInput]
+    ) -> MapHotspotClusterDatasetFingerprint {
+        var hash: UInt64 = 0xcbf29ce484222325
+        let sortedHotspots = hotspots.sorted { lhs, rhs in
+            lhs.id < rhs.id
+        }
+
+        for hotspot in sortedHotspots {
+            mix(value: hotspot.id.utf8, into: &hash)
+            mix(value: UInt64(hotspot.count), into: &hash)
+            mix(value: hotspot.intensity.bitPattern, into: &hash)
+            mix(value: hotspot.visualState.rawValue.utf8, into: &hash)
+            mix(value: hotspot.centerCoordinate.latitude.bitPattern, into: &hash)
+            mix(value: hotspot.centerCoordinate.longitude.bitPattern, into: &hash)
+        }
+
+        return MapHotspotClusterDatasetFingerprint(
+            digestHex: String(format: "%016llx", hash),
+            hotspotCount: hotspots.count,
+            aggregatedCount: hotspots.reduce(0) { partialResult, hotspot in
+                partialResult + hotspot.count
+            }
+        )
+    }
+
+    /// 현재 카메라 상태를 핫스팟 렌더링용 뷰포트 fingerprint로 양자화합니다.
+    /// - Parameters:
+    ///   - viewportCenter: 현재 뷰포트 중심 좌표입니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    /// - Returns: 의미 있는 뷰포트 변화만 구분하는 fingerprint입니다.
+    func makeViewportFingerprint(
+        viewportCenter: CLLocationCoordinate2D?,
+        cameraDistance: Double
+    ) -> MapHotspotClusterViewportFingerprint {
+        let normalizedDistance = normalizedCameraDistance(cameraDistance)
+        let viewportRadius = makeViewportRadius(cameraDistance: normalizedDistance)
+        let centerBucketMeters = centerBucketSizeMeters(viewportRadius: viewportRadius)
+        let bucketedCenter = bucketedCenterIndexes(
+            for: viewportCenter,
+            bucketMeters: centerBucketMeters
+        )
+        let distanceBucketMeters = Int((normalizedDistance / 80.0).rounded() * 80.0)
+
+        return MapHotspotClusterViewportFingerprint(
+            latitudeBucketIndex: bucketedCenter?.0,
+            longitudeBucketIndex: bucketedCenter?.1,
+            distanceBucketMeters: distanceBucketMeters,
+            viewportRadiusMeters: Int(viewportRadius.rounded())
+        )
+    }
+
+    /// 렌더링 정책 파라미터를 fingerprint로 고정합니다.
+    /// - Parameters:
+    ///   - maxVisible: 최종 렌더링 최대 개수입니다.
+    ///   - pageMultiplier: 후보 풀 확장 배수입니다.
+    ///   - clusterDistanceThreshold: 클러스터 모드 전환 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 셀 거리 비율입니다.
+    ///   - minCellMeters: 셀 거리 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 거리 최대값(미터)입니다.
+    /// - Returns: 렌더링 정책이 바뀌었는지 비교할 tuning fingerprint입니다.
+    func makeTuningFingerprint(
+        maxVisible: Int,
+        pageMultiplier: Int,
+        clusterDistanceThreshold: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> MapHotspotClusterTuningFingerprint {
+        MapHotspotClusterTuningFingerprint(
+            maxVisible: maxVisible,
+            pageMultiplier: pageMultiplier,
+            clusterDistanceThresholdMeters: Int(clusterDistanceThreshold.rounded()),
+            distanceRatioPermille: Int((distanceRatio * 1_000.0).rounded()),
+            minCellMeters: Int(minCellMeters.rounded()),
+            maxCellMeters: Int(maxCellMeters.rounded())
+        )
+    }
+
+    /// 기존 snapshot을 그대로 재사용할 수 있는지 판단합니다.
+    /// - Parameters:
+    ///   - snapshot: 이전에 계산된 핫스팟 렌더링 snapshot입니다.
+    ///   - datasetFingerprint: 현재 입력 fingerprint입니다.
+    ///   - viewportFingerprint: 현재 뷰포트 fingerprint입니다.
+    ///   - tuningFingerprint: 현재 렌더링 정책 fingerprint입니다.
+    /// - Returns: 세 fingerprint가 모두 같으면 `true`입니다.
+    func canReuseSnapshot(
+        _ snapshot: MapHotspotClusterSnapshot?,
+        datasetFingerprint: MapHotspotClusterDatasetFingerprint,
+        viewportFingerprint: MapHotspotClusterViewportFingerprint,
+        tuningFingerprint: MapHotspotClusterTuningFingerprint
+    ) -> Bool {
+        guard let snapshot else { return false }
+        return snapshot.datasetFingerprint == datasetFingerprint
+            && snapshot.viewportFingerprint == viewportFingerprint
+            && snapshot.tuningFingerprint == tuningFingerprint
+    }
+
+    /// 현재 입력/뷰포트 기준의 핫스팟 렌더링 snapshot을 생성합니다.
+    /// - Parameters:
+    ///   - hotspots: 렌더링할 핫스팟 입력 목록입니다.
+    ///   - datasetFingerprint: 현재 입력 fingerprint입니다.
+    ///   - viewportFingerprint: 현재 뷰포트 fingerprint입니다.
+    ///   - tuningFingerprint: 현재 렌더링 정책 fingerprint입니다.
+    ///   - viewportCenter: 현재 뷰포트 중심 좌표입니다.
+    ///   - cameraDistance: 현재 카메라 거리(미터)입니다.
+    ///   - maxVisible: 최종 렌더링 최대 개수입니다.
+    ///   - pageMultiplier: 후보 풀 확장 배수입니다.
+    ///   - clusterDistanceThreshold: 클러스터 모드 전환 거리(미터)입니다.
+    ///   - distanceRatio: 카메라 거리 대비 셀 거리 비율입니다.
+    ///   - minCellMeters: 셀 거리 최소값(미터)입니다.
+    ///   - maxCellMeters: 셀 거리 최대값(미터)입니다.
+    /// - Returns: fingerprint와 최종 렌더링 노드를 함께 담은 snapshot입니다.
+    func makeRenderSnapshot(
+        hotspots: [NearbyHotspotRenderInput],
+        datasetFingerprint: MapHotspotClusterDatasetFingerprint,
+        viewportFingerprint: MapHotspotClusterViewportFingerprint,
+        tuningFingerprint: MapHotspotClusterTuningFingerprint,
+        viewportCenter: CLLocationCoordinate2D?,
+        cameraDistance: Double,
+        maxVisible: Int,
+        pageMultiplier: Int,
+        clusterDistanceThreshold: Double,
+        distanceRatio: Double,
+        minCellMeters: Double,
+        maxCellMeters: Double
+    ) -> MapHotspotClusterSnapshot {
+        let normalizedDistance = normalizedCameraDistance(cameraDistance)
+        let nodes = clusterAnnotationService.renderHotspots(
+            hotspots: hotspots,
+            viewportCenter: viewportCenter,
+            cameraDistance: normalizedDistance,
+            maxVisible: maxVisible,
+            pageMultiplier: pageMultiplier,
+            clusterDistanceThreshold: clusterDistanceThreshold,
+            distanceRatio: distanceRatio,
+            minCellMeters: minCellMeters,
+            maxCellMeters: maxCellMeters
+        )
+
+        return MapHotspotClusterSnapshot(
+            datasetFingerprint: datasetFingerprint,
+            viewportFingerprint: viewportFingerprint,
+            tuningFingerprint: tuningFingerprint,
+            sourceHotspotCount: hotspots.count,
+            renderedNodeCount: nodes.count,
+            nodes: nodes
+        )
+    }
+
+    /// 클러스터 계산에서 사용할 카메라 거리를 최소 유효값으로 보정합니다.
+    /// - Parameter cameraDistance: 현재 지도 카메라 거리(미터)입니다.
+    /// - Returns: 핫스팟 렌더링에 사용할 정규화된 거리(미터)입니다.
+    private func normalizedCameraDistance(_ cameraDistance: Double) -> Double {
+        guard cameraDistance.isFinite, cameraDistance > 0 else { return 180.0 }
+        return max(180.0, cameraDistance)
+    }
+
+    /// 핫스팟 후보 필터링에 사용할 뷰포트 반경을 계산합니다.
+    /// - Parameter cameraDistance: 정규화된 현재 카메라 거리(미터)입니다.
+    /// - Returns: 핫스팟 후보 필터링 반경(미터)입니다.
+    private func makeViewportRadius(cameraDistance: Double) -> Double {
+        max(240.0, min(10_000.0, cameraDistance * 1.35))
+    }
+
+    /// 뷰포트 중심 이동을 의미 있는 diff로 묶을 버킷 크기를 계산합니다.
+    /// - Parameter viewportRadius: 현재 뷰포트 반경(미터)입니다.
+    /// - Returns: 중심 좌표 양자화에 사용할 버킷 크기(미터)입니다.
+    private func centerBucketSizeMeters(viewportRadius: Double) -> Double {
+        max(24.0, min(240.0, viewportRadius * 0.08))
+    }
+
+    /// 위경도 중심 좌표를 버킷 인덱스로 양자화합니다.
+    /// - Parameters:
+    ///   - center: 현재 뷰포트 중심 좌표입니다.
+    ///   - bucketMeters: 버킷 크기(미터)입니다.
+    /// - Returns: 위도/경도 버킷 인덱스 쌍입니다. 중심 좌표가 없으면 `nil`입니다.
+    private func bucketedCenterIndexes(
+        for center: CLLocationCoordinate2D?,
+        bucketMeters: Double
+    ) -> (Int, Int)? {
+        guard let center else { return nil }
+        guard center.latitude.isFinite, center.longitude.isFinite else { return nil }
+
+        let latitudeDegreesPerMeter = 1.0 / 111_320.0
+        let longitudeDegreesPerMeter = 1.0 / max(1.0, 111_320.0 * cos(center.latitude * .pi / 180.0))
+        let latitudeBucketDegrees = bucketMeters * latitudeDegreesPerMeter
+        let longitudeBucketDegrees = bucketMeters * longitudeDegreesPerMeter
+
+        let latitudeIndex = Int((center.latitude / latitudeBucketDegrees).rounded())
+        let longitudeIndex = Int((center.longitude / longitudeBucketDegrees).rounded())
+        return (latitudeIndex, longitudeIndex)
+    }
+
+    /// FNV-1a 스타일 rolling hash에 문자열 바이트를 반영합니다.
+    /// - Parameters:
+    ///   - value: hash에 섞을 문자열 바이트 시퀀스입니다.
+    ///   - hash: 누적 중인 64-bit hash 값입니다.
+    private func mix<S: Sequence>(value: S, into hash: inout UInt64) where S.Element == UInt8 {
+        for byte in value {
+            hash ^= UInt64(byte)
+            hash &*= 1099511628211
+        }
+    }
+
+    /// FNV-1a 스타일 rolling hash에 64-bit 값을 반영합니다.
+    /// - Parameters:
+    ///   - value: hash에 섞을 64-bit 값입니다.
+    ///   - hash: 누적 중인 64-bit hash 값입니다.
+    private func mix(value: UInt64, into hash: inout UInt64) {
+        withUnsafeBytes(of: value.littleEndian) { bytes in
+            mix(value: bytes, into: &hash)
+        }
+    }
+}

--- a/dogArea/Views/MapView/MapViewModel.swift
+++ b/dogArea/Views/MapView/MapViewModel.swift
@@ -340,6 +340,10 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     @Published var locationSharingEnabled: Bool = false
     @Published var nearbyHotspots: [NearbyHotspotDTO] = [] {
         didSet {
+            guard oldValue != nearbyHotspots
+                    || (nearbyHotspots.isEmpty && renderableNearbyHotspotNodes.isEmpty == false) else {
+                return
+            }
             refreshRenderableNearbyHotspots()
         }
     }
@@ -380,8 +384,10 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     let metricTracker = AppMetricTracker.shared
     private let nearbyService = NearbyPresenceService()
     private let heatmapAggregationService: MapHeatmapAggregationServicing
+    private let hotspotClusterRenderingService: MapHotspotClusterRenderingServicing
     private var nearbyTickTimer: Timer? = nil
     private var heatmapAggregationSnapshot: MapHeatmapAggregationSnapshot?
+    private var hotspotClusterSnapshot: MapHotspotClusterSnapshot?
     private var heatmapRefreshTask: Task<Void, Never>?
     private var latestHeatmapRefreshRequestID: UUID?
     private var lastPresenceSentAt: Date = .distantPast
@@ -624,6 +630,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         heatmapAggregationService: MapHeatmapAggregationServicing = MapHeatmapAggregationService(),
         walkPointSnapshotService: MapWalkPointSnapshotServicing = MapWalkPointSnapshotService(),
         clusterAnnotationService: MapClusterAnnotationServicing = MapClusterAnnotationService(),
+        hotspotClusterRenderingService: MapHotspotClusterRenderingServicing? = nil,
         widgetSnapshotStore: WalkWidgetSnapshotStoring = DefaultWalkWidgetSnapshotStore.shared,
         liveActivityService: WalkLiveActivityServicing = WalkLiveActivityService(),
         eventCenter: AppEventCenterProtocol = DefaultAppEventCenter.shared
@@ -639,6 +646,8 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
         self.heatmapAggregationService = heatmapAggregationService
         self.walkPointSnapshotService = walkPointSnapshotService
         self.clusterAnnotationService = clusterAnnotationService
+        self.hotspotClusterRenderingService = hotspotClusterRenderingService
+            ?? MapHotspotClusterRenderingService(clusterAnnotationService: clusterAnnotationService)
         self.widgetSnapshotStore = widgetSnapshotStore
         self.liveActivityService = liveActivityService
         self.eventCenter = eventCenter
@@ -2642,8 +2651,7 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
     /// 뷰포트/LOD/캡 규칙으로 근처 핫스팟 렌더링 노드를 계산합니다.
     func refreshRenderableNearbyHotspots() {
         guard isNearbyHotspotFeatureAvailable, nearbyHotspotEnabled else {
-            renderableNearbyHotspotNodes = []
-            selectedNearbyHotspotID = nil
+            clearRenderableNearbyHotspots(preserveSnapshot: false)
             return
         }
 
@@ -2659,8 +2667,35 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
 
         let viewportCenter = resolvedHotspotViewportCenter()
         let distance = max(180.0, resolvedHotspotViewportDistance())
-        let nodes = clusterAnnotationService.renderHotspots(
+        let datasetFingerprint = hotspotClusterRenderingService.makeDatasetFingerprint(from: inputs)
+        let viewportFingerprint = hotspotClusterRenderingService.makeViewportFingerprint(
+            viewportCenter: viewportCenter,
+            cameraDistance: distance
+        )
+        let tuningFingerprint = hotspotClusterRenderingService.makeTuningFingerprint(
+            maxVisible: hotspotMaxVisible,
+            pageMultiplier: hotspotPageMultiplier,
+            clusterDistanceThreshold: hotspotClusterDistanceThreshold,
+            distanceRatio: clusterCellDistanceRatio,
+            minCellMeters: clusterCellMinMeters,
+            maxCellMeters: clusterCellMaxMeters
+        )
+
+        if hotspotClusterRenderingService.canReuseSnapshot(
+            hotspotClusterSnapshot,
+            datasetFingerprint: datasetFingerprint,
+            viewportFingerprint: viewportFingerprint,
+            tuningFingerprint: tuningFingerprint
+        ) {
+            synchronizeSelectedNearbyHotspotID()
+            return
+        }
+
+        let snapshot = hotspotClusterRenderingService.makeRenderSnapshot(
             hotspots: inputs,
+            datasetFingerprint: datasetFingerprint,
+            viewportFingerprint: viewportFingerprint,
+            tuningFingerprint: tuningFingerprint,
             viewportCenter: viewportCenter,
             cameraDistance: distance,
             maxVisible: hotspotMaxVisible,
@@ -2671,11 +2706,34 @@ class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate, WCSes
             maxCellMeters: clusterCellMaxMeters
         )
 
-        renderableNearbyHotspotNodes = nodes
+        applyRenderableNearbyHotspotSnapshot(snapshot)
+    }
+
+    /// 최신 핫스팟 렌더링 snapshot을 화면 상태에 반영합니다.
+    /// - Parameter snapshot: 화면에 반영할 최신 핫스팟 렌더링 snapshot입니다.
+    private func applyRenderableNearbyHotspotSnapshot(_ snapshot: MapHotspotClusterSnapshot) {
+        hotspotClusterSnapshot = snapshot
+        renderableNearbyHotspotNodes = snapshot.nodes
+        synchronizeSelectedNearbyHotspotID()
+    }
+
+    /// 현재 선택된 핫스팟이 최신 렌더링 노드에 없으면 선택 상태를 해제합니다.
+    private func synchronizeSelectedNearbyHotspotID() {
+        let nodes = hotspotClusterSnapshot?.nodes ?? renderableNearbyHotspotNodes
         if let selectedNearbyHotspotID,
            nodes.contains(where: { $0.id == selectedNearbyHotspotID }) == false {
             self.selectedNearbyHotspotID = nil
         }
+    }
+
+    /// 핫스팟 렌더링 표시 상태를 비우고 필요 시 snapshot 재사용 상태도 함께 초기화합니다.
+    /// - Parameter preserveSnapshot: `true`면 마지막 snapshot을 유지하고, `false`면 함께 비웁니다.
+    private func clearRenderableNearbyHotspots(preserveSnapshot: Bool) {
+        if preserveSnapshot == false {
+            hotspotClusterSnapshot = nil
+        }
+        renderableNearbyHotspotNodes = []
+        selectedNearbyHotspotID = nil
     }
 
     /// 핫스팟 렌더링 계산에 사용할 뷰포트 중심 좌표를 해석합니다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -31,6 +31,7 @@ swift scripts/map_motion_pack_unit_check.swift
 swift scripts/map_walking_invalidation_reduction_unit_check.swift
 swift scripts/map_heatmap_trigger_gating_unit_check.swift
 swift scripts/map_walk_point_snapshot_cache_unit_check.swift
+swift scripts/map_hotspot_cluster_trigger_gating_unit_check.swift
 swift scripts/quest_motion_pack_unit_check.swift
 swift scripts/quest_stage1_policy_unit_check.swift
 swift scripts/quest_stage2_engine_unit_check.swift

--- a/scripts/map_hotspot_cluster_trigger_gating_unit_check.swift
+++ b/scripts/map_hotspot_cluster_trigger_gating_unit_check.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
+let model = load("dogArea/Source/Domain/Map/Models/MapHotspotClusterSnapshot.swift")
+let service = load("dogArea/Source/Domain/Map/Services/MapHotspotClusterRenderingService.swift")
+let doc = load("docs/map-hotspot-cluster-trigger-gating-v1.md")
+let readme = load("README.md")
+let iosCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(model.contains("struct MapHotspotClusterDatasetFingerprint"), "hotspot dataset fingerprint model should exist")
+assertTrue(model.contains("struct MapHotspotClusterViewportFingerprint"), "hotspot viewport fingerprint model should exist")
+assertTrue(model.contains("struct MapHotspotClusterTuningFingerprint"), "hotspot tuning fingerprint model should exist")
+assertTrue(model.contains("struct MapHotspotClusterSnapshot"), "hotspot cluster snapshot model should exist")
+
+assertTrue(service.contains("protocol MapHotspotClusterRenderingServicing"), "hotspot rendering service should be protocol-first")
+assertTrue(service.contains("final class MapHotspotClusterRenderingService"), "hotspot rendering service concrete type should exist")
+assertTrue(service.contains("func makeDatasetFingerprint"), "service should fingerprint hotspot inputs")
+assertTrue(service.contains("func makeViewportFingerprint"), "service should fingerprint the viewport")
+assertTrue(service.contains("func makeTuningFingerprint"), "service should fingerprint tuning values")
+assertTrue(service.contains("func canReuseSnapshot"), "service should expose snapshot reuse gating")
+assertTrue(service.contains("distanceBucketMeters = Int((normalizedDistance / 80.0).rounded() * 80.0)"), "viewport fingerprint should quantize camera distance into 80m buckets")
+
+assertTrue(mapViewModel.contains("private let hotspotClusterRenderingService: MapHotspotClusterRenderingServicing"), "MapViewModel should inject the hotspot rendering service")
+assertTrue(mapViewModel.contains("private var hotspotClusterSnapshot: MapHotspotClusterSnapshot?"), "MapViewModel should retain the latest hotspot snapshot")
+assertTrue(mapViewModel.contains("hotspotClusterRenderingService: MapHotspotClusterRenderingServicing? = nil"), "MapViewModel init should allow overriding the hotspot rendering service")
+assertTrue(mapViewModel.contains("hotspotClusterRenderingService.canReuseSnapshot"), "MapViewModel should reuse hotspot snapshots when fingerprints match")
+assertTrue(mapViewModel.contains("applyRenderableNearbyHotspotSnapshot(snapshot)"), "MapViewModel should apply hotspot results through a snapshot helper")
+assertTrue(!mapViewModel.contains("let nodes = clusterAnnotationService.renderHotspots("), "MapViewModel should not call renderHotspots directly anymore")
+
+assertTrue(doc.contains("#504"), "doc should reference issue #504")
+assertTrue(doc.contains("0.9초 heartbeat"), "doc should explain the previous heartbeat recompute path")
+assertTrue(doc.contains("hotspot cluster 재계산 `0회`"), "doc should explain the after recompute reduction")
+assertTrue(doc.contains("renderableNearbyHotspotNodes"), "doc should explain publish suppression and stability")
+
+assertTrue(readme.contains("docs/map-hotspot-cluster-trigger-gating-v1.md"), "README should index the hotspot trigger gating doc")
+assertTrue(iosCheck.contains("swift scripts/map_hotspot_cluster_trigger_gating_unit_check.swift"), "ios_pr_check should run the hotspot trigger gating check")
+
+print("PASS: map hotspot cluster trigger gating checks")


### PR DESCRIPTION
## Summary
- add fingerprint-based hotspot cluster snapshot/model/service for map rendering
- reuse hotspot cluster results unless camera viewport, tuning, or hotspot dataset meaningfully changes
- add docs and static checks for issue #504

## Testing
- swift scripts/map_hotspot_cluster_trigger_gating_unit_check.swift
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17" build-for-testing
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapPrimaryActionIsNotObscuredByTabBar -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapAddPointControlRemainsHittableWhileWalking -only-testing:dogAreaUITests/FeatureRegressionUITests/testFeatureRegression_MapWalkingRuntimeKeepsRootRenderCountBelowThreshold test-without-building

Closes #504