### PR TITLE
tooling: add manual closure comment renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - 위젯 액션 종료 코멘트 템플릿 v1: `docs/widget-action-closure-comment-template-v1.md`
 - Manual evidence helper v1: `docs/manual-evidence-helper-v1.md`
 - Manual evidence validator v1: `docs/manual-evidence-validator-v1.md`
+- Manual closure comment renderer v1: `docs/manual-closure-comment-renderer-v1.md`
 - Widget state CTA taxonomy v1: `docs/widget-state-cta-taxonomy-v1.md`
 - Widget Lock Screen accessory family plan v1: `docs/widget-lock-screen-accessory-family-plan-v1.md`
 - Watch Smart Stack glance plan v1: `docs/watch-smart-stack-glance-plan-v1.md`
@@ -214,6 +215,7 @@
 - 위젯 액션 기능 회귀 UI: `bash scripts/run_widget_action_regression_ui_tests.sh`
 - blocker evidence helper: `bash scripts/render_manual_evidence_pack.sh <widget|auth-smtp> --write`
 - blocker evidence validator: `bash scripts/validate_manual_evidence_pack.sh <widget|auth-smtp> <filled-markdown>`
+- blocker closure renderer: `bash scripts/render_closure_comment_from_evidence.sh <widget|auth-smtp> ...`
 - Backend drift / RPC contract 전용 체크: `bash scripts/backend_migration_drift_check.sh`
 - Backend smoke entrypoint: `bash scripts/backend_pr_check.sh`
 - Live Supabase smoke matrix: `DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/backend_pr_check.sh`

--- a/docs/manual-closure-comment-renderer-v1.md
+++ b/docs/manual-closure-comment-renderer-v1.md
@@ -1,0 +1,48 @@
+# Manual Closure Comment Renderer v1
+
+- Issue: #676
+- Relates to: #408, #482
+
+## 목적
+- validated evidence를 최종 종료 코멘트 형태로 빠르게 변환한다.
+- 위젯은 다건 evidence를 case 단위로 집계하고, auth-smtp는 운영 evidence에서 provider/dns/positive case를 자동 채운다.
+- 마지막 수작업을 줄이되, 실제 실증 결과 입력 자체는 사용자가 유지한다.
+
+## 엔트리포인트
+- 스크립트: `bash scripts/render_closure_comment_from_evidence.sh`
+
+## 지원 모드
+- `widget`
+  - 입력: validated widget evidence 파일 8개가 들어있는 디렉터리 또는 단일 파일
+  - 요구사항:
+    - 모든 `WD-001` ... `WD-008` evidence가 있어야 함
+    - 각 파일은 validator를 통과해야 함
+    - 각 파일은 `Pass`여야 함
+  - 출력:
+    - `#408` 종료 코멘트 초안
+- `auth-smtp`
+  - 입력: validated auth smtp evidence 파일 1개
+  - 추가 플래그:
+    - `--negative-guard "<text>"`
+    - `--negative-provider-event "<text>"`
+  - 출력:
+    - `#482` 종료 코멘트 초안
+
+## 사용법
+- 위젯
+  - `bash scripts/render_closure_comment_from_evidence.sh widget .codex_tmp/widget-evidence-dir`
+  - `bash scripts/render_closure_comment_from_evidence.sh widget .codex_tmp/widget-evidence-dir --write`
+- auth-smtp
+  - `bash scripts/render_closure_comment_from_evidence.sh auth-smtp .codex_tmp/auth-smtp-evidence-pack.md --negative-guard "SMTP-101: cooldown suppressed with retry_after_seconds=60" --negative-provider-event "SMTP-102: bounce observed in provider dashboard" --write`
+
+## 출력 규칙
+- 기본은 stdout 출력
+- `--write` 기본 경로
+  - widget: `.codex_tmp/widget-action-closure-comment.md`
+  - auth-smtp: `.codex_tmp/auth-smtp-closure-comment.md`
+- `--output <path>`로 별도 경로 지정 가능
+
+## 운영 규칙
+- renderer는 validator 통과 전 evidence를 받지 않는다.
+- renderer가 comment body를 만든다고 해서 이슈를 자동 종료하지는 않는다.
+- `#408`, `#482` 종료 전에는 실제 로그/스크린샷/실수신 결과가 채워졌는지 최종 검토가 필요하다.

--- a/docs/manual-evidence-validator-v1.md
+++ b/docs/manual-evidence-validator-v1.md
@@ -35,6 +35,9 @@
 - evidence를 채운 뒤 validator 실행
   - `bash scripts/validate_manual_evidence_pack.sh widget .codex_tmp/widget-action-evidence-pack.md`
   - `bash scripts/validate_manual_evidence_pack.sh auth-smtp .codex_tmp/auth-smtp-evidence-pack.md`
+- validator 통과 뒤 closure comment 생성
+  - `bash scripts/render_closure_comment_from_evidence.sh widget <evidence-dir> --write`
+  - `bash scripts/render_closure_comment_from_evidence.sh auth-smtp .codex_tmp/auth-smtp-evidence-pack.md --negative-guard \"...\" --negative-provider-event \"...\" --write`
 
 ## 출력 규칙
 - 성공 시

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -22,6 +22,7 @@ swift scripts/auth_smtp_live_send_validation_matrix_unit_check.swift
 swift scripts/auth_smtp_closure_pack_unit_check.swift
 swift scripts/manual_evidence_helper_unit_check.swift
 swift scripts/manual_evidence_validator_unit_check.swift
+swift scripts/manual_closure_comment_renderer_unit_check.swift
 swift scripts/auth_service_mail_channel_separation_unit_check.swift
 swift scripts/auth_mail_observability_unit_check.swift
 swift scripts/season_canonical_server_state_unit_check.swift

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -100,6 +100,7 @@ swift scripts/widget_action_real_device_evidence_unit_check.swift
 swift scripts/widget_action_closure_pack_unit_check.swift
 swift scripts/manual_evidence_helper_unit_check.swift
 swift scripts/manual_evidence_validator_unit_check.swift
+swift scripts/manual_closure_comment_renderer_unit_check.swift
 swift scripts/watch_smart_stack_glance_plan_unit_check.swift
 swift scripts/watch_main_scroll_overflow_unit_check.swift
 swift scripts/watch_app_icon_asset_unit_check.swift

--- a/scripts/manual_closure_comment_renderer_unit_check.swift
+++ b/scripts/manual_closure_comment_renderer_unit_check.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// Loads a repository-relative UTF-8 text file.
+/// - Parameter relativePath: Repository-relative path to read.
+/// - Returns: Decoded file contents.
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .utf8) else {
+        fputs("Failed to load \(relativePath)\n", stderr)
+        exit(1)
+    }
+    return text
+}
+
+/// Asserts that a condition holds for the renderer contract.
+/// - Parameters:
+///   - condition: Condition to validate.
+///   - message: Failure message printed to stderr.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("Assertion failed: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+/// Runs the renderer script and captures combined output.
+/// - Parameters:
+///   - arguments: CLI arguments passed to the renderer.
+///   - expectSuccess: Whether the script should succeed.
+/// - Returns: Combined stdout and stderr.
+func runRenderer(arguments: [String], expectSuccess: Bool) -> String {
+    let process = Process()
+    process.currentDirectoryURL = root
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = ["scripts/render_closure_comment_from_evidence.sh"] + arguments
+
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+
+    do {
+        try process.run()
+    } catch {
+        fputs("Failed to launch renderer: \(error)\n", stderr)
+        exit(1)
+    }
+
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8) ?? ""
+
+    if expectSuccess && process.terminationStatus != 0 {
+        fputs("Renderer should have succeeded.\n\(output)\n", stderr)
+        exit(1)
+    }
+    if !expectSuccess && process.terminationStatus == 0 {
+        fputs("Renderer should have failed.\n\(output)\n", stderr)
+        exit(1)
+    }
+    return output
+}
+
+/// Writes temporary markdown content into a dedicated directory.
+/// - Parameters:
+///   - directory: Base directory.
+///   - filename: File name to create.
+///   - content: Markdown body to write.
+/// - Returns: URL for the written file.
+func writeMarkdown(in directory: URL, filename: String, content: String) -> URL {
+    let url = directory.appendingPathComponent(filename)
+    do {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    } catch {
+        fputs("Failed to write markdown: \(error)\n", stderr)
+        exit(1)
+    }
+    return url
+}
+
+let rendererScript = load("scripts/render_closure_comment_from_evidence.sh")
+let rendererDoc = load("docs/manual-closure-comment-renderer-v1.md")
+let validatorDoc = load("docs/manual-evidence-validator-v1.md")
+let readme = load("README.md")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+let backendPRCheck = load("scripts/backend_pr_check.sh")
+let widgetTemplate = load("docs/widget-action-real-device-evidence-template-v1.md")
+let authTemplate = load("docs/auth-smtp-rollout-evidence-template-v1.md")
+
+assertTrue(rendererScript.contains("render_widget_comment"), "renderer should support widget rendering")
+assertTrue(rendererScript.contains("render_auth_comment"), "renderer should support auth rendering")
+assertTrue(rendererDoc.contains("render_closure_comment_from_evidence.sh widget"), "renderer doc should include widget usage")
+assertTrue(rendererDoc.contains("render_closure_comment_from_evidence.sh auth-smtp"), "renderer doc should include auth usage")
+assertTrue(validatorDoc.contains("validate_manual_evidence_pack.sh"), "validator doc should still mention validator")
+assertTrue(readme.contains("docs/manual-closure-comment-renderer-v1.md"), "README should link renderer doc")
+assertTrue(iosPRCheck.contains("manual_closure_comment_renderer_unit_check.swift"), "ios_pr_check should run renderer check")
+assertTrue(backendPRCheck.contains("manual_closure_comment_renderer_unit_check.swift"), "backend_pr_check should run renderer check")
+
+func filledWidget(caseID: String, summary: String) -> String {
+    widgetTemplate
+        .replacingOccurrences(of: "- Date:", with: "- Date: 2026-03-10")
+        .replacingOccurrences(of: "- Tester:", with: "- Tester: codex")
+        .replacingOccurrences(of: "- Device / OS:", with: "- Device / OS: iPhone 16 / iOS 18.5")
+        .replacingOccurrences(of: "- App Build:", with: "- App Build: 2026.03.10.1")
+        .replacingOccurrences(of: "- Widget Family:", with: "- Widget Family: systemMedium")
+        .replacingOccurrences(of: "- Case ID:", with: "- Case ID: \(caseID)")
+        .replacingOccurrences(of: "- 앱 상태:", with: "- 앱 상태: cold start")
+        .replacingOccurrences(of: "- 인증 상태:", with: "- 인증 상태: 로그인")
+        .replacingOccurrences(of: "- Action Route:", with: "- Action Route: widget://\(caseID.lowercased())")
+        .replacingOccurrences(of: "- Expected Result:", with: "- Expected Result: expected destination opens")
+        .replacingOccurrences(of: "- Summary:", with: "- Summary: \(summary)")
+        .replacingOccurrences(of: "- Final Screen:", with: "- Final Screen: FinalScreen")
+        .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
+        .replacingOccurrences(of: "[WidgetAction] ...", with: "[WidgetAction] action=\(caseID) request_id=req-\(caseID)")
+        .replacingOccurrences(of: "onOpenURL received: ...", with: "onOpenURL received: widget://\(caseID.lowercased())")
+        .replacingOccurrences(of: "consumePendingWidgetActionIfNeeded ...", with: "consumePendingWidgetActionIfNeeded consumed=\(caseID)")
+        .replacingOccurrences(of: "request_id=...", with: "request_id=req-\(caseID)")
+        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+}
+
+let widgetDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+let widgetCases = [
+    "WD-001": "rival tab opened",
+    "WD-002": "hotspot broad preset applied",
+    "WD-003": "quest detail opened",
+    "WD-004": "quest recovery opened",
+    "WD-005": "territory goal opened",
+    "WD-006": "walk started from widget",
+    "WD-007": "walk ended from widget",
+    "WD-008": "auth overlay defer worked",
+]
+for (caseID, summary) in widgetCases {
+    _ = writeMarkdown(in: widgetDirectory, filename: "\(caseID).md", content: filledWidget(caseID: caseID, summary: summary))
+}
+
+let widgetOutput = runRenderer(arguments: ["widget", widgetDirectory.path], expectSuccess: true)
+assertTrue(widgetOutput.contains("실기기 위젯 액션 검증을 완료했습니다."), "widget comment should include intro")
+assertTrue(widgetOutput.contains("`WD-001`: Pass - rival tab opened"), "widget comment should include WD-001 summary")
+assertTrue(widgetOutput.contains("`WD-008`: Pass - auth overlay defer worked"), "widget comment should include WD-008 summary")
+assertTrue(widgetOutput.contains("`#408` DoD를 충족했으므로 종료합니다."), "widget comment should include closure line")
+
+let incompleteWidgetDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+_ = writeMarkdown(in: incompleteWidgetDirectory, filename: "WD-001.md", content: filledWidget(caseID: "WD-001", summary: "only one case"))
+let incompleteWidgetOutput = runRenderer(arguments: ["widget", incompleteWidgetDirectory.path], expectSuccess: false)
+assertTrue(incompleteWidgetOutput.contains("missing widget case WD-002"), "widget renderer should fail on missing case set")
+
+let filledAuth = authTemplate
+    .replacingOccurrences(of: "- Date:", with: "- Date: 2026-03-10")
+    .replacingOccurrences(of: "- Operator:", with: "- Operator: codex")
+    .replacingOccurrences(of: "- Supabase Project:", with: "- Supabase Project: ttjiknenynbhbpoqoesq")
+    .replacingOccurrences(of: "- Provider:", with: "- Provider: Resend")
+    .replacingOccurrences(of: "- Sender Domain:", with: "- Sender Domain: auth.dogarea.app")
+    .replacingOccurrences(of: "- SPF:", with: "- SPF: pass")
+    .replacingOccurrences(of: "- DKIM:", with: "- DKIM: verified")
+    .replacingOccurrences(of: "- DMARC:", with: "- DMARC: present")
+    .replacingOccurrences(of: "- Provider Verified Timestamp:", with: "- Provider Verified Timestamp: 2026-03-10T12:00:00Z")
+    .replacingOccurrences(of: "- Evidence Screenshot:", with: "- Evidence Screenshot: smtp-domain.png")
+    .replacingOccurrences(of: "- SMTP Host:", with: "- SMTP Host: smtp.resend.com")
+    .replacingOccurrences(of: "- SMTP Port:", with: "- SMTP Port: 587")
+    .replacingOccurrences(of: "- SMTP User Mask:", with: "- SMTP User Mask: re_***")
+    .replacingOccurrences(of: "- Sender Name:", with: "- Sender Name: DogArea Auth")
+    .replacingOccurrences(of: "- Sender Email:", with: "- Sender Email: auth@auth.dogarea.app")
+    .replacingOccurrences(of: "- `email_sent`:", with: "- `email_sent`: true")
+    .replacingOccurrences(of: "- `auth.email.max_frequency`:", with: "- `auth.email.max_frequency`: 60")
+    .replacingOccurrences(of: "- Settings Screenshot:", with: "- Settings Screenshot: smtp-settings.png")
+    .replacingOccurrences(of: "| signup confirmation |  |  |  |  |  |  |  |", with: "| signup confirmation | a***@dogarea.test | 2026-03-10 12:00 | yes | yes | req-1 | msg-1 | ok |")
+    .replacingOccurrences(of: "| password reset |  |  |  |  |  |  |  |", with: "| password reset | a***@dogarea.test | 2026-03-10 12:05 | yes | yes | req-2 | msg-2 | ok |")
+    .replacingOccurrences(of: "| email change |  |  |  |  |  |  |  |", with: "| email change | a***@dogarea.test | 2026-03-10 12:10 | yes | yes | req-3 | msg-3 | ok |")
+    .replacingOccurrences(of: "- bounce:", with: "- bounce: none observed")
+    .replacingOccurrences(of: "- reject:", with: "- reject: none observed")
+    .replacingOccurrences(of: "- deferred:", with: "- deferred: none observed")
+    .replacingOccurrences(of: "- provider_event_id:", with: "- provider_event_id: evt-1")
+    .replacingOccurrences(of: "- Dashboard / Webhook Evidence:", with: "- Dashboard / Webhook Evidence: resend-dashboard.png")
+    .replacingOccurrences(of: "- rollback path:", with: "- rollback path: revert to previous SMTP config")
+    .replacingOccurrences(of: "- secret rotation owner:", with: "- secret rotation owner: ops@dogarea")
+    .replacingOccurrences(of: "- tested backup path:", with: "- tested backup path: staging resend account")
+    .replacingOccurrences(of: "- notes:", with: "- notes: none")
+    .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
+    .replacingOccurrences(of: "- Remaining Blockers:", with: "- Remaining Blockers: none")
+    .replacingOccurrences(of: "- Linked Issue / PR Comment:", with: "- Linked Issue / PR Comment: issue comment url")
+
+let authURL = writeMarkdown(in: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString), filename: "auth.md", content: filledAuth)
+let authOutput = runRenderer(
+    arguments: [
+        "auth-smtp",
+        authURL.path,
+        "--negative-guard", "SMTP-101: cooldown suppressed with retry_after_seconds=60",
+        "--negative-provider-event", "SMTP-102: bounce observed with provider_event_id=evt-1",
+    ],
+    expectSuccess: true
+)
+assertTrue(authOutput.contains("Provider: Resend"), "auth comment should include provider")
+assertTrue(authOutput.contains("`SMTP-001`: recipient=a***@dogarea.test, accepted=yes, mailbox=yes, provider_message_id=msg-1"), "auth comment should include SMTP-001 summary")
+assertTrue(authOutput.contains("`SMTP-101`: SMTP-101: cooldown suppressed with retry_after_seconds=60"), "auth comment should include guard summary")
+assertTrue(authOutput.contains("`#482` DoD를 충족했으므로 종료합니다."), "auth comment should include closure line")
+
+let authMissingFlagOutput = runRenderer(arguments: ["auth-smtp", authURL.path], expectSuccess: false)
+assertTrue(authMissingFlagOutput.contains("--negative-guard is required for auth-smtp"), "auth renderer should require negative guard flag")
+
+print("PASS: manual closure comment renderer contract checks")

--- a/scripts/render_closure_comment_from_evidence.sh
+++ b/scripts/render_closure_comment_from_evidence.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/render_closure_comment_from_evidence.sh widget <evidence-dir-or-file> [--write] [--output <path>]
+  bash scripts/render_closure_comment_from_evidence.sh auth-smtp <evidence-file> --negative-guard <text> --negative-provider-event <text> [--write] [--output <path>]
+EOF
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+line_by_prefix() {
+  local prefix="$1"
+  local file="$2"
+  awk -v prefix="$prefix" 'index($0, prefix) == 1 { print; exit }' "$file"
+}
+
+extract_prefixed_value() {
+  local prefix="$1"
+  local file="$2"
+  local line value
+  line="$(line_by_prefix "$prefix" "$file")"
+  [[ -n "$line" ]] || {
+    printf 'render_closure_comment_from_evidence.sh: missing line %s in %s\n' "$prefix" "$file" >&2
+    exit 1
+  }
+  value="${line#"$prefix"}"
+  trim "$value"
+}
+
+collect_row_message() {
+  local scenario="$1"
+  local file="$2"
+  awk -F'|' -v scenario="$scenario" '
+    {
+      first = $2
+      gsub(/^[ \t]+|[ \t]+$/, "", first)
+      if (first == scenario) {
+        recipientMask = $3
+        acceptedState = $5
+        receivedState = $6
+        providerMessageID = $8
+        gsub(/^[ \t]+|[ \t]+$/, "", recipientMask)
+        gsub(/^[ \t]+|[ \t]+$/, "", acceptedState)
+        gsub(/^[ \t]+|[ \t]+$/, "", receivedState)
+        gsub(/^[ \t]+|[ \t]+$/, "", providerMessageID)
+        printf "recipient=%s, accepted=%s, mailbox=%s, provider_message_id=%s", recipientMask, acceptedState, receivedState, providerMessageID
+        exit
+      }
+    }
+  ' "$file"
+}
+
+kind="${1:-}"
+input_path="${2:-}"
+shift $(( $# >= 2 ? 2 : $# ))
+
+[[ -n "$kind" && -n "$input_path" ]] || {
+  usage
+  exit 1
+}
+
+negative_guard=""
+negative_provider_event=""
+write_mode=0
+output_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --negative-guard)
+      negative_guard="${2:-}"
+      shift 2
+      ;;
+    --negative-provider-event)
+      negative_provider_event="${2:-}"
+      shift 2
+      ;;
+    --write)
+      write_mode=1
+      shift
+      ;;
+    --output|-o)
+      output_path="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'render_closure_comment_from_evidence.sh: unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$kind" in
+  widget)
+    default_output_path=".codex_tmp/widget-action-closure-comment.md"
+    ;;
+  auth-smtp)
+    default_output_path=".codex_tmp/auth-smtp-closure-comment.md"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac
+
+if [[ -z "$output_path" && "$write_mode" == "1" ]]; then
+  output_path="$default_output_path"
+fi
+
+render_widget_comment() {
+  local path="$1"
+  local -a files
+  local -a expected_ids=(WD-001 WD-002 WD-003 WD-004 WD-005 WD-006 WD-007 WD-008)
+  local summary_map_file
+  summary_map_file="$(mktemp)"
+  trap 'rm -f "$summary_map_file"' RETURN
+
+  if [[ -d "$path" ]]; then
+    while IFS= read -r file; do
+      files+=("$file")
+    done < <(find "$path" -maxdepth 1 -type f -name '*.md' | sort)
+  else
+    files=("$path")
+  fi
+
+  [[ "${#files[@]}" -gt 0 ]] || {
+    printf 'render_closure_comment_from_evidence.sh: no widget evidence files found\n' >&2
+    exit 1
+  }
+
+  for file in "${files[@]}"; do
+    bash scripts/validate_manual_evidence_pack.sh widget "$file" >/dev/null || return 1
+    local case_id summary pass_fail
+    case_id="$(extract_prefixed_value "- Case ID:" "$file")"
+    summary="$(extract_prefixed_value "- Summary:" "$file")"
+    pass_fail="$(extract_prefixed_value "- Pass / Fail:" "$file")"
+    if [[ "$pass_fail" != "Pass" && "$pass_fail" != "PASS" ]]; then
+      printf 'render_closure_comment_from_evidence.sh: widget case %s is not passing\n' "$case_id" >&2
+      exit 1
+    fi
+    printf '%s\t%s\n' "$case_id" "Pass - $summary" >> "$summary_map_file"
+  done
+
+  for case_id in "${expected_ids[@]}"; do
+    if ! awk -F'\t' -v case_id="$case_id" '$1 == case_id { found = 1 } END { exit(found ? 0 : 1) }' "$summary_map_file"; then
+      printf 'render_closure_comment_from_evidence.sh: missing widget case %s\n' "$case_id" >&2
+      exit 1
+    fi
+  done
+
+  summary_for_case() {
+    local case_id="$1"
+    awk -F'\t' -v case_id="$case_id" '$1 == case_id { print $2; exit }' "$summary_map_file"
+  }
+
+  cat <<EOF
+실기기 위젯 액션 검증을 완료했습니다.
+
+검증 기준 문서
+- \`docs/widget-action-real-device-validation-matrix-v1.md\`
+- \`docs/widget-action-real-device-evidence-runbook-v1.md\`
+- \`docs/widget-action-closure-checklist-v1.md\`
+
+완료 케이스
+- \`WD-001\`: $(summary_for_case WD-001)
+- \`WD-002\`: $(summary_for_case WD-002)
+- \`WD-003\`: $(summary_for_case WD-003)
+- \`WD-004\`: $(summary_for_case WD-004)
+- \`WD-005\`: $(summary_for_case WD-005)
+- \`WD-006\`: $(summary_for_case WD-006)
+- \`WD-007\`: $(summary_for_case WD-007)
+- \`WD-008\`: $(summary_for_case WD-008)
+
+공통 로그 확인
+- \`WidgetAction\`
+- \`onOpenURL received\`
+- \`consumePendingWidgetActionIfNeeded\`
+
+남은 blocker
+- 없음
+
+결론
+- \`#408\` DoD를 충족했으므로 종료합니다.
+EOF
+}
+
+render_auth_comment() {
+  local file="$1"
+  [[ -n "$negative_guard" ]] || {
+    printf 'render_closure_comment_from_evidence.sh: --negative-guard is required for auth-smtp\n' >&2
+    exit 1
+  }
+  [[ -n "$negative_provider_event" ]] || {
+    printf 'render_closure_comment_from_evidence.sh: --negative-provider-event is required for auth-smtp\n' >&2
+    exit 1
+  }
+
+  bash scripts/validate_manual_evidence_pack.sh auth-smtp "$file" >/dev/null || return 1
+
+  local provider sender project spf dkim dmarc
+  provider="$(extract_prefixed_value "- Provider:" "$file")"
+  sender="$(extract_prefixed_value "- Sender Domain:" "$file")"
+  project="$(extract_prefixed_value "- Supabase Project:" "$file")"
+  spf="$(extract_prefixed_value "- SPF:" "$file")"
+  dkim="$(extract_prefixed_value "- DKIM:" "$file")"
+  dmarc="$(extract_prefixed_value "- DMARC:" "$file")"
+
+  local signup_summary reset_summary change_summary
+  signup_summary="$(collect_row_message "signup confirmation" "$file")"
+  reset_summary="$(collect_row_message "password reset" "$file")"
+  change_summary="$(collect_row_message "email change" "$file")"
+
+  cat <<EOF
+custom SMTP rollout 운영 증적을 확인했습니다.
+
+검증 기준 문서
+- \`docs/auth-smtp-provider-selection-dns-secret-checklist-v1.md\`
+- \`docs/auth-smtp-rollout-evidence-runbook-v1.md\`
+- \`docs/auth-smtp-live-send-validation-matrix-v1.md\`
+- \`docs/auth-smtp-closure-checklist-v1.md\`
+
+provider / sender
+- Provider: $provider
+- Sender Domain: $sender
+- Supabase Project: $project
+
+DNS verification
+- SPF: $spf
+- DKIM: $dkim
+- DMARC: $dmarc
+
+Positive cases
+- \`SMTP-001\`: $signup_summary
+- \`SMTP-002\`: $reset_summary
+- \`SMTP-003\`: $change_summary
+
+Negative / guard evidence
+- \`SMTP-101\`: $negative_guard
+- \`SMTP-102\` or \`SMTP-103\`: $negative_provider_event
+
+Rollback / rotation
+- rollback path: $(extract_prefixed_value "- rollback path:" "$file")
+- secret rotation owner: $(extract_prefixed_value "- secret rotation owner:" "$file")
+
+남은 blocker
+- 없음
+
+결론
+- \`#482\` DoD를 충족했으므로 종료합니다.
+EOF
+}
+
+if [[ "$kind" == "widget" ]]; then
+  rendered="$(render_widget_comment "$input_path")"
+else
+  rendered="$(render_auth_comment "$input_path")"
+fi
+
+if [[ -n "$output_path" ]]; then
+  mkdir -p "$(dirname "$output_path")"
+  printf '%s\n' "$rendered" > "$output_path"
+  printf 'WROTE %s\n' "$output_path"
+else
+  printf '%s\n' "$rendered"
+fi


### PR DESCRIPTION
## Summary
- add a renderer that converts validated widget/auth evidence into close-ready GitHub comments
- document the renderer and wire its unit check into backend/iOS PR checks
- extend the validator runbook so the manual evidence flow ends in rendered closure comments

Closes #676