### PR TITLE
[QA] Define PR fast smoke and nightly release gate matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@
 - Backend Edge observability adoption matrix v1: `docs/backend-edge-observability-adoption-matrix-v1.md`
 - Backend Edge failure dashboard view v1: `docs/backend-edge-failure-dashboard-view-v1.md`
 - 릴리즈 회귀 체크리스트 v1: `docs/release-regression-checklist-v1.md`
+- PR fast smoke gate v1: `docs/pr-fast-smoke-gate-v1.md`
+- PR fast smoke gate report template v1: `docs/pr-fast-smoke-gate-report-template-v1.md`
+- Nightly full regression gate v1: `docs/nightly-full-regression-gate-v1.md`
+- Release real-device evidence matrix v1: `docs/release-real-device-evidence-matrix-v1.md`
 - 릴리즈 회귀 실행 리포트(2026-02-26): `docs/release-regression-report-2026-02-26.md`
 - 에픽 #21 클로저 증적 스냅샷 v1: `docs/epic-21-closure-evidence-v1.md`
 - 에픽 #123 클로저 증적 스냅샷 v1: `docs/epic-123-closure-evidence-v1.md`

--- a/docs/nightly-full-regression-gate-v1.md
+++ b/docs/nightly-full-regression-gate-v1.md
@@ -1,0 +1,112 @@
+# Nightly Full Regression Gate v1
+
+- Issue: #707
+- Relates to: #270, #266
+
+## 목적
+- fast smoke에서 다 못 보는 장시간/상태 전이/실기기 의존 회귀를 nightly에서 잡는다.
+- nightly 범위와 실기기 증적 요구를 분리해서 release gate 운영 기준을 고정한다.
+
+## fast smoke와의 경계
+- fast smoke는 `빠른 차단`
+- nightly는 `깊은 재현 + 증적 축적`
+- nightly에서 반드시 포함할 것
+  - 긴 산책 세션
+  - 오프라인 후 복구
+  - nearby-presence 오류/복구
+  - widget 상태 전이
+  - watch 큐/동기화/종료 요약
+
+## nightly 대상 축
+
+| Axis ID | 축 | 자동화 | 실기기 필요 | 핵심 목표 |
+| --- | --- | --- | --- | --- |
+| `NF-001` | 긴 산책 세션 | 일부 자동 + 수동 증적 | 예 | 20분+ 세션에서도 저장/복구/요약이 무너지지 않는지 확인 |
+| `NF-002` | 오프라인 후 복구 | 자동 + 수동 | 예 | session/points/meta/outbox 수렴 순서와 재전송 안정성 확인 |
+| `NF-003` | nearby-presence 오류/복구 | 자동 + 수동 | 예 | 401/500/network loss 이후 banner/backoff/recovery 확인 |
+| `NF-004` | widget 상태 전이 | 자동 + 실기기 | 예 | cold/background/foreground + auth state별 수렴 확인 |
+| `NF-005` | watch 큐/동기화/종료 요약 | 자동 + 실기기 | 예 | watch queue 적재/flush/종료 요약 품질 확인 |
+
+## 시나리오 정의
+
+### NF-001 긴 산책 세션
+- 최소 조건
+  - 20분 이상
+  - addPoint / auto record / stop alert / save까지 포함
+- pass 기준
+  - 세션 종료 후 홈/목록/상세/위젯 상태가 동일하게 반영
+  - 메모리 폭증이나 세션 유실 없음
+
+### NF-002 오프라인 후 복구
+- 최소 조건
+  - 오프라인 저장
+  - 온라인 복귀
+  - outbox 재전송
+- pass 기준
+  - `session -> points -> meta` 순으로 다시 밀림
+  - 중복 저장/영구 pending 없음
+
+### NF-003 nearby-presence 오류/복구
+- 최소 조건
+  - 401
+  - 500
+  - network loss
+- pass 기준
+  - session downgrade 오탐 없음
+  - retry/backoff가 과호출 없이 동작
+  - 복구 후 member 경로 200 재확인
+
+### NF-004 widget 상태 전이
+- 최소 조건
+  - `cold start`
+  - `background`
+  - `foreground`
+  - `로그인`
+  - `로그아웃/auth overlay`
+- pass 기준
+  - action route가 소실되지 않음
+  - 앱/위젯/Live Activity가 같은 상태로 수렴
+
+### NF-005 watch 큐/동기화/종료 요약
+- 최소 조건
+  - watch start
+  - addPoint
+  - end
+  - reconnect / retry
+- pass 기준
+  - watch queue 손실률이 허용 범위 내
+  - 종료 요약 화면이 실제 저장 결과와 일치
+
+## 산출물 규칙
+- nightly 실행 결과는 아래 3종을 남긴다.
+  - summary report
+  - failing surface별 로그
+  - 실기기 증적 매트릭스 업데이트
+- 실기기 증적 기준 문서
+  - `docs/release-real-device-evidence-matrix-v1.md`
+
+## flaky 구간 재시도 / 보류 규칙
+- 동일 축이 1회 실패하면 즉시 `retry 1회`
+- 2회 연속 실패면 `FAIL`
+- 아래 조건이면 `HOLD`
+  - 외부 provider outage
+  - 디바이스/OS 실험실 문제
+  - known flaky tag가 이미 열린 이슈로 추적 중
+- `HOLD`일 때도 실패 흔적과 근거 로그는 남긴다.
+
+## nightly summary 형식
+| Axis | Status | Retry | Real Device Evidence | Bucket |
+| --- | --- | --- | --- | --- |
+| `NF-001` | PASS | `0` | `RD-001` | - |
+
+## bucket taxonomy
+- `walk_long_session`
+- `offline_recovery`
+- `nearby_presence_recovery`
+- `widget_state_transition`
+- `watch_queue_sync`
+
+## GO / NO-GO 규칙
+- `NF-001`, `NF-002`, `NF-003` 중 하나라도 `FAIL`이면 `NO-GO`
+- `NF-004`, `NF-005`는 release surface에 직접 영향이 있으면 `NO-GO`
+- `HOLD`는 근거 이슈와 만료 시각 없이 남기지 않는다.

