### PR TITLE
tooling: add manual evidence validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - 위젯 액션 종료 체크리스트 v1: `docs/widget-action-closure-checklist-v1.md`
 - 위젯 액션 종료 코멘트 템플릿 v1: `docs/widget-action-closure-comment-template-v1.md`
 - Manual evidence helper v1: `docs/manual-evidence-helper-v1.md`
+- Manual evidence validator v1: `docs/manual-evidence-validator-v1.md`
 - Widget state CTA taxonomy v1: `docs/widget-state-cta-taxonomy-v1.md`
 - Widget Lock Screen accessory family plan v1: `docs/widget-lock-screen-accessory-family-plan-v1.md`
 - Watch Smart Stack glance plan v1: `docs/watch-smart-stack-glance-plan-v1.md`
@@ -212,6 +213,7 @@
 - 문서/유닛만 빠르게 체크: `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
 - 위젯 액션 기능 회귀 UI: `bash scripts/run_widget_action_regression_ui_tests.sh`
 - blocker evidence helper: `bash scripts/render_manual_evidence_pack.sh <widget|auth-smtp> --write`
+- blocker evidence validator: `bash scripts/validate_manual_evidence_pack.sh <widget|auth-smtp> <filled-markdown>`
 - Backend drift / RPC contract 전용 체크: `bash scripts/backend_migration_drift_check.sh`
 - Backend smoke entrypoint: `bash scripts/backend_pr_check.sh`
 - Live Supabase smoke matrix: `DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/backend_pr_check.sh`

--- a/docs/auth-smtp-rollout-evidence-runbook-v1.md
+++ b/docs/auth-smtp-rollout-evidence-runbook-v1.md
@@ -83,6 +83,7 @@
 9. bounce/reject/deferred가 있으면 provider event 캡처를 남긴다.
 10. rollback readiness와 secret rotation 담당자를 기록한다.
 11. `docs/auth-smtp-rollout-evidence-template-v1.md` 형식으로 issue 또는 PR 코멘트에 남긴다.
+12. 코멘트로 올리기 전 `bash scripts/validate_manual_evidence_pack.sh auth-smtp <filled-markdown>` 으로 완결성을 검사한다.
 
 ## 실수신 시나리오 규칙
 ### Signup confirmation

--- a/docs/manual-evidence-helper-v1.md
+++ b/docs/manual-evidence-helper-v1.md
@@ -39,6 +39,9 @@
 - 원하는 경로로 쓰기
   - `bash scripts/render_manual_evidence_pack.sh widget --output .codex_tmp/widget-pack.md`
   - `bash scripts/render_manual_evidence_pack.sh auth-smtp --output .codex_tmp/auth-smtp-pack.md`
+- 채운 뒤 validator 실행
+  - `bash scripts/validate_manual_evidence_pack.sh widget .codex_tmp/widget-action-evidence-pack.md`
+  - `bash scripts/validate_manual_evidence_pack.sh auth-smtp .codex_tmp/auth-smtp-evidence-pack.md`
 
 ## 출력 규칙
 - 기본은 stdout 출력이다.

--- a/docs/manual-evidence-validator-v1.md
+++ b/docs/manual-evidence-validator-v1.md
@@ -1,0 +1,50 @@
+# Manual Evidence Validator v1
+
+- Issue: #674
+- Relates to: #408, #482
+
+## 목적
+- helper로 만든 evidence pack이 실제 closure 용도로 충분히 채워졌는지 빠르게 확인한다.
+- 템플릿을 반쯤 채운 채 issue를 닫으려는 실수를 줄인다.
+- `#408`, `#482` blocker를 끝내는 마지막 수동 단계에 실패를 더 앞단에서 잡는다.
+
+## 엔트리포인트
+- 스크립트: `bash scripts/validate_manual_evidence_pack.sh`
+
+## 지원 모드
+- `widget`
+  - 대상: `#408`
+  - 입력: 실기기 결과를 채운 markdown 파일
+  - 검사:
+    - 메타/실행 조건/결과 필수 줄 비어있지 않음
+    - `step-1`, `step-2` 스크린샷 경로 존재
+    - `WidgetAction`, `onOpenURL received`, `consumePendingWidgetActionIfNeeded`, `request_id=` 로그 존재
+    - 템플릿 placeholder literal이 그대로 남아있지 않음
+- `auth-smtp`
+  - 대상: `#482`
+  - 입력: 운영 증적을 채운 markdown 파일
+  - 검사:
+    - DNS / SMTP 설정 / rollback 필드 비어있지 않음
+    - `signup confirmation`, `password reset`, `email change` 시나리오 행이 전부 채워짐
+    - pass/fail 및 blocker 결론 필드 존재
+
+## 사용법
+- helper로 pack 생성
+  - `bash scripts/render_manual_evidence_pack.sh widget --write`
+  - `bash scripts/render_manual_evidence_pack.sh auth-smtp --write`
+- evidence를 채운 뒤 validator 실행
+  - `bash scripts/validate_manual_evidence_pack.sh widget .codex_tmp/widget-action-evidence-pack.md`
+  - `bash scripts/validate_manual_evidence_pack.sh auth-smtp .codex_tmp/auth-smtp-evidence-pack.md`
+
+## 출력 규칙
+- 성공 시
+  - `PASS: widget evidence is complete`
+  - `PASS: auth-smtp evidence is complete`
+- 실패 시
+  - non-zero exit
+  - 누락된 필드/placeholder/미완성 scenario row를 항목별로 출력
+
+## 운영 규칙
+- validator 통과는 closure의 필요조건이지 충분조건은 아니다.
+- `#408`은 실기기 결과 자체가 필요하고, `#482`는 실제 운영 SMTP 증적 자체가 필요하다.
+- 템플릿 구조가 바뀌면 validator와 정적 체크를 같이 갱신한다.

--- a/docs/widget-action-real-device-evidence-runbook-v1.md
+++ b/docs/widget-action-real-device-evidence-runbook-v1.md
@@ -67,6 +67,7 @@
 7. 최종 도착 화면에서 `step-2`를 저장한다.
 8. `docs/widget-action-real-device-evidence-template-v1.md` 형식으로 결과를 기록한다.
 9. 이슈 또는 PR 코멘트에 템플릿 본문과 스크린샷/로그를 함께 남긴다.
+10. 코멘트로 올리기 전 `bash scripts/validate_manual_evidence_pack.sh widget <filled-markdown>` 으로 완결성을 검사한다.
 
 ## Pass 기준
 - 기대한 탭/상세 화면에 도착한다.

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -21,6 +21,7 @@ swift scripts/auth_smtp_rollout_evidence_unit_check.swift
 swift scripts/auth_smtp_live_send_validation_matrix_unit_check.swift
 swift scripts/auth_smtp_closure_pack_unit_check.swift
 swift scripts/manual_evidence_helper_unit_check.swift
+swift scripts/manual_evidence_validator_unit_check.swift
 swift scripts/auth_service_mail_channel_separation_unit_check.swift
 swift scripts/auth_mail_observability_unit_check.swift
 swift scripts/season_canonical_server_state_unit_check.swift

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -99,6 +99,7 @@ swift scripts/widget_action_regression_pack_unit_check.swift
 swift scripts/widget_action_real_device_evidence_unit_check.swift
 swift scripts/widget_action_closure_pack_unit_check.swift
 swift scripts/manual_evidence_helper_unit_check.swift
+swift scripts/manual_evidence_validator_unit_check.swift
 swift scripts/watch_smart_stack_glance_plan_unit_check.swift
 swift scripts/watch_main_scroll_overflow_unit_check.swift
 swift scripts/watch_app_icon_asset_unit_check.swift

--- a/scripts/manual_evidence_validator_unit_check.swift
+++ b/scripts/manual_evidence_validator_unit_check.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// Loads a repository-relative UTF-8 text file.
+/// - Parameter relativePath: Repository-relative path to read.
+/// - Returns: Decoded file contents.
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .utf8) else {
+        fputs("Failed to load \(relativePath)\n", stderr)
+        exit(1)
+    }
+    return text
+}
+
+/// Asserts that a condition holds for the validator contract.
+/// - Parameters:
+///   - condition: Condition to validate.
+///   - message: Failure message printed to stderr.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("Assertion failed: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+/// Executes the validator with the provided arguments.
+/// - Parameters:
+///   - arguments: CLI arguments passed to the validator script.
+///   - expectSuccess: Whether the process should exit successfully.
+/// - Returns: Combined UTF-8 output from stdout and stderr.
+func runValidator(arguments: [String], expectSuccess: Bool) -> String {
+    let process = Process()
+    process.currentDirectoryURL = root
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = ["scripts/validate_manual_evidence_pack.sh"] + arguments
+
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+
+    do {
+        try process.run()
+    } catch {
+        fputs("Failed to launch validator: \(error)\n", stderr)
+        exit(1)
+    }
+
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8) ?? ""
+
+    if expectSuccess && process.terminationStatus != 0 {
+        fputs("Validator should have succeeded.\n\(output)\n", stderr)
+        exit(1)
+    }
+
+    if !expectSuccess && process.terminationStatus == 0 {
+        fputs("Validator should have failed.\n\(output)\n", stderr)
+        exit(1)
+    }
+
+    return output
+}
+
+/// Writes temporary markdown content for validator test cases.
+/// - Parameter content: Markdown body to write.
+/// - Returns: Temporary file URL containing the provided content.
+func writeTemporaryMarkdown(_ content: String) -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent(UUID().uuidString)
+        .appendingPathExtension("md")
+    do {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    } catch {
+        fputs("Failed to write temp markdown: \(error)\n", stderr)
+        exit(1)
+    }
+    return url
+}
+
+let validatorScript = load("scripts/validate_manual_evidence_pack.sh")
+let validatorDoc = load("docs/manual-evidence-validator-v1.md")
+let helperDoc = load("docs/manual-evidence-helper-v1.md")
+let widgetRunbook = load("docs/widget-action-real-device-evidence-runbook-v1.md")
+let authRunbook = load("docs/auth-smtp-rollout-evidence-runbook-v1.md")
+let readme = load("README.md")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+let backendPRCheck = load("scripts/backend_pr_check.sh")
+let widgetTemplate = load("docs/widget-action-real-device-evidence-template-v1.md")
+let authTemplate = load("docs/auth-smtp-rollout-evidence-template-v1.md")
+
+assertTrue(validatorScript.contains("validate_widget"), "validator should define widget validation")
+assertTrue(validatorScript.contains("validate_auth_smtp"), "validator should define auth smtp validation")
+assertTrue(validatorDoc.contains("validate_manual_evidence_pack.sh widget"), "doc should include widget validator usage")
+assertTrue(validatorDoc.contains("validate_manual_evidence_pack.sh auth-smtp"), "doc should include auth-smtp validator usage")
+assertTrue(helperDoc.contains("render_manual_evidence_pack.sh"), "helper doc should still mention render helper")
+assertTrue(widgetRunbook.contains("validate_manual_evidence_pack.sh widget"), "widget runbook should reference validator")
+assertTrue(authRunbook.contains("validate_manual_evidence_pack.sh auth-smtp"), "auth runbook should reference validator")
+assertTrue(readme.contains("docs/manual-evidence-validator-v1.md"), "README should link validator doc")
+assertTrue(iosPRCheck.contains("manual_evidence_validator_unit_check.swift"), "ios_pr_check should run validator check")
+assertTrue(backendPRCheck.contains("manual_evidence_validator_unit_check.swift"), "backend_pr_check should run validator check")
+
+let filledWidget = widgetTemplate
+    .replacingOccurrences(of: "- Date:", with: "- Date: 2026-03-10")
+    .replacingOccurrences(of: "- Tester:", with: "- Tester: codex")
+    .replacingOccurrences(of: "- Device / OS:", with: "- Device / OS: iPhone 16 / iOS 18.5")
+    .replacingOccurrences(of: "- App Build:", with: "- App Build: 2026.03.10.1")
+    .replacingOccurrences(of: "- Widget Family:", with: "- Widget Family: systemMedium")
+    .replacingOccurrences(of: "- Case ID:", with: "- Case ID: WD-001")
+    .replacingOccurrences(of: "- 앱 상태:", with: "- 앱 상태: cold start")
+    .replacingOccurrences(of: "- 인증 상태:", with: "- 인증 상태: 로그인")
+    .replacingOccurrences(of: "- Action Route:", with: "- Action Route: widget://walk/start")
+    .replacingOccurrences(of: "- Expected Result:", with: "- Expected Result: map start deck opens")
+    .replacingOccurrences(of: "- Summary:", with: "- Summary: expected route opened")
+    .replacingOccurrences(of: "- Final Screen:", with: "- Final Screen: MapView")
+    .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
+    .replacingOccurrences(of: "[WidgetAction] ...", with: "[WidgetAction] action=startWalk request_id=abc")
+    .replacingOccurrences(of: "onOpenURL received: ...", with: "onOpenURL received: widget://walk/start")
+    .replacingOccurrences(of: "consumePendingWidgetActionIfNeeded ...", with: "consumePendingWidgetActionIfNeeded consumed=startWalk")
+    .replacingOccurrences(of: "request_id=...", with: "request_id=abc")
+    .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: WD-001-step-1.png")
+    .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: WD-001-step-2.png")
+
+let filledAuth = authTemplate
+    .replacingOccurrences(of: "- Date:", with: "- Date: 2026-03-10")
+    .replacingOccurrences(of: "- Operator:", with: "- Operator: codex")
+    .replacingOccurrences(of: "- Supabase Project:", with: "- Supabase Project: ttjiknenynbhbpoqoesq")
+    .replacingOccurrences(of: "- Provider:", with: "- Provider: Resend")
+    .replacingOccurrences(of: "- Sender Domain:", with: "- Sender Domain: auth.dogarea.app")
+    .replacingOccurrences(of: "- SPF:", with: "- SPF: pass")
+    .replacingOccurrences(of: "- DKIM:", with: "- DKIM: verified")
+    .replacingOccurrences(of: "- DMARC:", with: "- DMARC: present")
+    .replacingOccurrences(of: "- Provider Verified Timestamp:", with: "- Provider Verified Timestamp: 2026-03-10T12:00:00Z")
+    .replacingOccurrences(of: "- Evidence Screenshot:", with: "- Evidence Screenshot: smtp-domain.png")
+    .replacingOccurrences(of: "- SMTP Host:", with: "- SMTP Host: smtp.resend.com")
+    .replacingOccurrences(of: "- SMTP Port:", with: "- SMTP Port: 587")
+    .replacingOccurrences(of: "- SMTP User Mask:", with: "- SMTP User Mask: re_***")
+    .replacingOccurrences(of: "- Sender Name:", with: "- Sender Name: DogArea Auth")
+    .replacingOccurrences(of: "- Sender Email:", with: "- Sender Email: auth@auth.dogarea.app")
+    .replacingOccurrences(of: "- `email_sent`:", with: "- `email_sent`: true")
+    .replacingOccurrences(of: "- `auth.email.max_frequency`:", with: "- `auth.email.max_frequency`: 60")
+    .replacingOccurrences(of: "- Settings Screenshot:", with: "- Settings Screenshot: smtp-settings.png")
+    .replacingOccurrences(of: "| signup confirmation |  |  |  |  |  |  |  |", with: "| signup confirmation | a***@dogarea.test | 2026-03-10 12:00 | yes | yes | req-1 | msg-1 | ok |")
+    .replacingOccurrences(of: "| password reset |  |  |  |  |  |  |  |", with: "| password reset | a***@dogarea.test | 2026-03-10 12:05 | yes | yes | req-2 | msg-2 | ok |")
+    .replacingOccurrences(of: "| email change |  |  |  |  |  |  |  |", with: "| email change | a***@dogarea.test | 2026-03-10 12:10 | yes | yes | req-3 | msg-3 | ok |")
+    .replacingOccurrences(of: "- bounce:", with: "- bounce: none observed")
+    .replacingOccurrences(of: "- reject:", with: "- reject: none observed")
+    .replacingOccurrences(of: "- deferred:", with: "- deferred: none observed")
+    .replacingOccurrences(of: "- provider_event_id:", with: "- provider_event_id: evt-1")
+    .replacingOccurrences(of: "- Dashboard / Webhook Evidence:", with: "- Dashboard / Webhook Evidence: resend-dashboard.png")
+    .replacingOccurrences(of: "- rollback path:", with: "- rollback path: revert to previous SMTP config")
+    .replacingOccurrences(of: "- secret rotation owner:", with: "- secret rotation owner: ops@dogarea")
+    .replacingOccurrences(of: "- tested backup path:", with: "- tested backup path: staging resend account")
+    .replacingOccurrences(of: "- notes:", with: "- notes: none")
+    .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
+    .replacingOccurrences(of: "- Remaining Blockers:", with: "- Remaining Blockers: none")
+    .replacingOccurrences(of: "- Linked Issue / PR Comment:", with: "- Linked Issue / PR Comment: issue comment url")
+
+let rawWidgetURL = writeTemporaryMarkdown(widgetTemplate)
+let rawAuthURL = writeTemporaryMarkdown(authTemplate)
+let filledWidgetURL = writeTemporaryMarkdown(filledWidget)
+let filledAuthURL = writeTemporaryMarkdown(filledAuth)
+
+let rawWidgetOutput = runValidator(arguments: ["widget", rawWidgetURL.path], expectSuccess: false)
+assertTrue(rawWidgetOutput.contains("FAIL: widget evidence is incomplete"), "raw widget template should fail")
+assertTrue(rawWidgetOutput.contains("empty value: - Date:"), "raw widget template should flag empty date")
+assertTrue(rawWidgetOutput.contains("placeholder literal remains: [WidgetAction] ..."), "raw widget template should flag placeholder log")
+
+let filledWidgetOutput = runValidator(arguments: ["widget", filledWidgetURL.path], expectSuccess: true)
+assertTrue(filledWidgetOutput.contains("PASS: widget evidence is complete"), "filled widget evidence should pass")
+
+let rawAuthOutput = runValidator(arguments: ["auth-smtp", rawAuthURL.path], expectSuccess: false)
+assertTrue(rawAuthOutput.contains("FAIL: auth-smtp evidence is incomplete"), "raw auth template should fail")
+assertTrue(rawAuthOutput.contains("empty value: - Provider:"), "raw auth template should flag empty provider")
+assertTrue(rawAuthOutput.contains("incomplete scenario row: signup confirmation"), "raw auth template should flag empty scenario row")
+
+let filledAuthOutput = runValidator(arguments: ["auth-smtp", filledAuthURL.path], expectSuccess: true)
+assertTrue(filledAuthOutput.contains("PASS: auth-smtp evidence is complete"), "filled auth evidence should pass")
+
+print("PASS: manual evidence validator contract checks")

--- a/scripts/validate_manual_evidence_pack.sh
+++ b/scripts/validate_manual_evidence_pack.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/validate_manual_evidence_pack.sh <widget|auth-smtp> <markdown-path>
+
+Examples:
+  bash scripts/validate_manual_evidence_pack.sh widget .codex_tmp/widget-action-evidence-pack.md
+  bash scripts/validate_manual_evidence_pack.sh auth-smtp .codex_tmp/auth-smtp-evidence-pack.md
+EOF
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+line_by_prefix() {
+  local prefix="$1"
+  local file="$2"
+  awk -v prefix="$prefix" 'index($0, prefix) == 1 { print; exit }' "$file"
+}
+
+errors=()
+
+add_error() {
+  errors+=("$1")
+}
+
+require_nonempty_prefixed_line() {
+  local prefix="$1"
+  local file="$2"
+  local line value
+
+  line="$(line_by_prefix "$prefix" "$file")"
+  if [[ -z "$line" ]]; then
+    add_error "missing line: $prefix"
+    return
+  fi
+
+  value="${line#"$prefix"}"
+  value="$(trim "$value")"
+  if [[ -z "$value" ]]; then
+    add_error "empty value: $prefix"
+  fi
+}
+
+require_absent_literal() {
+  local literal="$1"
+  local file="$2"
+  if grep -Fqx "$literal" "$file"; then
+    add_error "placeholder literal remains: $literal"
+  fi
+}
+
+require_contains() {
+  local literal="$1"
+  local file="$2"
+  if ! grep -Fq "$literal" "$file"; then
+    add_error "missing content: $literal"
+  fi
+}
+
+require_auth_row_filled() {
+  local scenario="$1"
+  local file="$2"
+  local row
+
+  row="$(awk -F'|' -v scenario="$scenario" '
+    {
+      first = $2
+      gsub(/^[ \t]+|[ \t]+$/, "", first)
+      if (first == scenario) {
+        print $0
+        exit
+      }
+    }
+  ' "$file")"
+
+  if [[ -z "$row" ]]; then
+    add_error "missing scenario row: $scenario"
+    return
+  fi
+
+  awk -F'|' -v row="$row" -v scenario="$scenario" '
+    BEGIN {
+      split(row, cells, "|")
+      fail = 0
+      for (i = 3; i <= 9; i++) {
+        value = cells[i]
+        gsub(/^[ \t]+|[ \t]+$/, "", value)
+        if (value == "") {
+          fail = 1
+        }
+      }
+      if (fail == 1) {
+        exit 1
+      }
+    }
+  ' || add_error "incomplete scenario row: $scenario"
+}
+
+validate_widget() {
+  local file="$1"
+
+  require_nonempty_prefixed_line "- Date:" "$file"
+  require_nonempty_prefixed_line "- Tester:" "$file"
+  require_nonempty_prefixed_line "- Device / OS:" "$file"
+  require_nonempty_prefixed_line "- App Build:" "$file"
+  require_nonempty_prefixed_line "- Widget Family:" "$file"
+  require_nonempty_prefixed_line "- Case ID:" "$file"
+  require_nonempty_prefixed_line "- 앱 상태:" "$file"
+  require_nonempty_prefixed_line "- 인증 상태:" "$file"
+  require_nonempty_prefixed_line "- Action Route:" "$file"
+  require_nonempty_prefixed_line "- Expected Result:" "$file"
+  require_nonempty_prefixed_line "- Summary:" "$file"
+  require_nonempty_prefixed_line "- Final Screen:" "$file"
+  require_nonempty_prefixed_line "- Pass / Fail:" "$file"
+  require_nonempty_prefixed_line "- \`step-1\`:" "$file"
+  require_nonempty_prefixed_line "- \`step-2\`:" "$file"
+
+  require_contains "[WidgetAction]" "$file"
+  require_contains "onOpenURL received" "$file"
+  require_contains "consumePendingWidgetActionIfNeeded" "$file"
+  require_contains "request_id=" "$file"
+
+  require_absent_literal "[WidgetAction] ..." "$file"
+  require_absent_literal "onOpenURL received: ..." "$file"
+  require_absent_literal "consumePendingWidgetActionIfNeeded ..." "$file"
+  require_absent_literal "request_id=..." "$file"
+}
+
+validate_auth_smtp() {
+  local file="$1"
+
+  require_nonempty_prefixed_line "- Date:" "$file"
+  require_nonempty_prefixed_line "- Operator:" "$file"
+  require_nonempty_prefixed_line "- Supabase Project:" "$file"
+  require_nonempty_prefixed_line "- Provider:" "$file"
+  require_nonempty_prefixed_line "- Sender Domain:" "$file"
+  require_nonempty_prefixed_line "- SPF:" "$file"
+  require_nonempty_prefixed_line "- DKIM:" "$file"
+  require_nonempty_prefixed_line "- DMARC:" "$file"
+  require_nonempty_prefixed_line "- Provider Verified Timestamp:" "$file"
+  require_nonempty_prefixed_line "- Evidence Screenshot:" "$file"
+  require_nonempty_prefixed_line "- SMTP Host:" "$file"
+  require_nonempty_prefixed_line "- SMTP Port:" "$file"
+  require_nonempty_prefixed_line "- SMTP User Mask:" "$file"
+  require_nonempty_prefixed_line "- Sender Name:" "$file"
+  require_nonempty_prefixed_line "- Sender Email:" "$file"
+  require_nonempty_prefixed_line "- \`email_sent\`:" "$file"
+  require_nonempty_prefixed_line "- \`auth.email.max_frequency\`:" "$file"
+  require_nonempty_prefixed_line "- Settings Screenshot:" "$file"
+  require_nonempty_prefixed_line "- bounce:" "$file"
+  require_nonempty_prefixed_line "- reject:" "$file"
+  require_nonempty_prefixed_line "- deferred:" "$file"
+  require_nonempty_prefixed_line "- provider_event_id:" "$file"
+  require_nonempty_prefixed_line "- Dashboard / Webhook Evidence:" "$file"
+  require_nonempty_prefixed_line "- rollback path:" "$file"
+  require_nonempty_prefixed_line "- secret rotation owner:" "$file"
+  require_nonempty_prefixed_line "- tested backup path:" "$file"
+  require_nonempty_prefixed_line "- Pass / Fail:" "$file"
+  require_nonempty_prefixed_line "- Remaining Blockers:" "$file"
+  require_nonempty_prefixed_line "- Linked Issue / PR Comment:" "$file"
+
+  require_auth_row_filled "signup confirmation" "$file"
+  require_auth_row_filled "password reset" "$file"
+  require_auth_row_filled "email change" "$file"
+}
+
+kind="${1:-}"
+path="${2:-}"
+
+if [[ -z "$kind" || -z "$path" ]]; then
+  usage
+  exit 1
+fi
+
+[[ -f "$path" ]] || {
+  printf 'validate_manual_evidence_pack.sh: missing file: %s\n' "$path" >&2
+  exit 1
+}
+
+case "$kind" in
+  widget)
+    validate_widget "$path"
+    ;;
+  auth-smtp)
+    validate_auth_smtp "$path"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac
+
+if [[ "${#errors[@]}" -gt 0 ]]; then
+  printf 'FAIL: %s evidence is incomplete\n' "$kind" >&2
+  for error in "${errors[@]}"; do
+    printf ' - %s\n' "$error" >&2
+  done
+  exit 1
+fi
+
+printf 'PASS: %s evidence is complete\n' "$kind"


### PR DESCRIPTION
## Summary
- add a shared validator script for filled widget and auth-smtp evidence markdown
- reject half-filled templates before they are pasted into blocker closure comments
- wire the validator into README, runbooks, and backend/iOS static checks

## Verification
- swift scripts/manual_evidence_validator_unit_check.swift
- swift scripts/manual_evidence_helper_unit_check.swift
- swift scripts/widget_action_real_device_evidence_unit_check.swift
- swift scripts/auth_smtp_rollout_evidence_unit_check.swift
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #674
Relates to #408
Relates to #482