### PR TITLE
tooling: add blocker evidence helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ playground.xcworkspace
 # .swiftpm
 
 .build/
+.codex_tmp/
 
 # CocoaPods
 #

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - 위젯 액션 실기기 증적 템플릿 v1: `docs/widget-action-real-device-evidence-template-v1.md`
 - 위젯 액션 종료 체크리스트 v1: `docs/widget-action-closure-checklist-v1.md`
 - 위젯 액션 종료 코멘트 템플릿 v1: `docs/widget-action-closure-comment-template-v1.md`
+- Manual evidence helper v1: `docs/manual-evidence-helper-v1.md`
 - Widget state CTA taxonomy v1: `docs/widget-state-cta-taxonomy-v1.md`
 - Widget Lock Screen accessory family plan v1: `docs/widget-lock-screen-accessory-family-plan-v1.md`
 - Watch Smart Stack glance plan v1: `docs/watch-smart-stack-glance-plan-v1.md`
@@ -210,6 +211,7 @@
 - 전체 체크(iOS/watchOS build 포함): `bash scripts/ios_pr_check.sh`
 - 문서/유닛만 빠르게 체크: `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
 - 위젯 액션 기능 회귀 UI: `bash scripts/run_widget_action_regression_ui_tests.sh`
+- blocker evidence helper: `bash scripts/render_manual_evidence_pack.sh <widget|auth-smtp> --write`
 - Backend drift / RPC contract 전용 체크: `bash scripts/backend_migration_drift_check.sh`
 - Backend smoke entrypoint: `bash scripts/backend_pr_check.sh`
 - Live Supabase smoke matrix: `DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/backend_pr_check.sh`

--- a/docs/auth-smtp-rollout-evidence-runbook-v1.md
+++ b/docs/auth-smtp-rollout-evidence-runbook-v1.md
@@ -15,6 +15,7 @@
 - live-send validation matrix: `docs/auth-smtp-live-send-validation-matrix-v1.md`
 - 복붙용 기록 템플릿: `docs/auth-smtp-rollout-evidence-template-v1.md`
 - 종료 체크리스트: `docs/auth-smtp-closure-checklist-v1.md`
+- helper: `bash scripts/render_manual_evidence_pack.sh auth-smtp --write`
 
 ## 최소 증적 세트
 - provider 선택 정보

--- a/docs/manual-evidence-helper-v1.md
+++ b/docs/manual-evidence-helper-v1.md
@@ -1,0 +1,54 @@
+# Manual Evidence Helper v1
+
+- Issue: #672
+- Relates to: #408, #482
+
+## 목적
+- blocker 상태인 manual evidence 이슈를 한 번에 시작할 수 있게 한다.
+- 저장소에 이미 있는 runbook/template/checklist를 한 명령으로 합쳐서 보여주거나 `.codex_tmp/`에 떨어뜨린다.
+- 운영자나 QA가 문서 여러 개를 직접 오가며 복붙하는 비용을 줄인다.
+
+## 엔트리포인트
+- 스크립트: `bash scripts/render_manual_evidence_pack.sh`
+
+## 지원 모드
+- `widget`
+  - 대상 이슈: `#408`
+  - 포함 문서
+    - `docs/widget-action-real-device-evidence-runbook-v1.md`
+    - `docs/widget-action-real-device-validation-matrix-v1.md`
+    - `docs/widget-action-closure-checklist-v1.md`
+    - `docs/widget-action-real-device-evidence-template-v1.md`
+    - `docs/widget-action-closure-comment-template-v1.md`
+- `auth-smtp`
+  - 대상 이슈: `#482`
+  - 포함 문서
+    - `docs/auth-smtp-rollout-evidence-runbook-v1.md`
+    - `docs/auth-smtp-live-send-validation-matrix-v1.md`
+    - `docs/auth-smtp-closure-checklist-v1.md`
+    - `docs/auth-smtp-rollout-evidence-template-v1.md`
+    - `docs/auth-smtp-closure-comment-template-v1.md`
+
+## 사용법
+- stdout으로 바로 보기
+  - `bash scripts/render_manual_evidence_pack.sh widget`
+  - `bash scripts/render_manual_evidence_pack.sh auth-smtp`
+- `.codex_tmp/`에 기본 파일로 쓰기
+  - `bash scripts/render_manual_evidence_pack.sh widget --write`
+  - `bash scripts/render_manual_evidence_pack.sh auth-smtp --write`
+- 원하는 경로로 쓰기
+  - `bash scripts/render_manual_evidence_pack.sh widget --output .codex_tmp/widget-pack.md`
+  - `bash scripts/render_manual_evidence_pack.sh auth-smtp --output .codex_tmp/auth-smtp-pack.md`
+
+## 출력 규칙
+- 기본은 stdout 출력이다.
+- `--write`를 주면 아래 기본 경로를 사용한다.
+  - widget: `.codex_tmp/widget-action-evidence-pack.md`
+  - auth-smtp: `.codex_tmp/auth-smtp-evidence-pack.md`
+- `--output`을 주면 그 경로를 우선 사용한다.
+- 출력에는 runbook/matrix/checklist 경로와 evidence template/closure comment template 본문이 함께 들어간다.
+
+## 운영 규칙
+- 이 helper는 evidence를 대신 채우지 않는다.
+- `#408`, `#482`는 실제 실기기/운영 증적이 들어오기 전까지 닫지 않는다.
+- template 경로가 바뀌면 이 helper와 정적 체크를 같이 갱신한다.

--- a/docs/widget-action-real-device-evidence-runbook-v1.md
+++ b/docs/widget-action-real-device-evidence-runbook-v1.md
@@ -12,6 +12,7 @@
 - 검증 축 정의: `docs/widget-action-real-device-validation-matrix-v1.md`
 - 복붙용 기록 템플릿: `docs/widget-action-real-device-evidence-template-v1.md`
 - 종료 체크리스트: `docs/widget-action-closure-checklist-v1.md`
+- helper: `bash scripts/render_manual_evidence_pack.sh widget --write`
 - 자동 회귀 러너: `bash scripts/run_widget_action_regression_ui_tests.sh`
 
 ## 최소 증적 세트

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -20,6 +20,7 @@ swift scripts/auth_smtp_provider_checklist_unit_check.swift
 swift scripts/auth_smtp_rollout_evidence_unit_check.swift
 swift scripts/auth_smtp_live_send_validation_matrix_unit_check.swift
 swift scripts/auth_smtp_closure_pack_unit_check.swift
+swift scripts/manual_evidence_helper_unit_check.swift
 swift scripts/auth_service_mail_channel_separation_unit_check.swift
 swift scripts/auth_mail_observability_unit_check.swift
 swift scripts/season_canonical_server_state_unit_check.swift

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -98,6 +98,7 @@ swift scripts/widget_lock_screen_accessory_plan_unit_check.swift
 swift scripts/widget_action_regression_pack_unit_check.swift
 swift scripts/widget_action_real_device_evidence_unit_check.swift
 swift scripts/widget_action_closure_pack_unit_check.swift
+swift scripts/manual_evidence_helper_unit_check.swift
 swift scripts/watch_smart_stack_glance_plan_unit_check.swift
 swift scripts/watch_main_scroll_overflow_unit_check.swift
 swift scripts/watch_app_icon_asset_unit_check.swift

--- a/scripts/manual_evidence_helper_unit_check.swift
+++ b/scripts/manual_evidence_helper_unit_check.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// Loads a repository-relative UTF-8 text file.
+/// - Parameter relativePath: Repository-relative path to read.
+/// - Returns: Decoded file contents.
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .utf8) else {
+        fputs("Failed to load \(relativePath)\n", stderr)
+        exit(1)
+    }
+    return text
+}
+
+/// Asserts that a condition holds for the manual evidence helper contract.
+/// - Parameters:
+///   - condition: Condition to validate.
+///   - message: Failure message printed to stderr.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("Assertion failed: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+/// Runs the evidence helper script and captures stdout/stderr.
+/// - Parameter arguments: Arguments passed to the script.
+/// - Returns: Combined UTF-8 output from the launched process.
+func runHelper(arguments: [String]) -> String {
+    let process = Process()
+    process.currentDirectoryURL = root
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = ["scripts/render_manual_evidence_pack.sh"] + arguments
+
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+
+    do {
+        try process.run()
+    } catch {
+        fputs("Failed to launch helper: \(error)\n", stderr)
+        exit(1)
+    }
+
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8) ?? ""
+
+    guard process.terminationStatus == 0 else {
+        fputs("Helper failed with status \(process.terminationStatus)\n\(output)\n", stderr)
+        exit(1)
+    }
+
+    return output
+}
+
+let helperScript = load("scripts/render_manual_evidence_pack.sh")
+let helperDoc = load("docs/manual-evidence-helper-v1.md")
+let widgetRunbook = load("docs/widget-action-real-device-evidence-runbook-v1.md")
+let authRunbook = load("docs/auth-smtp-rollout-evidence-runbook-v1.md")
+let readme = load("README.md")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+let backendPRCheck = load("scripts/backend_pr_check.sh")
+
+assertTrue(helperScript.contains("widget|auth-smtp"), "helper usage should define both modes")
+assertTrue(helperScript.contains(".codex_tmp/widget-action-evidence-pack.md"), "helper should define widget default output")
+assertTrue(helperScript.contains(".codex_tmp/auth-smtp-evidence-pack.md"), "helper should define auth smtp default output")
+assertTrue(helperDoc.contains("bash scripts/render_manual_evidence_pack.sh widget"), "doc should include widget usage")
+assertTrue(helperDoc.contains("bash scripts/render_manual_evidence_pack.sh auth-smtp"), "doc should include auth-smtp usage")
+assertTrue(widgetRunbook.contains("render_manual_evidence_pack.sh"), "widget runbook should mention helper")
+assertTrue(authRunbook.contains("render_manual_evidence_pack.sh"), "auth smtp runbook should mention helper")
+assertTrue(readme.contains("docs/manual-evidence-helper-v1.md"), "README should link helper doc")
+assertTrue(iosPRCheck.contains("manual_evidence_helper_unit_check.swift"), "ios_pr_check should run helper check")
+assertTrue(backendPRCheck.contains("manual_evidence_helper_unit_check.swift"), "backend_pr_check should run helper check")
+
+let widgetOutput = runHelper(arguments: ["widget"])
+assertTrue(widgetOutput.contains("# Widget Action Evidence Pack v1"), "widget output should include title")
+assertTrue(widgetOutput.contains("docs/widget-action-real-device-evidence-template-v1.md"), "widget output should include template path")
+assertTrue(widgetOutput.contains("docs/widget-action-closure-comment-template-v1.md"), "widget output should include closure template path")
+assertTrue(widgetOutput.contains("## Evidence Template"), "widget output should include evidence section")
+assertTrue(widgetOutput.contains("## Closure Comment Template"), "widget output should include closure section")
+
+let authOutput = runHelper(arguments: ["auth-smtp"])
+assertTrue(authOutput.contains("# Auth SMTP Evidence Pack v1"), "auth output should include title")
+assertTrue(authOutput.contains("docs/auth-smtp-rollout-evidence-template-v1.md"), "auth output should include template path")
+assertTrue(authOutput.contains("docs/auth-smtp-closure-comment-template-v1.md"), "auth output should include closure template path")
+
+let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+let tempOutputURL = tempDirectory.appendingPathComponent("manual-evidence-pack-test.md")
+let writeOutput = runHelper(arguments: ["widget", "--output", tempOutputURL.path])
+assertTrue(writeOutput.contains("WROTE \(tempOutputURL.path)"), "write mode should report output path")
+let writtenText = (try? String(contentsOf: tempOutputURL, encoding: .utf8)) ?? ""
+assertTrue(writtenText.contains("# Widget Action Evidence Pack v1"), "written file should include widget title")
+assertTrue(writtenText.contains("docs/widget-action-real-device-evidence-template-v1.md"), "written file should include widget template path")
+
+print("PASS: manual evidence helper contract checks")

