### PR TITLE
fix: refresh walk control widget elapsed timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - Walk widget action state model v1: `docs/walk-widget-action-state-model-v1.md`
 - Walk widget action convergence v1: `docs/walk-widget-action-convergence-v1.md`
 - Walk Live Activity copy/timer policy v1: `docs/walk-live-activity-copy-timer-v1.md`
+- Walk Control Widget timer refresh v1: `docs/walk-control-widget-timer-refresh-v1.md`
 - Walk Live Activity priority v1: `docs/walk-live-activity-priority-v1.md`
 - Watch action feedback UX v1: `docs/watch-action-feedback-ux-v1.md`
 - Watch selected pet context UX v1: `docs/watch-selected-pet-context-ux-v1.md`

--- a/docs/walk-control-widget-timer-refresh-v1.md
+++ b/docs/walk-control-widget-timer-refresh-v1.md
@@ -1,0 +1,38 @@
+# Walk Control Widget Timer Refresh v1
+
+Issue: #615
+
+## Problem
+
+- `WalkControlWidget` rendered elapsed time as a frozen string.
+- timeline policy refreshed once after `15m`, so a running walk could look stale.
+- walk widget reload signature ignored the timer axis, so app-side snapshot saves could skip `reloadTimelines`.
+
+## Canonical Rules
+
+1. While `isWalking == true`, the widget elapsed time must render with timer-style text from the walk start reference.
+2. While `isWalking == false`, elapsed time stays frozen text.
+3. `WalkWidgetSnapshot` must persist `startedAt` so widget rendering does not depend on repeated foreground sync writes.
+4. `timelineReloadSignature` must include the timer axis through:
+   - `startedAt`
+   - `elapsed minute bucket`
+   - `updatedAt minute bucket`
+5. The signature must not use raw `elapsedSeconds` per save, to avoid 5-second reload churn.
+
+## Timeline Policy
+
+- active walk: next refresh after `60s`
+- pending action: next refresh after `30s`
+- requires app open: next refresh after `120s`
+- idle state: next refresh after `15m`
+
+## Surface Contract
+
+- `WalkControlWidget` home/lock widget follows the same timer interpretation for all supported families.
+- action state copy continues to override status copy, but timer rendering must stay independent from action badge presentation.
+
+## Forbidden
+
+- no fallback to fixed elapsed strings while walking
+- no raw `elapsedSeconds` signature that reloads every app-side save
+- no `reloadAllTimelines()` workaround

--- a/dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift
+++ b/dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift
@@ -213,6 +213,7 @@ struct WalkWidgetActionState: Codable, Equatable {
 
 struct WalkWidgetSnapshot: Codable, Equatable {
     let isWalking: Bool
+    let startedAt: TimeInterval
     let elapsedSeconds: Int
     let petName: String
     let petContext: WalkWidgetPetContext?
@@ -220,6 +221,18 @@ struct WalkWidgetSnapshot: Codable, Equatable {
     let statusMessage: String?
     let actionState: WalkWidgetActionState?
     let updatedAt: TimeInterval
+
+    enum CodingKeys: String, CodingKey {
+        case isWalking
+        case startedAt
+        case elapsedSeconds
+        case petName
+        case petContext
+        case status
+        case statusMessage
+        case actionState
+        case updatedAt
+    }
 
     var normalizedPetContext: WalkWidgetPetContext {
         petContext ?? .legacyFallback(petName: petName, isWalking: isWalking)
@@ -230,24 +243,79 @@ struct WalkWidgetSnapshot: Codable, Equatable {
         return actionState.isExpired ? nil : actionState
     }
 
+    var timerReferenceDate: Date {
+        let inferredStartedAt = max(0, updatedAt - Double(max(0, elapsedSeconds)))
+        let referenceTimestamp = startedAt > 0 ? startedAt : inferredStartedAt
+        return Date(timeIntervalSince1970: referenceTimestamp)
+    }
+
+    var elapsedReloadMinuteBucket: Int {
+        max(0, elapsedSeconds / 60)
+    }
+
+    var updatedAtReloadMinuteBucket: Int {
+        max(0, Int(updatedAt / 60.0))
+    }
+
     var timelineReloadSignature: String {
-        [
+        let petContext = normalizedPetContext
+        let actionState = normalizedActionState
+        let startedAtSignature = String(Int(startedAt.rounded(.down)))
+        let components = [
             String(isWalking),
-            normalizedPetContext.petName,
-            normalizedPetContext.source.rawValue,
-            normalizedPetContext.startPolicy.rawValue,
-            normalizedPetContext.fallbackReason ?? "",
+            startedAtSignature,
+            String(elapsedReloadMinuteBucket),
+            String(updatedAtReloadMinuteBucket),
+            petContext.petName,
+            petContext.source.rawValue,
+            petContext.startPolicy.rawValue,
+            petContext.fallbackReason ?? "",
             status.rawValue,
             statusMessage ?? "",
-            normalizedActionState?.kind.rawValue ?? "",
-            normalizedActionState?.phase.rawValue ?? "",
-            normalizedActionState?.followUp.rawValue ?? "",
-            normalizedActionState?.message ?? ""
-        ].joined(separator: "|")
+            actionState?.kind.rawValue ?? "",
+            actionState?.phase.rawValue ?? "",
+            actionState?.followUp.rawValue ?? "",
+            actionState?.message ?? ""
+        ]
+        return components.joined(separator: "|")
+    }
+
+    /// 산책 위젯 스냅샷을 명시적인 타이머 기준 시각과 함께 생성합니다.
+    /// - Parameters:
+    ///   - isWalking: 현재 산책 진행 여부입니다.
+    ///   - startedAt: timer-style 렌더링 기준이 되는 산책 시작 시각입니다.
+    ///   - elapsedSeconds: 현재까지 누적된 경과 시간(초)입니다.
+    ///   - petName: 위젯에 표시할 반려견 이름입니다.
+    ///   - petContext: 선택 반려견 문맥 정보입니다.
+    ///   - status: 위젯 상태 배지용 canonical 상태입니다.
+    ///   - statusMessage: 상태 보조 문구입니다.
+    ///   - actionState: 위젯 액션 오버레이 상태입니다.
+    ///   - updatedAt: 마지막 갱신 시각입니다.
+    init(
+        isWalking: Bool,
+        startedAt: TimeInterval,
+        elapsedSeconds: Int,
+        petName: String,
+        petContext: WalkWidgetPetContext?,
+        status: WalkWidgetSnapshotStatus,
+        statusMessage: String?,
+        actionState: WalkWidgetActionState?,
+        updatedAt: TimeInterval
+    ) {
+        self.isWalking = isWalking
+        self.startedAt = startedAt
+        self.elapsedSeconds = elapsedSeconds
+        self.petName = petName
+        self.petContext = petContext
+        self.status = status
+        self.statusMessage = statusMessage
+        self.actionState = actionState
+        self.updatedAt = updatedAt
     }
 
     static let initial = WalkWidgetSnapshot(
         isWalking: false,
+        startedAt: 0,
         elapsedSeconds: 0,
         petName: "반려견",
         petContext: .init(
@@ -262,6 +330,23 @@ struct WalkWidgetSnapshot: Codable, Equatable {
         actionState: nil,
         updatedAt: Date().timeIntervalSince1970
     )
+
+    /// 레거시 저장본까지 호환하도록 산책 위젯 스냅샷을 디코딩합니다.
+    /// - Parameter decoder: 공유 저장소의 직렬화 데이터를 해석할 디코더입니다.
+    /// - Throws: 지원하지 않는 형식일 때 디코딩 오류를 그대로 전달합니다.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.isWalking = try container.decode(Bool.self, forKey: .isWalking)
+        self.elapsedSeconds = try container.decode(Int.self, forKey: .elapsedSeconds)
+        self.petName = try container.decode(String.self, forKey: .petName)
+        self.petContext = try container.decodeIfPresent(WalkWidgetPetContext.self, forKey: .petContext)
+        self.status = try container.decode(WalkWidgetSnapshotStatus.self, forKey: .status)
+        self.statusMessage = try container.decodeIfPresent(String.self, forKey: .statusMessage)
+        self.actionState = try container.decodeIfPresent(WalkWidgetActionState.self, forKey: .actionState)
+        self.updatedAt = try container.decode(TimeInterval.self, forKey: .updatedAt)
+        let inferredStartedAt = max(0, updatedAt - Double(max(0, elapsedSeconds)))
+        self.startedAt = try container.decodeIfPresent(TimeInterval.self, forKey: .startedAt) ?? inferredStartedAt
+    }
 }
 
 enum TerritoryWidgetSnapshotStatus: String, Codable {
@@ -723,6 +808,7 @@ final class DefaultWalkWidgetSnapshotStore: WalkWidgetSnapshotStoring {
         }
         return WalkWidgetSnapshot(
             isWalking: decoded.isWalking,
+            startedAt: decoded.startedAt,
             elapsedSeconds: decoded.elapsedSeconds,
             petName: decoded.petName,
             petContext: decoded.petContext ?? decoded.normalizedPetContext,
@@ -739,6 +825,7 @@ final class DefaultWalkWidgetSnapshotStore: WalkWidgetSnapshotStoring {
         let previous = load()
         let normalizedSnapshot = WalkWidgetSnapshot(
             isWalking: snapshot.isWalking,
+            startedAt: snapshot.startedAt,
             elapsedSeconds: snapshot.elapsedSeconds,
             petName: snapshot.petName,
             petContext: snapshot.normalizedPetContext,

--- a/dogArea/Views/GlobalViews/BaseView/RootView.swift
+++ b/dogArea/Views/GlobalViews/BaseView/RootView.swift
@@ -481,6 +481,7 @@ struct RootView: View {
         walkWidgetSnapshotStore.save(
             WalkWidgetSnapshot(
                 isWalking: current.isWalking,
+                startedAt: current.startedAt,
                 elapsedSeconds: current.elapsedSeconds,
                 petName: current.petName,
                 petContext: current.petContext ?? current.normalizedPetContext,

--- a/dogArea/Views/MapView/MapViewModelSupport/MapViewModel+WidgetRuntimeSupport.swift
+++ b/dogArea/Views/MapView/MapViewModelSupport/MapViewModel+WidgetRuntimeSupport.swift
@@ -169,8 +169,13 @@ extension MapViewModel {
             actionStateOverride: actionStateOverride,
             now: now
         )
+        let startedAtTimestamp = resolveWalkWidgetStartedAt(
+            currentSnapshot: currentSnapshot,
+            now: now
+        )
         let snapshot = WalkWidgetSnapshot(
             isWalking: isWalking,
+            startedAt: startedAtTimestamp,
             elapsedSeconds: Int(max(0, time.rounded(.down))),
             petName: petContext.petName,
             petContext: petContext,
@@ -181,6 +186,27 @@ extension MapViewModel {
         )
         widgetSnapshotStore.save(snapshot)
         lastWidgetSnapshotSyncAt = now
+    }
+
+    /// 현재 앱 세션과 기존 저장본을 기준으로 위젯 타이머 기준 시각을 계산합니다.
+    /// - Parameters:
+    ///   - currentSnapshot: 기존 공유 저장소에 남아 있는 위젯 스냅샷입니다.
+    ///   - now: 이번 스냅샷 저장 기준 시각입니다.
+    /// - Returns: 위젯에서 timer-style 렌더링에 사용할 시작 시각입니다.
+    private func resolveWalkWidgetStartedAt(
+        currentSnapshot: WalkWidgetSnapshot,
+        now: Date
+    ) -> TimeInterval {
+        if isWalking {
+            return startTime.timeIntervalSince1970
+        }
+
+        if currentSnapshot.startedAt > 0 {
+            return currentSnapshot.startedAt
+        }
+
+        let inferredStartedAt = now.timeIntervalSince1970 - Double(Int(max(0, time.rounded(.down))))
+        return max(0, inferredStartedAt)
     }
 
     /// 앱 세션을 정본으로 위젯 액션 상태를 다시 계산합니다.

--- a/dogAreaWidgetExtension/WalkControlIntents.swift
+++ b/dogAreaWidgetExtension/WalkControlIntents.swift
@@ -204,6 +204,7 @@ private func preparePendingRoute(kind: WalkWidgetActionKind, contextId: String?)
         store.save(
             .init(
                 isWalking: current.isWalking,
+                startedAt: current.startedAt,
                 elapsedSeconds: current.elapsedSeconds,
                 petName: current.petName,
                 petContext: current.petContext ?? current.normalizedPetContext,

--- a/dogAreaWidgetExtension/Widgets/WalkControlWidget.swift
+++ b/dogAreaWidgetExtension/Widgets/WalkControlWidget.swift
@@ -6,6 +6,26 @@ struct WalkControlTimelineEntry: TimelineEntry {
     let snapshot: WalkWidgetSnapshot
 }
 
+private enum WalkControlElapsedDisplayMode {
+    case liveTimer(referenceDate: Date)
+    case frozen(text: String)
+}
+
+private struct WalkControlElapsedTextView: View {
+    let displayMode: WalkControlElapsedDisplayMode
+
+    var body: some View {
+        switch displayMode {
+        case .liveTimer(let referenceDate):
+            Text(referenceDate, style: .timer)
+                .monospacedDigit()
+        case .frozen(let text):
+            Text(text)
+                .monospacedDigit()
+        }
+    }
+}
+
 struct WalkControlTimelineProvider: TimelineProvider {
     private let snapshotStore: WalkWidgetSnapshotStoring
 
@@ -36,9 +56,28 @@ struct WalkControlTimelineProvider: TimelineProvider {
     ///   - completion: 타임라인 생성 결과를 전달하는 콜백입니다.
     func getTimeline(in context: Context, completion: @escaping (Timeline<WalkControlTimelineEntry>) -> Void) {
         let now = Date()
-        let entry = WalkControlTimelineEntry(date: now, snapshot: snapshotStore.load())
-        let next = now.addingTimeInterval(15 * 60)
+        let snapshot = snapshotStore.load()
+        let entry = WalkControlTimelineEntry(date: now, snapshot: snapshot)
+        let next = nextRefreshDate(for: snapshot, from: now)
         completion(Timeline(entries: [entry], policy: .after(next)))
+    }
+
+    /// 현재 위젯 스냅샷 상태에 맞는 다음 타임라인 갱신 시각을 계산합니다.
+    /// - Parameters:
+    ///   - snapshot: 위젯에 렌더링할 현재 산책 스냅샷입니다.
+    ///   - now: 타임라인 계산 기준 시각입니다.
+    /// - Returns: 시스템에 요청할 다음 타임라인 갱신 시각입니다.
+    private func nextRefreshDate(for snapshot: WalkWidgetSnapshot, from now: Date) -> Date {
+        if snapshot.isWalking {
+            return now.addingTimeInterval(60)
+        }
+        if snapshot.normalizedActionState?.phase == .pending {
+            return now.addingTimeInterval(30)
+        }
+        if snapshot.normalizedActionState?.phase == .requiresAppOpen {
+            return now.addingTimeInterval(120)
+        }
+        return now.addingTimeInterval(15 * 60)
     }
 }
 
@@ -74,7 +113,7 @@ struct WalkControlWidgetEntryView: View {
             HStack(spacing: 6) {
                 Image(systemName: "clock")
                     .foregroundStyle(.secondary)
-                Text(WidgetFormatting.formattedElapsed(entry.snapshot.elapsedSeconds))
+                WalkControlElapsedTextView(displayMode: elapsedDisplayMode)
                     .font(.system(.body, design: .rounded).monospacedDigit())
             }
 
@@ -103,6 +142,13 @@ struct WalkControlWidgetEntryView: View {
 
     private var effectiveStatusMessage: String? {
         activeActionState?.message ?? entry.snapshot.statusMessage
+    }
+
+    private var elapsedDisplayMode: WalkControlElapsedDisplayMode {
+        if entry.snapshot.isWalking {
+            return .liveTimer(referenceDate: entry.snapshot.timerReferenceDate)
+        }
+        return .frozen(text: WidgetFormatting.formattedElapsed(entry.snapshot.elapsedSeconds))
     }
 
     private var preferredActionKind: WalkWidgetActionKind {
@@ -249,6 +295,7 @@ struct WalkControlWidget: Widget {
         date: Date(),
         snapshot: .init(
             isWalking: true,
+            startedAt: Date().addingTimeInterval(-824).timeIntervalSince1970,
             elapsedSeconds: 824,
             petName: "나무",
             petContext: .init(

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -99,6 +99,7 @@ swift scripts/watch_sync_recovery_ux_unit_check.swift
 swift scripts/watch_walk_end_summary_ux_unit_check.swift
 swift scripts/walk_live_activity_priority_unit_check.swift
 swift scripts/walk_live_activity_copy_timer_unit_check.swift
+swift scripts/walk_control_widget_timer_refresh_unit_check.swift
 swift scripts/walk_widget_action_state_model_unit_check.swift
 swift scripts/walk_widget_action_convergence_unit_check.swift
 swift scripts/walk_widget_pet_context_policy_unit_check.swift

--- a/scripts/walk_control_widget_timer_refresh_unit_check.swift
+++ b/scripts/walk_control_widget_timer_refresh_unit_check.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .utf8) else {
+        fputs("Failed to load \(relativePath)\n", stderr)
+        exit(1)
+    }
+    return text
+}
+
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("Assertion failed: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let doc = load("docs/walk-control-widget-timer-refresh-v1.md")
+let widget = load("dogAreaWidgetExtension/Widgets/WalkControlWidget.swift")
+let snapshotStore = load("dogArea/Source/WidgetBridge/WalkWidgetSnapshotStore.swift")
+let widgetRuntime = load("dogArea/Views/MapView/MapViewModelSupport/MapViewModel+WidgetRuntimeSupport.swift")
+let readme = load("README.md")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(doc.contains("# Walk Control Widget Timer Refresh v1"), "doc title should exist")
+assertTrue(doc.contains("Issue: #615"), "doc should reference issue #615")
+assertTrue(doc.contains("active walk: next refresh after `60s`"), "doc should define active walk timeline cadence")
+assertTrue(doc.contains("elapsed minute bucket"), "doc should define minute bucket reload rule")
+
+assertTrue(widget.contains("enum WalkControlElapsedDisplayMode"), "widget should declare elapsed display mode")
+assertTrue(widget.contains("struct WalkControlElapsedTextView"), "widget should render elapsed time through dedicated view")
+assertTrue(widget.contains("Text(referenceDate, style: .timer)"), "widget should use timer-style elapsed rendering")
+assertTrue(widget.contains("nextRefreshDate(for: snapshot, from: now)"), "widget provider should compute state-aware next refresh date")
+assertTrue(widget.contains("return now.addingTimeInterval(60)"), "widget provider should refresh every minute while walking")
+
+assertTrue(snapshotStore.contains("let startedAt: TimeInterval"), "snapshot should persist startedAt")
+assertTrue(snapshotStore.contains("var timerReferenceDate: Date"), "snapshot should expose timer reference date")
+assertTrue(snapshotStore.contains("var elapsedReloadMinuteBucket: Int"), "snapshot should derive elapsed minute bucket")
+assertTrue(snapshotStore.contains("var updatedAtReloadMinuteBucket: Int"), "snapshot should derive updatedAt minute bucket")
+assertTrue(snapshotStore.contains("String(Int(startedAt.rounded(.down)))"), "reload signature should include startedAt")
+
+assertTrue(widgetRuntime.contains("resolveWalkWidgetStartedAt("), "widget runtime should resolve startedAt before saving")
+assertTrue(readme.contains("docs/walk-control-widget-timer-refresh-v1.md"), "README should link the widget timer refresh doc")
+assertTrue(iosPRCheck.contains("walk_control_widget_timer_refresh_unit_check.swift"), "ios_pr_check should run widget timer refresh check")
+
+print("PASS: walk control widget timer refresh unit checks")


### PR DESCRIPTION
## Summary
- keep a stable widget walk start timestamp and use it for timer-style elapsed rendering
- add timeline refresh cadence for walking, pending, requires-app-open, and idle widget states
- document the timer refresh contract and gate it in ios_pr_check

## Testing
- swift scripts/walk_control_widget_timer_refresh_unit_check.swift
- swift scripts/walk_widget_action_state_model_unit_check.swift
- xcodebuild -skipPackagePluginValidation -project dogArea.xcodeproj -target dogAreaWidgetExtension -configuration Debug CODE_SIGNING_ALLOWED=NO build
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #615