### PR TITLE
fix: route profile image uploads through member auth

### DIFF
--- a/docs/backend-upload-profile-image-owner-binding-policy-v1.md
+++ b/docs/backend-upload-profile-image-owner-binding-policy-v1.md
@@ -29,6 +29,8 @@
 ## rationale
 
 - member path는 caller supplied `ownerId`를 신뢰하면 안 됩니다.
+- 앱 HTTP 클라이언트도 member 세션이 있으면 반드시 member bearer를 먼저 사용해야 합니다.
+- `upload-profile-image`를 anon-first로 호출하면 회원 프로필 편집도 anon path로 해석되어 `403 ANON_OWNER_NAMESPACE_REQUIRED`가 발생합니다.
 - anon path는 완전 차단보다 temporary namespace 격리가 더 현실적입니다.
 - path를 물리적으로 분리해야 운영 중 object ownership drift를 빨리 찾을 수 있습니다.
 
@@ -44,6 +46,7 @@
 - `upload_profile member=200`
 - `upload_profile app=200`
 - `upload_profile member_mismatch=403`
+- `anon bearer + member ownerId => 403 ANON_OWNER_NAMESPACE_REQUIRED`
 
 ## related
 

--- a/dogArea/Source/Infrastructure/Supabase/Services/SupabaseAuthAndAssetServices.swift
+++ b/dogArea/Source/Infrastructure/Supabase/Services/SupabaseAuthAndAssetServices.swift
@@ -348,6 +348,23 @@ final class SupabaseProfileImageRepository: ProfileImageRepository {
         try await upload(data: data, ownerId: ownerId, imageKind: "pet")
     }
 
