### PR TITLE
docs: define quest surface policy for home map and widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - 날씨 치환/스트릭 보호 서버 엔진 v1: `docs/weather-replacement-shield-engine-v1.md`
 - 날씨 연동 UX/fallback/접근성 v1: `docs/weather-ux-fallback-accessibility-v1.md`
 - 퀘스트 Stage1 템플릿/난이도 정책 v1: `docs/quest-stage1-template-difficulty-policy-v1.md`
+- 퀘스트 표면 정책(홈/지도/위젯 경계) v1: `docs/quest-surface-policy-v1.md`
 - 퀘스트 Stage2 진행/클레임 백엔드 엔진 v1: `docs/quest-stage2-progress-claim-engine-v1.md`
 - 퀘스트 실패 완충(자동 연장 슬롯) v1: `docs/quest-failure-buffer-v1.md`
 - 퀘스트 Stage3 UX/리마인드 v1: `docs/quest-stage3-ux-reminder-v1.md`

--- a/docs/quest-surface-policy-v1.md
+++ b/docs/quest-surface-policy-v1.md
@@ -1,0 +1,105 @@
+# Quest Surface Policy v1
+
+## 1. 목적
+- 산책 중 자동 추적 가능한 퀘스트와 홈 전용 수동 미션의 경계를 먼저 고정한다.
+- 홈/지도/위젯이 같은 퀘스트 상태를 서로 다르게 해석하지 않도록 source of truth를 정의한다.
+- 후속 이슈 `#465`, `#467`, `#468`이 같은 정책 위에서 HUD/토스트/배너 우선순위를 구현할 수 있게 한다.
+
+## 2. 표면별 source of truth
+| surface | primary role | source of truth | 비고 |
+| --- | --- | --- | --- |
+| `home` | 실내/수동 미션 체크, 보상 수령, 상세 설명 | `IndoorMissionBoard` | 현재 앱의 실내 미션 체크 흐름을 유지한다. |
+| `map` | 산책 중 자동 추적 진행 피드백 | server canonical quest summary | 지도는 산책 중 자동 추적 가능한 상태만 올린다. |
+| `widget` | 짧은 진행률/보상 가능 상태 확인 | server canonical quest summary mirror | 위젯은 지도/홈을 대신 판단하지 않고 mirror 역할만 한다. |
+
+## 3. 지도에 기본 노출 가능한 자동 추적 조건
+아래 조건만 `산책 중 Companion HUD` 기본 노출 후보로 취급한다.
+
+| rule | counting rule | exclusion rule |
+| --- | --- | --- |
+| `walk_duration` | 산책 세션이 실제 walking 상태일 때만 누적 | 일시정지, 종료 확인, 복구 대기 구간 제외 |
+| `walk_distance` | 유효 위치 샘플 간 거리만 누적 | 정지 드리프트, 낮은 정확도 샘플 제외 |
+| `new_tile` / `new territory tile` | 신규 타일/영역 점령 시만 증가 | 이미 점령한 타일 재방문 제외 |
+| `active_walking_time` | 정지 구간을 제외한 active walking 시간만 집계 | 휴식 후보, 자동 종료 경고, 복구 지연 구간 제외 |
+
+### 3.1 자동 추적 후보가 아닌 항목
+아래 항목은 자기 보고 또는 실내 행위 성격이 강하므로 지도 HUD 기본 노출 대상이 아니다.
+- `recordCleanup`
+- `petCareCheck`
+- `trainingCheck`
+- 사진 정리, 브러싱, 물 챙김, 컨디션 체크, 실내 훈련 같은 home checklist 류
+
+정책상 이들은 `home only manual checklist` 버킷으로 유지한다.
+
+## 4. 대표 미션 선택 규칙
+지도 HUD에는 `대표 1개 + 추가 n개` 구조만 허용한다.
+
+우선순위는 아래 순서다.
+1. `claimable == true`
+2. 자동 추적 가능 + 진행률 `85% 이상`
+3. 자동 추적 가능 + 진행률 높은 순
+4. 자동 추적 불가지만 summary-only로 알려야 하는 상태
+
+대표 후보가 없으면 지도는 quest HUD를 비우거나 empty state만 노출한다.
+
+## 5. 지도/홈/위젯의 역할 경계
+### 5.1 Home
+- 실내/수동 미션 체크리스트의 primary surface
+- 완료 확인 및 보상 수령의 canonical surface
+- 자동 미션은 필요 시 보조 요약으로만 설명
+
+### 5.2 Map
+- `산책 중 실제로 자동 추적 가능한 항목`만 HUD/토스트 후보
+- 실내/자기보고형 미션은 지도에 올리지 않음
+- 완료 시점에는 `보상 가능`까지만 알림
+- 즉시 수령은 하지 않고 홈 퀘스트 보드 또는 관련 상세 화면으로 유도
+
+### 5.3 Widget
+- server canonical quest summary의 mirror
+- 진행률/보상 가능 상태 확인 + 앱 진입 요청만 담당
+- widget가 home/manual mission semantics를 새로 정의하지 않음
+
+## 6. 보상 흐름 정책
+지도/위젯에서 허용하는 최종 상태는 `보상 가능`까지다.
+
+| surface | allowed action |
+| --- | --- |
+| `map` | 보상 가능 알림, 홈/퀘스트 보드 진입 유도 |
+| `widget` | 보상 가능 표시, 앱 라우트 요청 |
+| `home` | 실제 claim 수행, 완료 상태 반영 |
+
+즉시 수령을 지도에서 허용하지 않는 이유:
+- 산책 흐름을 끊는다.
+- 다중 미션/다중 보상 처리 시 오류 복구가 복잡해진다.
+- `critical banner`, `watch sync`, `offline recovery`와 충돌 가능성이 크다.
+
+## 7. 상태 표현 충돌 방지 규칙
+- `home`의 실내 미션 완료와 `map/widget`의 자동 퀘스트 완료는 서로 다른 surface role로 유지한다.
+- `map`과 `widget`은 같은 server canonical summary를 사용하므로, 같은 quest instance에 대해 다른 completion 의미를 만들지 않는다.
+- `home`은 실내 체크/수동 보상 흐름을 담당하되, 자동 퀘스트 요약을 참고 정보로만 소비한다.
+
+## 8. QA 시나리오
+### 8.1 단일 산책 자동 미션
+- 조건: `walk_duration` 1개 active, 진행률 40%
+- 기대: 지도 대표 HUD 1개, 홈은 실내 미션 흐름 유지, 위젯은 동일 진행률 mirror
+
+### 8.2 다중 자동 미션
+- 조건: `walk_duration 70%`, `new_tile 90%`, `active_walking_time 20%`
+- 기대: 지도는 `new_tile`을 대표로 선택, 나머지는 `추가 n개`
+
+### 8.3 실내 미션 혼합
+- 조건: `recordCleanup`, `petCareCheck` active + `walk_duration` 55%
+- 기대: 지도는 `walk_duration`만 노출, 홈은 실내 체크리스트 유지
+
+### 8.4 보상 가능 상태
+- 조건: server canonical quest가 `completed + claimable`
+- 기대: 지도/위젯은 `보상 가능`까지만 노출, claim은 홈에서 처리
+
+## 9. 구현 인계
+- `#465`: HUD + milestone toast + expandable checklist는 본 문서의 자동 추적 규칙과 대표 미션 규칙을 그대로 사용한다.
+- `#467`: collapsed/expanded 최소 정보셋은 본 문서의 대표 1개 + 추가 n개 규칙을 전제로 한다.
+- `#468`: critical banner 우선순위와 quest HUD 공존 규칙은 본 문서의 `map = progress feedback only` 경계를 침범하지 않아야 한다.
+
+## 10. 코드 기준점
+- 정책 모델: `dogArea/Source/Domain/Quest/Models/QuestSurfacePolicyModels.swift`
+- 정책 서비스: `dogArea/Source/Domain/Quest/Services/QuestSurfacePolicyService.swift`

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		A56300010000000000000002 /* HomeMissionTrackingPresentationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56300010000000000000012 /* HomeMissionTrackingPresentationService.swift */; };
 		A56300010000000000000003 /* HomeMissionTrackingBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56300010000000000000013 /* HomeMissionTrackingBadgeView.swift */; };
 		A56300010000000000000004 /* HomeMissionTrackingModeOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56300010000000000000014 /* HomeMissionTrackingModeOverviewView.swift */; };