--- a/scripts/render_manual_evidence_pack.sh
+++ b/scripts/render_manual_evidence_pack.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/render_manual_evidence_pack.sh <widget|auth-smtp> [--write] [--output <path>]
+
+Examples:
+  bash scripts/render_manual_evidence_pack.sh widget
+  bash scripts/render_manual_evidence_pack.sh widget --write
+  bash scripts/render_manual_evidence_pack.sh auth-smtp --output .codex_tmp/auth-smtp-pack.md
+
+Options:
+  --write         Write to default path under .codex_tmp/
+  --output PATH   Write to a specific output path
+  -h, --help      Print usage
+EOF
+}
+
+die() {
+  printf 'render_manual_evidence_pack.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+kind=""
+write_mode=0
+output_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    widget|auth-smtp)
+      [[ -z "$kind" ]] || die "kind is already set to '$kind'"
+      kind="$1"
+      shift
+      ;;
+    --write)
+      write_mode=1
+      shift
+      ;;
+    --output|-o)
+      [[ $# -ge 2 ]] || die "--output requires a path"
+      output_path="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$kind" ]] || {
+  usage
+  exit 1
+}
+
+case "$kind" in
+  widget)
+    pack_title="Widget Action Evidence Pack v1"
+    related_issue="#408"
+    runbook_path="docs/widget-action-real-device-evidence-runbook-v1.md"
+    matrix_path="docs/widget-action-real-device-validation-matrix-v1.md"
+    checklist_path="docs/widget-action-closure-checklist-v1.md"
+    evidence_template_path="docs/widget-action-real-device-evidence-template-v1.md"
+    closure_template_path="docs/widget-action-closure-comment-template-v1.md"
+    default_output_path=".codex_tmp/widget-action-evidence-pack.md"
+    ;;
+  auth-smtp)
+    pack_title="Auth SMTP Evidence Pack v1"
+    related_issue="#482"
+    runbook_path="docs/auth-smtp-rollout-evidence-runbook-v1.md"
+    matrix_path="docs/auth-smtp-live-send-validation-matrix-v1.md"
+    checklist_path="docs/auth-smtp-closure-checklist-v1.md"
+    evidence_template_path="docs/auth-smtp-rollout-evidence-template-v1.md"
+    closure_template_path="docs/auth-smtp-closure-comment-template-v1.md"
+    default_output_path=".codex_tmp/auth-smtp-evidence-pack.md"
+    ;;
+esac
+
+[[ -f "$runbook_path" ]] || die "missing runbook: $runbook_path"
+[[ -f "$matrix_path" ]] || die "missing matrix: $matrix_path"
+[[ -f "$checklist_path" ]] || die "missing checklist: $checklist_path"
+[[ -f "$evidence_template_path" ]] || die "missing evidence template: $evidence_template_path"
+[[ -f "$closure_template_path" ]] || die "missing closure template: $closure_template_path"
+
+if [[ -z "$output_path" && "$write_mode" == "1" ]]; then
+  output_path="$default_output_path"
+fi
+
+render_pack() {
+  cat <<EOF
+# $pack_title
+
+- Related issue: $related_issue
+- Generated at: $(date '+%Y-%m-%d %H:%M:%S %z')
+- Runbook: \`$runbook_path\`
+- Validation matrix: \`$matrix_path\`
+- Closure checklist: \`$checklist_path\`
+- Evidence template: \`$evidence_template_path\`
+- Closure comment template: \`$closure_template_path\`
+
+## Evidence Template
+
+$(cat "$evidence_template_path")
+
+## Closure Comment Template
+
+$(cat "$closure_template_path")
+EOF
+}
+
+if [[ -n "$output_path" ]]; then
+  mkdir -p "$(dirname "$output_path")"
+  render_pack > "$output_path"
+  printf 'WROTE %s\n' "$output_path"
+else
+  render_pack
+fi


### PR DESCRIPTION
## Summary
- add a shared helper script that renders the widget and auth-smtp manual evidence packs
- support stdout and `.codex_tmp/` write mode so blocker evidence can start from one command
- wire the helper into docs, README, and backend/iOS static checks

## Verification
- bash scripts/render_manual_evidence_pack.sh widget | sed -n "1,24p"
- bash scripts/render_manual_evidence_pack.sh auth-smtp --write
- swift scripts/manual_evidence_helper_unit_check.swift
- swift scripts/widget_action_real_device_evidence_unit_check.swift
- swift scripts/widget_action_closure_pack_unit_check.swift
- swift scripts/auth_smtp_rollout_evidence_unit_check.swift
- swift scripts/auth_smtp_closure_pack_unit_check.swift
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #672
Relates to #408
Relates to #482