### PR TITLE
ci: implement fast smoke and nightly regression gates

### DIFF
--- a/.github/workflows/ios-pr-check.yml
+++ b/.github/workflows/ios-pr-check.yml
@@ -1,13 +1,13 @@
-name: iOS PR Check
+name: ios-full-check
 
 on:
-  pull_request:
+  push:
     branches:
       - main
   workflow_dispatch:
 
 jobs:
-  ios-pr-check:
+  ios-full-check:
     runs-on: macos-14
     timeout-minutes: 60
 
@@ -18,5 +18,5 @@ jobs:
       - name: Xcode Version
         run: xcodebuild -version
 
-      - name: Run iOS/watchOS PR checks
+      - name: Run iOS/watchOS full checks
         run: bash scripts/ios_pr_check.sh

--- a/.github/workflows/nightly-full-regression-gate.yml
+++ b/.github/workflows/nightly-full-regression-gate.yml
@@ -1,0 +1,39 @@
+name: nightly-full-regression-gate
+
+on:
+  schedule:
+    - cron: "0 19 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-full-regression-gate
+  cancel-in-progress: false
+
+jobs:
+  nightly_full_regression_gate:
+    name: NF nightly_full_regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5.10"
+
+      - name: Run nightly regression artifact pipeline
+        env:
+          DOGAREA_TEST_EMAIL: ${{ secrets.DOGAREA_TEST_EMAIL }}
+          DOGAREA_TEST_PASSWORD: ${{ secrets.DOGAREA_TEST_PASSWORD }}
+        run: bash scripts/run_nightly_full_regression_gate.sh
+
+      - name: Upload nightly regression artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-full-regression-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/nightly-full-regression
+          if-no-files-found: error

--- a/.github/workflows/pr-fast-smoke-gate.yml
+++ b/.github/workflows/pr-fast-smoke-gate.yml
@@ -1,0 +1,159 @@
+name: pr-fast-smoke-gate
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: pr-fast-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fs_001_map_root_ui:
+    name: FS-001 map_root_ui
+    runs-on: macos-14
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Xcode Version
+        run: xcodebuild -version
+
+      - name: Prepare artifact directory
+        run: mkdir -p .artifacts/pr-fast-smoke/logs
+
+      - name: Run FS-001 map root UI smoke
+        run: bash scripts/run_pr_fast_smoke_map_ui_tests.sh | tee .artifacts/pr-fast-smoke/logs/FS-001-map_root_ui.log
+
+      - name: Upload FS-001 log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-fast-smoke-FS-001-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/pr-fast-smoke/logs/FS-001-map_root_ui.log
+          if-no-files-found: error
+
+  fs_002_widget_layout:
+    name: FS-002 widget_layout
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5.10"
+
+      - name: Prepare artifact directory
+        run: mkdir -p .artifacts/pr-fast-smoke/logs
+
+      - name: Run FS-002 widget family / clipping checks
+        run: bash scripts/run_pr_fast_smoke_widget_layout_checks.sh | tee .artifacts/pr-fast-smoke/logs/FS-002-widget_layout.log
+
+      - name: Upload FS-002 log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-fast-smoke-FS-002-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/pr-fast-smoke/logs/FS-002-widget_layout.log
+          if-no-files-found: error
+
+  fs_003_widget_action:
+    name: FS-003 widget_action
+    runs-on: macos-14
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Xcode Version
+        run: xcodebuild -version
+
+      - name: Prepare artifact directory
+        run: mkdir -p .artifacts/pr-fast-smoke/logs
+
+      - name: Run FS-003 widget start/end action smoke
+        run: bash scripts/run_widget_action_regression_ui_tests.sh | tee .artifacts/pr-fast-smoke/logs/FS-003-widget_action.log
+
+      - name: Upload FS-003 log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-fast-smoke-FS-003-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/pr-fast-smoke/logs/FS-003-widget_action.log
+          if-no-files-found: error
+
+  fs_004_watch_basic_action:
+    name: FS-004 watch_basic_action
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5.10"
+
+      - name: Prepare artifact directory
+        run: mkdir -p .artifacts/pr-fast-smoke/logs
+
+      - name: Run FS-004 watch baseline contract checks
+        run: bash scripts/run_pr_fast_smoke_watch_contract_checks.sh | tee .artifacts/pr-fast-smoke/logs/FS-004-watch_basic_action.log
+
+      - name: Upload FS-004 log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-fast-smoke-FS-004-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/pr-fast-smoke/logs/FS-004-watch_basic_action.log
+          if-no-files-found: error
+
+  fs_005_sync_recovery:
+    name: FS-005 sync_recovery
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5.10"
+
+      - name: Prepare artifact directory
+        run: mkdir -p .artifacts/pr-fast-smoke/logs
+
+      - name: Run FS-005 backend baseline checks
+        run: bash scripts/backend_pr_check.sh | tee .artifacts/pr-fast-smoke/logs/FS-005-backend_pr_check.log
+
+      - name: Run FS-005 member auth + nearby smoke
+        env:
+          DOGAREA_TEST_EMAIL: ${{ secrets.DOGAREA_TEST_EMAIL }}
+          DOGAREA_TEST_PASSWORD: ${{ secrets.DOGAREA_TEST_PASSWORD }}
+        run: |
+          if [[ -z "${DOGAREA_TEST_EMAIL:-}" || -z "${DOGAREA_TEST_PASSWORD:-}" ]]; then
+            echo "FS-005 requires DOGAREA_TEST_EMAIL and DOGAREA_TEST_PASSWORD secrets"
+            exit 1
+          fi
+          DOGAREA_AUTH_SMOKE_ITERATIONS=1 bash scripts/auth_member_401_smoke_check.sh | tee .artifacts/pr-fast-smoke/logs/FS-005-auth_member_401_smoke.log
+
+      - name: Upload FS-005 logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-fast-smoke-FS-005-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/pr-fast-smoke/logs/FS-005-*.log
+          if-no-files-found: error

--- a/docs/nightly-full-regression-gate-v1.md
+++ b/docs/nightly-full-regression-gate-v1.md
@@ -18,6 +18,20 @@
   - watch 큐/동기화/종료 요약
   - member full sweep / 5xx zero-budget 추세 확인
 
+## Workflow binding
+- GitHub Actions workflow: `.github/workflows/nightly-full-regression-gate.yml`
+- runner: `bash scripts/run_nightly_full_regression_gate.sh`
+- artifact root: `.artifacts/nightly-full-regression`
+- artifact directory contract
+  - `reports/`
+  - `logs/`
+  - `evidence/`
+- manual blocker linkage
+  - `bash scripts/manual_blocker_evidence_status.sh --write-missing`
+  - `bash scripts/render_manual_evidence_pack.sh`
+  - `bash scripts/validate_manual_evidence_pack.sh`
+- nightly workflow는 실기기 전용 축을 무인화했다고 가정하지 않는다. 대신 sample artifact / blocker evidence / live smoke 결과를 한곳에 모아 다음 날 triage 가능하게 만든다.
+
 ## nightly 대상 축
 
 | Axis ID | 축 | 자동화 | 실기기 필요 | 핵심 목표 |

--- a/docs/pr-fast-smoke-gate-v1.md
+++ b/docs/pr-fast-smoke-gate-v1.md
@@ -24,6 +24,18 @@
 - member auth + nearby smoke: `DOGAREA_AUTH_SMOKE_ITERATIONS=1 bash scripts/auth_member_401_smoke_check.sh`
 - member full sweep / 5xx zero-budget 기준: `docs/member-supabase-http-full-sweep-v1.md`, `docs/member-supabase-http-5xx-zero-budget-gate-v1.md`
 
+## Workflow binding
+- GitHub Actions workflow: `.github/workflows/pr-fast-smoke-gate.yml`
+- comprehensive main/manual workflow: `.github/workflows/ios-pr-check.yml`
+- workflow step naming은 `FS-001` ~ `FS-005`를 그대로 사용한다.
+- workflow runner script binding
+  - `FS-001`: `bash scripts/run_pr_fast_smoke_map_ui_tests.sh`
+  - `FS-002`: `bash scripts/run_pr_fast_smoke_widget_layout_checks.sh`
+  - `FS-003`: `bash scripts/run_widget_action_regression_ui_tests.sh`
+  - `FS-004`: `bash scripts/run_pr_fast_smoke_watch_contract_checks.sh`
+  - `FS-005`: `bash scripts/backend_pr_check.sh` + `bash scripts/auth_member_401_smoke_check.sh`
+- PR에서는 fast smoke workflow를 primary status surface로 사용하고, `ios-pr-check.yml`은 comprehensive main/manual validation으로 분리한다.
+
 ## 대상 축
 
 | Axis ID | 축 | 자동화 | 대표 진입점 | 포함 이유 |

--- a/docs/project-settings-dependency-stability-v1.md
+++ b/docs/project-settings-dependency-stability-v1.md
@@ -26,14 +26,17 @@
 2. iOS build
 3. watchOS build
 
-## 5. CI PR 체크 기준
+## 5. CI 역할 분리 기준
 - 워크플로 파일: `.github/workflows/ios-pr-check.yml`
 - 트리거:
-  - `pull_request` to `main`
+  - `push` to `main`
   - `workflow_dispatch`
-- 머지 게이트:
-  - iOS/watchOS 빌드 실패 시 머지 차단
-  - 문서/계약 스크립트 실패 시 머지 차단
+- 역할:
+  - `ios-pr-check.yml`은 comprehensive main/manual validation
+  - PR 머지 게이트는 `.github/workflows/pr-fast-smoke-gate.yml`
+- main/manual validation 기준:
+  - iOS/watchOS 빌드 실패 시 실패
+  - 문서/계약 스크립트 실패 시 실패
 
 ## 6. Drift 방지 규칙
 - `project.pbxproj`의 deployment target/Swift 버전 변경은 별도 이슈에서만 수행한다.
@@ -42,5 +45,6 @@
 
 ## 7. 재현 체크리스트
 1. 클린 체크아웃 후 `bash scripts/ios_pr_check.sh` 실행 가능
-2. 동일 브랜치 PR에서 `iOS PR Check` 통과
-3. 문서(`README`, 본 문서) 기준으로 신규 환경에서도 동일 절차 재현 가능
+2. `main` push 또는 수동 실행에서 `ios-full-check` 통과
+3. 동일 브랜치 PR에서 `pr-fast-smoke-gate` 통과
+4. 문서(`README`, 본 문서) 기준으로 신규 환경에서도 동일 절차 재현 가능

--- a/scripts/backend_pr_check.sh
+++ b/scripts/backend_pr_check.sh
@@ -5,6 +5,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 echo "[dogArea-backend] running integration harness structure checks"
+swift scripts/pr_fast_smoke_gate_unit_check.swift
+swift scripts/nightly_full_regression_gate_unit_check.swift
 swift scripts/supabase_integration_harness_unit_check.swift
 swift scripts/member_supabase_http_inventory_unit_check.swift
 swift scripts/member_supabase_http_zero_budget_gate_unit_check.swift

--- a/scripts/nightly_full_regression_gate_unit_check.swift
+++ b/scripts/nightly_full_regression_gate_unit_check.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// Validates that a required nightly regression contract condition holds.
+/// - Parameters:
+///   - condition: Condition to validate for the workflow/document contract.
+///   - message: Failure message printed when the condition does not hold.
 @inline(__always)
 func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
     if !condition() {
@@ -10,6 +14,9 @@ func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
 
 let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
 
+/// Loads a repository-relative UTF-8 text file.
+/// - Parameter path: Repository-relative path to load.
+/// - Returns: Decoded file contents.
 func load(_ path: String) -> String {
     let data = try! Data(contentsOf: root.appendingPathComponent(path))
     return String(decoding: data, as: UTF8.self)
@@ -18,8 +25,13 @@ func load(_ path: String) -> String {
 let nightly = load("docs/nightly-full-regression-gate-v1.md")
 let matrix = load("docs/release-real-device-evidence-matrix-v1.md")
 let readme = load("README.md")
+let workflow = load(".github/workflows/nightly-full-regression-gate.yml")
 
 assertTrue(nightly.contains("- Issue: #707"), "nightly gate doc must reference issue #707")
+assertTrue(nightly.contains(".github/workflows/nightly-full-regression-gate.yml"), "nightly doc must bind the workflow file")
+assertTrue(nightly.contains("scripts/run_nightly_full_regression_gate.sh"), "nightly doc must reference the runner script")
+assertTrue(nightly.contains(".artifacts/nightly-full-regression"), "nightly doc must define the artifact root")
+assertTrue(nightly.contains("manual_blocker_evidence_status.sh"), "nightly doc must link blocker evidence runner")
 assertTrue(nightly.contains("긴 산책 세션"), "nightly gate doc must include long walk session axis")
 assertTrue(nightly.contains("오프라인 후 복구"), "nightly gate doc must include offline recovery axis")
 assertTrue(nightly.contains("nearby-presence 오류/복구"), "nightly gate doc must include nearby recovery axis")
@@ -44,5 +56,11 @@ assertTrue(matrix.contains("step-1"), "real-device evidence matrix must standard
 assertTrue(matrix.contains("request_id"), "real-device evidence matrix must require request correlation when available")
 assertTrue(readme.contains("docs/nightly-full-regression-gate-v1.md"), "README must index nightly gate doc")
 assertTrue(readme.contains("docs/release-real-device-evidence-matrix-v1.md"), "README must index real-device evidence matrix")
+assertTrue(workflow.contains("name: nightly-full-regression-gate"), "workflow must use canonical nightly gate name")
+assertTrue(workflow.contains("schedule:"), "workflow must run on a schedule")
+assertTrue(workflow.contains("workflow_dispatch:"), "workflow must support manual dispatch")
+assertTrue(workflow.contains("run_nightly_full_regression_gate.sh"), "workflow must run the nightly regression runner")
+assertTrue(workflow.contains(".artifacts/nightly-full-regression"), "workflow must upload the nightly artifact root")
+assertTrue(workflow.contains("actions/upload-artifact@v4"), "workflow must upload nightly artifacts")
 
 print("PASS: nightly full regression gate unit checks")

--- a/scripts/pr_fast_smoke_gate_unit_check.swift
+++ b/scripts/pr_fast_smoke_gate_unit_check.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// Validates that a required fast smoke contract condition holds.
+/// - Parameters:
+///   - condition: Condition to validate for the workflow/document contract.
+///   - message: Failure message printed when the condition does not hold.
 @inline(__always)
 func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
     if !condition() {
@@ -10,6 +14,9 @@ func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {
 
 let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
 
+/// Loads a repository-relative UTF-8 text file.
+/// - Parameter path: Repository-relative path to load.
+/// - Returns: Decoded file contents.
 func load(_ path: String) -> String {
     let data = try! Data(contentsOf: root.appendingPathComponent(path))
     return String(decoding: data, as: UTF8.self)
@@ -18,9 +25,13 @@ func load(_ path: String) -> String {
 let guide = load("docs/pr-fast-smoke-gate-v1.md")
 let template = load("docs/pr-fast-smoke-gate-report-template-v1.md")
 let readme = load("README.md")
+let workflow = load(".github/workflows/pr-fast-smoke-gate.yml")
+let fullCheckWorkflow = load(".github/workflows/ios-pr-check.yml")
 
 assertTrue(guide.contains("- Issue: #705"), "fast smoke doc must reference issue #705")
 assertTrue(guide.contains("## 역할 경계"), "fast smoke doc must define boundary from nightly")
+assertTrue(guide.contains(".github/workflows/pr-fast-smoke-gate.yml"), "fast smoke doc must bind the dedicated workflow file")
+assertTrue(guide.contains(".github/workflows/ios-pr-check.yml"), "fast smoke doc must describe ios full check role separation")
 assertTrue(guide.contains("FS-001"), "fast smoke doc must define map axis")
 assertTrue(guide.contains("FS-002"), "fast smoke doc must define widget layout axis")
 assertTrue(guide.contains("FS-003"), "fast smoke doc must define widget action axis")
@@ -41,5 +52,22 @@ assertTrue(template.contains("## Failure Triage"), "fast smoke template must inc
 assertTrue(template.contains("## Final Decision"), "fast smoke template must include final decision section")
 assertTrue(readme.contains("docs/pr-fast-smoke-gate-v1.md"), "README must index fast smoke guide")
 assertTrue(readme.contains("docs/pr-fast-smoke-gate-report-template-v1.md"), "README must index fast smoke template")
+assertTrue(workflow.contains("name: pr-fast-smoke-gate"), "workflow must use canonical fast smoke workflow name")
+assertTrue(workflow.contains("pull_request:"), "workflow must trigger on pull_request")
+assertTrue(workflow.contains("workflow_dispatch:"), "workflow must support manual rerun")
+assertTrue(workflow.contains("FS-001 map_root_ui"), "workflow must expose FS-001 job naming")
+assertTrue(workflow.contains("FS-002 widget_layout"), "workflow must expose FS-002 job naming")
+assertTrue(workflow.contains("FS-003 widget_action"), "workflow must expose FS-003 job naming")
+assertTrue(workflow.contains("FS-004 watch_basic_action"), "workflow must expose FS-004 job naming")
+assertTrue(workflow.contains("FS-005 sync_recovery"), "workflow must expose FS-005 job naming")
+assertTrue(workflow.contains("run_pr_fast_smoke_map_ui_tests.sh"), "workflow must run dedicated FS-001 runner")
+assertTrue(workflow.contains("run_pr_fast_smoke_widget_layout_checks.sh"), "workflow must run dedicated FS-002 runner")
+assertTrue(workflow.contains("run_widget_action_regression_ui_tests.sh"), "workflow must run FS-003 widget action runner")
+assertTrue(workflow.contains("run_pr_fast_smoke_watch_contract_checks.sh"), "workflow must run dedicated FS-004 runner")
+assertTrue(workflow.contains("auth_member_401_smoke_check.sh"), "workflow must run FS-005 auth smoke")
+assertTrue(workflow.contains("actions/upload-artifact@v4"), "workflow must upload fast smoke artifacts")
+assertTrue(fullCheckWorkflow.contains("name: ios-full-check"), "ios full check workflow must be renamed to clarify role")
+assertTrue(fullCheckWorkflow.contains("push:"), "ios full check workflow must run on main push")
+assertTrue(!fullCheckWorkflow.contains("pull_request:"), "ios full check workflow should no longer duplicate PR fast smoke on pull_request")
 
 print("PASS: pr fast smoke gate unit checks")

--- a/scripts/project_stability_unit_check.swift
+++ b/scripts/project_stability_unit_check.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// Validates that a project stability invariant holds.
+/// - Parameters:
+///   - condition: Condition that must remain true.
+///   - message: Failure message printed when the invariant breaks.
 @inline(__always)
 func assertTrue(_ condition: Bool, _ message: String) {
     if !condition {
@@ -10,6 +14,9 @@ func assertTrue(_ condition: Bool, _ message: String) {
 
 let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
 
+/// Loads a repository-relative UTF-8 text file.
+/// - Parameter relativePath: Repository-relative file path to read.
+/// - Returns: Decoded file contents.
 func load(_ relativePath: String) -> String {
     let url = root.appendingPathComponent(relativePath)
     let data = try! Data(contentsOf: url)
@@ -28,8 +35,9 @@ assertTrue(pbxproj.contains("SWIFT_VERSION = 5.0;"), "project should pin Swift v
 assertTrue(pbxproj.contains("path = dogAreaSplash.json;"), "project should use repo-relative splash animation path")
 assertTrue(!pbxproj.contains("path = ../../../../dogAreaSplash.json;"), "project should avoid unstable relative splash path")
 
-assertTrue(workflow.contains("name: iOS PR Check"), "workflow should be named iOS PR Check")
-assertTrue(workflow.contains("pull_request:"), "workflow should run on pull_request")
+assertTrue(workflow.contains("name: ios-full-check"), "workflow should be named ios-full-check")
+assertTrue(workflow.contains("push:"), "workflow should run on push")
+assertTrue(!workflow.contains("pull_request:"), "full check workflow should no longer run on pull_request")
 assertTrue(workflow.contains("branches:"), "workflow should specify target branches")
 assertTrue(workflow.contains("- main"), "workflow should target main branch")
 assertTrue(workflow.contains("bash scripts/ios_pr_check.sh"), "workflow should run shared PR check script")
@@ -40,7 +48,7 @@ assertTrue(script.contains("-scheme \"dogAreaWatch Watch App\""), "shared script
 
 assertTrue(doc.contains("## 2. 기준 툴체인/타깃"), "stability doc should include toolchain baseline")
 assertTrue(doc.contains("## 4. 로컬/CI 공통 체크 명령"), "stability doc should include unified commands")
-assertTrue(doc.contains("## 5. CI PR 체크 기준"), "stability doc should include CI criteria")
+assertTrue(doc.contains("## 5. CI 역할 분리 기준"), "stability doc should include CI role split criteria")
 
 assertTrue(readme.contains("docs/project-settings-dependency-stability-v1.md"), "README should reference project stability doc")
 assertTrue(readme.contains("bash scripts/ios_pr_check.sh"), "README should expose unified local check command")

--- a/scripts/run_nightly_full_regression_gate.sh
+++ b/scripts/run_nightly_full_regression_gate.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACT_DIR="${DOGAREA_NIGHTLY_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/nightly-full-regression}"
+REPORT_DIR="$ARTIFACT_DIR/reports"
+LOG_DIR="$ARTIFACT_DIR/logs"
+EVIDENCE_DIR="$ARTIFACT_DIR/evidence"
+SUMMARY_PATH="$REPORT_DIR/nightly-full-regression-summary.md"
+MANUAL_STATUS_PATH="$REPORT_DIR/manual-blocker-status.txt"
+BACKEND_LOG_PATH="$LOG_DIR/backend-pr-check.log"
+AUTH_SMOKE_LOG_PATH="$LOG_DIR/auth-member-401-smoke.log"
+DOC_LOG_PATH="$LOG_DIR/nightly-doc-contracts.log"
+
+mkdir -p "$REPORT_DIR" "$LOG_DIR" "$EVIDENCE_DIR"
+cd "$ROOT_DIR"
+
+extract_surface_status() {
+  local surface="$1"
+  local file="$2"
+  awk -v target="== ${surface} ==" '
+    $0 == target { in_block=1; next }
+    /^== / && in_block { exit }
+    in_block && /^status: / { print $2; exit }
+  ' "$file"
+}
+
+render_summary() {
+  local nf003_status="$1"
+  local nf003_evidence="$2"
+  local nf003_note="$3"
+  local widget_status="$4"
+  local widget_axis_status="HOLD"
+  local widget_evidence='RD-004 + evidence/widget-action-evidence-pack.md'
+  local widget_note='Real-device widget transition evidence pending'
+
+  if [[ "$widget_status" == "complete" ]]; then
+    widget_axis_status="PASS"
+    widget_note='Widget evidence pack is complete and closure-ready'
+  elif [[ "$widget_status" == "incomplete" ]]; then
+    widget_note='Widget evidence pack exists but validator is still failing'
+  fi
+
+  cat > "$SUMMARY_PATH" <<EOF_SUMMARY
+# Nightly Full Regression Gate Report
+
+- Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+- Runner: scripts/run_nightly_full_regression_gate.sh
+- Artifact Root: ${ARTIFACT_DIR#"$ROOT_DIR"/}
+
+## Summary
+| Axis | Status | Retry | Real Device Evidence | Bucket |
+| --- | --- | --- | --- | --- |
+| NF-001 | HOLD | 0 | RD-001 | walk_long_session |
+| NF-002 | HOLD | 0 | RD-002 | offline_recovery |
+| NF-003 | ${nf003_status} | 0 | ${nf003_evidence} | nearby_presence_recovery |
+| NF-004 | ${widget_axis_status} | 0 | ${widget_evidence} | widget_state_transition |
+| NF-005 | HOLD | 0 | RD-005, RD-006 | watch_queue_sync |
+
+## Detail
+- NF-001: Long walk session remains a real-device evidence track. Use docs/release-real-device-evidence-matrix-v1.md and collect RD-001.
+- NF-002: Offline recovery remains a real-device evidence track. Use docs/release-real-device-evidence-matrix-v1.md and collect RD-002.
+- NF-003: ${nf003_note}
+- NF-004: ${widget_note}
+- NF-005: Watch queue/sync remains a real-device evidence track. Use docs/release-real-device-evidence-matrix-v1.md and collect RD-005, RD-006.
+
+## Artifacts
+- reports/manual-blocker-status.txt
+- evidence/widget-action-evidence-pack.md
+- evidence/auth-smtp-evidence-pack.md
+- logs/backend-pr-check.log
+- logs/auth-member-401-smoke.log
+EOF_SUMMARY
+}
+
+echo "[NightlyGate] Validate docs/contracts"
+{
+  swift scripts/nightly_full_regression_gate_unit_check.swift
+  swift scripts/manual_blocker_evidence_status_unit_check.swift
+  swift scripts/manual_evidence_validator_unit_check.swift
+} | tee "$DOC_LOG_PATH"
+
+echo "[NightlyGate] Render blocker evidence status"
+bash scripts/manual_blocker_evidence_status.sh --write-missing | tee "$MANUAL_STATUS_PATH"
+
+if [[ -f ".codex_tmp/widget-action-evidence-pack.md" ]]; then
+  cp ".codex_tmp/widget-action-evidence-pack.md" "$EVIDENCE_DIR/widget-action-evidence-pack.md"
+fi
+if [[ -f ".codex_tmp/auth-smtp-evidence-pack.md" ]]; then
+  cp ".codex_tmp/auth-smtp-evidence-pack.md" "$EVIDENCE_DIR/auth-smtp-evidence-pack.md"
+fi
+
+widget_status="$(extract_surface_status widget "$MANUAL_STATUS_PATH")"
+
+nf003_status="HOLD"
+nf003_evidence='`reports/manual-blocker-status.txt` + `logs/backend-pr-check.log`'
+nf003_note='Live backend smoke skipped because DOGAREA_TEST_EMAIL/DOGAREA_TEST_PASSWORD are not set'
+
+echo "[NightlyGate] Run backend baseline checks"
+if bash scripts/backend_pr_check.sh > >(tee "$BACKEND_LOG_PATH") 2>&1; then
+  nf003_note='backend_pr_check baseline passed; live member smoke not executed'
+else
+  nf003_status='FAIL'
+  nf003_evidence='`logs/backend-pr-check.log`'
+  nf003_note='backend_pr_check failed before live recovery verification'
+fi
+
+if [[ "$nf003_status" != "FAIL" && -n "${DOGAREA_TEST_EMAIL:-}" && -n "${DOGAREA_TEST_PASSWORD:-}" ]]; then
+  echo "[NightlyGate] Run member auth + nearby live smoke"
+  if DOGAREA_AUTH_SMOKE_ITERATIONS="${DOGAREA_AUTH_SMOKE_ITERATIONS:-1}" bash scripts/auth_member_401_smoke_check.sh > >(tee "$AUTH_SMOKE_LOG_PATH") 2>&1; then
+    nf003_status='PASS'
+    nf003_evidence='`logs/backend-pr-check.log`, `logs/auth-member-401-smoke.log`'
+    nf003_note='backend baseline and live member auth/nearby smoke both passed'
+  else
+    nf003_status='FAIL'
+    nf003_evidence='`logs/auth-member-401-smoke.log`'
+    nf003_note='member auth + nearby smoke failed'
+  fi
+fi
+
+render_summary "$nf003_status" "$nf003_evidence" "$nf003_note" "$widget_status"
+
+if [[ "$nf003_status" == "FAIL" ]]; then
+  echo "[NightlyGate] FAIL: NF-003 backend/live smoke axis failed"
+  exit 1
+fi
+
+echo "[NightlyGate] Done"
+echo "[NightlyGate] Summary: $SUMMARY_PATH"

--- a/scripts/run_pr_fast_smoke_map_ui_tests.sh
+++ b/scripts/run_pr_fast_smoke_map_ui_tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DESTINATION="${1:-platform=iOS Simulator,name=iPhone 16,OS=18.5}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-$HOME/Library/Developer/Xcode/DerivedData/dogArea-pr-fast-smoke-map}"
+
+run_ui_test() {
+  local test_case="${1:-}"
+  if [[ -z "$test_case" ]]; then
+    echo "[PRFastSmoke][FS-001] Missing test case name"
+    return 1
+  fi
+
+  xcodebuild -scheme dogArea \
+    -derivedDataPath "$DERIVED_DATA_PATH" \
+    -destination "$DESTINATION" \
+    "-only-testing:dogAreaUITests/FeatureRegressionUITests/$test_case" \
+    test-without-building
+}
+
+cd "$PROJECT_ROOT"
+
+echo "[PRFastSmoke][FS-001] Destination: $DESTINATION"
+echo "[PRFastSmoke][FS-001] DerivedData: $DERIVED_DATA_PATH"
+
+echo "[PRFastSmoke][FS-001] build-for-testing"
+xcodebuild -scheme dogArea \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  -destination "$DESTINATION" \
+  build-for-testing
+
+run_ui_test "testFeatureRegression_MapPrimaryActionIsNotObscuredByTabBar"
+run_ui_test "testFeatureRegression_MapAddPointControlRemainsHittableWhileWalking"
+run_ui_test "testFeatureRegression_MapBottomControllerStaysAnchoredAndCompactAtRest"
+run_ui_test "testFeatureRegression_MapWalkingTopHUDStaysBelowSafeAreaAndAboveBottomControls"
+
+echo "[PRFastSmoke][FS-001] Done"

--- a/scripts/run_pr_fast_smoke_watch_contract_checks.sh
+++ b/scripts/run_pr_fast_smoke_watch_contract_checks.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[PRFastSmoke][FS-004] watch baseline contract checks"
+swift scripts/watch_control_info_surface_split_unit_check.swift
+swift scripts/watch_action_feedback_ux_unit_check.swift
+swift scripts/watch_addpoint_haptic_policy_unit_check.swift
+swift scripts/watch_walk_end_summary_ux_unit_check.swift
+
+echo "[PRFastSmoke][FS-004] Done"
+echo "[PRFastSmoke][FS-004] Manual device confirmation remains a release/nightly evidence task when watch surface is impacted"

--- a/scripts/run_pr_fast_smoke_widget_layout_checks.sh
+++ b/scripts/run_pr_fast_smoke_widget_layout_checks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[PRFastSmoke][FS-002] widget family / clipping checks"
+swift scripts/widget_lock_screen_accessory_plan_unit_check.swift
+swift scripts/walk_control_widget_family_layout_unit_check.swift
+swift scripts/home_widget_family_layout_budget_unit_check.swift
+swift scripts/widget_state_cta_taxonomy_unit_check.swift
+
+echo "[PRFastSmoke][FS-002] Done"


### PR DESCRIPTION
## Summary
- add a dedicated PR fast smoke workflow with FS-001..FS-005 job names
- add a nightly full regression workflow with artifact/sample evidence pipeline
- split ios full check off pull_request and keep it as main/manual comprehensive validation

## Validation
- ruby YAML parse for all updated workflows
- swift scripts/pr_fast_smoke_gate_unit_check.swift
- swift scripts/nightly_full_regression_gate_unit_check.swift
- bash scripts/run_pr_fast_smoke_widget_layout_checks.sh
- bash scripts/run_pr_fast_smoke_watch_contract_checks.sh
- bash scripts/run_nightly_full_regression_gate.sh
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #725
Closes #723