+		A46400010000000000000001 /* QuestSurfacePolicyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46400010000000000000011 /* QuestSurfacePolicyModels.swift */; };
+		A46400010000000000000002 /* QuestSurfacePolicyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46400010000000000000012 /* QuestSurfacePolicyService.swift */; };
 		A56500010000000000000006 /* MapWalkActiveValueCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56500010000000000000016 /* MapWalkActiveValueCardView.swift */; };
 		A56500010000000000000007 /* MapWalkSavedOutcomeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56500010000000000000017 /* MapWalkSavedOutcomeCardView.swift */; };
 		A56500010000000000000008 /* WalkCompletionValueFlowCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56500010000000000000018 /* WalkCompletionValueFlowCardView.swift */; };
@@ -564,6 +566,8 @@
 		A45800010000000000000011 /* HomeWeatherWalkGuidanceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherWalkGuidanceService.swift; sourceTree = "<group>"; };
 		A45800010000000000000012 /* HomeWeatherGuidancePresentationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherGuidancePresentationModels.swift; sourceTree = "<group>"; };
 		A45800010000000000000013 /* HomeWeatherGuidanceSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherGuidanceSheetView.swift; sourceTree = "<group>"; };
+		A46400010000000000000011 /* QuestSurfacePolicyModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestSurfacePolicyModels.swift; sourceTree = "<group>"; };
+		A46400010000000000000012 /* QuestSurfacePolicyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestSurfacePolicyService.swift; sourceTree = "<group>"; };
 		A47500010000000000000011 /* WeatherReplacementSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherReplacementSummary.swift; sourceTree = "<group>"; };
 		A47500010000000000000012 /* WeatherReplacementSummaryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherReplacementSummaryStore.swift; sourceTree = "<group>"; };
 		A47500010000000000000013 /* SupabaseWeatherReplacementServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseWeatherReplacementServices.swift; sourceTree = "<group>"; };
@@ -980,6 +984,31 @@
 				A37600010000000000000012 /* SettingsPetManagementService.swift */,
 				A50000010000000000000012 /* SettingsProductSurfaceService.swift */,
 				9D5A36B3041BCFBBD4C59BDC /* SettingsSeasonProfileSummaryService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		A46400010000000000000021 /* Quest */ = {
+			isa = PBXGroup;
+			children = (
+				A46400010000000000000022 /* Models */,
+				A46400010000000000000023 /* Services */,
+			);
+			path = Quest;
+			sourceTree = "<group>";
+		};
+		A46400010000000000000022 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A46400010000000000000011 /* QuestSurfacePolicyModels.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		A46400010000000000000023 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				A46400010000000000000012 /* QuestSurfacePolicyService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1646,6 +1675,7 @@
 			children = (
 				A50700010000000000000021 /* Auth */,
 				DAF0A0024200000000000001 /* Home */,
+				A46400010000000000000021 /* Quest */,
 				DAF0A0044200000000000001 /* Map */,
 				A37600010000000000000001 /* Profile */,
 				DAF0A0074200000000000001 /* Recovery */,
@@ -2133,6 +2163,7 @@
 				A47500010000000000000003 /* SupabaseWeatherReplacementServices.swift in Sources */,
 				A50700010000000000000003 /* AuthMailActionStateStore.swift in Sources */,
 				A56300010000000000000001 /* HomeMissionTrackingModels.swift in Sources */,
+				A46400010000000000000001 /* QuestSurfacePolicyModels.swift in Sources */,
 				A56400010000000000000003 /* HomeMissionGuideStateStore.swift in Sources */,
 				A56500010000000000000004 /* WalkValueGuideStateStore.swift in Sources */,
 				DAE147A11420000000000001 /* HomeWeeklyStatisticsService.swift in Sources */,
@@ -2141,6 +2172,7 @@
 				A56300010000000000000002 /* HomeMissionTrackingPresentationService.swift in Sources */,
 				A56400010000000000000002 /* HomeMissionGuidePresentationService.swift in Sources */,
 				A50600010000000000000001 /* HomeIndoorMissionPetContextSnapshotService.swift in Sources */,
+				A46400010000000000000002 /* QuestSurfacePolicyService.swift in Sources */,
 				DAED25022AFA1D430044715A /* SplashView.swift in Sources */,
 				DA99F9E62AFA4F3E00B1483F /* Color.swift in Sources */,
 				DA3F9BD32AE0FF8A0048550C /* RootView.swift in Sources */,

--- a/dogArea/Source/Domain/Quest/Models/QuestSurfacePolicyModels.swift
+++ b/dogArea/Source/Domain/Quest/Models/QuestSurfacePolicyModels.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// 퀘스트 상태를 소비하는 제품 표면을 정의합니다.
+enum QuestSurface: String, CaseIterable {
+    case home
+    case map
+    case widget
+}
+
+/// 각 표면에서 미션을 어떤 수준으로 노출할지 정의합니다.
+enum QuestSurfaceVisibilityBucket: String, CaseIterable {
+    case automaticDuringWalk
+    case manualHomeOnly
+    case mapSummaryOnly
+}
+
+/// 표면별로 어떤 계층이 canonical source of truth인지 정의합니다.
+enum QuestSurfaceSourceOfTruth: String, CaseIterable {
+    case localIndoorMissionBoard
+    case serverCanonicalQuestSummary
+    case widgetMirrorOfServerSummary
+}
+
+/// 산책 중 자동 추적 가능한 조건을 정의합니다.
+enum QuestAutomaticTrackingRuleKind: String, CaseIterable {
+    case walkDuration
+    case walkDistance
+    case newlyCapturedTerritoryTile
+    case activeWalkingTime
+}
+
+/// 지도/위젯에 노출할 자동 추적 규칙 설명 모델입니다.
+struct QuestAutomaticTrackingRule: Equatable {
+    let kind: QuestAutomaticTrackingRuleKind
+    let title: String
+    let countingRule: String
+    let exclusionRule: String
+}
+
+/// 지도 HUD에서 대표로 노출할 미션 후보 요약입니다.
+struct QuestMapMissionCandidate: Equatable {
+    let missionId: String
+    let title: String
+    let progressRatio: Double
+    let remainingSummary: String
+    let isClaimable: Bool
+    let isAutomaticTrackable: Bool
+}
+
+/// 보상 수령을 어느 표면에서 처리할지 정의합니다.
+enum QuestRewardFlowPolicy: String, CaseIterable {
+    case mapShowsClaimableStateOnly
+    case homeHandlesClaimCollection
+}
+
+/// QA가 그대로 재현할 수 있는 정책 시나리오입니다.
+struct QuestSurfaceQAScenario: Equatable {
+    let title: String
+    let setup: String
+    let expectedMapBehavior: String
+    let expectedHomeBehavior: String
+    let expectedWidgetBehavior: String
+}
+
+/// 퀘스트 표면 정책 스냅샷입니다.
+struct QuestSurfacePolicySnapshot: Equatable {
+    let automaticTrackingRules: [QuestAutomaticTrackingRule]
+    let homeOnlyMissionCategories: [IndoorMissionCategory]
+    let rewardFlow: [QuestRewardFlowPolicy]
+    let homeSourceOfTruth: QuestSurfaceSourceOfTruth
+    let mapSourceOfTruth: QuestSurfaceSourceOfTruth
+    let widgetSourceOfTruth: QuestSurfaceSourceOfTruth
+    let qaScenarios: [QuestSurfaceQAScenario]
+}

--- a/dogArea/Source/Domain/Quest/Services/QuestSurfacePolicyService.swift
+++ b/dogArea/Source/Domain/Quest/Services/QuestSurfacePolicyService.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+protocol QuestSurfacePolicyResolving {
+    /// 산책/홈/위젯에 공통 적용할 퀘스트 표면 정책 스냅샷을 생성합니다.
+    /// - Returns: 자동 추적 규칙, 표면별 source of truth, QA 시나리오를 담은 정책 스냅샷입니다.
+    func makePolicySnapshot() -> QuestSurfacePolicySnapshot
+
+    /// 현재 홈 전용 미션 카테고리를 어느 표면 bucket으로 분류할지 반환합니다.
+    /// - Parameter category: 홈 실내 미션 카드의 카테고리입니다.
+    /// - Returns: 홈/지도/요약 중 어떤 노출 버킷에 속하는지 나타내는 정책 값입니다.
+    func classifyHomeMissionCategory(_ category: IndoorMissionCategory) -> QuestSurfaceVisibilityBucket
+
+    /// 지도 HUD에서 대표 미션으로 노출할 후보를 선택합니다.
+    /// - Parameter candidates: 현재 산책 중 표시 가능한 미션 후보 목록입니다.
+    /// - Returns: 보상 가능 상태와 진행률 우선순위를 반영한 대표 후보입니다. 후보가 없으면 `nil`입니다.
+    func selectPrimaryMapCandidate(from candidates: [QuestMapMissionCandidate]) -> QuestMapMissionCandidate?
+}
+
+final class QuestSurfacePolicyService: QuestSurfacePolicyResolving {
+    /// 산책/홈/위젯에 공통 적용할 퀘스트 표면 정책 스냅샷을 생성합니다.
+    /// - Returns: 자동 추적 규칙, 표면별 source of truth, QA 시나리오를 담은 정책 스냅샷입니다.
+    func makePolicySnapshot() -> QuestSurfacePolicySnapshot {
+        QuestSurfacePolicySnapshot(
+            automaticTrackingRules: automaticTrackingRules(),
+            homeOnlyMissionCategories: IndoorMissionCategory.allCases,
+            rewardFlow: [.mapShowsClaimableStateOnly, .homeHandlesClaimCollection],
+            homeSourceOfTruth: .localIndoorMissionBoard,
+            mapSourceOfTruth: .serverCanonicalQuestSummary,
+            widgetSourceOfTruth: .widgetMirrorOfServerSummary,
+            qaScenarios: makeQAScenarios()
+        )
+    }
+
+    /// 현재 홈 전용 미션 카테고리를 어느 표면 bucket으로 분류할지 반환합니다.
+    /// - Parameter category: 홈 실내 미션 카드의 카테고리입니다.
+    /// - Returns: 홈/지도/요약 중 어떤 노출 버킷에 속하는지 나타내는 정책 값입니다.
+    func classifyHomeMissionCategory(_ category: IndoorMissionCategory) -> QuestSurfaceVisibilityBucket {
+        switch category {
+        case .recordCleanup, .petCareCheck, .trainingCheck:
+            return .manualHomeOnly
+        }
+    }
+
+    /// 지도 HUD에서 대표 미션으로 노출할 후보를 선택합니다.
+    /// - Parameter candidates: 현재 산책 중 표시 가능한 미션 후보 목록입니다.
+    /// - Returns: 보상 가능 상태와 진행률 우선순위를 반영한 대표 후보입니다. 후보가 없으면 `nil`입니다.
+    func selectPrimaryMapCandidate(from candidates: [QuestMapMissionCandidate]) -> QuestMapMissionCandidate? {
+        candidates.max { lhs, rhs in
+            priorityScore(for: lhs) < priorityScore(for: rhs)
+        }
+    }
+
+    /// 자동 추적 가능한 산책 기반 퀘스트 규칙을 반환합니다.
+    /// - Returns: 지도/위젯에서 동일 의미로 재사용할 자동 추적 규칙 목록입니다.
+    private func automaticTrackingRules() -> [QuestAutomaticTrackingRule] {
+        [
+            QuestAutomaticTrackingRule(
+                kind: .walkDuration,
+                title: "산책 시간",
+                countingRule: "산책 세션이 실제 walking 상태일 때만 누적합니다.",
+                exclusionRule: "일시정지, 종료 확인 시트, 복구 대기 구간은 시간 누적에서 제외합니다."
+            ),
+            QuestAutomaticTrackingRule(
+                kind: .walkDistance,
+                title: "이동 거리",
+                countingRule: "유효 위치 샘플 간 이동 거리만 누적합니다.",
+                exclusionRule: "정지 상태 드리프트, 낮은 정확도 샘플, 복구 전 더미 위치는 제외합니다."
+            ),
+            QuestAutomaticTrackingRule(
+                kind: .newlyCapturedTerritoryTile,
+                title: "신규 점령 타일",
+                countingRule: "시즌/영역 타일이 새로 점령되거나 표시될 때만 증가합니다.",
+                exclusionRule: "이미 점령한 타일 재방문과 heatmap 가시화만으로는 증가하지 않습니다."
+            ),
+            QuestAutomaticTrackingRule(
+                kind: .activeWalkingTime,
+                title: "유효 산책 지속 시간",
+                countingRule: "과도한 정지 구간을 제외한 active walking 구간만 집계합니다.",
+                exclusionRule: "휴식 후보, 자동 종료 경고, watch/offline 복구 지연 구간은 기본 집계에서 제외합니다."
+            )
+        ]
+    }
+
+    /// 대표 미션 후보의 우선순위 점수를 계산합니다.
+    /// - Parameter candidate: 우선순위를 계산할 지도 표시 후보입니다.
+    /// - Returns: 값이 클수록 지도 HUD 대표 미션으로 우선 노출해야 하는 점수입니다.
+    private func priorityScore(for candidate: QuestMapMissionCandidate) -> Int {
+        if candidate.isClaimable {
+            return 4_000
+        }
+        if candidate.isAutomaticTrackable == false {
+            return 500
+        }
+        let nearCompletionBoost = candidate.progressRatio >= 0.85 ? 1_000 : 0
+        let progressScore = Int((candidate.progressRatio * 100).rounded())
+        return 2_000 + nearCompletionBoost + progressScore
+    }
+
+    /// QA가 그대로 재현할 수 있는 정책 시나리오 목록을 생성합니다.
+    /// - Returns: 단일 미션, 다중 미션, 실내 혼합, 보상 가능 상태를 포함한 QA 시나리오 목록입니다.
+    private func makeQAScenarios() -> [QuestSurfaceQAScenario] {
+        [
+            QuestSurfaceQAScenario(
+                title: "단일 산책 자동 미션",
+                setup: "walk_duration 1개만 active 상태이며 진행률이 40%입니다.",
+                expectedMapBehavior: "지도는 해당 미션 1개를 HUD 대표 항목으로 노출합니다.",
+                expectedHomeBehavior: "홈은 실내 미션 카드와 별도로 자동 미션 요약만 유지합니다.",
+                expectedWidgetBehavior: "위젯은 같은 진행률/미션명을 서버 summary 기준으로 반영합니다."
+            ),
+            QuestSurfaceQAScenario(
+                title: "다중 산책 자동 미션",
+                setup: "walk_duration 70%, new_tile 90%, activeWalkingTime 20%가 동시에 active 상태입니다.",
+                expectedMapBehavior: "지도는 near-complete인 new_tile을 대표 1개로 노출하고 추가 n개만 요약합니다.",
+                expectedHomeBehavior: "홈은 자동 미션 완료 여부를 보조 요약으로만 보여주고 실내 체크 흐름과 섞지 않습니다.",
+                expectedWidgetBehavior: "위젯은 서버가 선택한 대표 summary를 그대로 노출합니다."
+            ),
+            QuestSurfaceQAScenario(
+                title: "실내 미션 혼합",
+                setup: "recordCleanup과 petCareCheck는 active, walk_duration은 55% 진행 중입니다.",
+                expectedMapBehavior: "지도는 walk_duration만 노출하고 실내 미션은 지도에 올리지 않습니다.",
+                expectedHomeBehavior: "홈은 실내 미션 체크리스트를 계속 primary로 노출합니다.",
+                expectedWidgetBehavior: "위젯은 산책 기반 summary만 보여주며 실내 체크는 반영하지 않습니다."
+            ),
+            QuestSurfaceQAScenario(
+                title: "보상 가능 상태",
+                setup: "서버 canonical quest가 completed+claimable 상태입니다.",
+                expectedMapBehavior: "지도는 '보상 가능'까지만 알리고 즉시 수령은 홈 퀘스트 보드 진입으로 유도합니다.",
+                expectedHomeBehavior: "홈은 실제 보상 수령 CTA와 완료 후 상태 전이를 담당합니다.",
+                expectedWidgetBehavior: "위젯은 보상 가능 상태를 반영하되 claim action은 앱 라우트만 요청합니다."
+            )
+        ]
+    }
+}

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -38,6 +38,7 @@ swift scripts/map_walk_point_snapshot_cache_unit_check.swift
 swift scripts/map_hotspot_cluster_trigger_gating_unit_check.swift
 swift scripts/quest_motion_pack_unit_check.swift
 swift scripts/quest_stage1_policy_unit_check.swift
+swift scripts/quest_surface_policy_unit_check.swift
 swift scripts/quest_stage2_engine_unit_check.swift
 swift scripts/season_motion_pack_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift

--- a/scripts/quest_surface_policy_unit_check.swift
+++ b/scripts/quest_surface_policy_unit_check.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// 조건식을 검증하고 실패 시 오류 메시지를 출력한 뒤 프로세스를 종료합니다.
+/// - Parameters:
+///   - condition: 검증할 조건입니다.
+///   - message: 실패 시 출력할 메시지입니다.
+@inline(__always)
+func assertTrue(_ condition: Bool, _ message: String) {
+    if !condition {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 지정한 상대 경로의 UTF-8 텍스트 파일 내용을 읽어 문자열로 반환합니다.
+/// - Parameter relativePath: 저장소 루트 기준 상대 경로입니다.
+/// - Returns: 파일의 UTF-8 문자열 본문입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let policy = load("docs/quest-surface-policy-v1.md")
+let model = load("dogArea/Source/Domain/Quest/Models/QuestSurfacePolicyModels.swift")
+let service = load("dogArea/Source/Domain/Quest/Services/QuestSurfacePolicyService.swift")
+let readme = load("README.md")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(policy.contains("source of truth"), "Policy should define surface source of truth")
+assertTrue(policy.contains("walk_duration"), "Policy should include walk_duration automatic tracking rule")
+assertTrue(policy.contains("walk_distance"), "Policy should include walk_distance automatic tracking rule")
+assertTrue(policy.contains("new_tile"), "Policy should include new tile automatic tracking rule")
+assertTrue(policy.contains("recordCleanup"), "Policy should keep record cleanup as home-only mission")
+assertTrue(policy.contains("보상 가능"), "Policy should define claimable-only map feedback")
+assertTrue(policy.contains("즉시 수령"), "Policy should explicitly mention immediate claim policy")
+assertTrue(policy.contains("#465"), "Policy should hand off to issue #465")
+assertTrue(policy.contains("#467"), "Policy should hand off to issue #467")
+assertTrue(policy.contains("#468"), "Policy should hand off to issue #468")
+
+assertTrue(model.contains("enum QuestSurfaceVisibilityBucket"), "Model should define surface visibility bucket")
+assertTrue(model.contains("enum QuestSurfaceSourceOfTruth"), "Model should define source of truth enum")
+assertTrue(model.contains("struct QuestMapMissionCandidate"), "Model should define map mission candidate")
+assertTrue(model.contains("struct QuestSurfacePolicySnapshot"), "Model should define policy snapshot")
+
+assertTrue(service.contains("protocol QuestSurfacePolicyResolving"), "Service should expose policy protocol")
+assertTrue(service.contains("func makePolicySnapshot() -> QuestSurfacePolicySnapshot"), "Service should build policy snapshot")
+assertTrue(service.contains("func selectPrimaryMapCandidate(from candidates: [QuestMapMissionCandidate])"), "Service should define representative mission selection")
+assertTrue(service.contains("candidate.isClaimable"), "Representative mission selection should prioritize claimable state")
+assertTrue(service.contains("IndoorMissionCategory.allCases"), "Service should classify current indoor mission categories as home-only")
+
+assertTrue(readme.contains("docs/quest-surface-policy-v1.md"), "README should index quest surface policy doc")
+assertTrue(prCheck.contains("swift scripts/quest_surface_policy_unit_check.swift"), "ios_pr_check should run quest surface policy gate")
+
+print("PASS: quest surface policy unit checks")


### PR DESCRIPTION
## Summary
- define a canonical quest surface policy for Home, Map, and Widget
- add quest domain models and a policy service for representative quest/reward flow decisions
- document QA scenarios and enforce the policy with ios_pr_check

Closes #464