### PR TITLE
test: add widget action regression pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - 근처 사용자 익명 핫스팟 명세 v1: `docs/nearby-anonymous-hotspot-v1.md`
 - 핫스팟 위젯 프라이버시 매핑 v1: `docs/hotspot-widget-privacy-mapping-v1.md`
 - 핫스팟 위젯 반경 preset v1: `docs/hotspot-widget-radius-preset-v1.md`
+- 위젯 액션 실기기 검증 매트릭스 v1: `docs/widget-action-real-device-validation-matrix-v1.md`
 - Widget state CTA taxonomy v1: `docs/widget-state-cta-taxonomy-v1.md`
 - Widget Lock Screen accessory family plan v1: `docs/widget-lock-screen-accessory-family-plan-v1.md`
 - Watch Smart Stack glance plan v1: `docs/watch-smart-stack-glance-plan-v1.md`
@@ -199,6 +200,7 @@
 
 - 전체 체크(iOS/watchOS build 포함): `bash scripts/ios_pr_check.sh`
 - 문서/유닛만 빠르게 체크: `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
+- 위젯 액션 기능 회귀 UI: `bash scripts/run_widget_action_regression_ui_tests.sh`
 - Backend drift / RPC contract 전용 체크: `bash scripts/backend_migration_drift_check.sh`
 - Backend smoke entrypoint: `bash scripts/backend_pr_check.sh`
 - Live Supabase smoke matrix: `DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/backend_pr_check.sh`

--- a/docs/ui-regression-matrix-v1.md
+++ b/docs/ui-regression-matrix-v1.md
@@ -8,6 +8,7 @@
 ## 실행 경로
 - 디자인 감사 캡처: `bash scripts/run_design_audit_ui_tests.sh`
 - 기능 회귀 UI: `bash scripts/run_feature_regression_ui_tests.sh`
+- 위젯 액션 기능 회귀 UI: `bash scripts/run_widget_action_regression_ui_tests.sh`
 - 문서/테스트 정합성 체크: `swift scripts/ui_regression_matrix_unit_check.swift`
 
 ## 문서-화면-테스트 매핑
@@ -51,6 +52,10 @@
 | `FR-RIVAL-002` | `docs/rival-tab-ui-design-spec-v1.md` | 라이벌 푸터 버튼 라우팅 | `FeatureRegressionUITests/testFeatureRegression_RivalFooterButtonsRouteToMapAndSettings` | 지도/설정으로의 전환 및 복귀 확인 |
 | `FR-RIVAL-003` | `docs/rival-top-safearea-contract-v1.md`, `#629` | 긴 부제/큰 글자 크기에서도 라이벌 헤더와 첫 배지 행이 status bar 아래에 유지되는지 | `FeatureRegressionUITests/testFeatureRegression_RivalHeaderStaysBelowStatusBarWithLongSubtitle` | 작은 화면과 접근성 글자 크기에서 라이벌 제목/부제/배지 행이 safe area 아래로 안정적으로 감싸지는지 확인 |
 | `FR-WIDGET-001` | `docs/hotspot-widget-privacy-mapping-v1.md` | 위젯 기본 딥링크 라우트 | `FeatureRegressionUITests/testFeatureRegression_WidgetRouteOpensRivalTab` | 위젯 탭 후 라이벌 탭 진입과 첫 상태 표시 확인 |
+| `FR-WIDGET-002` | `docs/hotspot-widget-radius-preset-v1.md`, `docs/widget-action-real-device-validation-matrix-v1.md` | 핫스팟 위젯 preset 라우트 | `FeatureRegressionUITests/testFeatureRegression_HotspotWidgetRouteOpensRivalWithMatchingRadiusPreset` | 실기기에서 3km preset이 cold start / foreground 모두에서 동일하게 유지되는지 확인 |
+| `FR-WIDGET-003` | `docs/quest-rival-widget-next-action-recovery-v1.md`, `docs/widget-action-real-device-validation-matrix-v1.md` | 퀘스트 위젯 상세 CTA 라우트 | `FeatureRegressionUITests/testFeatureRegression_QuestWidgetRouteOpensQuestMissionBoard` | background 상태에서도 홈 퀘스트 카드 위치와 상세 배너가 같이 복구되는지 확인 |
+| `FR-WIDGET-004` | `docs/quest-rival-widget-next-action-recovery-v1.md`, `docs/widget-action-real-device-validation-matrix-v1.md` | 퀘스트 위젯 recovery CTA 라우트 | `FeatureRegressionUITests/testFeatureRegression_QuestWidgetRecoveryRouteOpensQuestMissionBoard` | foreground 상태에서도 recovery 배너와 미션 카드 위치가 같이 노출되는지 확인 |
+| `FR-WIDGET-005` | `docs/territory-widget-goal-deeplink-v1.md`, `docs/widget-action-real-device-validation-matrix-v1.md` | 영역 위젯 목표 상세 딥링크 | `FeatureRegressionUITests/testFeatureRegression_TerritoryWidgetRouteOpensGoalDetail` | 실기기에서 cold start 진입 시 목표 상세 직접 진입과 탭바 숨김이 유지되는지 확인 |
 | `QA-MULTIPET-001` | `docs/multi-dog-selection-ux-v1.md`, `docs/multi-pet-session-nm-v2.md` | 다견 선택/활성 상태 전환 | `swift scripts/multi_dog_selection_ux_unit_check.swift`, `swift scripts/settings_pet_management_unit_check.swift` | 선택 반려견 변경 후 홈/목록/설정 반영 확인 |
 
 ## 수동 QA 체크리스트
