### PR TITLE
docs: add issue 476 closure evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 - 이슈 #520 클로저 증적 스냅샷 v1: `docs/issue-520-closure-evidence-v1.md`
 - 이슈 #506 클로저 증적 스냅샷 v1: `docs/issue-506-closure-evidence-v1.md`
 - 이슈 #503 클로저 증적 스냅샷 v1: `docs/issue-503-closure-evidence-v1.md`
+- 이슈 #476 클로저 증적 스냅샷 v1: `docs/issue-476-closure-evidence-v1.md`
 - 게임 레이어 공통 관측/QA 기준 v1: `docs/game-layer-observability-qa-v1.md`
 - 다중 반려견 산책 N:M 2차 설계 v2: `docs/multi-pet-session-nm-v2.md`
 - 다견 1차 선택 반려견 UX v1: `docs/multi-dog-selection-ux-v1.md`

--- a/docs/issue-476-closure-evidence-v1.md
+++ b/docs/issue-476-closure-evidence-v1.md
@@ -1,0 +1,50 @@
+# Issue #476 Closure Evidence v1
+
+## 대상
+- issue: `#476`
+- title: `산책 중 4Hz 지도 invalidation 제거`
+
+## 구현 근거
+- 구현 PR: `#560`
+- 핵심 문서:
+  - `docs/map-walking-invalidation-reduction-v1.md`
+- 핵심 구현 파일:
+  - `dogArea/Views/MapView/MapSubViews/MapSubView.swift`
+  - `dogArea/Views/MapView/MapSubViews/StartButtonView.swift`
+  - `dogArea/Views/MapView/MapView.swift`
+  - `dogArea/Views/MapView/MapViewModel.swift`
+  - `dogArea/Views/MapView/MapSubViews/MapRenderBudgetProbeOverlayView.swift`
+
+## DoD 판정
+### 1. 지도 루트의 250ms ticker가 제거됨
+- 기존 `MapSubView` 루트의 `motionTicker`/`motionNow` 구조가 제거됐다.
+- 산책 중 4Hz invalidation 원인이던 루트 시간 구동 상태가 더 이상 존재하지 않는다.
+- 판정: `PASS`
+
+### 2. 시간/애니메이션 invalidation이 leaf 계층으로 격리됨
+- ripple, trail marker, elapsed time이 각각 전용 subview 또는 timeline으로 내려갔다.
+- `MapRenderBudgetProbeOverlayView`도 지도 본체 바깥 overlay 계층으로 분리됐다.
+- 판정: `PASS`
+
+### 3. 위치 publish도 의미 있는 변화일 때만 반영됨
+- `publishMapLocationIfNeeded` / `shouldPublishMapLocation` 경로가 추가돼 위치 업데이트가 바로 루트 invalidation으로 번지지 않도록 정리됐다.
+- 판정: `PASS`
+
+### 4. render budget 회귀 기준이 문서와 테스트로 고정됨
+- 설계 문서는 안정화 이후 3.2초 구간 `count = 0`, 회귀 기준 `3초 동안 count <= 6`을 명시한다.
+- UI 회귀 테스트와 정적 체크가 이 기준을 계속 감시한다.
+- 판정: `PASS`
+
+## 검증 근거
+- 정적 체크
+  - `swift scripts/map_walking_invalidation_reduction_unit_check.swift`
+  - `swift scripts/map_motion_ticker_layer_split_unit_check.swift`
+  - `swift scripts/issue_476_closure_evidence_unit_check.swift`
+- UI 회귀 기준
+  - `dogAreaUITests/FeatureRegressionUITests.testFeatureRegression_MapWalkingRuntimeKeepsRootRenderCountBelowThreshold`
+- 저장소 게이트
+  - `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`
+
+## 결론
+- `#476`의 요구사항은 구현, 문서, 회귀 기준, 정적 체크 근거까지 확보됐다.
+- 이 문서를 기준으로 `#476`은 종료 가능하다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -56,6 +56,7 @@ swift scripts/issue_522_closure_evidence_unit_check.swift
 swift scripts/issue_520_closure_evidence_unit_check.swift
 swift scripts/issue_506_closure_evidence_unit_check.swift
 swift scripts/issue_503_closure_evidence_unit_check.swift
+swift scripts/issue_476_closure_evidence_unit_check.swift
 swift scripts/game_layer_observability_qa_unit_check.swift
 swift scripts/game_layer_kpi_dashboard_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift

--- a/scripts/issue_476_closure_evidence_unit_check.swift
+++ b/scripts/issue_476_closure_evidence_unit_check.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// 조건이 참인지 검증합니다.
+/// - Parameters:
+///   - condition: 평가할 조건식입니다.
+///   - message: 실패 시 출력할 설명입니다.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 UTF-8 텍스트 파일을 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 상대 경로입니다.
+/// - Returns: 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let evidence = load("docs/issue-476-closure-evidence-v1.md")
+let designDoc = load("docs/map-walking-invalidation-reduction-v1.md")
+let mapSubView = load("dogArea/Views/MapView/MapSubViews/MapSubView.swift")
+let mapView = load("dogArea/Views/MapView/MapView.swift")
+let mapViewModel = load("dogArea/Views/MapView/MapViewModel.swift")
+let startButton = load("dogArea/Views/MapView/MapSubViews/StartButtonView.swift")
+let renderBudget = load("dogArea/Views/MapView/MapSubViews/MapRenderBudgetProbeOverlayView.swift")
+let uiTests = load("dogAreaUITests/FeatureRegressionUITests.swift")
+let readme = load("README.md")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(evidence.contains("#476"), "evidence doc should reference issue #476")
+assertTrue(evidence.contains("PR: `#560`") || evidence.contains("PR `#560`"), "evidence doc should reference implementation PR #560")
+assertTrue(evidence.contains("PASS"), "evidence doc should record PASS DoD results")
+assertTrue(evidence.contains("종료 가능"), "evidence doc should conclude that the issue can close")
+assertTrue(designDoc.contains("250ms 루트 ticker 제거"), "design doc should record root ticker removal")
+assertTrue(designDoc.contains("3초 동안 count <= 6"), "design doc should record the render budget threshold")
+assertTrue(!mapSubView.contains("motionTicker"), "MapSubView should not keep a root motion ticker")
+assertTrue(!mapSubView.contains("motionNow"), "MapSubView should not keep root motion state")
+assertTrue(mapSubView.contains("MapTrailMarkerAnnotationView"), "MapSubView should isolate trail marker animation")
+assertTrue(mapView.contains("MapRenderBudgetProbeOverlayView()"), "MapView should host the render budget overlay")
+assertTrue(renderBudget.contains("struct MapRenderBudgetProbeOverlayView"), "render budget overlay type should exist")
+assertTrue(startButton.contains("MapWalkingElapsedTimeValueText"), "elapsed time display should be localized to StartButtonView")
+assertTrue(mapViewModel.contains("publishMapLocationIfNeeded"), "MapViewModel should gate location publishes")
+assertTrue(mapViewModel.contains("shouldPublishMapLocation"), "MapViewModel should decide whether location changes are meaningful")
+assertTrue(uiTests.contains("testFeatureRegression_MapWalkingRuntimeKeepsRootRenderCountBelowThreshold"), "UI regression should cover the root render budget")
+assertTrue(readme.contains("docs/issue-476-closure-evidence-v1.md"), "README should index the issue #476 closure evidence doc")
+assertTrue(prCheck.contains("swift scripts/issue_476_closure_evidence_unit_check.swift"), "ios_pr_check should include the issue #476 closure evidence check")
+
+print("PASS: issue #476 closure evidence unit checks")


### PR DESCRIPTION
Closes #476
Refs #560

- add repository-side closure evidence for issue #476
- add static closure check and wire it into ios_pr_check
- keep implementation scope unchanged; this PR documents and verifies the already-merged map invalidation reduction work