### PR TITLE
feat: define map quest overlay priority matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 - 퀘스트 표면 정책(홈/지도/위젯 경계) v1: `docs/quest-surface-policy-v1.md`
 - 지도 퀘스트 피드백 HUD 정책 v1: `docs/map-quest-feedback-hud-v1.md`
 - 지도 퀘스트 HUD 최소 정보셋 v1: `docs/map-quest-hud-minimum-info-set-v1.md`
+- 지도 상단 overlay 우선순위 매트릭스 v1: `docs/map-quest-overlay-priority-matrix-v1.md`
 - 퀘스트 Stage2 진행/클레임 백엔드 엔진 v1: `docs/quest-stage2-progress-claim-engine-v1.md`
 - 퀘스트 실패 완충(자동 연장 슬롯) v1: `docs/quest-failure-buffer-v1.md`
 - 퀘스트 Stage3 UX/리마인드 v1: `docs/quest-stage3-ux-reminder-v1.md`

--- a/docs/map-quest-overlay-priority-matrix-v1.md
+++ b/docs/map-quest-overlay-priority-matrix-v1.md
@@ -1,0 +1,93 @@
+# 지도 상단 overlay 우선순위 매트릭스 v1
+
+## 목적
+
+`MapView`는 이미 recovery / recoverable session / return-to-origin / sync / runtime / offline / watch 상태를 top banner priority로 다룹니다.  
+여기에 `#465`의 quest feedback HUD와 `#467`의 HUD 정보셋을 실제로 얹으려면, **어떤 표면이 top overlay slot을 점유하고 어떤 표면이 toast slot으로 빠지는지**를 먼저 고정해야 합니다.
+
+이 문서는 `#468`의 구현 기준입니다.
+
+## 3계층 분류
+
+이 문서의 canonical 분류는 `critical / operational / progress` 3계층입니다.
+
+- `critical`
+  - `recoveryIssue`
+  - `recoverableSession`
+  - `returnToOrigin`
+- `operational`
+  - `syncOutbox`
+  - `runtimeGuard`
+  - `offlineMode`
+  - `watchStatus`
+  - `guestBackup`
+- `progress`
+  - quest companion HUD
+  - quest expanded checklist
+  - quest milestone toast
+
+## 슬롯 역할
+
+### top overlay slot
+
+- 지도 chrome 안에서 **동시에 하나의 banner 계층만** 점유합니다.
+- quest HUD는 top overlay slot의 독립 banner가 아니라, banner가 비었을 때는 `primary progress surface`, operational banner가 있을 때만 `collapsed secondary row`로 공존합니다.
+- 작은 화면 또는 season tile detail 패널이 열린 상태에서는 `single top slot`만 허용합니다.
+
+### toast slot
+
+- milestone toast는 top overlay slot과 분리된 비차단 피드백 전용입니다.
+- toast는 화면 reflow를 일으키지 않습니다.
+- critical banner 전환 중에는 보이지 않고 queue에 들어갑니다.
+
+## 기본 결정
+
+- critical banner는 항상 단독 노출
+- operational banner는 quest HUD보다 top slot 우선권을 가짐
+- quest HUD는 기본 persistent
+- critical 등장 시 즉시 숨김
+- operational 등장 시 `collapsed single line`로 축약
+- 사용자가 HUD를 닫으면 `120초` suppress
+- 단, 대표 미션 상태가 `completed` 또는 `claimable`로 상승하면 suppress를 즉시 해제 가능
+
+## animation / transition guard
+
+- top slot은 `1.5초` stable window 안에서는 잦은 교체를 피하고 coalesce
+- non-critical 교체는 `0.35초` coalescing window로 묶음
+- critical preemption만 즉시 교체 허용
+- toast는 top slot이 안정화되기 전에는 `queued until top slot settles`
+
+## 상태표
+
+| 시나리오 | active tier | top overlay slot | quest HUD | toast slot | 비고 |
+| --- | --- | --- | --- | --- | --- |
+| 권한/복구/종료 제안 | critical | critical banner only | hidden by critical banner | queued | critical가 끝난 뒤 HUD 복귀 |
+| sync/runtime/offline 배너 + regular 화면 | operational | operational banner + collapsed HUD | collapsed single line | queued | 배너가 내려가면 HUD 원래 상태 복귀 |
+| watch/guest 배너 + compact 화면 | operational | operational banner only | hidden by density guard | queued | 작은 화면에서는 공존 금지 |
+| quest만 활성 | progress | quest HUD only | expanded | visible | 대표 미션 1개 중심 |
+| quest 다중 진행 | progress | quest HUD only | collapsed single line | visible | `대표 1개 + 추가 n개` 유지 |
+| 사용자가 HUD 닫음 | 없음 또는 operational | none 또는 operational banner only | suppressed by user | visible | suppress duration 120초 |
+
+## runtime 해석 규칙
+
+1. `critical`이 있으면 quest HUD는 숨기고 toast도 queue로 돌립니다.
+2. `operational`만 있으면:
+   - regular density: banner + collapsed HUD 공존
+   - compact density 또는 season detail expanded: banner only
+3. `progress`만 있으면 HUD가 top overlay의 주 surface가 됩니다.
+4. toast는 `critical`과 경쟁하지 않고, `operational`과도 동시에 튀지 않게 stable window 뒤로 밀립니다.
+
+## 구현 메모
+
+- top slot priority는 기존 `MapTopBannerKind` ordering과 별개로 `tier -> slot mode` 해석 단계를 한 번 더 둡니다.
+- quest HUD의 `expanded / collapsed / suppressed / hiddenByCritical`는 banner queue와 분리된 상태로 유지해야 합니다.
+- milestone toast는 `banner queue`에 넣지 말고 별도 lane으로 다룹니다.
+- `#465`의 toast/haptic 정책과 `#467`의 collapsed 정보셋은 이 매트릭스 위에서만 실행합니다.
+
+## QA 포인트
+
+- critical banner가 떠 있을 때 quest HUD가 top chrome에서 완전히 사라지는지
+- operational banner가 있을 때 HUD가 1줄 collapsed로만 남는지
+- 작은 화면에서 banner + HUD 이중 노출이 발생하지 않는지
+- milestone toast가 critical banner 전환 중에 겹쳐 뜨지 않는지
+- 사용자가 HUD를 닫은 뒤 120초 내에 재등장하지 않는지

--- a/dogArea.xcodeproj/project.pbxproj
+++ b/dogArea.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		A46500010000000000000002 /* QuestMapFeedbackPolicyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46500010000000000000012 /* QuestMapFeedbackPolicyService.swift */; };
 		A46700010000000000000001 /* QuestMapHUDInfoSetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46700010000000000000011 /* QuestMapHUDInfoSetModels.swift */; };
 		A46700010000000000000002 /* QuestMapHUDInfoSetPolicyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46700010000000000000012 /* QuestMapHUDInfoSetPolicyService.swift */; };
+		A46800010000000000000001 /* QuestMapOverlayPriorityModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46800010000000000000011 /* QuestMapOverlayPriorityModels.swift */; };
+		A46800010000000000000002 /* QuestMapOverlayPriorityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46800010000000000000012 /* QuestMapOverlayPriorityService.swift */; };
 		A56500010000000000000006 /* MapWalkActiveValueCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56500010000000000000016 /* MapWalkActiveValueCardView.swift */; };
 		A56500010000000000000007 /* MapWalkSavedOutcomeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56500010000000000000017 /* MapWalkSavedOutcomeCardView.swift */; };
 		A56500010000000000000008 /* WalkCompletionValueFlowCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56500010000000000000018 /* WalkCompletionValueFlowCardView.swift */; };
@@ -576,6 +578,8 @@
 		A46500010000000000000012 /* QuestMapFeedbackPolicyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMapFeedbackPolicyService.swift; sourceTree = "<group>"; };
 		A46700010000000000000011 /* QuestMapHUDInfoSetModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMapHUDInfoSetModels.swift; sourceTree = "<group>"; };
 		A46700010000000000000012 /* QuestMapHUDInfoSetPolicyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMapHUDInfoSetPolicyService.swift; sourceTree = "<group>"; };
+		A46800010000000000000011 /* QuestMapOverlayPriorityModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMapOverlayPriorityModels.swift; sourceTree = "<group>"; };
+		A46800010000000000000012 /* QuestMapOverlayPriorityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMapOverlayPriorityService.swift; sourceTree = "<group>"; };
 		A47500010000000000000011 /* WeatherReplacementSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherReplacementSummary.swift; sourceTree = "<group>"; };
 		A47500010000000000000012 /* WeatherReplacementSummaryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherReplacementSummaryStore.swift; sourceTree = "<group>"; };
 		A47500010000000000000013 /* SupabaseWeatherReplacementServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseWeatherReplacementServices.swift; sourceTree = "<group>"; };
@@ -1011,6 +1015,7 @@
 				A46400010000000000000011 /* QuestSurfacePolicyModels.swift */,
 				A46500010000000000000011 /* QuestMapFeedbackPolicyModels.swift */,
 				A46700010000000000000011 /* QuestMapHUDInfoSetModels.swift */,
+				A46800010000000000000011 /* QuestMapOverlayPriorityModels.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1021,6 +1026,7 @@
 				A46400010000000000000012 /* QuestSurfacePolicyService.swift */,
 				A46500010000000000000012 /* QuestMapFeedbackPolicyService.swift */,
 				A46700010000000000000012 /* QuestMapHUDInfoSetPolicyService.swift */,
+				A46800010000000000000012 /* QuestMapOverlayPriorityService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -2178,6 +2184,7 @@
 				A46400010000000000000001 /* QuestSurfacePolicyModels.swift in Sources */,
 				A46500010000000000000001 /* QuestMapFeedbackPolicyModels.swift in Sources */,
 				A46700010000000000000001 /* QuestMapHUDInfoSetModels.swift in Sources */,
+				A46800010000000000000001 /* QuestMapOverlayPriorityModels.swift in Sources */,
 				A56400010000000000000003 /* HomeMissionGuideStateStore.swift in Sources */,
 				A56500010000000000000004 /* WalkValueGuideStateStore.swift in Sources */,
 				DAE147A11420000000000001 /* HomeWeeklyStatisticsService.swift in Sources */,
@@ -2189,6 +2196,7 @@
 				A46400010000000000000002 /* QuestSurfacePolicyService.swift in Sources */,
 				A46500010000000000000002 /* QuestMapFeedbackPolicyService.swift in Sources */,
 				A46700010000000000000002 /* QuestMapHUDInfoSetPolicyService.swift in Sources */,
+				A46800010000000000000002 /* QuestMapOverlayPriorityService.swift in Sources */,
 				DAED25022AFA1D430044715A /* SplashView.swift in Sources */,
 				DA99F9E62AFA4F3E00B1483F /* Color.swift in Sources */,
 				DA3F9BD32AE0FF8A0048550C /* RootView.swift in Sources */,

