### PR TITLE
tooling: add closure comment poster helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - Manual evidence helper v1: `docs/manual-evidence-helper-v1.md`
 - Manual evidence validator v1: `docs/manual-evidence-validator-v1.md`
 - Manual closure comment renderer v1: `docs/manual-closure-comment-renderer-v1.md`
+- Manual closure comment poster v1: `docs/manual-closure-comment-poster-v1.md`
 - Widget state CTA taxonomy v1: `docs/widget-state-cta-taxonomy-v1.md`
 - Widget Lock Screen accessory family plan v1: `docs/widget-lock-screen-accessory-family-plan-v1.md`
 - Watch Smart Stack glance plan v1: `docs/watch-smart-stack-glance-plan-v1.md`
@@ -218,6 +219,7 @@
 - blocker evidence helper: `bash scripts/render_manual_evidence_pack.sh <widget|auth-smtp> --write`
 - blocker evidence validator: `bash scripts/validate_manual_evidence_pack.sh <widget|auth-smtp> <filled-markdown>`
 - blocker closure renderer: `bash scripts/render_closure_comment_from_evidence.sh <widget|auth-smtp> ...`
+- blocker closure poster: `bash scripts/post_closure_comment_from_evidence.sh <widget|auth-smtp> --issue <number> ... [--post]`
 - Backend drift / RPC contract 전용 체크: `bash scripts/backend_migration_drift_check.sh`
 - Backend smoke entrypoint: `bash scripts/backend_pr_check.sh`
 - Live Supabase smoke matrix: `DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/backend_pr_check.sh`

--- a/docs/auth-smtp-rollout-evidence-runbook-v1.md
+++ b/docs/auth-smtp-rollout-evidence-runbook-v1.md
@@ -84,6 +84,7 @@
 10. rollback readiness와 secret rotation 담당자를 기록한다.
 11. `docs/auth-smtp-rollout-evidence-template-v1.md` 형식으로 issue 또는 PR 코멘트에 남긴다.
 12. 코멘트로 올리기 전 `bash scripts/validate_manual_evidence_pack.sh auth-smtp <filled-markdown>` 으로 완결성을 검사한다.
+13. closure comment를 바로 게시하려면 `bash scripts/post_closure_comment_from_evidence.sh auth-smtp --issue 482 <filled-markdown> --negative-guard "..." --negative-provider-event "..." --post`를 사용한다.
 
 ## 실수신 시나리오 규칙
 ### Signup confirmation

--- a/docs/manual-closure-comment-poster-v1.md
+++ b/docs/manual-closure-comment-poster-v1.md
@@ -1,0 +1,47 @@
+# Manual Closure Comment Poster v1
+
+- Issue: #684
+- Relates to: #408, #482
+
+## 목적
+- validator와 renderer를 통과한 evidence를 GitHub issue comment로 바로 게시한다.
+- 마지막 복붙 단계를 제거하되, 잘못된 surface/issue 조합으로 닫는 실수를 막는다.
+
+## 엔트리포인트
+- 스크립트: `bash scripts/post_closure_comment_from_evidence.sh`
+
+## 지원 surface / issue 조합
+- `widget` -> `#408`
+- `auth-smtp` -> `#482`
+
+다른 issue 번호로는 실행되지 않는다.
+
+## 동작 순서
+1. surface / issue 조합을 검증한다.
+2. 기존 renderer를 호출해 closure comment를 만든다.
+3. 기본값에서는 stdout으로 출력만 한다.
+4. `--post`를 주면 `gh issue comment`로 실제 게시한다.
+
+## 사용법
+- widget dry-run
+  - `bash scripts/post_closure_comment_from_evidence.sh widget --issue 408 .codex_tmp/widget-evidence-dir`
+- widget post
+  - `bash scripts/post_closure_comment_from_evidence.sh widget --issue 408 .codex_tmp/widget-evidence-dir --post`
+- auth-smtp dry-run
+  - `bash scripts/post_closure_comment_from_evidence.sh auth-smtp --issue 482 .codex_tmp/auth-smtp-evidence-pack.md --negative-guard "SMTP-101: cooldown suppressed with retry_after_seconds=60" --negative-provider-event "SMTP-102: bounce observed in provider dashboard"`
+- auth-smtp post
+  - `bash scripts/post_closure_comment_from_evidence.sh auth-smtp --issue 482 .codex_tmp/auth-smtp-evidence-pack.md --negative-guard "SMTP-101: cooldown suppressed with retry_after_seconds=60" --negative-provider-event "SMTP-102: bounce observed in provider dashboard" --post`
+
+## 출력 규칙
+- 기본은 dry-run이며 rendered comment만 출력한다.
+- `--post`를 주면 `gh issue comment`를 호출한다.
+- `--output <path>`를 주면 renderer 결과를 해당 경로에 남긴 뒤 dry-run/post를 진행한다.
+
+## 운영 규칙
+- 이 스크립트는 validator를 우회하지 않는다. 실제 검증은 renderer 내부에서 다시 강제된다.
+- surface/issue canonical pair가 맞지 않으면 즉시 실패한다.
+- 실제 issue close는 별도 판단으로 진행한다. 이 스크립트는 comment 게시까지만 담당한다.
+
+## 테스트 seam
+- `DOGAREA_GH_BIN`으로 `gh` 대체 바이너리를 주입할 수 있다.
+- 로컬 계약 테스트는 fake `gh`로 `issue comment` 호출 인자를 검증한다.

--- a/docs/manual-closure-comment-renderer-v1.md
+++ b/docs/manual-closure-comment-renderer-v1.md
@@ -45,4 +45,5 @@
 ## 운영 규칙
 - renderer는 validator 통과 전 evidence를 받지 않는다.
 - renderer가 comment body를 만든다고 해서 이슈를 자동 종료하지는 않는다.
+- 실제 게시가 필요하면 `bash scripts/post_closure_comment_from_evidence.sh ... --post`를 사용한다.
 - `#408`, `#482` 종료 전에는 실제 로그/스크린샷/실수신 결과가 채워졌는지 최종 검토가 필요하다.

--- a/docs/manual-evidence-validator-v1.md
+++ b/docs/manual-evidence-validator-v1.md
@@ -38,6 +38,8 @@
 - validator 통과 뒤 closure comment 생성
   - `bash scripts/render_closure_comment_from_evidence.sh widget <evidence-dir> --write`
   - `bash scripts/render_closure_comment_from_evidence.sh auth-smtp .codex_tmp/auth-smtp-evidence-pack.md --negative-guard \"...\" --negative-provider-event \"...\" --write`
+  - `bash scripts/post_closure_comment_from_evidence.sh widget --issue 408 <evidence-dir> --post`
+  - `bash scripts/post_closure_comment_from_evidence.sh auth-smtp --issue 482 .codex_tmp/auth-smtp-evidence-pack.md --negative-guard \"...\" --negative-provider-event \"...\" --post`
 
 ## 출력 규칙
 - 성공 시

--- a/docs/widget-action-real-device-evidence-runbook-v1.md
+++ b/docs/widget-action-real-device-evidence-runbook-v1.md
@@ -68,6 +68,7 @@
 8. `docs/widget-action-real-device-evidence-template-v1.md` 형식으로 결과를 기록한다.
 9. 이슈 또는 PR 코멘트에 템플릿 본문과 스크린샷/로그를 함께 남긴다.
 10. 코멘트로 올리기 전 `bash scripts/validate_manual_evidence_pack.sh widget <filled-markdown>` 으로 완결성을 검사한다.
+11. closure comment를 바로 게시하려면 `bash scripts/post_closure_comment_from_evidence.sh widget --issue 408 <evidence-dir> --post`를 사용한다.
 
 ## Pass 기준
 - 기대한 탭/상세 화면에 도착한다.

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -23,6 +23,7 @@ swift scripts/auth_smtp_closure_pack_unit_check.swift
 swift scripts/manual_evidence_helper_unit_check.swift
 swift scripts/manual_evidence_validator_unit_check.swift
 swift scripts/manual_closure_comment_renderer_unit_check.swift
+swift scripts/manual_closure_comment_poster_unit_check.swift
 swift scripts/auth_service_mail_channel_separation_unit_check.swift
 swift scripts/auth_mail_observability_unit_check.swift
 swift scripts/season_canonical_server_state_unit_check.swift

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -101,6 +101,7 @@ swift scripts/widget_action_closure_pack_unit_check.swift
 swift scripts/manual_evidence_helper_unit_check.swift
 swift scripts/manual_evidence_validator_unit_check.swift
 swift scripts/manual_closure_comment_renderer_unit_check.swift
+swift scripts/manual_closure_comment_poster_unit_check.swift
 swift scripts/watch_smart_stack_glance_plan_unit_check.swift
 swift scripts/watch_main_scroll_overflow_unit_check.swift
 swift scripts/watch_app_icon_asset_unit_check.swift

--- a/scripts/manual_closure_comment_poster_unit_check.swift
+++ b/scripts/manual_closure_comment_poster_unit_check.swift
@@ -1,0 +1,271 @@
+import Foundation
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+/// Loads a repository-relative UTF-8 text file.
+/// - Parameter relativePath: Repository-relative path to read.
+/// - Returns: Decoded file contents.
+func load(_ relativePath: String) -> String {
+    let url = root.appendingPathComponent(relativePath)
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .utf8) else {
+        fputs("Failed to load \(relativePath)\n", stderr)
+        exit(1)
+    }
+    return text
+}
+
+/// Loads a UTF-8 text file from an absolute URL.
+/// - Parameter url: File URL to read.
+/// - Returns: Decoded file contents.
+func loadAbsolute(_ url: URL) -> String {
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .utf8) else {
+        fputs("Failed to load \(url.path)\n", stderr)
+        exit(1)
+    }
+    return text
+}
+
+/// Asserts that a condition holds for the poster contract.
+/// - Parameters:
+///   - condition: Condition to validate.
+///   - message: Failure message printed to stderr.
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("Assertion failed: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+/// Runs the poster script and captures combined output.
+/// - Parameters:
+///   - arguments: CLI arguments passed to the poster.
+///   - environment: Extra environment values for the process.
+///   - expectSuccess: Whether the script should succeed.
+/// - Returns: Combined stdout and stderr.
+func runPoster(arguments: [String], environment: [String: String] = [:], expectSuccess: Bool) -> String {
+    let process = Process()
+    process.currentDirectoryURL = root
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = ["scripts/post_closure_comment_from_evidence.sh"] + arguments
+
+    var mergedEnvironment = ProcessInfo.processInfo.environment
+    environment.forEach { mergedEnvironment[$0.key] = $0.value }
+    process.environment = mergedEnvironment
+
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+
+    do {
+        try process.run()
+    } catch {
+        fputs("Failed to launch poster: \(error)\n", stderr)
+        exit(1)
+    }
+
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8) ?? ""
+
+    if expectSuccess && process.terminationStatus != 0 {
+        fputs("Poster should have succeeded.\n\(output)\n", stderr)
+        exit(1)
+    }
+    if !expectSuccess && process.terminationStatus == 0 {
+        fputs("Poster should have failed.\n\(output)\n", stderr)
+        exit(1)
+    }
+    return output
+}
+
+/// Writes temporary markdown content into a dedicated directory.
+/// - Parameters:
+///   - directory: Base directory.
+///   - filename: File name to create.
+///   - content: Markdown body to write.
+/// - Returns: URL for the written file.
+func writeMarkdown(in directory: URL, filename: String, content: String) -> URL {
+    let url = directory.appendingPathComponent(filename)
+    do {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    } catch {
+        fputs("Failed to write markdown: \(error)\n", stderr)
+        exit(1)
+    }
+    return url
+}
+
+/// Creates a fake gh binary that records its arguments.
+/// - Parameter directory: Temporary directory that owns the fake binary.
+/// - Returns: URLs for the fake binary and captured log.
+func makeFakeGH(in directory: URL) -> (binary: URL, log: URL) {
+    let logURL = directory.appendingPathComponent("gh.log")
+    let binaryURL = directory.appendingPathComponent("fake-gh.sh")
+    let script = """
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf '%s\\n' "$*" >> "\(logURL.path)"
+    printf 'https://example.test/issues/comment\\n'
+    """
+    do {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try script.write(to: binaryURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+    } catch {
+        fputs("Failed to create fake gh: \(error)\n", stderr)
+        exit(1)
+    }
+    return (binaryURL, logURL)
+}
+
+let posterScript = load("scripts/post_closure_comment_from_evidence.sh")
+let posterDoc = load("docs/manual-closure-comment-poster-v1.md")
+let rendererDoc = load("docs/manual-closure-comment-renderer-v1.md")
+let validatorDoc = load("docs/manual-evidence-validator-v1.md")
+let widgetRunbook = load("docs/widget-action-real-device-evidence-runbook-v1.md")
+let authRunbook = load("docs/auth-smtp-rollout-evidence-runbook-v1.md")
+let readme = load("README.md")
+let iosPRCheck = load("scripts/ios_pr_check.sh")
+let backendPRCheck = load("scripts/backend_pr_check.sh")
+let widgetTemplate = load("docs/widget-action-real-device-evidence-template-v1.md")
+let authTemplate = load("docs/auth-smtp-rollout-evidence-template-v1.md")
+
+assertTrue(posterScript.contains("canonical_issue_for_surface"), "poster should validate canonical surface/issue pairs")
+assertTrue(posterScript.contains("gh issue comment"), "poster should post through gh issue comment")
+assertTrue(posterScript.contains("DOGAREA_GH_BIN"), "poster should expose gh override for tests")
+assertTrue(posterDoc.contains("widget --issue 408"), "poster doc should include widget usage")
+assertTrue(posterDoc.contains("auth-smtp --issue 482"), "poster doc should include auth usage")
+assertTrue(rendererDoc.contains("render_closure_comment_from_evidence.sh"), "renderer doc should remain linked")
+assertTrue(validatorDoc.contains("post_closure_comment_from_evidence.sh"), "validator doc should reference poster")
+assertTrue(widgetRunbook.contains("post_closure_comment_from_evidence.sh widget --issue 408"), "widget runbook should reference poster")
+assertTrue(authRunbook.contains("post_closure_comment_from_evidence.sh auth-smtp --issue 482"), "auth runbook should reference poster")
+assertTrue(readme.contains("docs/manual-closure-comment-poster-v1.md"), "README should link poster doc")
+assertTrue(readme.contains("post_closure_comment_from_evidence.sh"), "README should include poster helper command")
+assertTrue(iosPRCheck.contains("manual_closure_comment_poster_unit_check.swift"), "ios_pr_check should run poster check")
+assertTrue(backendPRCheck.contains("manual_closure_comment_poster_unit_check.swift"), "backend_pr_check should run poster check")
+
+func filledWidget(caseID: String, summary: String) -> String {
+    widgetTemplate
+        .replacingOccurrences(of: "- Date:", with: "- Date: 2026-03-10")
+        .replacingOccurrences(of: "- Tester:", with: "- Tester: codex")
+        .replacingOccurrences(of: "- Device / OS:", with: "- Device / OS: iPhone 16 / iOS 18.5")
+        .replacingOccurrences(of: "- App Build:", with: "- App Build: 2026.03.10")
+        .replacingOccurrences(of: "- Widget Family:", with: "- Widget Family: systemSmall")
+        .replacingOccurrences(of: "- Case ID:", with: "- Case ID: \(caseID)")
+        .replacingOccurrences(of: "- 앱 상태:", with: "- 앱 상태: background")
+        .replacingOccurrences(of: "- 인증 상태:", with: "- 인증 상태: member")
+        .replacingOccurrences(of: "- Action Route:", with: "- Action Route: dogarea://widget/\(caseID.lowercased())")
+        .replacingOccurrences(of: "- Expected Result:", with: "- Expected Result: app opens the correct surface")
+        .replacingOccurrences(of: "- Summary:", with: "- Summary: \(summary)")
+        .replacingOccurrences(of: "- Final Screen:", with: "- Final Screen: expected destination")
+        .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
+        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+        .replacingOccurrences(of: "- `step-fail`:", with: "- `step-fail`: not needed")
+        .replacingOccurrences(of: "[WidgetAction] ...", with: "[WidgetAction] route=\(caseID.lowercased())")
+        .replacingOccurrences(of: "onOpenURL received: ...", with: "onOpenURL received: dogarea://widget/\(caseID.lowercased())")
+        .replacingOccurrences(of: "consumePendingWidgetActionIfNeeded ...", with: "consumePendingWidgetActionIfNeeded action=\(caseID.lowercased())")
+        .replacingOccurrences(of: "request_id=...", with: "request_id=req-\(caseID.lowercased())")
+}
+
+let widgetTempDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+let widgetCases: [(String, String)] = [
+    ("WD-001", "member start route converged"),
+    ("WD-002", "member stop route converged"),
+    ("WD-003", "guest route deferred into auth"),
+    ("WD-004", "overlay replay converged"),
+    ("WD-005", "territory deeplink converged"),
+    ("WD-006", "quest deeplink converged"),
+    ("WD-007", "hotspot deeplink converged"),
+    ("WD-008", "pending action replay converged"),
+]
+for (caseID, summary) in widgetCases {
+    _ = writeMarkdown(in: widgetTempDir, filename: "\(caseID).md", content: filledWidget(caseID: caseID, summary: summary))
+}
+
+let widgetDryRunOutput = runPoster(arguments: ["widget", "--issue", "408", widgetTempDir.path], expectSuccess: true)
+assertTrue(widgetDryRunOutput.contains("실기기 위젯 액션 검증을 완료했습니다."), "widget dry-run should print closure comment")
+assertTrue(widgetDryRunOutput.contains("DRY RUN: no GitHub comment was posted."), "widget dry-run should explain posting did not happen")
+
+let widgetMismatchOutput = runPoster(arguments: ["widget", "--issue", "482", widgetTempDir.path], expectSuccess: false)
+assertTrue(widgetMismatchOutput.contains("surface widget must target issue #408"), "widget poster should reject mismatched issue")
+
+let fakeWidgetGH = makeFakeGH(in: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString))
+let widgetPostOutput = runPoster(
+    arguments: ["widget", "--issue", "408", widgetTempDir.path, "--post"],
+    environment: ["DOGAREA_GH_BIN": fakeWidgetGH.binary.path],
+    expectSuccess: true
+)
+let widgetGHLog = loadAbsolute(fakeWidgetGH.log)
+assertTrue(widgetGHLog.contains("issue comment 408 --body-file"), "widget post should call gh issue comment with issue 408")
+assertTrue(widgetPostOutput.contains("POSTED issue #408"), "widget post should report successful post")
+
+let filledAuth = authTemplate
+    .replacingOccurrences(of: "- Date:", with: "- Date: 2026-03-10")
+    .replacingOccurrences(of: "- Operator:", with: "- Operator: codex")
+    .replacingOccurrences(of: "- Supabase Project:", with: "- Supabase Project: ttjiknenynbhbpoqoesq")
+    .replacingOccurrences(of: "- Provider:", with: "- Provider: Resend")
+    .replacingOccurrences(of: "- Sender Domain:", with: "- Sender Domain: auth.dogarea.app")
+    .replacingOccurrences(of: "- SPF:", with: "- SPF: pass")
+    .replacingOccurrences(of: "- DKIM:", with: "- DKIM: verified")
+    .replacingOccurrences(of: "- DMARC:", with: "- DMARC: present")
+    .replacingOccurrences(of: "- Provider Verified Timestamp:", with: "- Provider Verified Timestamp: 2026-03-10T12:00:00Z")
+    .replacingOccurrences(of: "- Evidence Screenshot:", with: "- Evidence Screenshot: smtp-domain.png")
+    .replacingOccurrences(of: "- SMTP Host:", with: "- SMTP Host: smtp.resend.com")
+    .replacingOccurrences(of: "- SMTP Port:", with: "- SMTP Port: 587")
+    .replacingOccurrences(of: "- SMTP User Mask:", with: "- SMTP User Mask: re_***")
+    .replacingOccurrences(of: "- Sender Name:", with: "- Sender Name: DogArea Auth")
+    .replacingOccurrences(of: "- Sender Email:", with: "- Sender Email: auth@auth.dogarea.app")
+    .replacingOccurrences(of: "- `email_sent`:", with: "- `email_sent`: true")
+    .replacingOccurrences(of: "- `auth.email.max_frequency`:", with: "- `auth.email.max_frequency`: 60")
+    .replacingOccurrences(of: "- Settings Screenshot:", with: "- Settings Screenshot: smtp-settings.png")
+    .replacingOccurrences(of: "| signup confirmation |  |  |  |  |  |  |  |", with: "| signup confirmation | a***@dogarea.test | 2026-03-10 12:00 | yes | yes | req-1 | msg-1 | ok |")
+    .replacingOccurrences(of: "| password reset |  |  |  |  |  |  |  |", with: "| password reset | a***@dogarea.test | 2026-03-10 12:05 | yes | yes | req-2 | msg-2 | ok |")
+    .replacingOccurrences(of: "| email change |  |  |  |  |  |  |  |", with: "| email change | a***@dogarea.test | 2026-03-10 12:10 | yes | yes | req-3 | msg-3 | ok |")
+    .replacingOccurrences(of: "- bounce:", with: "- bounce: none observed")
+    .replacingOccurrences(of: "- reject:", with: "- reject: none observed")
+    .replacingOccurrences(of: "- deferred:", with: "- deferred: none observed")
+    .replacingOccurrences(of: "- provider_event_id:", with: "- provider_event_id: evt-1")
+    .replacingOccurrences(of: "- Dashboard / Webhook Evidence:", with: "- Dashboard / Webhook Evidence: resend-dashboard.png")
+    .replacingOccurrences(of: "- rollback path:", with: "- rollback path: revert to previous SMTP config")
+    .replacingOccurrences(of: "- secret rotation owner:", with: "- secret rotation owner: ops@dogarea")
+    .replacingOccurrences(of: "- tested backup path:", with: "- tested backup path: staging resend account")
+    .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
+    .replacingOccurrences(of: "- Remaining Blockers:", with: "- Remaining Blockers: none")
+    .replacingOccurrences(of: "- Linked Issue / PR Comment:", with: "- Linked Issue / PR Comment: issue comment url")
+
+let authURL = writeMarkdown(in: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString), filename: "auth.md", content: filledAuth)
+let authDryRunOutput = runPoster(
+    arguments: [
+        "auth-smtp",
+        "--issue", "482",
+        authURL.path,
+        "--negative-guard", "SMTP-101: cooldown suppressed with retry_after_seconds=60",
+        "--negative-provider-event", "SMTP-102: bounce observed with provider_event_id=evt-1",
+    ],
+    expectSuccess: true
+)
+assertTrue(authDryRunOutput.contains("custom SMTP rollout 운영 증적을 확인했습니다."), "auth dry-run should print closure comment")
+assertTrue(authDryRunOutput.contains("DRY RUN: no GitHub comment was posted."), "auth dry-run should explain posting did not happen")
+
+let fakeAuthGH = makeFakeGH(in: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString))
+let authPostOutput = runPoster(
+    arguments: [
+        "auth-smtp",
+        "--issue", "482",
+        authURL.path,
+        "--negative-guard", "SMTP-101: cooldown suppressed with retry_after_seconds=60",
+        "--negative-provider-event", "SMTP-102: bounce observed with provider_event_id=evt-1",
+        "--post",
+    ],
+    environment: ["DOGAREA_GH_BIN": fakeAuthGH.binary.path],
+    expectSuccess: true
+)
+let authGHLog = loadAbsolute(fakeAuthGH.log)
+assertTrue(authGHLog.contains("issue comment 482 --body-file"), "auth post should call gh issue comment with issue 482")
+assertTrue(authPostOutput.contains("POSTED issue #482"), "auth post should report successful post")
+
+print("PASS: manual closure comment poster contract checks")

--- a/scripts/post_closure_comment_from_evidence.sh
+++ b/scripts/post_closure_comment_from_evidence.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/post_closure_comment_from_evidence.sh widget --issue 408 <evidence-dir-or-file> [--post] [--output <path>]
+  bash scripts/post_closure_comment_from_evidence.sh auth-smtp --issue 482 <evidence-file> --negative-guard <text> --negative-provider-event <text> [--post] [--output <path>]
+
+Notes:
+  - Default mode is dry-run. The rendered closure comment is printed to stdout.
+  - Use --post to actually publish the rendered comment with gh issue comment.
+  - Surface and issue must match the canonical pair:
+      widget -> #408
+      auth-smtp -> #482
+EOF
+}
+
+die() {
+  printf 'post_closure_comment_from_evidence.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+canonical_issue_for_surface() {
+  local surface="$1"
+  case "$surface" in
+    widget)
+      printf '408'
+      ;;
+    auth-smtp)
+      printf '482'
+      ;;
+    *)
+      die "unsupported surface: $surface"
+      ;;
+  esac
+}
+
+kind=""
+issue_number=""
+evidence_path=""
+negative_guard=""
+negative_provider_event=""
+post_mode=0
+output_path=""
+gh_bin="${DOGAREA_GH_BIN:-gh}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    widget|auth-smtp)
+      [[ -z "$kind" ]] || die "surface is already set to '$kind'"
+      kind="$1"
+      shift
+      ;;
+    --issue)
+      [[ $# -ge 2 ]] || die "--issue requires a value"
+      issue_number="${2#\#}"
+      shift 2
+      ;;
+    --negative-guard)
+      [[ $# -ge 2 ]] || die "--negative-guard requires a value"
+      negative_guard="$2"
+      shift 2
+      ;;
+    --negative-provider-event)
+      [[ $# -ge 2 ]] || die "--negative-provider-event requires a value"
+      negative_provider_event="$2"
+      shift 2
+      ;;
+    --post)
+      post_mode=1
+      shift
+      ;;
+    --output|-o)
+      [[ $# -ge 2 ]] || die "--output requires a path"
+      output_path="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      die "unknown argument: $1"
+      ;;
+    *)
+      [[ -z "$evidence_path" ]] || die "evidence path is already set to '$evidence_path'"
+      evidence_path="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$kind" ]] || {
+  usage
+  exit 1
+}
+[[ -n "$issue_number" ]] || die "--issue is required"
+[[ -n "$evidence_path" ]] || die "evidence path is required"
+
+expected_issue="$(canonical_issue_for_surface "$kind")"
+if [[ "$issue_number" != "$expected_issue" ]]; then
+  die "surface $kind must target issue #$expected_issue (got #$issue_number)"
+fi
+
+if [[ "$kind" == "auth-smtp" ]]; then
+  [[ -n "$negative_guard" ]] || die "--negative-guard is required for auth-smtp"
+  [[ -n "$negative_provider_event" ]] || die "--negative-provider-event is required for auth-smtp"
+fi
+
+rendered_output_path="$output_path"
+cleanup_output=0
+if [[ -z "$rendered_output_path" ]]; then
+  rendered_output_path="$(mktemp)"
+  cleanup_output=1
+fi
+
+cleanup() {
+  if [[ "$cleanup_output" == "1" && -f "$rendered_output_path" ]]; then
+    rm -f "$rendered_output_path"
+  fi
+}
+trap cleanup EXIT
+
+renderer_args=(
+  "$kind"
+  "$evidence_path"
+)
+
+if [[ "$kind" == "auth-smtp" ]]; then
+  renderer_args+=(
+    --negative-guard "$negative_guard"
+    --negative-provider-event "$negative_provider_event"
+  )
+fi
+
+renderer_args+=(--output "$rendered_output_path")
+
+bash scripts/render_closure_comment_from_evidence.sh "${renderer_args[@]}" >/dev/null
+
+if [[ "$post_mode" != "1" ]]; then
+  cat "$rendered_output_path"
+  printf '\n'
+  printf 'DRY RUN: no GitHub comment was posted. Re-run with --post to publish to issue #%s.\n' "$issue_number" >&2
+  exit 0
+fi
+
+command -v "$gh_bin" >/dev/null 2>&1 || die "gh binary not found: $gh_bin"
+"$gh_bin" issue comment "$issue_number" --body-file "$rendered_output_path"
+printf 'POSTED issue #%s using %s\n' "$issue_number" "$gh_bin"


### PR DESCRIPTION
## Summary
- add a poster helper that reuses the validated evidence renderer and publishes via gh issue comment
- enforce canonical surface/issue pairs for widget (#408) and auth-smtp (#482)
- wire docs and PR checks for the new posting step

## Verification
- swift scripts/manual_closure_comment_poster_unit_check.swift
- swift scripts/manual_closure_comment_renderer_unit_check.swift
- swift scripts/manual_evidence_validator_unit_check.swift
- swift scripts/manual_evidence_helper_unit_check.swift
- swift scripts/widget_action_closure_pack_unit_check.swift
- swift scripts/widget_action_real_device_evidence_unit_check.swift
- swift scripts/auth_smtp_closure_pack_unit_check.swift
- swift scripts/auth_smtp_rollout_evidence_unit_check.swift
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

Closes #684