### PR TITLE
docs: add issue 520 closure evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@
 - 이슈 #530 클로저 증적 스냅샷 v1: `docs/issue-530-closure-evidence-v1.md`
 - 이슈 #529 클로저 증적 스냅샷 v1: `docs/issue-529-closure-evidence-v1.md`
 - 이슈 #522 클로저 증적 스냅샷 v1: `docs/issue-522-closure-evidence-v1.md`
+- 이슈 #520 클로저 증적 스냅샷 v1: `docs/issue-520-closure-evidence-v1.md`
 - 게임 레이어 공통 관측/QA 기준 v1: `docs/game-layer-observability-qa-v1.md`
 - 다중 반려견 산책 N:M 2차 설계 v2: `docs/multi-pet-session-nm-v2.md`
 - 다견 1차 선택 반려견 UX v1: `docs/multi-dog-selection-ux-v1.md`

--- a/docs/issue-520-closure-evidence-v1.md
+++ b/docs/issue-520-closure-evidence-v1.md
@@ -1,0 +1,55 @@
+# Issue #520 Closure Evidence v1
+
+## 대상
+- issue: `#520`
+- title: `start/addPoint/endWalk 단계별 피드백·햅틱·disabled state 정리`
+
+## 구현 근거
+- 구현 PR: `#548`
+- 핵심 문서:
+  - `docs/watch-action-feedback-ux-v1.md`
+- 핵심 구현 파일:
+  - `dogAreaWatch Watch App/WatchActionFeedbackModels.swift`
+  - `dogAreaWatch Watch App/WatchActionButtonView.swift`
+  - `dogAreaWatch Watch App/ContentsViewModel.swift`
+  - `dogAreaWatch Watch App/WatchPrimaryActionDockView.swift`
+  - `dogAreaWatch Watch App/ContentView.swift`
+
+## DoD 판정
+### 1. start/addPoint/endWalk 각각에 성공/실패/큐 적재/중복 입력 억제 피드백이 정의됨
+- `WatchActionExecutionState`가 `processing`, `queued`, `acknowledged`, `completed`, `duplicateSuppressed`, `failed`, `confirmRequired`를 명시한다.
+- `ContentsViewModel`이 액션별 배너와 버튼 상태를 같은 상태기계로 해석한다.
+- 판정: `PASS`
+
+### 2. 처리 중에는 버튼이 비활성화되거나 상태가 바뀌어 중복 탭이 줄어듦
+- `WatchActionControlPresentation`이 `isDisabled`와 `showsProgress`를 노출한다.
+- `shouldSuppressDuplicateTap(for:)`와 액션별 cooldown/queued 차단 규칙이 적용되어 중복 입력을 억제한다.
+- 판정: `PASS`
+
+### 3. 햅틱이 성공/실패/경고를 구분하되 과도하지 않게 정리됨
+- `WatchActionFeedbackTone`이 `success`, `warning`, `failure`, `processing`을 분리한다.
+- UX 문서에서 성공/경고/실패/processing 무햅틱 규칙을 고정했다.
+- 판정: `PASS`
+
+### 4. 산책 종료에 오조작 방지용 확인 단계가 있음
+- `endWalk`는 1차 탭에서 바로 전송하지 않고 `confirmRequired`로 전환된다.
+- 3초 안 재탭 시에만 실제 종료 요청을 보낸다.
+- 판정: `PASS`
+
+### 5. watch 화면 크기를 고려해 피드백 정보량이 제한됨
+- 상단 상태, 최근 배너 1개, 메트릭 2개, 하단 상태 줄 중심으로 제한했다.
+- `WatchActionButtonView`와 `WatchActionBannerView`로 역할을 분리해 작은 화면에서 정보 밀도를 통제한다.
+- 판정: `PASS`
+
+## 검증 근거
+- 정적 체크
+  - `swift scripts/watch_action_feedback_ux_unit_check.swift`
+  - `swift scripts/issue_520_closure_evidence_unit_check.swift`
+- watch 빌드
+  - `xcodebuild -project dogArea.xcodeproj -scheme 'dogAreaWatch Watch App' -configuration Debug -destination 'generic/platform=watchOS Simulator' CODE_SIGNING_ALLOWED=NO build`
+- 저장소 게이트
+  - `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`
+
+## 결론
+- `#520`의 요구사항은 구현, 문서, 정적 체크, watch 빌드 근거까지 확보됐다.
+- 이 문서를 기준으로 `#520`은 종료 가능하다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -53,6 +53,7 @@ swift scripts/issue_532_closure_evidence_unit_check.swift
 swift scripts/issue_530_closure_evidence_unit_check.swift
 swift scripts/issue_529_closure_evidence_unit_check.swift
 swift scripts/issue_522_closure_evidence_unit_check.swift
+swift scripts/issue_520_closure_evidence_unit_check.swift
 swift scripts/game_layer_observability_qa_unit_check.swift
 swift scripts/game_layer_kpi_dashboard_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift

--- a/scripts/issue_520_closure_evidence_unit_check.swift
+++ b/scripts/issue_520_closure_evidence_unit_check.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// 조건이 참인지 검증합니다.
+/// - Parameters:
+///   - condition: 평가할 조건식입니다.
+///   - message: 실패 시 출력할 설명입니다.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 UTF-8 텍스트 파일을 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 상대 경로입니다.
+/// - Returns: 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let evidence = load("docs/issue-520-closure-evidence-v1.md")
+let uxDoc = load("docs/watch-action-feedback-ux-v1.md")
+let feedbackModels = load("dogAreaWatch Watch App/WatchActionFeedbackModels.swift")
+let buttonView = load("dogAreaWatch Watch App/WatchActionButtonView.swift")
+let actionDock = load("dogAreaWatch Watch App/WatchPrimaryActionDockView.swift")
+let contentView = load("dogAreaWatch Watch App/ContentView.swift")
+let viewModel = load("dogAreaWatch Watch App/ContentsViewModel.swift")
+let readme = load("README.md")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(evidence.contains("#520"), "evidence doc should reference issue #520")
+assertTrue(evidence.contains("PR: `#548`") || evidence.contains("PR `#548`"), "evidence doc should reference implementation PR #548")
+assertTrue(evidence.contains("PASS"), "evidence doc should record PASS DoD results")
+assertTrue(evidence.contains("watchOS Simulator"), "evidence doc should record watch build verification")
+assertTrue(evidence.contains("종료 가능"), "evidence doc should conclude that the issue can close")
+assertTrue(uxDoc.contains("processing") && uxDoc.contains("queued") && uxDoc.contains("duplicateSuppressed"), "ux doc should define staged action states")
+assertTrue(uxDoc.contains("3초 안 재탭"), "ux doc should define endWalk confirmation window")
+assertTrue(feedbackModels.contains("case processing") && feedbackModels.contains("case queued") && feedbackModels.contains("case duplicateSuppressed"), "feedback models should define processing queued and duplicate states")
+assertTrue(feedbackModels.contains("var confirmationWindow: TimeInterval"), "feedback models should define confirmation window")
+assertTrue(buttonView.contains("showsProgress"), "watch action button should render progress state")
+assertTrue(actionDock.contains("WatchActionButtonView"), "action dock should compose action buttons")
+assertTrue(contentView.contains("WatchPrimaryActionDockView"), "watch content should render the action dock")
+assertTrue(viewModel.contains("func handleActionTap(_ action: WatchActionType)") , "view model should expose action tap handler")
+assertTrue(viewModel.contains("shouldSuppressDuplicateTap(for: action)"), "view model should suppress duplicate taps")
+assertTrue(viewModel.contains("transition(action, to: .confirmRequired"), "view model should require confirmation for endWalk")
+assertTrue(readme.contains("docs/issue-520-closure-evidence-v1.md"), "README should index the issue #520 closure evidence doc")
+assertTrue(prCheck.contains("swift scripts/issue_520_closure_evidence_unit_check.swift"), "ios_pr_check should include the issue #520 closure evidence check")
+
+print("PASS: issue #520 closure evidence unit checks")


### PR DESCRIPTION
Closes #520
Refs #548

- add repository-side closure evidence for issue #520
- add static closure check and wire it into ios_pr_check
- keep implementation scope unchanged; this PR documents and verifies the already-merged UX work