+    /// 프로필 이미지 업로드 실패 상태 코드를 사용자 메시지로 변환합니다.
+    /// - Parameters:
+    ///   - statusCode: Edge Function이 반환한 HTTP 상태 코드입니다.
+    ///   - imageKind: 업로드 대상 종류(`user`/`pet`)입니다.
+    /// - Returns: 설정 화면에 바로 노출할 수 있는 지역화 메시지입니다.
+    private func localizedUploadFailureMessage(statusCode: Int, imageKind: String) -> String {
+        let assetName = imageKind == "pet" ? "반려견 프로필 사진" : "프로필 사진"
+        switch statusCode {
+        case 400:
+            return "\(assetName) 형식이 올바르지 않거나 너무 커서 업로드할 수 없어요. 이미지를 다시 선택해 주세요."
+        case 401, 403:
+            return "\(assetName) 업로드 권한을 확인하지 못했어요. 다시 로그인한 뒤 다시 시도해 주세요."
+        default:
+            return "\(assetName) 업로드에 실패했어요. 잠시 후 다시 시도해 주세요. (\(statusCode))"
+        }
+    }
+
     private func upload(data: Data, ownerId: String, imageKind: String) async throws -> String {
         let safeOwnerId = ownerId
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -357,11 +374,21 @@ final class SupabaseProfileImageRepository: ProfileImageRepository {
             imageBase64: data.base64EncodedString(),
             imageKind: imageKind
         )
-        let responseData = try await client.request(
-            .function(name: "upload-profile-image"),
-            method: .post,
-            body: requestBody
-        )
+        let responseData: Data
+        do {
+            responseData = try await client.request(
+                .function(name: "upload-profile-image"),
+                method: .post,
+                body: requestBody
+            )
+        } catch let httpError as SupabaseHTTPError {
+            if case .unexpectedStatusCode(let statusCode) = httpError {
+                throw SupabaseAssetError.serverError(
+                    localizedUploadFailureMessage(statusCode: statusCode, imageKind: imageKind)
+                )
+            }
+            throw SupabaseAssetError.serverError("프로필 사진 업로드 요청을 완료하지 못했어요. 네트워크 상태를 확인한 뒤 다시 시도해 주세요.")
+        }
         let decoded = try JSONDecoder().decode(UploadProfileImageResponseDTO.self, from: responseData)
         if let url = decoded.publicUrl, url.isEmpty == false {
             return url

--- a/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
+++ b/dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift
@@ -204,8 +204,7 @@ struct SupabaseHTTPClient {
     static let live = SupabaseHTTPClient()
     private static let edgeFunctionAnonRetryAllowlist: Set<String> = [
         "feature-control",
-        "nearby-presence",
-        "upload-profile-image"
+        "nearby-presence"
     ]
 
     private enum AccessTokenValidationState {

--- a/scripts/auth_edge_function_anon_retry_unit_check.swift
+++ b/scripts/auth_edge_function_anon_retry_unit_check.swift
@@ -16,6 +16,9 @@ func load(_ relativePath: String) -> String {
 }
 
 let infra = load("dogArea/Source/Infrastructure/Supabase/SupabaseInfrastructure.swift")
+let allowlistSnippet = infra.range(of: "private static let edgeFunctionAnonRetryAllowlist").map {
+    String(infra[$0.lowerBound...].prefix(180))
+} ?? ""
 
 assertTrue(
     infra.contains("private static let edgeFunctionAnonRetryAllowlist"),
@@ -23,9 +26,12 @@ assertTrue(
 )
 assertTrue(
     infra.contains("\"feature-control\"")
-        && infra.contains("\"nearby-presence\"")
-        && infra.contains("\"upload-profile-image\""),
-    "anon fallback allowlist should include feature-control, nearby-presence and upload-profile-image"
+        && infra.contains("\"nearby-presence\""),
+    "anon fallback allowlist should include feature-control and nearby-presence"
+)
+assertTrue(
+    !allowlistSnippet.contains("\"upload-profile-image\""),
+    "upload-profile-image should not use anon-first or anon-retry routing because member owner binding must stay authoritative"
 )
 assertTrue(
     infra.contains("private func shouldRetryWithAnonAuthorization("),

--- a/scripts/supabase_profile_image_upload_unit_check.swift
+++ b/scripts/supabase_profile_image_upload_unit_check.swift
@@ -38,9 +38,14 @@ let signingVM = load("dogArea/Views/SigningView/SigningViewModel.swift")
 let function = load("supabase/functions/upload-profile-image/index.ts")
 let readme = load("supabase/functions/upload-profile-image/README.md")
 let sharedHelper = load("supabase/functions/_shared/storage_upload.ts")
+let allowlistSnippet = infra.range(of: "private static let edgeFunctionAnonRetryAllowlist").map {
+    String(infra[$0.lowerBound...].prefix(180))
+} ?? ""
 
 assertTrue(infra.contains("SupabaseProfileImageRepository"), "infra should define SupabaseProfileImageRepository")
 assertTrue(infra.contains("upload-profile-image"), "infra should call upload-profile-image edge function")
+assertTrue(!allowlistSnippet.contains("\"upload-profile-image\""), "http client should not route upload-profile-image through anon-first allowlist")
+assertTrue(infra.contains("localizedUploadFailureMessage(statusCode: statusCode, imageKind: imageKind)"), "profile image repository should map upload status codes to user-facing failure copy")
 assertTrue(signingVM.contains("SupabaseProfileImageRepository.shared"), "signup should default to supabase image repository")
 
 assertTrue(function.contains("storage"), "edge function should call storage")


### PR DESCRIPTION
## Summary
- remove `upload-profile-image` from the anon-first/anon-retry edge function path
- keep member profile image uploads on member bearer so owner-bound uploads do not fail with `ANON_OWNER_NAMESPACE_REQUIRED`
- map common upload HTTP failures to clearer user-facing Korean copy
- harden static checks and owner-binding policy docs around the upload route

## Root cause
`upload-profile-image` was treated as an anon-first edge function in the app HTTP client. When a logged-in member edited a profile image, the request could go out with the anon bearer first. The backend correctly rejects `anon bearer + member ownerId` with `403 ANON_OWNER_NAMESPACE_REQUIRED`, so the app surfaced a profile upload failure even though the member session was valid.

## Validation
- `swift scripts/auth_edge_function_anon_retry_unit_check.swift`
- `swift scripts/supabase_profile_image_upload_unit_check.swift`
- `swift scripts/upload_profile_image_owner_binding_policy_unit_check.swift`
- `DOGAREA_AUTH_SMOKE_ITERATIONS=1 DOGAREA_TEST_EMAIL='jinnavis1@gmail.com' DOGAREA_TEST_PASSWORD='1q2w3e4r1!' bash scripts/auth_member_401_smoke_check.sh`
- `DOGAREA_DERIVED_DATA_PATH=.build/codex-730-build DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh`
- live repro:
  - anon bearer + member ownerId => `403 ANON_OWNER_NAMESPACE_REQUIRED`
  - member bearer + same ownerId => `200`

Closes #730