@@ -60,6 +65,7 @@
 - `QA-GOAL-01`: 홈 카드와 목표 상세 화면이 정보 구조상 중복되지 않고, 상세 화면에서 더 많은 문맥을 제공한다.
 - `QA-RIVAL-01`: 라이벌 탭에서 권한/동의/공유 ON/OFF 상태가 토스트와 배지에 일관되게 반영된다.
 - `QA-WIDGET-01`: 위젯 경로는 앱이 이미 살아있는 상태와 cold start 상태 모두에서 동일한 탭으로 도착한다.
+- `QA-WIDGET-02`: 실기기 검증 결과는 `docs/widget-action-real-device-validation-matrix-v1.md`에 남기고, `cold start / background / foreground / auth state / action` 축을 모두 채운다.
 
 ## 운영 규칙
 - 디자인 스크린샷 감사와 기능 회귀는 같은 파일/같은 스크립트에서 실행하지 않는다.

--- a/docs/widget-action-real-device-validation-matrix-v1.md
+++ b/docs/widget-action-real-device-validation-matrix-v1.md
@@ -1,0 +1,64 @@
+# Widget Action Real-Device Validation Matrix v1
+
+- Issue: #660
+- Relates to: #408
+
+## 목적
+- 위젯 액션 경로의 실기기 검증 결과를 한 문서에 남긴다.
+- simulator 자동 회귀와 분리된 real-device evidence 포맷을 고정한다.
+- cold start / background / foreground / auth state / action 축을 누락 없이 기록한다.
+
+## 자동 회귀 진입점
+- 전용 위젯 액션 UI 러너: `bash scripts/run_widget_action_regression_ui_tests.sh`
+- 정적 게이트: `swift scripts/widget_action_regression_pack_unit_check.swift`
+
+## 축 정의
+
+### 앱 상태 축
+- `cold start`: 앱이 완전히 종료된 상태에서 위젯 탭으로 진입
+- `background`: 앱이 최근 task switcher에 남아 있는 상태에서 위젯 탭으로 복귀
+- `foreground`: 앱이 이미 떠 있는 상태에서 위젯 액션을 재실행
+
+### 인증 상태 축
+- `로그인`: member 세션이 유효한 상태
+- `로그아웃`: guest 또는 member 세션이 없는 상태
+- `auth overlay`: 위젯 액션이 앱으로 넘어왔지만 인증 오버레이/로그인 요구로 defer 되는 상태
+
+### 액션 축
+- `open_rival_tab`
+- `open_hotspot_broad`
+- `open_quest_detail`
+- `open_quest_recovery`
+- `open_territory_goal`
+- `walk_start`
+- `walk_end`
+
+## 최소 실기기 검증 세트
+
+| Case ID | Device / OS | Widget Family | 앱 상태 | 인증 상태 | 액션 | 기대 결과 |
+| --- | --- | --- | --- | --- | --- | --- |
+| `WD-001` | iPhone 실제 기기 | `systemSmall` | `cold start` | `로그인` | `open_rival_tab` | 라이벌 탭으로 직접 진입하고 기본 상태가 보인다. |
+| `WD-002` | iPhone 실제 기기 | `systemSmall` | `cold start` | `로그인` | `open_hotspot_broad` | 라이벌 탭이 3km preset 문맥으로 열린다. |
+| `WD-003` | iPhone 실제 기기 | `systemMedium` | `background` | `로그인` | `open_quest_detail` | 홈 퀘스트 카드 위치로 이동하고 상세 배너가 보인다. |
+| `WD-004` | iPhone 실제 기기 | `systemMedium` | `foreground` | `로그인` | `open_quest_recovery` | 홈 퀘스트 카드 위치로 이동하고 recovery 배너가 보인다. |
+| `WD-005` | iPhone 실제 기기 | `systemMedium` | `cold start` | `로그인` | `open_territory_goal` | 목표 상세 화면으로 직접 진입하고 탭바는 숨겨진다. |
+| `WD-006` | iPhone 실제 기기 | `systemSmall` | `cold start` | `로그인` | `walk_start` | 앱 세션이 위젯 start 요청을 소비하고 walking 상태로 수렴한다. |
+| `WD-007` | iPhone 실제 기기 | `systemSmall` | `foreground` | `로그인` | `walk_end` | 앱 세션이 종료 요청을 소비하고 위젯/Live Activity 상태가 종료로 수렴한다. |
+| `WD-008` | iPhone 실제 기기 | `systemSmall` | `cold start` | `로그아웃` | `walk_start` | 즉시 시작하지 않고 `auth overlay` 또는 로그인 진입으로 defer 된다. |
+
+## 기록 템플릿
+
+| Date | Device / OS | Widget Family | 앱 상태 | 인증 상태 | 액션 | Expected | Actual | Debug Log / request_id | Pass/Fail |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| YYYY-MM-DD | iPhone 16 Pro / iOS 18.x | `systemSmall` | `cold start` | `로그인` | `open_rival_tab` | 라이벌 탭 진입 | 실제 결과 기입 | `[WidgetAction] onOpenURL received:` / `consumePendingWidgetActionIfNeeded` | PASS / FAIL |
+
+## 로그 확인 기준
+- `WidgetAction` 디버그 로그가 남아야 한다.
+- `onOpenURL received` 로그로 deep link 수신을 확인한다.
+- `consumePendingWidgetActionIfNeeded` 또는 defer/replay 경로로 액션 소비 여부를 확인한다.
+- 필요하면 `request_id` 또는 위젯 action route 문자열을 함께 남긴다.
+
+## 운영 규칙
+- `#408`을 닫을 때는 이 문서에 최소 실기기 검증 세트 결과가 채워져 있어야 한다.
+- simulator 결과만으로는 `real-device validation` DoD를 충족하지 않는다.
+- 새 widget action route를 추가하면 자동 회귀 스크립트와 이 문서의 최소 실기기 검증 세트를 같이 갱신한다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -95,6 +95,7 @@ swift scripts/backend_scheduler_ops_unit_check.swift
 swift scripts/backend_geo_fixture_lifecycle_unit_check.swift
 swift scripts/widget_summary_rpc_response_model_unit_check.swift
 swift scripts/widget_lock_screen_accessory_plan_unit_check.swift