--- a/dogArea/Source/Domain/Quest/Models/QuestMapOverlayPriorityModels.swift
+++ b/dogArea/Source/Domain/Quest/Models/QuestMapOverlayPriorityModels.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// 지도 상단 오버레이가 속하는 우선순위 계층을 정의합니다.
+enum QuestMapOverlayFeedbackTier: String, CaseIterable {
+    case critical = "critical"
+    case operational = "operational"
+    case progress = "progress"
+}
+
+/// 지도 상단 슬롯이 어떤 구성으로 점유되는지 정의합니다.
+enum QuestMapTopOverlaySlotMode: String, CaseIterable {
+    case none = "none"
+    case criticalBannerOnly = "critical_banner_only"
+    case operationalBannerOnly = "operational_banner_only"
+    case operationalBannerWithCollapsedHUD = "operational_banner_with_collapsed_hud"
+    case questHUDOnly = "quest_hud_only"
+}
+
+/// 퀘스트 HUD가 현재 어떤 방식으로 노출돼야 하는지 정의합니다.
+enum QuestMapOverlayHUDDisplayState: String, CaseIterable {
+    case hidden = "hidden"
+    case expanded = "expanded"
+    case collapsedSingleLine = "collapsed_single_line"
+    case hiddenByCriticalBanner = "hidden_by_critical_banner"
+    case hiddenByDensityGuard = "hidden_by_density_guard"
+    case suppressedByUser = "suppressed_by_user"
+}
+
+/// milestone toast가 어떤 상태로 처리돼야 하는지 정의합니다.
+enum QuestMapOverlayToastDisplayState: String, CaseIterable {
+    case hidden = "hidden"
+    case visible = "visible"
+    case queuedUntilTopSlotSettles = "queued_until_top_slot_settles"
+}
+
+/// 상단 오버레이 교체 시 적용해야 하는 전환 정책을 정의합니다.
+enum QuestMapOverlayTransitionPolicy: String, CaseIterable {
+    case immediate = "immediate"
+    case coalesceWithinStableWindow = "coalesce_within_stable_window"
+    case deferUntilCriticalClears = "defer_until_critical_clears"
+}
+
+/// 화면 밀도에 따라 HUD 공존 허용 여부를 판정하기 위한 분류입니다.
+enum QuestMapOverlayScreenDensity: String, CaseIterable {
+    case compact = "compact"
+    case regular = "regular"
+}
+
+/// 지도 상단 오버레이 런타임 판정 입력값입니다.
+struct QuestMapOverlayRuntimeContext: Equatable {
+    let activeBannerTier: QuestMapOverlayFeedbackTier?
+    let hasQuestHUDCandidate: Bool
+    let hasMultipleMissionSignals: Bool
+    let hasMilestoneToastCandidate: Bool
+    let isUserSuppressingHUD: Bool
+    let screenDensity: QuestMapOverlayScreenDensity
+    let isSeasonDetailExpanded: Bool
+}
+
+/// 지도 상단 오버레이 런타임 판정 결과입니다.
+struct QuestMapOverlayRuntimeResolution: Equatable {
+    let topSlotMode: QuestMapTopOverlaySlotMode
+    let hudDisplayState: QuestMapOverlayHUDDisplayState
+    let toastDisplayState: QuestMapOverlayToastDisplayState
+    let transitionPolicy: QuestMapOverlayTransitionPolicy
+    let restoreAfterSeconds: TimeInterval?
+}
+
+/// 구현자가 바로 옮길 수 있도록 정리한 상태표 행입니다.
+struct QuestMapOverlayStateMatrixRow: Equatable {
+    let title: String
+    let activeTier: QuestMapOverlayFeedbackTier?
+    let bannerExamples: [String]
+    let questHUDResult: QuestMapOverlayHUDDisplayState
+    let toastResult: QuestMapOverlayToastDisplayState
+    let topSlotMode: QuestMapTopOverlaySlotMode
+    let transitionPolicy: QuestMapOverlayTransitionPolicy
+    let notes: String
+}
+
+/// 지도 상단 오버레이 우선순위 정책 스냅샷입니다.
+struct QuestMapOverlayPrioritySnapshot: Equatable {
+    let tiers: [QuestMapOverlayFeedbackTier]
+    let topOverlayRole: String
+    let toastSlotRole: String
+    let manualHUDSuppressSeconds: TimeInterval
+    let minimumStableWindowSeconds: TimeInterval
+    let coalescingWindowSeconds: TimeInterval
+    let stateMatrix: [QuestMapOverlayStateMatrixRow]
+    let transitionGuardrail: String
+}

--- a/dogArea/Source/Domain/Quest/Services/QuestMapFeedbackPolicyService.swift
+++ b/dogArea/Source/Domain/Quest/Services/QuestMapFeedbackPolicyService.swift
@@ -12,6 +12,10 @@ protocol QuestMapFeedbackPolicyResolving {
     /// - Returns: 현재 지도 HUD가 어떤 정도로 접혀야 하는지 나타내는 상태입니다.
     func collapsedState(hasCriticalBanner: Bool, hasMultipleMissionSignals: Bool) -> QuestMapFeedbackCollapsedState
 
+    /// 상단 배너 계층과 milestone toast의 분리 운영 규칙을 설명합니다.
+    /// - Returns: `#468` 오버레이 우선순위 매트릭스 문서를 가리키는 설명 문자열입니다.
+    func overlayPriorityReference() -> String
+
     /// 현재 대표 미션 후보와 자동 추적 규칙으로 확장 체크리스트 섹션을 생성합니다.
     /// - Parameters:
     ///   - candidate: 현재 지도 HUD가 대표로 삼는 미션 후보입니다.
@@ -54,6 +58,12 @@ final class QuestMapFeedbackPolicyService: QuestMapFeedbackPolicyResolving {
             return .hiddenByCriticalBanner
         }
         return hasMultipleMissionSignals ? .compactSingleLine : .expanded
+    }
+
+    /// 상단 배너 계층과 milestone toast의 분리 운영 규칙을 설명합니다.
+    /// - Returns: `#468` 오버레이 우선순위 매트릭스 문서를 가리키는 설명 문자열입니다.
+    func overlayPriorityReference() -> String {
+        "상단 슬롯/토스트 슬롯 공존 규칙은 #468 문서와 `QuestMapOverlayPriorityService`를 기준으로 구현합니다."
     }
 
     /// 현재 대표 미션 후보와 자동 추적 규칙으로 확장 체크리스트 섹션을 생성합니다.

--- a/dogArea/Source/Domain/Quest/Services/QuestMapOverlayPriorityService.swift
+++ b/dogArea/Source/Domain/Quest/Services/QuestMapOverlayPriorityService.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+protocol QuestMapOverlayPriorityResolving {
+    /// 지도 상단 오버레이 우선순위 정책 스냅샷을 생성합니다.
+    /// - Returns: 상단 슬롯 역할, toast 역할, suppress 시간, 상태표를 포함한 정책 스냅샷입니다.
+    func makePolicySnapshot() -> QuestMapOverlayPrioritySnapshot
+
+    /// 현재 배너/HUD/toast 상황에 맞는 상단 오버레이 판정 결과를 계산합니다.
+    /// - Parameter context: 지도 상단에 동시에 경쟁하는 banner, HUD, toast의 런타임 입력값입니다.
+    /// - Returns: 현재 top slot, HUD, toast를 어떻게 노출해야 하는지 정의한 판정 결과입니다.
+    func resolve(context: QuestMapOverlayRuntimeContext) -> QuestMapOverlayRuntimeResolution
+}
+
+final class QuestMapOverlayPriorityService: QuestMapOverlayPriorityResolving {
+    /// 지도 상단 오버레이 우선순위 정책 스냅샷을 생성합니다.
+    /// - Returns: 상단 슬롯 역할, toast 역할, suppress 시간, 상태표를 포함한 정책 스냅샷입니다.
+    func makePolicySnapshot() -> QuestMapOverlayPrioritySnapshot {
+        QuestMapOverlayPrioritySnapshot(
+            tiers: [.critical, .operational, .progress],
+            topOverlayRole: "top overlay slot은 지도 chrome 안에서 동시에 하나의 banner 계층만 점유합니다. quest HUD는 banner가 비었을 때 full, operational banner일 때만 collapsed secondary row로 공존합니다.",
+            toastSlotRole: "toast slot은 top overlay와 분리된 짧은 비차단 피드백 전용 영역입니다. critical banner 전환 중에는 queue에 머물고, stable window 이후에만 노출합니다.",
+            manualHUDSuppressSeconds: 120,
+            minimumStableWindowSeconds: 1.5,
+            coalescingWindowSeconds: 0.35,
+            stateMatrix: stateMatrix(),
+            transitionGuardrail: "critical preemption 외에는 1.5초 stable window 안에서 top slot 교체를 coalesce하고, milestone toast는 top slot이 안정된 뒤에만 재개합니다."
+        )
+    }
+
+    /// 현재 배너/HUD/toast 상황에 맞는 상단 오버레이 판정 결과를 계산합니다.
+    /// - Parameter context: 지도 상단에 동시에 경쟁하는 banner, HUD, toast의 런타임 입력값입니다.
+    /// - Returns: 현재 top slot, HUD, toast를 어떻게 노출해야 하는지 정의한 판정 결과입니다.
+    func resolve(context: QuestMapOverlayRuntimeContext) -> QuestMapOverlayRuntimeResolution {
+        if context.activeBannerTier == .critical {
+            return QuestMapOverlayRuntimeResolution(
+                topSlotMode: .criticalBannerOnly,
+                hudDisplayState: .hiddenByCriticalBanner,
+                toastDisplayState: context.hasMilestoneToastCandidate ? .queuedUntilTopSlotSettles : .hidden,
+                transitionPolicy: .deferUntilCriticalClears,
+                restoreAfterSeconds: 0.35
+            )
+        }
+
+        if context.isUserSuppressingHUD {
+            return QuestMapOverlayRuntimeResolution(
+                topSlotMode: context.activeBannerTier == .operational ? .operationalBannerOnly : .none,
+                hudDisplayState: .suppressedByUser,
+                toastDisplayState: resolvedToastState(
+                    hasMilestoneToastCandidate: context.hasMilestoneToastCandidate,
+                    shouldQueueToast: context.activeBannerTier == .operational
+                ),
+                transitionPolicy: context.activeBannerTier == .operational
+                    ? .coalesceWithinStableWindow
+                    : .immediate,
+                restoreAfterSeconds: nil
+            )
+        }
+
+        if context.activeBannerTier == .operational {
+            let hidesHUDForDensity = shouldHideHUDForDensity(context: context)
+            let hudState: QuestMapOverlayHUDDisplayState = hidesHUDForDensity
+                ? .hiddenByDensityGuard
+                : .collapsedSingleLine
+            let topSlotMode: QuestMapTopOverlaySlotMode = hidesHUDForDensity || !context.hasQuestHUDCandidate
+                ? .operationalBannerOnly
+                : .operationalBannerWithCollapsedHUD
+            return QuestMapOverlayRuntimeResolution(
+                topSlotMode: topSlotMode,
+                hudDisplayState: hudState,
+                toastDisplayState: resolvedToastState(
+                    hasMilestoneToastCandidate: context.hasMilestoneToastCandidate,
+                    shouldQueueToast: true
+                ),
+                transitionPolicy: .coalesceWithinStableWindow,
+                restoreAfterSeconds: 0.35
+            )
+        }
+
+        if context.hasQuestHUDCandidate {
+            let hudState: QuestMapOverlayHUDDisplayState = context.hasMultipleMissionSignals
+                ? .collapsedSingleLine
+                : .expanded
+            return QuestMapOverlayRuntimeResolution(
+                topSlotMode: .questHUDOnly,
+                hudDisplayState: hudState,
+                toastDisplayState: resolvedToastState(
+                    hasMilestoneToastCandidate: context.hasMilestoneToastCandidate,
+                    shouldQueueToast: false
+                ),
+                transitionPolicy: .immediate,
+                restoreAfterSeconds: nil
+            )
+        }
+
+        return QuestMapOverlayRuntimeResolution(
+            topSlotMode: .none,
+            hudDisplayState: .hidden,
+            toastDisplayState: resolvedToastState(
+                hasMilestoneToastCandidate: context.hasMilestoneToastCandidate,
+                shouldQueueToast: false
+            ),
+            transitionPolicy: .immediate,
+            restoreAfterSeconds: nil
+        )
+    }
+
+    /// 작은 화면이나 시즌 타일 상세 패널 확장 상태에서 HUD를 숨겨야 하는지 판단합니다.
+    /// - Parameter context: 현재 지도 상단 오버레이 런타임 입력값입니다.
+    /// - Returns: compact density이거나 시즌 타일 상세가 열린 경우 `true`, 아니면 `false`입니다.
+    private func shouldHideHUDForDensity(context: QuestMapOverlayRuntimeContext) -> Bool {
+        context.screenDensity == .compact || context.isSeasonDetailExpanded
+    }
+
+    /// milestone toast가 바로 보일지, queue에 들어갈지 계산합니다.
+    /// - Parameters:
+    ///   - hasMilestoneToastCandidate: milestone toast를 띄울 이벤트가 존재하는지 여부입니다.
+    ///   - shouldQueueToast: 현재 top slot 전환 안정화가 끝날 때까지 toast를 지연해야 하는지 여부입니다.
+    /// - Returns: toast의 최종 노출 상태입니다.
+    private func resolvedToastState(
+        hasMilestoneToastCandidate: Bool,
+        shouldQueueToast: Bool
+    ) -> QuestMapOverlayToastDisplayState {
+        guard hasMilestoneToastCandidate else { return .hidden }
+        return shouldQueueToast ? .queuedUntilTopSlotSettles : .visible
+    }
+
+    /// 지도 상단 오버레이 상태표를 생성합니다.
+    /// - Returns: 구현자가 바로 사용할 수 있는 우선순위 매트릭스 행 목록입니다.
+    private func stateMatrix() -> [QuestMapOverlayStateMatrixRow] {
+        [
+            QuestMapOverlayStateMatrixRow(
+                title: "critical banner 단독 우선",
+                activeTier: .critical,
+                bannerExamples: ["recoveryIssue", "recoverableSession", "returnToOrigin"],
+                questHUDResult: .hiddenByCriticalBanner,
+                toastResult: .queuedUntilTopSlotSettles,
+                topSlotMode: .criticalBannerOnly,
+                transitionPolicy: .deferUntilCriticalClears,
+                notes: "권한/복구/종료 제안은 항상 단독 노출합니다. quest HUD는 자동 복귀하되 사용자 suppress 상태는 유지합니다."
+            ),
+            QuestMapOverlayStateMatrixRow(
+                title: "operational banner + collapsed HUD",
+                activeTier: .operational,
+                bannerExamples: ["syncOutbox", "runtimeGuard", "offlineMode"],
+                questHUDResult: .collapsedSingleLine,
+                toastResult: .queuedUntilTopSlotSettles,
+                topSlotMode: .operationalBannerWithCollapsedHUD,
+                transitionPolicy: .coalesceWithinStableWindow,
+                notes: "regular density에서는 operational banner 아래에 1줄 collapsed HUD만 공존시킵니다."
+            ),
+            QuestMapOverlayStateMatrixRow(
+                title: "compact density는 single top slot",
+                activeTier: .operational,
+                bannerExamples: ["watchStatus", "guestBackup"],
+                questHUDResult: .hiddenByDensityGuard,
+                toastResult: .queuedUntilTopSlotSettles,
+                topSlotMode: .operationalBannerOnly,
+                transitionPolicy: .coalesceWithinStableWindow,
+                notes: "좁은 화면이거나 시즌 타일 상세 패널이 열린 상태에서는 HUD를 숨기고 banner만 유지합니다."
+            ),
+            QuestMapOverlayStateMatrixRow(
+                title: "progress only는 HUD 우선",
+                activeTier: .progress,
+                bannerExamples: [],
+                questHUDResult: .expanded,
+                toastResult: .visible,
+                topSlotMode: .questHUDOnly,
+                transitionPolicy: .immediate,
+                notes: "critical/operational banner가 없으면 대표 quest HUD가 top overlay의 주인공이 됩니다."
+            ),
+            QuestMapOverlayStateMatrixRow(
+                title: "다중 미션은 collapsed 유지",
+                activeTier: .progress,
+                bannerExamples: [],
+                questHUDResult: .collapsedSingleLine,
+                toastResult: .visible,
+                topSlotMode: .questHUDOnly,
+                transitionPolicy: .immediate,
+                notes: "대표 1개 + 추가 n개 상태에서는 full HUD로 키우지 않고 single-line collapsed로 밀도를 제어합니다."
+            ),
+            QuestMapOverlayStateMatrixRow(
+                title: "사용자 dismiss는 timed suppress",
+                activeTier: nil,
+                bannerExamples: [],
+                questHUDResult: .suppressedByUser,
+                toastResult: .visible,
+                topSlotMode: .none,
+                transitionPolicy: .immediate,
+                notes: "사용자가 HUD를 닫으면 120초 동안 suppress하고, 대표 미션 상태가 completed/claimable로 상승하면 즉시 복귀를 허용합니다."
+            )
+        ]
+    }
+}

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -41,6 +41,7 @@ swift scripts/quest_stage1_policy_unit_check.swift
 swift scripts/quest_surface_policy_unit_check.swift
 swift scripts/map_quest_feedback_policy_unit_check.swift
 swift scripts/map_quest_hud_minimum_info_unit_check.swift
