### PR TITLE
docs: close quest hud policy issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - 라이벌 상단 safe area 계약 v1: `docs/rival-top-safearea-contract-v1.md`
 - 홈 refresh 중복 제거 umbrella v1: `docs/home-refresh-dedup-lightweight-v1.md`
 - 맵 파생 계산 경량화 umbrella v1: `docs/map-derived-calculation-lightweight-v1.md`
+- 이슈 #465 #467 클로저 증적 스냅샷 v1: `docs/issues-465-467-closure-evidence-v1.md`
 - 맵 하단 컨트롤러 anchored density v1: `docs/map-bottom-controller-anchored-density-v1.md`
 - 맵 add-point / walking deck 분리 계약 v1: `docs/map-add-point-walking-deck-separation-v1.md`
 - 맵 상단 slim HUD safe area 계약 v1: `docs/map-top-slim-hud-safearea-v1.md`

--- a/docs/issues-465-467-closure-evidence-v1.md
+++ b/docs/issues-465-467-closure-evidence-v1.md
@@ -1,0 +1,49 @@
+# Issues #465 #467 Closure Evidence v1
+
+## 대상
+- issues: `#465`, `#467`
+- theme: `산책 중 Quest Companion HUD`, `마일스톤 토스트`, `확장 체크리스트`, `HUD 최소 정보셋`
+
+## 구현 근거
+### #465 산책 중 퀘스트 Companion HUD·마일스톤 토스트·확장 체크리스트 설계
+- `#465`에서 요구한 기본 패턴은 저장소 문서 기준으로 `HUD + milestone toast + expandable checklist`로 정의됐다.
+- critical banner와 quest feedback의 우선순위는 별도 policy 문서에서 분리되어 있다.
+- overlay 경쟁 시 접힘 규칙은 `#468`의 overlay priority matrix와 함께 해석된다.
+- 근거 문서:
+  - `docs/map-quest-feedback-hud-v1.md`
+  - `docs/map-quest-overlay-priority-matrix-v1.md`
+
+### #467 산책 중 Companion HUD 최소 정보셋·축약 규칙 정의
+- `#467`에서 요구한 collapsed / expanded 정보셋, 줄 수 제한, empty state, 다중 미션 규칙은 최소 정보셋 정책 문서로 고정됐다.
+- collapsed HUD는 `2줄 + 상태 배지 1개` 기준으로 제한되고, expanded에서만 자세한 정보를 허용한다.
+- 근거 문서:
+  - `docs/map-quest-hud-minimum-info-set-v1.md`
+
+## DoD 판정
+### 1. #465 기본 피드백 계층이 모달 Alert가 아니라 비차단 HUD 중심으로 정의되어 있다
+- 기본값은 상시 HUD, milestone toast, expandable checklist의 3계층이다.
+- 진행 피드백은 모달 Alert 기본 사용을 금지하고, 예외 상황에만 Alert를 허용한다.
+- 판정: `PASS`
+
+### 2. #465 critical banner와 quest feedback의 우선순위가 정의되어 있다
+- quest feedback policy와 overlay priority matrix가 함께 존재한다.
+- 상단 overlay 경쟁 시 quest feedback이 어떻게 접히고 강등되는지 문서 기준이 있다.
+- 판정: `PASS`
+
+### 3. #467 collapsed / expanded 최소 정보셋과 축약 규칙이 명확하다
+- collapsed HUD는 대표 미션명, 한 줄 진행 요약, 상태 배지 수준으로 제한된다.
+- 다중 미션은 `대표 1개 + 추가 n개`, 완료/보상 가능/empty state 규칙도 문서화됐다.
+- 판정: `PASS`
+
+## 검증 근거
+- 정적 체크
+  - `swift scripts/map_quest_feedback_policy_unit_check.swift`
+  - `swift scripts/map_quest_hud_minimum_info_unit_check.swift`
+  - `swift scripts/map_quest_overlay_priority_unit_check.swift`
+  - `swift scripts/issues_465_467_closure_evidence_unit_check.swift`
+- PR 체크
+  - `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`
+
+## 결론
+- `#465`, `#467`은 둘 다 `지도 퀘스트 HUD 정책/정의` 범주 이슈로, 저장소 기준 구현 근거와 게이트가 존재한다.
+- 이 문서를 기준으로 두 이슈를 함께 닫아도 된다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -65,6 +65,7 @@ swift scripts/issue_503_closure_evidence_unit_check.swift
 swift scripts/issue_476_closure_evidence_unit_check.swift
 swift scripts/issues_610_611_612_closure_evidence_unit_check.swift
 swift scripts/issues_618_619_622_closure_evidence_unit_check.swift
+swift scripts/issues_465_467_closure_evidence_unit_check.swift
 swift scripts/game_layer_observability_qa_unit_check.swift
 swift scripts/game_layer_kpi_dashboard_unit_check.swift
 swift scripts/fault_injection_matrix_unit_check.swift

--- a/scripts/issues_465_467_closure_evidence_unit_check.swift
+++ b/scripts/issues_465_467_closure_evidence_unit_check.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// 조건이 참인지 검증합니다.
+/// - Parameters:
+///   - condition: 평가할 조건식입니다.
+///   - message: 실패 시 출력할 설명입니다.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if condition() == false {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// 저장소 루트 기준 상대 경로의 UTF-8 텍스트 파일을 읽습니다.
+/// - Parameter relativePath: 저장소 루트 기준 파일 상대 경로입니다.
+/// - Returns: 파일 본문 문자열입니다.
+func load(_ relativePath: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(relativePath))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let evidence = load("docs/issues-465-467-closure-evidence-v1.md")
+let feedbackDoc = load("docs/map-quest-feedback-hud-v1.md")
+let infoSetDoc = load("docs/map-quest-hud-minimum-info-set-v1.md")
+let priorityDoc = load("docs/map-quest-overlay-priority-matrix-v1.md")
+let readme = load("README.md")
+let prCheck = load("scripts/ios_pr_check.sh")
+
+assertTrue(evidence.contains("#465"), "evidence doc should reference issue #465")
+assertTrue(evidence.contains("#467"), "evidence doc should reference issue #467")
+assertTrue(evidence.contains("PASS"), "evidence doc should record PASS DoD results")
+assertTrue(evidence.contains("닫아도 된다"), "evidence doc should conclude that the issue bundle can close")
+assertTrue(feedbackDoc.contains("HUD + milestone toast + expandable checklist"), "quest feedback hud doc should define the three-layer feedback model")
+assertTrue(feedbackDoc.contains("critical banner"), "quest feedback hud doc should define banner priority assumptions")
+assertTrue(infoSetDoc.contains("2줄 + 상태 배지 1개"), "quest HUD info set doc should define the collapsed information budget")
+assertTrue(infoSetDoc.contains("대표 1개 + 추가 n개"), "quest HUD info set doc should define multi-mission compression")
+assertTrue(priorityDoc.contains("overlay"), "quest overlay priority doc should exist as supporting evidence")
+assertTrue(readme.contains("docs/issues-465-467-closure-evidence-v1.md"), "README should index the issue bundle closure evidence doc")
+assertTrue(prCheck.contains("swift scripts/issues_465_467_closure_evidence_unit_check.swift"), "ios_pr_check should include the issue bundle closure evidence check")
+
+print("PASS: issues #465 #467 closure evidence unit checks")


### PR DESCRIPTION
## Summary
- add closure evidence for the already-landed quest HUD policy work
- wire the new closure evidence gate into `ios_pr_check`
- close the related `Map/Quest HUD` policy issues together to avoid repeated single-issue verification cycles

## Scope
- `#465`: companion HUD / milestone toast / checklist policy is already documented and gated; this PR closes it with repository evidence
- `#467`: companion HUD minimum info set policy is already documented and gated; this PR closes it with repository evidence

## Verification
- `swift scripts/issues_465_467_closure_evidence_unit_check.swift`
- `swift scripts/map_quest_feedback_policy_unit_check.swift`
- `swift scripts/map_quest_hud_minimum_info_unit_check.swift`
- `swift scripts/map_quest_overlay_priority_unit_check.swift`
- `DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`

Closes #465
Closes #467
