### PR TITLE
fix: suppress same-day quest reminder after saved walk

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@
 - 퀘스트 Stage2 진행/클레임 백엔드 엔진 v1: `docs/quest-stage2-progress-claim-engine-v1.md`
 - 퀘스트 실패 완충(자동 연장 슬롯) v1: `docs/quest-failure-buffer-v1.md`
 - 퀘스트 Stage3 UX/리마인드 v1: `docs/quest-stage3-ux-reminder-v1.md`
+- 홈 퀘스트 리마인드 당일 산책 억제 v1: `docs/home-quest-reminder-same-day-suppression-v1.md`
 - 반려견 맞춤 난이도/쉬운 날 모드 v1: `docs/pet-adaptive-quest-difficulty-v1.md`
 - Feature Flag/롤아웃 모니터링 명세 v1: `docs/feature-flag-rollout-monitoring-v1.md`
 - ViewModel 현대화 리팩토링 명세 v1: `docs/viewmodel-modernization-v1.md`

--- a/docs/home-quest-reminder-same-day-suppression-v1.md
+++ b/docs/home-quest-reminder-same-day-suppression-v1.md
@@ -1,0 +1,33 @@
+# Home Quest Reminder Same-Day Suppression v1
+
+## Goal
+- Keep the existing `퀘스트 리마인드` toggle UX.
+- Suppress the same-day `20:00` reminder when the user already saved at least one walk record on that local day.
+- Resume the reminder normally on the next local day.
+
+## Rules
+- Reminder evaluation is `user-wide`, not selected-pet scoped.
+- Only saved walk records count. Started-only or discarded sessions do not count.
+- Local day boundaries follow `Calendar.autoupdatingCurrent` and `TimeZone.autoupdatingCurrent`.
+- Internal policy stays implicit to the user. The toggle still reads as a daily reminder setting.
+
+## Scheduling Policy
+- Replace the repeating trigger with a `one-shot` local notification.
+- On each resync:
+  - if a saved walk exists on the current local day, schedule the next reminder for tomorrow `20:00`
+  - otherwise, schedule today `20:00` when still upcoming
+  - otherwise, schedule tomorrow `20:00`
+- Automatic resync runs without prompting for notification authorization.
+- Manual toggle changes keep the existing permission prompt behavior.
+
+## Resync Triggers
+- initial load
+- visible reentry
+- manual refresh
+- app resume
+- local day change / timezone change
+- toggle on/off
+
+## Implementation Notes
+- Home builds the scheduling context from `walkRepository.fetchPolygons()` so the decision uses the latest saved walk records.
+- The reminder request identifier stays stable and pending/delivered requests are replaced on each resync.

--- a/dogArea/Source/Domain/Home/Services/HomeQuestReminderSupport.swift
+++ b/dogArea/Source/Domain/Home/Services/HomeQuestReminderSupport.swift
@@ -9,20 +9,27 @@ enum QuestReminderApplyResult: Equatable {
     case requiresPermission
 }
 
+/// 퀘스트 리마인드의 다음 1회 알림 시각을 계산할 때 필요한 입력 컨텍스트입니다.
+struct QuestReminderSchedulingContext {
+    let now: Date
+    let calendar: Calendar
+    let reminderHour: Int
+    let reminderMinute: Int
+    let hasSavedWalkOnCurrentDay: Bool
+}
+
 /// 퀘스트 리마인드 스케줄링 인터페이스입니다.
 protocol QuestReminderScheduling {
     /// 하루 1회 퀘스트 리마인드 스케줄을 적용합니다.
     /// - Parameters:
     ///   - enabled: 리마인드 활성화 여부입니다.
     ///   - allowAuthorizationPrompt: 권한 미결정 시 시스템 권한 팝업을 표시할지 여부입니다.
-    ///   - hour: 반복 알림 시각(시)입니다.
-    ///   - minute: 반복 알림 시각(분)입니다.
+    ///   - context: 다음 1회 알림 시각을 계산할 컨텍스트입니다.
     /// - Returns: 리마인드 적용 결과 상태입니다.
     func applyDailyReminder(
         enabled: Bool,
         allowAuthorizationPrompt: Bool,
-        hour: Int,
-        minute: Int
+        context: QuestReminderSchedulingContext
     ) async -> QuestReminderApplyResult
 }
 
@@ -58,14 +65,12 @@ final class LocalQuestReminderScheduler: QuestReminderScheduling {
     /// - Parameters:
     ///   - enabled: 리마인드 활성화 여부입니다.
     ///   - allowAuthorizationPrompt: 권한 미결정 시 시스템 권한 팝업을 표시할지 여부입니다.
-    ///   - hour: 반복 알림 시각(시)입니다.
-    ///   - minute: 반복 알림 시각(분)입니다.
+    ///   - context: 다음 1회 알림 시각을 계산할 컨텍스트입니다.
     /// - Returns: 리마인드 적용 결과 상태입니다.
     func applyDailyReminder(
         enabled: Bool,
         allowAuthorizationPrompt: Bool,
-        hour: Int,
-        minute: Int
+        context: QuestReminderSchedulingContext
     ) async -> QuestReminderApplyResult {
         guard enabled else {
             center.removePendingNotificationRequests(withIdentifiers: [requestId])
@@ -86,24 +91,57 @@ final class LocalQuestReminderScheduler: QuestReminderScheduling {
         }
 
         center.removePendingNotificationRequests(withIdentifiers: [requestId])
+        center.removeDeliveredNotifications(withIdentifiers: [requestId])
 
-        let content = UNMutableNotificationContent()
-        content.title = "오늘 산책 퀘스트 확인할 시간이에요"
-        content.body = "홈에서 오늘 미션을 확인하고, 짧게 기록해 진행도를 올려보세요."
-        content.sound = .default
-
-        var dateComponents = DateComponents()
-        dateComponents.hour = hour
-        dateComponents.minute = minute
-
-        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
-        let request = UNNotificationRequest(identifier: requestId, content: content, trigger: trigger)
+        let nextReminderDate = makeNextReminderDate(from: context)
+        let request = makeNotificationRequest(for: nextReminderDate, calendar: context.calendar)
 
         return await withCheckedContinuation { continuation in
             center.add(request) { error in
                 continuation.resume(returning: error == nil ? .enabled : .permissionDenied)
             }
         }
+    }
+
+    /// 현재 컨텍스트를 기준으로 다음 1회 리마인드 알림 시각을 계산합니다.
+    /// - Parameter context: 저장된 산책 여부와 현지 시간대 정보가 반영된 계산 입력입니다.
+    /// - Returns: 다음으로 예약해야 할 알림 시각입니다.
+    private func makeNextReminderDate(from context: QuestReminderSchedulingContext) -> Date {
+        let todayReminderDate = makeReminderDate(dayOffset: 0, context: context)
+        guard context.hasSavedWalkOnCurrentDay == false, context.now < todayReminderDate else {
+            return makeReminderDate(dayOffset: 1, context: context)
+        }
+        return todayReminderDate
+    }
+
+    /// 기준 날짜에서 지정한 일수만큼 이동한 알림 시각을 생성합니다.
+    /// - Parameters:
+    ///   - dayOffset: 오늘 기준으로 더할 날짜 오프셋입니다.
+    ///   - context: 시간대와 목표 시각이 담긴 리마인드 계산 컨텍스트입니다.
+    /// - Returns: 해당 일자의 목표 시각이 반영된 날짜입니다.
+    private func makeReminderDate(dayOffset: Int, context: QuestReminderSchedulingContext) -> Date {
+        let targetDate = context.calendar.date(byAdding: .day, value: dayOffset, to: context.now) ?? context.now
+        var dateComponents = context.calendar.dateComponents([.year, .month, .day], from: targetDate)
+        dateComponents.hour = context.reminderHour
+        dateComponents.minute = context.reminderMinute
+        dateComponents.second = 0
+        return context.calendar.date(from: dateComponents) ?? targetDate
+    }
+
+    /// 지정한 시각에 맞는 1회성 로컬 알림 요청을 생성합니다.
+    /// - Parameters:
+    ///   - date: 실제 알림이 울려야 하는 시각입니다.
+    ///   - calendar: 날짜 컴포넌트 추출에 사용할 현지 캘린더입니다.
+    /// - Returns: 시스템 알림 센터에 등록할 1회성 요청입니다.
+    private func makeNotificationRequest(for date: Date, calendar: Calendar) -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        content.title = "오늘 산책 퀘스트 확인할 시간이에요"
+        content.body = "홈에서 오늘 미션을 확인하고, 짧게 기록해 진행도를 올려보세요."
+        content.sound = .default
+
+        let dateComponents = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+        return UNNotificationRequest(identifier: requestId, content: content, trigger: trigger)
     }
 
     /// 알림 권한 상태를 확인하고 필요 시 사용자 권한 요청을 실행합니다.

--- a/dogArea/Views/HomeView/HomeViewModel.swift
+++ b/dogArea/Views/HomeView/HomeViewModel.swift
@@ -78,6 +78,7 @@ final class HomeViewModel: ObservableObject {
     var areaReferenceTask: Task<Void, Never>? = nil
     var weatherReplacementSummaryTask: Task<Void, Never>? = nil
     var seasonCanonicalSummaryTask: Task<Void, Never>? = nil
+    var questReminderSyncTask: Task<Void, Never>? = nil
     var hasSkippedInitialActiveSceneRefresh: Bool = false
     var indoorMissionPetContextPolygonFingerprint: HomeIndoorMissionPetContextPolygonFingerprint? = nil
     var indoorMissionPetContextAggregationSnapshot: HomeIndoorMissionPetContextAggregationSnapshot? = nil
@@ -181,14 +182,12 @@ final class HomeViewModel: ObservableObject {
         reloadUserInfo()
         reloadSeasonCatchupBuffStatus()
         performInitialRefresh()
-        Task { [weak self] in
-            await self?.syncQuestReminderOnLaunch()
-        }
     }
 
     deinit {
         areaReferenceTask?.cancel()
         weatherReplacementSummaryTask?.cancel()
         seasonCanonicalSummaryTask?.cancel()
+        questReminderSyncTask?.cancel()
     }
 }

--- a/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+SessionLifecycle.swift
+++ b/dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+SessionLifecycle.swift
@@ -67,6 +67,15 @@ private enum HomeRefreshTrigger: String {
             return false
         }
     }
+
+    var shouldRescheduleQuestReminder: Bool {
+        switch self {
+        case .initialLoad, .visibleReentry, .manualRefresh, .appResume, .timeBoundaryChange:
+            return true
+        case .petSelection:
+            return false
+        }
+    }
 }
 
 extension HomeViewModel {
@@ -138,6 +147,7 @@ extension HomeViewModel {
         }
 
         refreshIndoorMissions(now: now)
+        scheduleQuestReminderResyncIfNeeded(trigger: trigger, now: now)
     }
 
     /// 공용 날씨 스냅샷 저장소에서 최신 값을 읽어 홈 상태에 반영합니다.
@@ -483,23 +493,40 @@ extension HomeViewModel {
     }
 
     /// 앱 진입 시 저장된 퀘스트 리마인드 설정을 로컬 알림 스케줄과 동기화합니다.
-    func syncQuestReminderOnLaunch() async {
+    func syncQuestReminderOnLaunch(now: Date = Date()) async {
+        await syncQuestReminderForCurrentState(now: now, allowAuthorizationPrompt: false)
+    }
+
+    /// 현재 저장된 산책 기록과 리마인드 설정을 바탕으로 다음 1회 알림 일정을 다시 계산합니다.
+    /// - Parameters:
+    ///   - now: 오늘 여부와 다음 예약 시각을 판단할 기준 시각입니다.
+    ///   - allowAuthorizationPrompt: 권한 미결정 시 시스템 권한 팝업을 허용할지 여부입니다.
+    func syncQuestReminderForCurrentState(
+        now: Date = Date(),
+        allowAuthorizationPrompt: Bool
+    ) async {
         await applyQuestReminderPreference(
             enabled: questReminderEnabled,
-            allowAuthorizationPrompt: false
+            allowAuthorizationPrompt: allowAuthorizationPrompt,
+            reference: now
         )
     }
 
     /// 퀘스트 리마인드 설정 변경을 로컬 알림 스케줄에 적용하고 상태 메시지를 갱신합니다.
+    /// - Parameters:
+    ///   - enabled: 사용자가 저장한 리마인드 토글 상태입니다.
+    ///   - allowAuthorizationPrompt: 권한 미결정 시 시스템 권한 팝업을 허용할지 여부입니다.
+    ///   - reference: 오늘 저장 완료 여부와 다음 알림 시각을 판정할 기준 시각입니다.
     func applyQuestReminderPreference(
         enabled: Bool,
-        allowAuthorizationPrompt: Bool
+        allowAuthorizationPrompt: Bool,
+        reference: Date = Date()
     ) async {
+        let schedulingContext = makeQuestReminderSchedulingContext(reference: reference)
         let result = await questReminderScheduler.applyDailyReminder(
             enabled: enabled,
             allowAuthorizationPrompt: allowAuthorizationPrompt,
-            hour: HomeQuestReminderConstants.hour,
-            minute: HomeQuestReminderConstants.minute
+            context: schedulingContext
         )
 
         await MainActor.run {
@@ -519,6 +546,53 @@ extension HomeViewModel {
             case .requiresPermission:
                 break
             }
+        }
+    }
+
+    /// 현재 refresh 트리거가 리마인드 재평가를 요구하면 기존 작업을 취소하고 다시 예약합니다.
+    /// - Parameters:
+    ///   - trigger: 이번 홈 갱신을 유발한 트리거입니다.
+    ///   - now: 오늘 저장 여부와 다음 예약 시각 계산에 사용할 기준 시각입니다.
+    private func scheduleQuestReminderResyncIfNeeded(trigger: HomeRefreshTrigger, now: Date = Date()) {
+        guard trigger.shouldRescheduleQuestReminder else { return }
+        questReminderSyncTask?.cancel()
+        questReminderSyncTask = Task { [weak self] in
+            await self?.syncQuestReminderForCurrentState(now: now, allowAuthorizationPrompt: false)
+        }
+    }
+
+    /// 현재 로컬 저장 산책 기록을 기준으로 퀘스트 리마인드 계산 입력을 생성합니다.
+    /// - Parameter reference: 오늘 경계와 다음 알림 시각 계산에 사용할 기준 시각입니다.
+    /// - Returns: 저장 산책 여부와 현지 캘린더가 반영된 리마인드 스케줄 컨텍스트입니다.
+    func makeQuestReminderSchedulingContext(reference: Date = Date()) -> QuestReminderSchedulingContext {
+        let calendar = currentCalendar()
+        let savedPolygons = walkRepository.fetchPolygons()
+        return QuestReminderSchedulingContext(
+            now: reference,
+            calendar: calendar,
+            reminderHour: HomeQuestReminderConstants.hour,
+            reminderMinute: HomeQuestReminderConstants.minute,
+            hasSavedWalkOnCurrentDay: hasSavedWalkOnCurrentDay(
+                reference: reference,
+                polygons: savedPolygons,
+                calendar: calendar
+            )
+        )
+    }
+
+    /// 저장된 산책 기록 중 현재 로컬 날짜에 속하는 완료 기록이 있는지 판정합니다.
+    /// - Parameters:
+    ///   - reference: 오늘 경계를 판정할 기준 시각입니다.
+    ///   - polygons: 로컬에 저장된 완료 산책 기록 목록입니다.
+    ///   - calendar: 현지 시간대가 반영된 캘린더입니다.
+    /// - Returns: 오늘 저장된 산책 기록이 하나라도 있으면 `true`입니다.
+    func hasSavedWalkOnCurrentDay(
+        reference: Date,
+        polygons: [Polygon],
+        calendar: Calendar
+    ) -> Bool {
+        polygons.contains { polygon in
+            calendar.isDate(Date(timeIntervalSince1970: polygon.createdAt), inSameDayAs: reference)
         }
     }
 

--- a/scripts/home_quest_reminder_same_day_suppression_unit_check.swift
+++ b/scripts/home_quest_reminder_same_day_suppression_unit_check.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let support = load("dogArea/Source/Domain/Home/Services/HomeQuestReminderSupport.swift")
+let sessionLifecycle = load("dogArea/Views/HomeView/HomeViewModelSupport/HomeViewModel+SessionLifecycle.swift")
+let homeViewModel = load("dogArea/Views/HomeView/HomeViewModel.swift")
+let doc = load("docs/home-quest-reminder-same-day-suppression-v1.md")
+
+assertTrue(
+    support.contains("struct QuestReminderSchedulingContext"),
+    "quest reminder support should define a scheduling context"
+)
+assertTrue(
+    support.contains("hasSavedWalkOnCurrentDay"),
+    "quest reminder context should model whether a saved walk already exists on the local day"
+)
+assertTrue(
+    support.contains("makeNextReminderDate(from context: QuestReminderSchedulingContext)"),
+    "quest reminder scheduler should compute the next one-shot reminder date"
+)
+assertTrue(
+    support.contains("repeats: false"),
+    "quest reminder scheduler should use a one-shot notification trigger"
+)
+assertTrue(
+    sessionLifecycle.contains("func makeQuestReminderSchedulingContext(reference: Date = Date()) -> QuestReminderSchedulingContext"),
+    "home session lifecycle should build quest reminder scheduling context"
+)
+assertTrue(
+    sessionLifecycle.contains("walkRepository.fetchPolygons()"),
+    "quest reminder scheduling should evaluate the latest saved polygons from the repository"
+)
+assertTrue(
+    sessionLifecycle.contains("calendar.isDate(Date(timeIntervalSince1970: polygon.createdAt), inSameDayAs: reference)"),
+    "quest reminder suppression should use local calendar day boundaries against saved walk timestamps"
+)
+assertTrue(
+    sessionLifecycle.contains("func scheduleQuestReminderResyncIfNeeded(trigger: HomeRefreshTrigger, now: Date = Date())"),
+    "home refresh lifecycle should reschedule quest reminders when launch or time boundary triggers occur"
+)
+assertTrue(
+    homeViewModel.contains("var questReminderSyncTask: Task<Void, Never>? = nil"),
+    "home view model should retain a cancellable quest reminder resync task"
+)
+assertTrue(
+    doc.contains("user-wide") && doc.contains("one-shot") && doc.contains("toggle on/off"),
+    "quest reminder suppression doc should capture user-wide one-shot scheduling policy"
+)
+
+print("PASS: home quest reminder same-day suppression unit checks")

--- a/scripts/home_viewmodel_support_split_unit_check.swift
+++ b/scripts/home_viewmodel_support_split_unit_check.swift
@@ -28,7 +28,7 @@ assertTrue(mainFile.contains("let areaReferenceRepository: AreaReferenceReposito
 assertTrue(mainFile.contains("deinit {"), "HomeViewModel main file should keep lifecycle cleanup")
 
 assertTrue(sessionLifecycle.contains("extension HomeViewModel"), "session lifecycle support should extend HomeViewModel")
-assertTrue(sessionLifecycle.contains("func syncQuestReminderOnLaunch() async"), "session lifecycle support should own quest reminder launch sync")
+assertTrue(sessionLifecycle.contains("func syncQuestReminderOnLaunch(now: Date = Date()) async"), "session lifecycle support should own quest reminder launch sync")
 assertTrue(areaProgress.contains("func combinedAreas() -> [AreaMeter]"), "area progress support should own combined area helpers")
 assertTrue(areaProgress.contains("func makeDayBoundarySplitContribution(reference: Date) -> DayBoundarySplitContribution?"), "area progress support should own boundary contribution logic")
 assertTrue(indoorMissionFlow.contains("func makeIndoorMissionPetContext(reference: Date) -> IndoorMissionPetContext"), "indoor mission support should own pet mission context")

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -45,6 +45,7 @@ swift scripts/map_quest_hud_minimum_info_unit_check.swift
 swift scripts/map_quest_overlay_priority_unit_check.swift
 swift scripts/quest_stage2_engine_unit_check.swift
 swift scripts/season_motion_pack_unit_check.swift
+swift scripts/home_quest_reminder_same_day_suppression_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift
 swift scripts/epic_21_closure_evidence_unit_check.swift
 swift scripts/epic_123_closure_evidence_unit_check.swift

--- a/scripts/quest_stage3_ux_reminder_unit_check.swift
+++ b/scripts/quest_stage3_ux_reminder_unit_check.swift
@@ -33,11 +33,11 @@ let homeViewModel = loadMany([
 let spec = load("docs/quest-stage3-ux-reminder-v1.md")
 let report = load("docs/cycle-170-quest-stage3-ux-reminder-report-2026-03-01.md")
 
-assertTrue(homeView.contains("QuestWidgetTab"), "HomeView should define daily/weekly quest widget tabs")
-assertTrue(homeView.contains("questWidgetTabSelector"), "HomeView should render quest tab selector")
-assertTrue(homeView.contains("questReminderToggleRow"), "HomeView should render quest reminder toggle row")
-assertTrue(homeView.contains("weeklyQuestSummary"), "HomeView should render weekly quest summary view")
-assertTrue(homeView.contains("questAlternativeSuggestionCard"), "HomeView should render alternative action suggestion card")
+assertTrue(homeView.contains("HomeQuestWidgetTab"), "HomeView should define daily/weekly quest widget tabs")
+assertTrue(homeView.contains("HomeQuestWidgetTabSelectorView"), "HomeView should render quest tab selector")
+assertTrue(homeView.contains("HomeQuestReminderToggleRowView"), "HomeView should render quest reminder toggle row")
+assertTrue(homeView.contains("HomeMissionSectionView"), "HomeView should render the quest/mission summary section")
+assertTrue(homeView.contains("HomeQuestAlternativeSuggestionCardView"), "HomeView should render alternative action suggestion card")
 
 assertTrue(homeViewModel.contains("setQuestReminderEnabled"), "HomeViewModel should expose reminder preference toggle")
 assertTrue(homeViewModel.contains("LocalQuestReminderScheduler"), "HomeViewModel should include local reminder scheduler")


### PR DESCRIPTION
## Summary
- suppress the 20:00 quest reminder when the user already has a saved walk record on the same local day
- resync reminder scheduling on launch and refresh paths with a one-shot local-day scheduling context
- add docs and regression checks for same-day suppression policy

Closes #642