--- a/docs/pr-fast-smoke-gate-report-template-v1.md
+++ b/docs/pr-fast-smoke-gate-report-template-v1.md
@@ -1,0 +1,39 @@
+# PR Fast Smoke Gate Report Template v1
+
+- For: #705
+
+## 메타
+- Date:
+- Runner:
+- Branch / Commit:
+- PR:
+
+## Summary
+| Axis | Status | Auto/Manual | Evidence | Bucket |
+| --- | --- | --- | --- | --- |
+| `FS-001 map_root_ui` | PASS | Auto | `FeatureRegressionUITests` | - |
+| `FS-002 widget_layout` | PASS | Auto | `widget layout checks` | - |
+| `FS-003 widget_action` | PASS | Auto | `widget action regression` | - |
+| `FS-004 watch_basic_action` | SKIPPED | Manual | `watch 영향 없음` | - |
+| `FS-005 sync_recovery` | PASS | Auto | `backend_pr_check + auth smoke` | - |
+
+## Detail
+| Scenario ID | Command / Surface | Expected | Actual | Evidence Link / Log | Owner | Next Action |
+| --- | --- | --- | --- | --- | --- | --- |
+| `FS-001` | `FeatureRegressionUITests` | 지도 primary action 가림 없음 |  |  |  |  |
+| `FS-002` | widget family checks | clipping 없음 |  |  |  |  |
+| `FS-003` | widget action regression | start/end 상태 수렴 |  |  |  |  |
+| `FS-004` | watch basic action | start/addPoint/end 확인 |  |  |  |  |
+| `FS-005` | backend/auth smoke | member auth + nearby 복구 성공 |  |  |  |  |
+
+## Failure Triage
+- First failing bucket:
+- First failing step:
+- Retry attempted:
+- Retry result:
+- Escalation issue:
+
+## Final Decision
+- Gate Result: `GO | NO-GO`
+- Blocking Items:
+- Follow-up Actions:

--- a/docs/pr-fast-smoke-gate-v1.md
+++ b/docs/pr-fast-smoke-gate-v1.md
@@ -1,0 +1,129 @@
+# PR Fast Smoke Gate v1
+
+- Issue: #705
+- Relates to: #270, #266
+
+## 목적
+- PR 직전에 빠르게 돌려서 main 유입을 막아야 하는 핵심 회귀만 잡는다.
+- 실패 시 어떤 축이 깨졌는지 한눈에 보이는 요약 형식을 고정한다.
+- nightly full gate와 역할이 겹치지 않도록 fast smoke의 경계를 문서로 확정한다.
+
+## 역할 경계
+- `fast smoke`: 15분 안쪽으로 끝나는 핵심 진입/상태 수렴 확인
+- `nightly full gate`: 장시간 세션, 오프라인 복구, 실기기 증적, flaky 재시도 판단
+- fast smoke에 넣지 않는 것
+  - 20분 이상 장시간 산책
+  - watch 실기기 장시간 큐 복구
+  - 실기기 증적 수집이 필요한 항목 전체
+
+## 실행 진입점
+- iOS 정적/문서 게이트: `DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh`
+- map UI 회귀: `bash scripts/run_feature_regression_ui_tests.sh`
+- widget action 회귀: `bash scripts/run_widget_action_regression_ui_tests.sh`
+- backend/sync smoke: `bash scripts/backend_pr_check.sh`
+- member auth + nearby smoke: `DOGAREA_AUTH_SMOKE_ITERATIONS=1 bash scripts/auth_member_401_smoke_check.sh`
+
+## 대상 축
+
+| Axis ID | 축 | 자동화 | 대표 진입점 | 포함 이유 |
+| --- | --- | --- | --- | --- |
+| `FS-001` | map root UI 회귀 | 자동 | `FeatureRegressionUITests` 중 지도 핵심 케이스 | 탭바/상단 chrome/primary action 가림은 바로 사용자 차단으로 이어진다. |
+| `FS-002` | widget family / clipping | 자동 | 위젯 layout 관련 unit check + widget regression | 홈 화면 clipping/overflow는 PR 단계에서 빨리 잡아야 한다. |
+| `FS-003` | widget start/end action smoke | 자동 | `run_widget_action_regression_ui_tests.sh` | 앱/위젯/Live Activity 수렴 실패는 높은 빈도로 회귀한다. |
+| `FS-004` | watch start / addPoint / end 기본 smoke | 수동 최소 확인 | watch simulator 또는 실기기 기본 3액션 | watch 표면은 완전 자동화가 약해서 PR에서 최소 경로라도 본다. |
+| `FS-005` | sync / outbox / nearby-presence 복구 smoke | 자동 | `backend_pr_check.sh`, `auth_member_401_smoke_check.sh` | 401/500/404 회귀가 앱 전체 신뢰성을 무너뜨린다. |
+
+## 시나리오 정의
+
+### FS-001 map root UI 회귀
+- 최소 확인
+  - 지도 탭 진입 가능
+  - primary action이 탭바에 가려지지 않음
+  - top chrome이 safe area 아래에서 안정적으로 보임
+- pass 기준
+  - `testFeatureRegression_MapPrimaryActionIsNotObscuredByTabBar` 통과
+  - 지도 루트 진입 실패나 overlay 충돌 실패가 없음
+- fail bucket
+  - `map_root_ui`
+
+### FS-002 widget family / clipping
+- 최소 확인
+  - `systemSmall`, `systemMedium`, lock-screen accessory 주요 레이아웃이 clipping 없이 렌더됨
+  - CTA/핵심 수치가 family별로 잘리지 않음
+- pass 기준
+  - widget family layout 관련 정적 체크 통과
+  - widget regression pack에서 family 레이아웃 실패가 없음
+- fail bucket
+  - `widget_layout`
+
+### FS-003 widget start/end action smoke
+- 최소 확인
+  - start 액션 후 앱/위젯/Live Activity가 같은 상태로 수렴
+  - end 액션 후 종료 상태가 일관되게 반영
+- pass 기준
+  - widget action regression UI 케이스 통과
+  - `widget_intent_openapp_unit_check.swift`가 깨지지 않음
+- fail bucket
+  - `widget_action`
+
+### FS-004 watch start / addPoint / end 기본 smoke
+- 최소 확인
+  - start
+  - addPoint
+  - end
+- 자동화/수동 구분
+  - 기본 계약/unit check는 자동
+  - 최종 버튼 체감/상태 수렴은 PR 영향 범위가 watch에 걸릴 때만 수동 확인
+- pass 기준
+  - 관련 watch contract/unit check 전부 통과
+  - watch 영향 PR이면 start/addPoint/end 결과를 수동으로 1회 기록
+- fail bucket
+  - `watch_basic_action`
+
+### FS-005 sync / outbox / nearby-presence 복구 smoke
+- 최소 확인
+  - member auth 경로에서 401 downgrade 없음
+  - nearby-presence member/app smoke 성공
+  - outbox/sync 핵심 route 404/500 없음
+- pass 기준
+  - `backend_pr_check.sh` 통과
+  - `auth_member_401_smoke_check.sh`에서 member 경로 200 유지
+- fail bucket
+  - `sync_recovery`
+
+## 자동화 vs 수동 판단 규칙
+- 기본값은 자동화 우선
+- 아래 조건 중 하나면 수동 확인 1세트 추가
+  - watch 화면/액션을 직접 건드림
+  - widget deep link / action route를 건드림
+  - map root overlay hierarchy를 건드림
+- 실기기만 가능한 증적은 fast smoke가 아니라 `nightly full gate` 문서로 넘긴다.
+
+## 결과 리포트 형식
+- summary는 1 screen 안에 들어와야 한다.
+- 축별 상태는 `PASS | FAIL | BLOCKED | SKIPPED`만 사용한다.
+- 실패 행에는 반드시 `bucket`, `first failing step`, `next owner`가 포함돼야 한다.
+
+### 상단 요약 표
+| Axis | Status | Auto/Manual | Evidence | Bucket |
+| --- | --- | --- | --- | --- |
+| `FS-001 map_root_ui` | PASS | Auto | `FeatureRegressionUITests` | - |
+
+### 상세 표
+| Scenario ID | Command / Surface | Expected | Actual | Evidence Link / Log | Owner | Next Action |
+| --- | --- | --- | --- | --- | --- | --- |
+| `FS-003` | `run_widget_action_regression_ui_tests.sh` | start/end 상태 수렴 | 실제 결과 | xcresult / console log | `@owner` | rerun / fix |
+
+## 종합 판단 규칙
+- 아래 중 하나면 `NO-GO`
+  - `FS-001`, `FS-003`, `FS-005` 중 하나라도 `FAIL`
+  - 자동화 필수 축이 `BLOCKED`
+- 아래면 조건부 `GO`
+  - `FS-004`만 `SKIPPED`이고 watch 비영향 PR
+- manual only 이슈는 summary에 이유를 남기고 nightly queue에 연결한다.
+
+## 후속 이슈가 바로 사용할 입력값
+- 축 식별자: `FS-001` ~ `FS-005`
+- failure bucket: `map_root_ui`, `widget_layout`, `widget_action`, `watch_basic_action`, `sync_recovery`
+- 결과 상태: `PASS | FAIL | BLOCKED | SKIPPED`
+- 리포트 템플릿: `docs/pr-fast-smoke-gate-report-template-v1.md`

--- a/docs/release-real-device-evidence-matrix-v1.md
+++ b/docs/release-real-device-evidence-matrix-v1.md
@@ -1,0 +1,82 @@
+# Release Real-Device Evidence Matrix v1
+
+- Issue: #707
+- Relates to: #270, #266
+
+## 목적
+- 실기기에서만 검증 가능한 표면을 release gate 기준으로 표준화한다.
+- 스크린샷/로그/체크리스트 형식을 통일해서 반복 회귀를 추적 가능하게 만든다.
+
+## 증적 기본 세트
+- 기기 정보
+  - device model
+  - OS version
+  - app build / commit
+- 실행 조건
+  - app state
+  - auth state
+  - network state
+- 로그 증적
+  - 최소 3줄
+  - 관련 `request_id`가 있으면 포함
+- 화면 증적
+  - `step-1` 직후
+  - `step-2` 최종 상태
+  - 실패 시 `step-fail`
+- 체크리스트
+  - expected
+  - actual
+  - retry 여부
+  - pass/fail/hold
+
+## 파일명 규칙
+- 스크린샷
+  - `RD-001-step-1.png`
+  - `RD-001-step-2.png`
+  - `RD-001-step-fail.png`
+- 로그
+  - `RD-001-console.log`
+- 체크리스트
+  - `RD-001-checklist.md`
+
+## 실기기 매트릭스
+| Case ID | Surface | Device / OS | State | Expected | Required Evidence |
+| --- | --- | --- | --- | --- | --- |
+| `RD-001` | map 긴 산책 세션 | iPhone 실제 기기 / iOS 18+ | foreground -> background -> foreground | 장시간 세션 저장/요약 일치 | 스크린샷 2장 + 로그 + checklist |
+| `RD-002` | 오프라인 후 복구 | iPhone 실제 기기 / iOS 18+ | offline -> online | outbox 재전송 순서/복구 성공 | 스크린샷 2장 + 로그 + checklist |
+| `RD-003` | nearby-presence 오류/복구 | iPhone 실제 기기 / iOS 18+ | opt-in + error + recovery | 401/500/network loss 후 복구 | 스크린샷 2장 + 로그 + checklist |
+| `RD-004` | widget start/end 상태 전이 | iPhone 실제 기기 / iOS 18+ | cold/background/foreground | 위젯/앱/Live Activity 수렴 | 스크린샷 2장 + 로그 + checklist |
+| `RD-005` | watch start/addPoint/end | Apple Watch 실제 기기 / watchOS 11+ | connected / delayed sync | queue 손실 없이 동기화 | 스크린샷 2장 + 로그 + checklist |
+| `RD-006` | watch 종료 요약 | Apple Watch 실제 기기 / watchOS 11+ | walk end | 종료 요약과 앱 상세 일치 | 스크린샷 2장 + 로그 + checklist |
+
+## 체크리스트 표준 형식
+| Field | Description |
+| --- | --- |
+| `Case ID` | `RD-xxx` |
+| `Precondition` | 로그인/네트워크/앱 상태 |
+| `Action` | 탭/버튼/상태 전이 |
+| `Expected` | 기대 결과 |
+| `Actual` | 실제 결과 |
+| `Retry` | `none / retry-1 / retry-2` |
+| `Final Status` | `PASS / FAIL / HOLD` |
+| `Evidence Files` | 스크린샷/로그 파일명 |
+| `Follow-up Issue` | 후속 이슈 번호 |
+
+## 로그 표준
+- map / nearby
+  - `request_id`
+  - `SupabaseHTTP`
+  - `SyncOutbox`
+- widget
+  - `WidgetAction`
+  - `onOpenURL received`
+  - `consumePendingWidgetActionIfNeeded`
+- watch
+  - queue 적재/flush
+  - action route
+  - end summary 반영 로그
+
+## 운영 규칙
+- release 직전에는 `RD-001` ~ `RD-006` 중 변경 범위에 해당하는 케이스만 필수 수행
+- `widget`이나 `watch` 미영향 PR은 해당 케이스를 `SKIPPED`로 남길 수 있다.
+- `HOLD`는 flaky/infra 사유와 재실행 계획 없이 남길 수 없다.

--- a/scripts/ios_pr_check.sh
+++ b/scripts/ios_pr_check.sh
@@ -52,6 +52,8 @@ swift scripts/quest_stage2_engine_unit_check.swift
 swift scripts/season_motion_pack_unit_check.swift
 swift scripts/home_quest_reminder_same_day_suppression_unit_check.swift
 swift scripts/release_regression_checklist_unit_check.swift
+swift scripts/pr_fast_smoke_gate_unit_check.swift
+swift scripts/nightly_full_regression_gate_unit_check.swift
 swift scripts/epic_21_closure_evidence_unit_check.swift
 swift scripts/epic_123_closure_evidence_unit_check.swift
 swift scripts/epic_420_closure_evidence_unit_check.swift

--- a/scripts/nightly_full_regression_gate_unit_check.swift
+++ b/scripts/nightly_full_regression_gate_unit_check.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ path: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(path))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let nightly = load("docs/nightly-full-regression-gate-v1.md")
+let matrix = load("docs/release-real-device-evidence-matrix-v1.md")
+let readme = load("README.md")
+
+assertTrue(nightly.contains("- Issue: #707"), "nightly gate doc must reference issue #707")
+assertTrue(nightly.contains("긴 산책 세션"), "nightly gate doc must include long walk session axis")
+assertTrue(nightly.contains("오프라인 후 복구"), "nightly gate doc must include offline recovery axis")
+assertTrue(nightly.contains("nearby-presence 오류/복구"), "nightly gate doc must include nearby recovery axis")
+assertTrue(nightly.contains("widget 상태 전이"), "nightly gate doc must include widget state transition axis")
+assertTrue(nightly.contains("watch 큐/동기화/종료 요약"), "nightly gate doc must include watch queue axis")
+assertTrue(nightly.contains("retry 1회"), "nightly gate doc must define flaky retry policy")
+assertTrue(nightly.contains("HOLD"), "nightly gate doc must define hold rule")
+assertTrue(nightly.contains("walk_long_session"), "nightly gate doc must define long walk bucket")
+assertTrue(nightly.contains("offline_recovery"), "nightly gate doc must define offline bucket")
+assertTrue(nightly.contains("nearby_presence_recovery"), "nightly gate doc must define nearby bucket")
+assertTrue(nightly.contains("widget_state_transition"), "nightly gate doc must define widget bucket")
+assertTrue(nightly.contains("watch_queue_sync"), "nightly gate doc must define watch bucket")
+assertTrue(matrix.contains("## 증적 기본 세트"), "real-device evidence matrix must define evidence bundle")
+assertTrue(matrix.contains("RD-001"), "real-device evidence matrix must define map case")
+assertTrue(matrix.contains("RD-002"), "real-device evidence matrix must define offline recovery case")
+assertTrue(matrix.contains("RD-003"), "real-device evidence matrix must define nearby recovery case")
+assertTrue(matrix.contains("RD-004"), "real-device evidence matrix must define widget case")
+assertTrue(matrix.contains("RD-005"), "real-device evidence matrix must define watch queue case")
+assertTrue(matrix.contains("RD-006"), "real-device evidence matrix must define watch summary case")
+assertTrue(matrix.contains("PASS / FAIL / HOLD"), "real-device evidence matrix must standardize final states")
+assertTrue(matrix.contains("step-1"), "real-device evidence matrix must standardize screenshot naming")
+assertTrue(matrix.contains("request_id"), "real-device evidence matrix must require request correlation when available")
+assertTrue(readme.contains("docs/nightly-full-regression-gate-v1.md"), "README must index nightly gate doc")
+assertTrue(readme.contains("docs/release-real-device-evidence-matrix-v1.md"), "README must index real-device evidence matrix")
+
+print("PASS: nightly full regression gate unit checks")

--- a/scripts/pr_fast_smoke_gate_unit_check.swift
+++ b/scripts/pr_fast_smoke_gate_unit_check.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@inline(__always)
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+func load(_ path: String) -> String {
+    let data = try! Data(contentsOf: root.appendingPathComponent(path))
+    return String(decoding: data, as: UTF8.self)
+}
+
+let guide = load("docs/pr-fast-smoke-gate-v1.md")
+let template = load("docs/pr-fast-smoke-gate-report-template-v1.md")
+let readme = load("README.md")
+
+assertTrue(guide.contains("- Issue: #705"), "fast smoke doc must reference issue #705")
+assertTrue(guide.contains("## 역할 경계"), "fast smoke doc must define boundary from nightly")
+assertTrue(guide.contains("FS-001"), "fast smoke doc must define map axis")
+assertTrue(guide.contains("FS-002"), "fast smoke doc must define widget layout axis")
+assertTrue(guide.contains("FS-003"), "fast smoke doc must define widget action axis")
+assertTrue(guide.contains("FS-004"), "fast smoke doc must define watch axis")
+assertTrue(guide.contains("FS-005"), "fast smoke doc must define sync recovery axis")
+assertTrue(guide.contains("PASS | FAIL | BLOCKED | SKIPPED"), "fast smoke doc must freeze result states")
+assertTrue(guide.contains("map_root_ui"), "fast smoke doc must define failure bucket")
+assertTrue(guide.contains("widget_layout"), "fast smoke doc must define widget layout bucket")
+assertTrue(guide.contains("widget_action"), "fast smoke doc must define widget action bucket")
+assertTrue(guide.contains("watch_basic_action"), "fast smoke doc must define watch bucket")
+assertTrue(guide.contains("sync_recovery"), "fast smoke doc must define sync recovery bucket")
+assertTrue(guide.contains("run_feature_regression_ui_tests.sh"), "fast smoke doc must reference map regression runner")
+assertTrue(guide.contains("run_widget_action_regression_ui_tests.sh"), "fast smoke doc must reference widget regression runner")
+assertTrue(guide.contains("backend_pr_check.sh"), "fast smoke doc must reference backend smoke runner")
+assertTrue(template.contains("## Summary"), "fast smoke template must include summary section")
+assertTrue(template.contains("## Detail"), "fast smoke template must include detail section")
+assertTrue(template.contains("## Failure Triage"), "fast smoke template must include triage section")
+assertTrue(template.contains("## Final Decision"), "fast smoke template must include final decision section")
+assertTrue(readme.contains("docs/pr-fast-smoke-gate-v1.md"), "README must index fast smoke guide")
+assertTrue(readme.contains("docs/pr-fast-smoke-gate-report-template-v1.md"), "README must index fast smoke template")
+
+print("PASS: pr fast smoke gate unit checks")


### PR DESCRIPTION
Closes #705
Closes #707

## Summary
- define the PR fast smoke gate scope, pass/fail buckets and report format
- add a reusable PR fast smoke report template
- define the nightly full regression gate boundary, flaky retry policy and GO/NO-GO rules
- standardize the real-device evidence matrix for map/widget/watch/realtime release surfaces
- wire new static checks into README and ios_pr_check

## Validation
- swift scripts/pr_fast_smoke_gate_unit_check.swift
- swift scripts/nightly_full_regression_gate_unit_check.swift
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh