### PR TITLE
feat: define map quest feedback hud policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 - 날씨 연동 UX/fallback/접근성 v1: `docs/weather-ux-fallback-accessibility-v1.md`
 - 퀘스트 Stage1 템플릿/난이도 정책 v1: `docs/quest-stage1-template-difficulty-policy-v1.md`
 - 퀘스트 표면 정책(홈/지도/위젯 경계) v1: `docs/quest-surface-policy-v1.md`
+- 지도 퀘스트 피드백 HUD 정책 v1: `docs/map-quest-feedback-hud-v1.md`
 - 퀘스트 Stage2 진행/클레임 백엔드 엔진 v1: `docs/quest-stage2-progress-claim-engine-v1.md`
 - 퀘스트 실패 완충(자동 연장 슬롯) v1: `docs/quest-failure-buffer-v1.md`
 - 퀘스트 Stage3 UX/리마인드 v1: `docs/quest-stage3-ux-reminder-v1.md`

--- a/docs/map-quest-feedback-hud-v1.md
+++ b/docs/map-quest-feedback-hud-v1.md
@@ -1,0 +1,118 @@
+# 지도 퀘스트 피드백 HUD 정책 v1
+
+## 목적
+산책 중 퀘스트/미션 진행을 홈으로 돌아가지 않고도 이해할 수 있게 만들되, 지도 가시성과 조작성을 해치지 않는 피드백 체계를 고정합니다.
+
+핵심 원칙은 `모달 Alert`가 아니라 `HUD + milestone toast + expandable checklist` 3계층입니다.
+
+## 계층 역할
+
+### 1. Companion HUD
+- 지도 상단 overlay에 상시 유지되는 기본 피드백 계층입니다.
+- `대표 미션 1개 + 추가 n개`만 요약합니다.
+- 보여주는 정보는 최대 3줄입니다.
+  - 미션명
+  - 현재 진행도
+  - 남은 조건 1줄 요약
+- 기본 상태에서는 펼침(`expanded`)을 사용합니다.
+- 자동 추적 신호가 여러 개면 `compactSingleLine`로 접습니다.
+- `critical banner`가 올라오면 `hiddenByCriticalBanner`로 밀립니다.
+
+### 2. Milestone Toast
+- 아래 이벤트에서만 짧게 노출합니다.
+  - 50% 도달
+  - 조건 충족 직전(near completion)
+  - 완료(completed)
+  - 보상 가능(claimable)
+- 토스트는 모두 `auto-dismiss`입니다.
+- 중복 억제 window를 둡니다.
+  - halfway: 45초
+  - near completion: 45초
+  - completed: 90초
+  - claimable: 120초
+- 기본 copy/haptic 정책
+  - halfway: `절반 넘겼어요` + `progressPulse`
+  - near completion: `거의 다 왔어요` + `progressPulse`
+  - completed: `퀘스트 완료` + `completionSuccess`
+  - claimable: `보상 받을 수 있어요` + `rewardReady`
+- map에서는 상태만 알려주고, `즉시 보상 수령`은 하지 않습니다.
+
+### 3. Expandable Checklist
+- HUD 탭 시 바텀시트/드로어로 확장합니다.
+- 섹션은 2개로 나눕니다.
+  - `산책 중 바로 반영돼요`
+  - `홈에서 직접 확인해요`
+- 자동 추적 가능한 항목은 counting rule 중심으로 보여줍니다.
+- 홈 전용 미션은 이유를 함께 명시합니다.
+  - 예: 돌봄/훈련/정리 미션은 홈 보드에서 직접 체크
+
+## 우선순위 규칙
+1. `critical banner`
+2. `quest companion HUD`
+3. `passive status`
+
+정리하면:
+- 권한/복구/종료 제안 같은 파괴 가능성 안내가 항상 우선입니다.
+- quest feedback는 산책 흐름을 보조하는 정보여야 하며, 조작을 막아서는 안 됩니다.
+- `모달 Alert`는 권한/오류/파괴적 확인 예외 상황에만 남깁니다.
+
+## Source of Truth 정렬
+- Home: `localIndoorMissionBoard`
+- Map: `serverCanonicalQuestSummary`
+- Widget: `widgetMirrorOfServerSummary`
+
+지도 HUD는 widget summary와 같은 서버 canonical quest summary를 재맥락화해서 씁니다.
+즉, 지도용 별도 계산 로직을 새로 만드는 대신 기존 quest summary snapshot을 지도용 표현 정책에 맞게 소비합니다.
+
+## 산책 중 자동 추적 가능 조건
+`#464` 정책을 그대로 이어받습니다.
+- 산책 시간
+- 이동 거리
+- 신규 점령 타일
+- 유효 산책 지속 시간
+
+## 홈 전용 직접 체크 항목
+다음 카테고리는 지도에서 완료 처리하지 않습니다.
+- `recordCleanup`
+- `petCareCheck`
+- `trainingCheck`
+
+지도에서는 체크리스트 하단 섹션으로만 설명하고, 실제 조작은 홈 보드에서 이어집니다.
+
+## 보상 처리 정책
+- 지도: `보상 가능` 상태만 노출
+- 홈: 실제 `보상 수령` 처리
+- 위젯: claim route를 요청할 수는 있으나 canonical completion/claim state는 앱과 서버가 결정
+
+따라서 map toast/HUD copy는 아래 원칙을 따릅니다.
+- 허용: `보상 받을 수 있어요`, `홈 퀘스트 보드에서 이어집니다`
+- 금지: `지금 바로 수령`, `자동 수령 완료`
+
+## 작은 화면 / 다중 배너 규칙
+- 기본은 대표 미션 1개만 유지
+- 추가 미션은 `추가 n개 진행 중` 수준으로 축약
+- 작은 화면에서 critical banner와 quest HUD가 충돌하면 HUD는 숨김
+- toast는 상단 chrome 아래에 짧게 오버레이되며 지도 조작 hit-test를 막지 않음
+- checklist는 사용자가 명시적으로 탭했을 때만 확장
+
+## QA 시나리오
+1. critical banner 동시 노출
+- setup: 위치 권한 복구 banner + 자동 미션 진행
+- expected: banner 우선, HUD 숨김 또는 축약, toast 지연
+
+2. 자동 미션 3개 동시 진행
+- setup: 1개는 90%, 2개는 중간 진행
+- expected: 대표 1개 + 추가 n개, near completion toast 1회
+
+3. completed -> claimable 전이
+- setup: 완료 직후 claimable 상태 전이
+- expected: completed toast 후 claimable toast 1회, 즉시 claim은 없음
+
+4. 직접 체크 미션 혼합
+- setup: 자동 미션 1개 + 홈 전용 직접 체크 2개
+- expected: map HUD는 자동 미션만, checklist 하단에 홈 전용 섹션
+
+## 후속 이슈 연결
+- `#467`: companion HUD 최소 정보셋/축약 규칙 구체화
+- `#468`: critical banner와 동시 노출 우선순위/접힘 규칙 런타임 반영
+- `#453`: 홈 미션 lifecycle/완료 흐름과 copy 정합성 유지

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		A56300010000000000000004 /* HomeMissionTrackingModeOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56300010000000000000014 /* HomeMissionTrackingModeOverviewView.swift */; };
 		A46400010000000000000001 /* QuestSurfacePolicyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46400010000000000000011 /* QuestSurfacePolicyModels.swift */; };
 		A46400010000000000000002 /* QuestSurfacePolicyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46400010000000000000012 /* QuestSurfacePolicyService.swift */; };
+		A46500010000000000000001 /* QuestMapFeedbackPolicyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46500010000000000000011 /* QuestMapFeedbackPolicyModels.swift */; };
+		A46500010000000000000002 /* QuestMapFeedbackPolicyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46500010000000000000012 /* QuestMapFeedbackPolicyService.swift */; };
 		A56500010000000000000006 /* MapWalkActiveValueCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56500010000000000000016 /* MapWalkActiveValueCardView.swift */; };
 		A56500010000000000000007 /* MapWalkSavedOutcomeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56500010000000000000017 /* MapWalkSavedOutcomeCardView.swift */; };
 		A56500010000000000000008 /* WalkCompletionValueFlowCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56500010000000000000018 /* WalkCompletionValueFlowCardView.swift */; };
@@ -568,6 +570,8 @@
 		A45800010000000000000013 /* HomeWeatherGuidanceSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWeatherGuidanceSheetView.swift; sourceTree = "<group>"; };
 		A46400010000000000000011 /* QuestSurfacePolicyModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestSurfacePolicyModels.swift; sourceTree = "<group>"; };
 		A46400010000000000000012 /* QuestSurfacePolicyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestSurfacePolicyService.swift; sourceTree = "<group>"; };
+		A46500010000000000000011 /* QuestMapFeedbackPolicyModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMapFeedbackPolicyModels.swift; sourceTree = "<group>"; };
+		A46500010000000000000012 /* QuestMapFeedbackPolicyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMapFeedbackPolicyService.swift; sourceTree = "<group>"; };
 		A47500010000000000000011 /* WeatherReplacementSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherReplacementSummary.swift; sourceTree = "<group>"; };
 		A47500010000000000000012 /* WeatherReplacementSummaryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherReplacementSummaryStore.swift; sourceTree = "<group>"; };
 		A47500010000000000000013 /* SupabaseWeatherReplacementServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseWeatherReplacementServices.swift; sourceTree = "<group>"; };
@@ -1001,6 +1005,7 @@
 			isa = PBXGroup;
 			children = (
 				A46400010000000000000011 /* QuestSurfacePolicyModels.swift */,
+				A46500010000000000000011 /* QuestMapFeedbackPolicyModels.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1009,6 +1014,7 @@
 			isa = PBXGroup;
 			children = (
 				A46400010000000000000012 /* QuestSurfacePolicyService.swift */,
+				A46500010000000000000012 /* QuestMapFeedbackPolicyService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -2164,6 +2170,7 @@
 				A50700010000000000000003 /* AuthMailActionStateStore.swift in Sources */,
 				A56300010000000000000001 /* HomeMissionTrackingModels.swift in Sources */,
 				A46400010000000000000001 /* QuestSurfacePolicyModels.swift in Sources */,
+				A46500010000000000000001 /* QuestMapFeedbackPolicyModels.swift in Sources */,
 				A56400010000000000000003 /* HomeMissionGuideStateStore.swift in Sources */,
 				A56500010000000000000004 /* WalkValueGuideStateStore.swift in Sources */,
 				DAE147A11420000000000001 /* HomeWeeklyStatisticsService.swift in Sources */,
@@ -2173,6 +2180,7 @@
 				A56400010000000000000002 /* HomeMissionGuidePresentationService.swift in Sources */,
 				A50600010000000000000001 /* HomeIndoorMissionPetContextSnapshotService.swift in Sources */,
 				A46400010000000000000002 /* QuestSurfacePolicyService.swift in Sources */,
+				A46500010000000000000002 /* QuestMapFeedbackPolicyService.swift in Sources */,
 				DAED25022AFA1D430044715A /* SplashView.swift in Sources */,
 				DA99F9E62AFA4F3E00B1483F /* Color.swift in Sources */,
 				DA3F9BD32AE0FF8A0048550C /* RootView.swift in Sources */,

--- a/dogArea/Source/Domain/Quest/Models/QuestMapFeedbackPolicyModels.swift
+++ b/dogArea/Source/Domain/Quest/Models/QuestMapFeedbackPolicyModels.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// 산책 중 지도에서 퀘스트 피드백을 전달하는 계층을 정의합니다.
+enum QuestMapFeedbackLayer: String, CaseIterable {
+    case companionHUD = "companion_hud"
+    case milestoneToast = "milestone_toast"
+    case expandedChecklist = "expanded_checklist"
+}
+
+/// 지도 상단 chrome 안에서 퀘스트 피드백이 차지하는 우선순위 tier를 정의합니다.
+enum QuestMapFeedbackPriorityTier: String, CaseIterable {
+    case criticalBanner = "critical_banner"
+    case questCompanionHUD = "quest_companion_hud"
+    case passiveStatus = "passive_status"
+}
+
+/// 마일스톤 토스트를 발화시키는 이벤트 종류를 정의합니다.
+enum QuestMapMilestoneTrigger: String, CaseIterable {
+    case halfway = "halfway"
+    case nearCompletion = "near_completion"
+    case completed = "completed"
+    case claimable = "claimable"
+}
+
+/// 토스트와 함께 재생할 햅틱 패턴을 정의합니다.
+enum QuestMapMilestoneHaptic: String, CaseIterable {
+    case progressPulse = "progress_pulse"
+    case completionSuccess = "completion_success"
+    case rewardReady = "reward_ready"
+}
+
+/// HUD가 현재 어떤 정도로 접혀 있어야 하는지 정의합니다.
+enum QuestMapFeedbackCollapsedState: String, CaseIterable {
+    case expanded = "expanded"
+    case compactSingleLine = "compact_single_line"
+    case iconOnly = "icon_only"
+    case hiddenByCriticalBanner = "hidden_by_critical_banner"
+}
+
+/// 체크리스트 항목이 어떤 진행 상태인지 정의합니다.
+enum QuestMapChecklistItemState: String, CaseIterable {
+    case autoChecked = "auto_checked"
+    case remainingDuringWalk = "remaining_during_walk"
+    case homeOnly = "home_only"
+}
+
+/// 지도 HUD 본문에 상시 유지할 대표 요약 모델입니다.
+struct QuestMapCompanionHUDPolicy: Equatable {
+    let titleLine: String
+    let progressLine: String
+    let remainingLine: String
+    let collapsedState: QuestMapFeedbackCollapsedState
+    let priorityTier: QuestMapFeedbackPriorityTier
+}
+
+/// milestone toast의 노출 규칙을 정의합니다.
+struct QuestMapMilestoneToastPolicy: Equatable {
+    let trigger: QuestMapMilestoneTrigger
+    let title: String
+    let body: String
+    let haptic: QuestMapMilestoneHaptic
+    let autoDismissSeconds: TimeInterval
+    let suppressDuplicateWindowSeconds: TimeInterval
+}
+
+/// 확장 체크리스트 항목 모델입니다.
+struct QuestMapChecklistItem: Equatable {
+    let title: String
+    let detail: String
+    let state: QuestMapChecklistItemState
+}
+
+/// 확장 체크리스트 섹션 모델입니다.
+struct QuestMapChecklistSection: Equatable {
+    let title: String
+    let items: [QuestMapChecklistItem]
+}
+
+/// 지도 퀘스트 피드백 QA 재현 시나리오입니다.
+struct QuestMapFeedbackQAScenario: Equatable {
+    let title: String
+    let setup: String
+    let expectedHUD: String
+    let expectedToast: String
+    let expectedChecklist: String
+}
+
+/// 지도 퀘스트 피드백 정책 스냅샷입니다.
+struct QuestMapFeedbackPolicySnapshot: Equatable {
+    let layers: [QuestMapFeedbackLayer]
+    let priorityTiers: [QuestMapFeedbackPriorityTier]
+    let defaultHUD: QuestMapCompanionHUDPolicy
+    let milestoneToasts: [QuestMapMilestoneToastPolicy]
+    let checklistSections: [QuestMapChecklistSection]
+    let qaScenarios: [QuestMapFeedbackQAScenario]
+}

--- a/dogArea/Source/Domain/Quest/Services/QuestMapFeedbackPolicyService.swift
+++ b/dogArea/Source/Domain/Quest/Services/QuestMapFeedbackPolicyService.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+protocol QuestMapFeedbackPolicyResolving {
+    /// 지도 산책 중 퀘스트 피드백의 기본 정책 스냅샷을 생성합니다.
+    /// - Returns: HUD, 토스트, 체크리스트, 우선순위, QA 시나리오를 포함한 정책 스냅샷입니다.
+    func makePolicySnapshot() -> QuestMapFeedbackPolicySnapshot
+
+    /// 상단 chrome 상황에 맞는 HUD 접힘 상태를 계산합니다.
+    /// - Parameters:
+    ///   - hasCriticalBanner: 권한/복구/종료 제안 같은 critical banner 노출 여부입니다.
+    ///   - hasMultipleMissionSignals: 동시에 보여줄 자동 추적 미션 신호가 여러 개인지 여부입니다.
+    /// - Returns: 현재 지도 HUD가 어떤 정도로 접혀야 하는지 나타내는 상태입니다.
+    func collapsedState(hasCriticalBanner: Bool, hasMultipleMissionSignals: Bool) -> QuestMapFeedbackCollapsedState
+
+    /// 현재 대표 미션 후보와 자동 추적 규칙으로 확장 체크리스트 섹션을 생성합니다.
+    /// - Parameters:
+    ///   - candidate: 현재 지도 HUD가 대표로 삼는 미션 후보입니다.
+    ///   - automaticRules: 산책 중 자동 추적 가능한 규칙 목록입니다.
+    /// - Returns: 산책 중 달성 가능한 조건과 홈 전용 조건을 나눈 체크리스트 섹션입니다.
+    func makeChecklistSections(
+        candidate: QuestMapMissionCandidate?,
+        automaticRules: [QuestAutomaticTrackingRule]
+    ) -> [QuestMapChecklistSection]
+}
+
+final class QuestMapFeedbackPolicyService: QuestMapFeedbackPolicyResolving {
+    /// 지도 산책 중 퀘스트 피드백의 기본 정책 스냅샷을 생성합니다.
+    /// - Returns: HUD, 토스트, 체크리스트, 우선순위, QA 시나리오를 포함한 정책 스냅샷입니다.
+    func makePolicySnapshot() -> QuestMapFeedbackPolicySnapshot {
+        let automaticRules = QuestSurfacePolicyService().makePolicySnapshot().automaticTrackingRules
+        return QuestMapFeedbackPolicySnapshot(
+            layers: [.companionHUD, .milestoneToast, .expandedChecklist],
+            priorityTiers: [.criticalBanner, .questCompanionHUD, .passiveStatus],
+            defaultHUD: QuestMapCompanionHUDPolicy(
+                titleLine: "오늘의 퀘스트",
+                progressLine: "대표 미션 1개 + 추가 진행 n개만 요약합니다.",
+                remainingLine: "산책 중 바로 달성 가능한 조건만 1줄로 남겨 보여줍니다.",
+                collapsedState: .expanded,
+                priorityTier: .questCompanionHUD
+            ),
+            milestoneToasts: milestoneToastPolicies(),
+            checklistSections: makeChecklistSections(candidate: nil, automaticRules: automaticRules),
+            qaScenarios: qaScenarios()
+        )
+    }
+
+    /// 상단 chrome 상황에 맞는 HUD 접힘 상태를 계산합니다.
+    /// - Parameters:
+    ///   - hasCriticalBanner: 권한/복구/종료 제안 같은 critical banner 노출 여부입니다.
+    ///   - hasMultipleMissionSignals: 동시에 보여줄 자동 추적 미션 신호가 여러 개인지 여부입니다.
+    /// - Returns: 현재 지도 HUD가 어떤 정도로 접혀야 하는지 나타내는 상태입니다.
+    func collapsedState(hasCriticalBanner: Bool, hasMultipleMissionSignals: Bool) -> QuestMapFeedbackCollapsedState {
+        if hasCriticalBanner {
+            return .hiddenByCriticalBanner
+        }
+        return hasMultipleMissionSignals ? .compactSingleLine : .expanded
+    }
+
+    /// 현재 대표 미션 후보와 자동 추적 규칙으로 확장 체크리스트 섹션을 생성합니다.
+    /// - Parameters:
+    ///   - candidate: 현재 지도 HUD가 대표로 삼는 미션 후보입니다.
+    ///   - automaticRules: 산책 중 자동 추적 가능한 규칙 목록입니다.
+    /// - Returns: 산책 중 달성 가능한 조건과 홈 전용 조건을 나눈 체크리스트 섹션입니다.
+    func makeChecklistSections(
+        candidate: QuestMapMissionCandidate?,
+        automaticRules: [QuestAutomaticTrackingRule]
+    ) -> [QuestMapChecklistSection] {
+        let walkingSection = QuestMapChecklistSection(
+            title: "산책 중 바로 반영돼요",
+            items: automaticRules.map { rule in
+                QuestMapChecklistItem(
+                    title: rule.title,
+                    detail: rule.countingRule,
+                    state: candidate?.isAutomaticTrackable == true ? .remainingDuringWalk : .autoChecked
+                )
+            }
+        )
+        let homeOnlySection = QuestMapChecklistSection(
+            title: "홈에서 직접 확인해요",
+            items: [
+                QuestMapChecklistItem(
+                    title: "직접 체크 미션",
+                    detail: "돌봄/훈련/정리 미션은 지도에서 자동 완료하지 않고 홈 보드에서 체크합니다.",
+                    state: .homeOnly
+                )
+            ]
+        )
+        return [walkingSection, homeOnlySection]
+    }
+
+    /// milestone toast 정책 목록을 생성합니다.
+    /// - Returns: 트리거별 copy, haptic, auto-dismiss, 중복 억제 규칙이 반영된 정책 목록입니다.
+    private func milestoneToastPolicies() -> [QuestMapMilestoneToastPolicy] {
+        [
+            QuestMapMilestoneToastPolicy(
+                trigger: .halfway,
+                title: "절반 넘겼어요",
+                body: "지금 pace를 유지하면 이번 산책 안에 충분히 달성할 수 있어요.",
+                haptic: .progressPulse,
+                autoDismissSeconds: 2.0,
+                suppressDuplicateWindowSeconds: 45
+            ),
+            QuestMapMilestoneToastPolicy(
+                trigger: .nearCompletion,
+                title: "거의 다 왔어요",
+                body: "남은 조건 한 가지만 더 채우면 바로 완료돼요.",
+                haptic: .progressPulse,
+                autoDismissSeconds: 2.2,
+                suppressDuplicateWindowSeconds: 45
+            ),
+            QuestMapMilestoneToastPolicy(
+                trigger: .completed,
+                title: "퀘스트 완료",
+                body: "산책 중 조건을 모두 채웠어요. 이제 보드에서 결과를 확인할 수 있어요.",
+                haptic: .completionSuccess,
+                autoDismissSeconds: 2.8,
+                suppressDuplicateWindowSeconds: 90
+            ),
+            QuestMapMilestoneToastPolicy(
+                trigger: .claimable,
+                title: "보상 받을 수 있어요",
+                body: "지도에서는 상태만 알려드리고, 실제 보상 수령은 홈 퀘스트 보드에서 이어집니다.",
+                haptic: .rewardReady,
+                autoDismissSeconds: 3.2,
+                suppressDuplicateWindowSeconds: 120
+            )
+        ]
+    }
+
+    /// 지도 퀘스트 피드백 QA 시나리오를 생성합니다.
+    /// - Returns: HUD, 토스트, 체크리스트 우선순위를 검증할 수 있는 대표 시나리오 목록입니다.
+    private func qaScenarios() -> [QuestMapFeedbackQAScenario] {
+        [
+            QuestMapFeedbackQAScenario(
+                title: "critical banner 우선",
+                setup: "권한 복구 banner와 퀘스트 진행 1개가 동시에 active입니다.",
+                expectedHUD: "퀘스트 HUD는 접히거나 숨겨지고 critical banner가 최상단을 점유합니다.",
+                expectedToast: "퀘스트 milestone toast는 critical banner가 내려간 뒤에만 다시 허용됩니다.",
+                expectedChecklist: "사용자가 HUD를 다시 열기 전까지 체크리스트는 자동 노출되지 않습니다."
+            ),
+            QuestMapFeedbackQAScenario(
+                title: "자동 미션 다중 진행",
+                setup: "자동 추적 미션 3개가 동시에 진행 중이며 그중 하나가 90%입니다.",
+                expectedHUD: "HUD는 대표 1개와 추가 n개 요약만 보여줍니다.",
+                expectedToast: "90%에 도달한 대표 미션만 near-completion toast를 1회 보여줍니다.",
+                expectedChecklist: "확장 체크리스트에는 자동 추적 항목과 남은 조건이 섹션별로 보입니다."
+            ),
+            QuestMapFeedbackQAScenario(
+                title: "완료 후 보상 가능 전이",
+                setup: "자동 미션이 completed에서 claimable로 전이됩니다.",
+                expectedHUD: "HUD는 '보상 가능' 상태를 유지하되 즉시 claim 버튼은 노출하지 않습니다.",
+                expectedToast: "completed 이후 claimable toast는 중복 없이 1회만 추가로 노출됩니다.",
+                expectedChecklist: "체크리스트 상단에는 완료 표시, 하단에는 홈에서 마무리하라는 안내가 나옵니다."
+            ),
+            QuestMapFeedbackQAScenario(
+                title: "직접 체크 미션 혼합",
+                setup: "산책 자동 미션 1개와 홈 전용 직접 체크 미션 2개가 함께 존재합니다.",
+                expectedHUD: "HUD는 산책 중 자동 미션만 요약합니다.",
+                expectedToast: "직접 체크 미션 때문에 지도 toast를 추가로 띄우지 않습니다.",
+                expectedChecklist: "체크리스트 하단에 홈 전용 항목을 별도 섹션으로 구분해 보여줍니다."
+            )
+        ]
+    }
+}

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -39,6 +39,7 @@ swift scripts/map_hotspot_cluster_trigger_gating_unit_check.swift
 swift scripts/quest_motion_pack_unit_check.swift
 swift scripts/quest_stage1_policy_unit_check.swift
 swift scripts/quest_surface_policy_unit_check.swift
+swift scripts/map_quest_feedback_policy_unit_check.swift
 swift scripts/quest_stage2_engine_unit_check.swift
 swift scripts/season_motion_pack_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift

--- a/scripts/map_quest_feedback_policy_unit_check.swift
+++ b/scripts/map_quest_feedback_policy_unit_check.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct Check {
+    static func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if !condition() {
+            fputs("FAIL: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let doc = try String(contentsOf: root.appendingPathComponent("docs/map-quest-feedback-hud-v1.md"), encoding: .utf8)
+let models = try String(contentsOf: root.appendingPathComponent("dogArea/Source/Domain/Quest/Models/QuestMapFeedbackPolicyModels.swift"), encoding: .utf8)
+let service = try String(contentsOf: root.appendingPathComponent("dogArea/Source/Domain/Quest/Services/QuestMapFeedbackPolicyService.swift"), encoding: .utf8)
+let readme = try String(contentsOf: root.appendingPathComponent("README.md"), encoding: .utf8)
+let prCheck = try String(contentsOf: root.appendingPathComponent("scripts/ios_pr_check.sh"), encoding: .utf8)
+
+Check.require(doc.contains("HUD + milestone toast + expandable checklist"), "doc must define three-layer feedback model")
+Check.require(doc.contains("critical banner"), "doc must define critical banner priority")
+Check.require(doc.contains("보상 가능"), "doc must define claimable copy policy")
+Check.require(doc.contains("recordCleanup"), "doc must list home-only categories")
+Check.require(doc.contains("#467") && doc.contains("#468"), "doc must link follow-up issues")
+
+Check.require(models.contains("enum QuestMapFeedbackLayer"), "models must define feedback layers")
+Check.require(models.contains("enum QuestMapMilestoneTrigger"), "models must define milestone triggers")
+Check.require(models.contains("enum QuestMapFeedbackCollapsedState"), "models must define collapsed states")
+Check.require(models.contains("struct QuestMapChecklistSection"), "models must define checklist sections")
+Check.require(models.contains("struct QuestMapFeedbackPolicySnapshot"), "models must define policy snapshot")
+
+Check.require(service.contains("protocol QuestMapFeedbackPolicyResolving"), "service must define protocol")
+Check.require(service.contains("func makePolicySnapshot()"), "service must build policy snapshot")
+Check.require(service.contains("func collapsedState("), "service must define collapsed state logic")
+Check.require(service.contains("func makeChecklistSections("), "service must define checklist policy")
+Check.require(service.contains("milestoneToastPolicies()"), "service must define milestone toast policies")
+Check.require(service.contains("QuestSurfacePolicyService().makePolicySnapshot().automaticTrackingRules"), "service must reuse #464 automatic tracking rules")
+
+Check.require(readme.contains("지도 퀘스트 피드백 HUD 정책 v1"), "README must index the doc")
+Check.require(prCheck.contains("swift scripts/map_quest_feedback_policy_unit_check.swift"), "ios_pr_check must run the new unit check")
+
+print("PASS: map quest feedback policy unit checks")


### PR DESCRIPTION
## Summary\n- add Quest map feedback HUD policy domain models and service\n- document HUD, milestone toast, checklist, and priority rules for map quest feedback\n- add static policy verification and wire it into ios_pr_check\n\nCloses #465