+swift scripts/widget_action_regression_pack_unit_check.swift
 swift scripts/watch_smart_stack_glance_plan_unit_check.swift
 swift scripts/watch_main_scroll_overflow_unit_check.swift
 swift scripts/watch_app_icon_asset_unit_check.swift

--- a/scripts/run_widget_action_regression_ui_tests.sh
+++ b/scripts/run_widget_action_regression_ui_tests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DESTINATION="${1:-platform=iOS Simulator,name=iPhone 16,OS=18.5}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-$HOME/Library/Developer/Xcode/DerivedData/dogArea-widget-action-regression}"
+
+echo "[WidgetActionRegressionUI] Destination: $DESTINATION"
+echo "[WidgetActionRegressionUI] DerivedData: $DERIVED_DATA_PATH"
+
+run_ui_test() {
+  local test_case="${1:-}"
+  if [[ -z "$test_case" ]]; then
+    echo "[WidgetActionRegressionUI] Missing test case name"
+    return 1
+  fi
+
+  xcodebuild -scheme dogArea \
+    -derivedDataPath "$DERIVED_DATA_PATH" \
+    -destination "$DESTINATION" \
+    "-only-testing:dogAreaUITests/FeatureRegressionUITests/$test_case" \
+    test-without-building
+}
+
+cd "$PROJECT_ROOT"
+
+echo "[WidgetActionRegressionUI] build-for-testing"
+xcodebuild -scheme dogArea \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  -destination "$DESTINATION" \
+  build-for-testing
+
+run_ui_test "testFeatureRegression_WidgetRouteOpensRivalTab"
+run_ui_test "testFeatureRegression_HotspotWidgetRouteOpensRivalWithMatchingRadiusPreset"
+run_ui_test "testFeatureRegression_QuestWidgetRouteOpensQuestMissionBoard"
+run_ui_test "testFeatureRegression_QuestWidgetRecoveryRouteOpensQuestMissionBoard"
+run_ui_test "testFeatureRegression_TerritoryWidgetRouteOpensGoalDetail"
+
+echo "[WidgetActionRegressionUI] Done"

--- a/scripts/widget_action_regression_pack_unit_check.swift
+++ b/scripts/widget_action_regression_pack_unit_check.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// Loads a text file relative to the repository root.
+/// - Parameter relativePath: Repository-relative file path.
+/// - Returns: UTF-8 decoded text contents.
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .utf8) else {
+        fputs("Failed to load \(relativePath)\n", stderr)
+        exit(1)
+    }
+    return text
+}
+
+/// Fails the script when the provided condition is false.
+/// - Parameters:
+///   - condition: Boolean condition to validate.
+///   - message: Failure message printed to stderr.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("Assertion failed: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let runner = load("scripts/run_widget_action_regression_ui_tests.sh")
+let doc = load("docs/widget-action-real-device-validation-matrix-v1.md")
+let readme = load("README.md")
+let uiRegressionMatrix = load("docs/ui-regression-matrix-v1.md")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+
+let expectedTests = [
+    "testFeatureRegression_WidgetRouteOpensRivalTab",
+    "testFeatureRegression_HotspotWidgetRouteOpensRivalWithMatchingRadiusPreset",
+    "testFeatureRegression_QuestWidgetRouteOpensQuestMissionBoard",
+    "testFeatureRegression_QuestWidgetRecoveryRouteOpensQuestMissionBoard",
+    "testFeatureRegression_TerritoryWidgetRouteOpensGoalDetail"
+]
+
+assertTrue(runner.contains("[WidgetActionRegressionUI] build-for-testing"), "runner should perform build-for-testing")
+assertTrue(runner.contains("test-without-building"), "runner should execute tests without rebuilding each case")
+for testName in expectedTests {
+    assertTrue(runner.contains(testName), "runner should include \(testName)")
+}
+
+assertTrue(doc.contains("# Widget Action Real-Device Validation Matrix v1"), "doc title should exist")
+assertTrue(doc.contains("Issue: #660"), "doc should reference issue #660")
+assertTrue(doc.contains("Relates to: #408"), "doc should reference #408")
+assertTrue(doc.contains("cold start"), "doc should define cold start axis")
+assertTrue(doc.contains("background"), "doc should define background axis")
+assertTrue(doc.contains("foreground"), "doc should define foreground axis")
+assertTrue(doc.contains("로그인"), "doc should define logged-in auth axis")
+assertTrue(doc.contains("로그아웃"), "doc should define logged-out auth axis")
+assertTrue(doc.contains("auth overlay"), "doc should define auth overlay defer axis")
+assertTrue(doc.contains("walk_start"), "doc should include walk_start action")
+assertTrue(doc.contains("walk_end"), "doc should include walk_end action")
+assertTrue(doc.contains("WidgetAction"), "doc should require WidgetAction log evidence")
+assertTrue(doc.contains("consumePendingWidgetActionIfNeeded"), "doc should require pending-action consumption evidence")
+
+assertTrue(readme.contains("docs/widget-action-real-device-validation-matrix-v1.md"), "README should link the widget action validation matrix")
+assertTrue(readme.contains("bash scripts/run_widget_action_regression_ui_tests.sh"), "README should expose the widget action regression runner")
+assertTrue(uiRegressionMatrix.contains("bash scripts/run_widget_action_regression_ui_tests.sh"), "UI regression matrix should list the widget action runner")
+assertTrue(uiRegressionMatrix.contains("FR-WIDGET-005"), "UI regression matrix should map dedicated widget cases")
+assertTrue(iosPRCheck.contains("widget_action_regression_pack_unit_check.swift"), "ios_pr_check should run the widget action regression pack check")
+
+print("PASS: widget action regression pack unit checks")


### PR DESCRIPTION
## Summary
- add a dedicated widget action regression UI runner for the five core widget route tests
- add a canonical real-device validation matrix for widget actions to reduce #408 blocker risk
- wire a static regression-pack gate into README, UI regression matrix, and ios_pr_check

## Verification
- swift scripts/widget_action_regression_pack_unit_check.swift
- swift scripts/widget_intent_openapp_unit_check.swift
- swift scripts/walk_widget_action_state_model_unit_check.swift
- swift scripts/walk_widget_action_convergence_unit_check.swift
- swift scripts/territory_widget_goal_deeplink_unit_check.swift
- swift scripts/quest_rival_widget_next_action_recovery_unit_check.swift
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh
- DERIVED_DATA_PATH=.build/codex-660-widget-action bash scripts/run_widget_action_regression_ui_tests.sh
  - confirmed build-for-testing entry and package resolution; stopped before full completion because fresh DerivedData SwiftPM recompilation was excessive in this environment

Closes #660
Relates to #408