+swift scripts/map_quest_overlay_priority_unit_check.swift
 swift scripts/quest_stage2_engine_unit_check.swift
 swift scripts/season_motion_pack_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift

--- a/scripts/map_quest_overlay_priority_unit_check.swift
+++ b/scripts/map_quest_overlay_priority_unit_check.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+struct Check {
+    static func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if !condition() {
+            fputs("FAIL: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ path: String) throws -> String {
+    try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
+}
+
+let doc = try load("docs/map-quest-overlay-priority-matrix-v1.md")
+let models = try load("dogArea/Source/Domain/Quest/Models/QuestMapOverlayPriorityModels.swift")
+let service = try load("dogArea/Source/Domain/Quest/Services/QuestMapOverlayPriorityService.swift")
+let readme = try load("README.md")
+let prCheck = try load("scripts/ios_pr_check.sh")
+
+Check.require(doc.contains("critical / operational / progress"), "doc must define three overlay tiers")
+Check.require(doc.contains("top overlay slot"), "doc must define top overlay slot role")
+Check.require(doc.contains("toast slot"), "doc must define toast slot role")
+Check.require(doc.contains("120초"), "doc must define HUD suppress duration")
+Check.require(doc.contains("1.5초"), "doc must define stable window")
+Check.require(doc.contains("0.35초"), "doc must define coalescing window")
+Check.require(doc.contains("recoveryIssue") && doc.contains("syncOutbox") && doc.contains("watchStatus"), "doc must map current banner kinds")
+Check.require(doc.contains("#465") && doc.contains("#467"), "doc must reference prerequisite issues")
+
+Check.require(models.contains("enum QuestMapOverlayFeedbackTier"), "models must define overlay tiers")
+Check.require(models.contains("enum QuestMapTopOverlaySlotMode"), "models must define top slot modes")
+Check.require(models.contains("enum QuestMapOverlayHUDDisplayState"), "models must define HUD display states")
+Check.require(models.contains("enum QuestMapOverlayToastDisplayState"), "models must define toast display states")
+Check.require(models.contains("struct QuestMapOverlayRuntimeContext"), "models must define runtime context")
+Check.require(models.contains("struct QuestMapOverlayRuntimeResolution"), "models must define runtime resolution")
+Check.require(models.contains("struct QuestMapOverlayStateMatrixRow"), "models must define state matrix rows")
+Check.require(models.contains("struct QuestMapOverlayPrioritySnapshot"), "models must define snapshot")
+
+Check.require(service.contains("protocol QuestMapOverlayPriorityResolving"), "service must define protocol")
+Check.require(service.contains("func makePolicySnapshot() -> QuestMapOverlayPrioritySnapshot"), "service must build snapshot")
+Check.require(service.contains("func resolve(context: QuestMapOverlayRuntimeContext) -> QuestMapOverlayRuntimeResolution"), "service must expose runtime resolution")
+Check.require(service.contains("shouldHideHUDForDensity"), "service must include density guard")
+Check.require(service.contains("resolvedToastState"), "service must include toast slot rule")
+Check.require(service.contains("stateMatrix()"), "service must define state matrix")
+
+Check.require(readme.contains("지도 상단 overlay 우선순위 매트릭스 v1"), "README must index overlay priority doc")
+Check.require(prCheck.contains("swift scripts/map_quest_overlay_priority_unit_check.swift"), "ios_pr_check must run overlay priority unit check")
+
+print("PASS: map quest overlay priority checks")


### PR DESCRIPTION
## Summary
- add a canonical map quest overlay priority model and resolver
- document the top overlay slot vs toast slot matrix for critical/operational/progress states
- add static coverage for the overlay priority policy and wire it into ios_pr_check

## Testing
- swift scripts/map_quest_feedback_policy_unit_check.swift
- swift scripts/map_quest_hud_minimum_info_unit_check.swift
- swift scripts/map_quest_overlay_priority_unit_check.swift
- DOGAREA_DERIVED_DATA_PATH=.build/codex-468-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #468