### PR TITLE
docs: add issue 506 closure evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@
 - 이슈 #529 클로저 증적 스냅샷 v1: `docs/issue-529-closure-evidence-v1.md`
 - 이슈 #522 클로저 증적 스냅샷 v1: `docs/issue-522-closure-evidence-v1.md`
 - 이슈 #520 클로저 증적 스냅샷 v1: `docs/issue-520-closure-evidence-v1.md`
+- 이슈 #506 클로저 증적 스냅샷 v1: `docs/issue-506-closure-evidence-v1.md`
 - 게임 레이어 공통 관측/QA 기준 v1: `docs/game-layer-observability-qa-v1.md`
 - 다중 반려견 산책 N:M 2차 설계 v2: `docs/multi-pet-session-nm-v2.md`
 - 다견 1차 선택 반려견 UX v1: `docs/multi-dog-selection-ux-v1.md`

--- a/docs/issue-506-closure-evidence-v1.md
+++ b/docs/issue-506-closure-evidence-v1.md
@@ -1,0 +1,48 @@
+# Issue #506 Closure Evidence v1
+
+## 대상
+- issue: `#506`
+- title: `indoor mission pet context 집계 snapshot/cache 도입`
+
+## 구현 근거
+- 구현 PR: `#534`
+- 핵심 문서:
+  - `docs/home-mission-pet-context-snapshot-v1.md`
+- 핵심 구현 파일:
+  - `dogArea/Source/Domain/Home/Services/HomeIndoorMissionPetContextSnapshotService.swift`
+  - `dogArea/Views/HomeView/HomeViewModel.swift`
+  - `dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+AreaProgress.swift`
+  - `dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+IndoorMissionFlow.swift`
+
+## DoD 판정
+### 1. 같은 입력으로 반복 refresh가 들어와도 집계 본연의 비용이 중복되지 않음
+- `HomeIndoorMissionPetContextSnapshotService`가 polygon fingerprint, 선택 반려견 식별자, 기준 시각을 기준으로 snapshot 재사용 여부를 판단한다.
+- `refreshIndoorMissions(now:)`는 cache hit 시 최근 14일/28일 집계를 다시 `filter/reduce`하지 않고 기존 snapshot을 그대로 재사용한다.
+- 판정: `PASS`
+
+### 2. polygon 입력이 실제로 바뀔 때만 snapshot이 무효화됨
+- `applySelectedPetStatistics(...)`가 집계 후 현재 홈 polygon 목록 기준 fingerprint를 갱신한다.
+- fingerprint가 달라진 경우에만 `indoorMissionPetContextAggregationSnapshot`을 `nil`로 비워 재집계를 유도한다.
+- 판정: `PASS`
+
+### 3. 시간 경계와 선택 반려견 변경이 재사용 조건에 정확히 반영됨
+- snapshot은 `selectedPetId`, `computedAt`, `validThrough`를 함께 저장한다.
+- 같은 polygon 목록이라도 선택 반려견이 바뀌거나 시간 경계를 넘으면 재사용되지 않는다.
+- 판정: `PASS`
+
+### 4. 반려견 표시 정보는 cache와 분리되어 기존 UI 의미를 유지함
+- snapshot은 집계값만 저장하고 `petName`, `ageYears`는 최종 `IndoorMissionPetContext` 조립 시점에 현재 선택 반려견에서 다시 읽는다.
+- 따라서 성능 최적화가 홈 미션 카드 문구/난이도 의미를 바꾸지 않는다.
+- 판정: `PASS`
+
+## 검증 근거
+- 정적 체크
+  - `swift scripts/home_mission_pet_context_snapshot_unit_check.swift`
+  - `swift scripts/home_refresh_entrypoint_unit_check.swift`
+  - `swift scripts/issue_506_closure_evidence_unit_check.swift`
+- 저장소 게이트
+  - `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`
+
+## 결론
+- `#506`의 요구사항은 구현, 문서, 정적 체크 근거까지 확보됐다.
+- 이 문서를 기준으로 `#506`은 종료 가능하다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -54,6 +54,7 @@ swift scripts/issue_530_closure_evidence_unit_check.swift
 swift scripts/issue_529_closure_evidence_unit_check.swift
 swift scripts/issue_522_closure_evidence_unit_check.swift
 swift scripts/issue_520_closure_evidence_unit_check.swift
+swift scripts/issue_506_closure_evidence_unit_check.swift
 swift scripts/game_layer_observability_qa_unit_check.swift
 swift scripts/game_layer_kpi_dashboard_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift

--- a/scripts/issue_506_closure_evidence_unit_check.swift
+++ b/scripts/issue_506_closure_evidence_unit_check.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// 조건이 참인지 검증합니다.
+/// - Parameters:
+///   - condition: 평가할 조건식입니다.
+///   - message: 실패 시 출력할 설명입니다.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 UTF-8 텍스트 파일을 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 상대 경로입니다.
+/// - Returns: 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let evidence = load("docs/issue-506-closure-evidence-v1.md")
+let designDoc = load("docs/home-mission-pet-context-snapshot-v1.md")
+let service = load("dogArea/Source/Domain/Home/Services/HomeIndoorMissionPetContextSnapshotService.swift")
+let homeViewModel = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let areaProgress = load("dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+AreaProgress.swift")
+let indoorMissionFlow = load("dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+IndoorMissionFlow.swift")
+let readme = load("README.md")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(evidence.contains("#506"), "evidence doc should reference issue #506")
+assertTrue(evidence.contains("PR: `#534`") || evidence.contains("PR `#534`"), "evidence doc should reference implementation PR #534")
+assertTrue(evidence.contains("PASS"), "evidence doc should record PASS DoD results")
+assertTrue(evidence.contains("종료 가능"), "evidence doc should conclude that the issue can close")
+assertTrue(
+    designDoc.contains("`filter/reduce` 0회") || designDoc.contains("filter/reduce"),
+    "design doc should record cache-hit savings"
+)
+assertTrue(service.contains("protocol HomeIndoorMissionPetContextSnapshotServicing"), "snapshot service protocol should exist")
+assertTrue(service.contains("func canReuseSnapshot("), "snapshot service should expose cache-hit decision logic")
+assertTrue(service.contains("func makeAggregationSnapshot("), "snapshot service should expose snapshot construction")
+assertTrue(service.contains("let validThrough: TimeInterval?"), "snapshot model should retain the next invalidation boundary")
+assertTrue(homeViewModel.contains("indoorMissionPetContextSnapshotService: HomeIndoorMissionPetContextSnapshotServicing"), "home view model should inject the snapshot service")
+assertTrue(areaProgress.contains("updateIndoorMissionPetContextPolygonFingerprint(for: polygonList)"), "selected pet statistics should refresh the polygon fingerprint")
+assertTrue(areaProgress.contains("indoorMissionPetContextAggregationSnapshot = nil"), "fingerprint change should invalidate the cached snapshot")
+assertTrue(indoorMissionFlow.contains("if indoorMissionPetContextSnapshotService.canReuseSnapshot("), "indoor mission flow should reuse the snapshot when inputs match")
+assertTrue(indoorMissionFlow.contains("indoorMissionPetContextAggregationSnapshot = snapshot"), "indoor mission flow should persist the computed snapshot")
+assertTrue(indoorMissionFlow.contains("petName: selectedPet?.petName ?? \"강아지\""), "final pet context should still compose display data from the current selected pet")
+assertTrue(readme.contains("docs/issue-506-closure-evidence-v1.md"), "README should index the issue #506 closure evidence doc")
+assertTrue(prCheck.contains("swift scripts/issue_506_closure_evidence_unit_check.swift"), "ios_pr_check should include the issue #506 closure evidence check")
+
+print("PASS: issue #506 closure evidence unit checks")


### PR DESCRIPTION
Closes #506
Refs #534

- add repository-side closure evidence for issue #506
- add static closure check and wire it into ios_pr_check
- keep implementation scope unchanged; this PR documents and verifies the already-merged snapshot/cache work