### PR TITLE
docs: add issue 529 closure evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@
 - 이슈 #533 클로저 증적 스냅샷 v1: `docs/issue-533-closure-evidence-v1.md`
 - 이슈 #532 클로저 증적 스냅샷 v1: `docs/issue-532-closure-evidence-v1.md`
 - 이슈 #530 클로저 증적 스냅샷 v1: `docs/issue-530-closure-evidence-v1.md`
+- 이슈 #529 클로저 증적 스냅샷 v1: `docs/issue-529-closure-evidence-v1.md`
 - 게임 레이어 공통 관측/QA 기준 v1: `docs/game-layer-observability-qa-v1.md`
 - 다중 반려견 산책 N:M 2차 설계 v2: `docs/multi-pet-session-nm-v2.md`
 - 다견 1차 선택 반려견 UX v1: `docs/multi-dog-selection-ux-v1.md`

--- a/docs/issue-529-closure-evidence-v1.md
+++ b/docs/issue-529-closure-evidence-v1.md
@@ -1,0 +1,50 @@
+# Issue #529 Closure Evidence v1
+
+## 대상
+- issue: `#529`
+- title: `산책 목록 화면 정보 구조·셀 디자인 최신화`
+
+## 구현 근거
+- 구현 PR: `#556`
+- 핵심 문서:
+  - `docs/walklist-design-refresh-v1.md`
+- 핵심 구현 파일:
+  - `dogArea/Views/WalkListView/WalkListView.swift`
+  - `dogArea/Views/WalkListView/WalkListPresentationService.swift`
+  - `dogArea/Views/WalkListView/WalkListSubView/WalkListDashboardHeaderView.swift`
+  - `dogArea/Views/WalkListView/WalkListSubView/WalkListCell.swift`
+
+## DoD 판정
+### 1. 산책 목록 화면이 최신 지도/설정 톤과 시각적으로 정합적임
+- 목록 화면이 `상단 허브 + 최신 surface card + 상태별 안내` 구조로 재정리됐다.
+- 기존의 얇은 border 반복 구조 대신 요약 허브와 메트릭 카드 중심 구조로 정리됐다.
+- 판정: `PASS`
+
+### 2. 셀만 보고도 기록 성격을 빠르게 파악 가능함
+- 셀에서 날짜/시간 외에 산책 시간, 영역 넓이, 포인트 수, 반려견 문맥을 함께 보여준다.
+- `WalkListMetricTileView` 기반으로 핵심 지표 우선순위가 정리됐다.
+- 판정: `PASS`
+
+### 3. guest/empty/filter empty/ready 상태가 일관된 체계로 정리됨
+- 상단 허브와 프레젠테이션 서비스가 guest, 기록 없음, 필터 결과 없음, 일반 상태를 같은 톤으로 해석한다.
+- 선택 반려견 문맥과 `전체 기록 보기` 전환도 상단 컨텍스트 안에서 같이 설명된다.
+- 판정: `PASS`
+
+### 4. 기존 동작(필터, 네비게이션, 새로고침)은 유지됨
+- `WalkListDetailView`로의 라우팅과 pull to refresh, guest 로그인 CTA, 선택 반려견 필터/전체 보기 전환이 유지된다.
+- 리디자인은 프레젠테이션과 구조 변경에 국한되고, 데이터 모델/필터 정책은 바뀌지 않았다.
+- 판정: `PASS`
+
+## 검증 근거
+- 정적 체크
+  - `swift scripts/walklist_design_refresh_unit_check.swift`
+  - `swift scripts/issue_529_closure_evidence_unit_check.swift`
+- 회귀 UI 테스트
+  - `FeatureRegressionUITests.testFeatureRegression_WalkListPrimaryContentIsNotObscuredByTabBar`
+  - `FeatureRegressionUITests.testFeatureRegression_WalkListHeaderSurfacesOverviewAndContextCards`
+- 저장소 게이트
+  - `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`
+
+## 결론
+- `#529`의 요구사항은 구현, 문서, UI 회귀, 정적 체크 근거까지 확보됐다.
+- 이 문서를 기준으로 `#529`는 종료 가능하다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -51,6 +51,7 @@ swift scripts/issue_566_closure_evidence_unit_check.swift
 swift scripts/issue_533_closure_evidence_unit_check.swift
 swift scripts/issue_532_closure_evidence_unit_check.swift
 swift scripts/issue_530_closure_evidence_unit_check.swift
+swift scripts/issue_529_closure_evidence_unit_check.swift
 swift scripts/game_layer_observability_qa_unit_check.swift
 swift scripts/game_layer_kpi_dashboard_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift

--- a/scripts/issue_529_closure_evidence_unit_check.swift
+++ b/scripts/issue_529_closure_evidence_unit_check.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// 조건이 참인지 검증합니다.
+/// - Parameters:
+///   - condition: 평가할 조건식입니다.
+///   - message: 실패 시 출력할 설명입니다.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 UTF-8 텍스트 파일을 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 상대 경로입니다.
+/// - Returns: 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let evidence = load("docs/issue-529-closure-evidence-v1.md")
+let designDoc = load("docs/walklist-design-refresh-v1.md")
+let walkListView = load("dogArea/Views/WalkListView/WalkListView.swift")
+let presentationService = load("dogArea/Views/WalkListView/WalkListPresentationService.swift")
+let headerView = load("dogArea/Views/WalkListView/WalkListSubView/WalkListDashboardHeaderView.swift")
+let walkListCell = load("dogArea/Views/WalkListView/WalkListSubView/WalkListCell.swift")
+let featureTests = load("dogAreaUITests/FeatureRegressionUITests.swift")
+let readme = load("README.md")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(evidence.contains("#529"), "evidence doc should reference issue #529")
+assertTrue(evidence.contains("PR: `#556`") || evidence.contains("PR `#556`"), "evidence doc should reference implementation PR #556")
+assertTrue(evidence.contains("PASS"), "evidence doc should record PASS DoD results")
+assertTrue(evidence.contains("WalkListMetricTileView"), "evidence doc should mention the metric tile-based cell hierarchy")
+assertTrue(evidence.contains("종료 가능"), "evidence doc should conclude that the issue can close")
+assertTrue(designDoc.contains("상단 허브"), "walk list design doc should describe the top hub hierarchy")
+assertTrue(walkListView.contains("WalkListDashboardHeaderView"), "WalkListView should render the dashboard header")
+assertTrue(presentationService.contains("func makeOverview"), "presentation service should define the overview builder")
+assertTrue(headerView.contains("walklist.header"), "dashboard header should expose a stable accessibility identifier")
+assertTrue(walkListCell.contains("WalkListMetricTileView"), "walk list cell should use metric tiles")
+assertTrue(walkListCell.contains("영역 넓이"), "walk list cell should surface area")
+assertTrue(walkListCell.contains("포인트 수"), "walk list cell should surface point count")
+assertTrue(featureTests.contains("testFeatureRegression_WalkListPrimaryContentIsNotObscuredByTabBar"), "feature regression tests should cover the walk list tab-bar safety case")
+assertTrue(featureTests.contains("testFeatureRegression_WalkListHeaderSurfacesOverviewAndContextCards"), "feature regression tests should cover the walk list header hierarchy")
+assertTrue(readme.contains("docs/issue-529-closure-evidence-v1.md"), "README should index the issue #529 closure evidence doc")
+assertTrue(prCheck.contains("swift scripts/issue_529_closure_evidence_unit_check.swift"), "ios_pr_check should include the issue #529 closure evidence check")
+
+print("PASS: issue #529 closure evidence unit checks")


### PR DESCRIPTION
## Summary
- add repository evidence for closing issue #529
- wire the new issue-level evidence unit check into `ios_pr_check`
- index the new closure evidence doc in the README

## Verification
- `swift scripts/issue_529_closure_evidence_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #529
Refs #556
