### PR TITLE
test: add bundled widget blocker closure posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@
 - blocker evidence validator: `bash scripts/validate_manual_evidence_pack.sh <widget|auth-smtp> <filled-markdown>`
 - blocker closure renderer: `bash scripts/render_closure_comment_from_evidence.sh <widget|auth-smtp> ...`
 - blocker closure poster: `bash scripts/post_closure_comment_from_evidence.sh <widget|auth-smtp> --issue <number> ... [--post]`
+- widget blocker bundle poster: `bash scripts/post_closure_comment_from_evidence.sh widget --all-related .codex_tmp/widget-real-device-evidence --post`
 - Backend drift / RPC contract 전용 체크: `bash scripts/backend_migration_drift_check.sh`
 - Backend smoke entrypoint: `bash scripts/backend_pr_check.sh`
 - Live Supabase smoke matrix: `DOGAREA_RUN_SUPABASE_SMOKE=1 DOGAREA_TEST_EMAIL=... DOGAREA_TEST_PASSWORD=... bash scripts/backend_pr_check.sh`

--- a/docs/manual-blocker-evidence-status-runner-v1.md
+++ b/docs/manual-blocker-evidence-status-runner-v1.md
@@ -25,6 +25,7 @@
   - `next-validate`
   - `next-render-closure`
   - `next-post-closure`
+  - `next-post-closure-bundle` (`widget`만 제공)
 
 ## 기본 경로
 - widget: `.codex_tmp/widget-real-device-evidence`

--- a/docs/manual-closure-comment-poster-v1.md
+++ b/docs/manual-closure-comment-poster-v1.md
@@ -17,7 +17,11 @@
 ## 사용법
 - widget dry-run
   - `bash scripts/post_closure_comment_from_evidence.sh widget --issue 408 .codex_tmp/widget-real-device-evidence`
+- widget bundle dry-run
+  - `bash scripts/post_closure_comment_from_evidence.sh widget --all-related .codex_tmp/widget-real-device-evidence`
 - widget post
   - `bash scripts/post_closure_comment_from_evidence.sh widget --issue 731 .codex_tmp/widget-real-device-evidence --post`
+- widget bundle post
+  - `bash scripts/post_closure_comment_from_evidence.sh widget --all-related .codex_tmp/widget-real-device-evidence --post`
 - auth-smtp dry-run
   - `bash scripts/post_closure_comment_from_evidence.sh auth-smtp --issue 482 .codex_tmp/auth-smtp-evidence-pack.md --negative-guard "SMTP-101: cooldown suppressed with retry_after_seconds=60" --negative-provider-event "SMTP-102: bounce observed in provider dashboard"`

--- a/scripts/manual_blocker_evidence_status.sh
+++ b/scripts/manual_blocker_evidence_status.sh
@@ -97,6 +97,15 @@ surface_closure_post_command() {
   esac
 }
 
+surface_bundle_post_command() {
+  local surface="$1"
+  local pack_path="$2"
+  case "$surface" in
+    widget) printf 'bash scripts/post_closure_comment_from_evidence.sh widget --all-related %q --post' "$pack_path" ;;
+    auth-smtp) printf 'n/a' ;;
+  esac
+}
+
 surface_issue_state() {
   local issue_number="$1"
   if [[ "${DOGAREA_SKIP_ISSUE_STATE:-0}" == "1" ]]; then
@@ -164,6 +173,9 @@ print_surface_status() {
   printf 'next-validate: %s\n' "$(surface_validate_command "$surface" "$pack_path")"
   printf 'next-render-closure: %s\n' "$(surface_closure_render_command "$surface" "$pack_path")"
   printf 'next-post-closure: %s\n' "$(surface_closure_post_command "$surface" "$issue_number" "$pack_path")"
+  if [[ "$surface" == "widget" ]]; then
+    printf 'next-post-closure-bundle: %s\n' "$(surface_bundle_post_command "$surface" "$pack_path")"
+  fi
   printf '\n'
 }
 

--- a/scripts/manual_blocker_evidence_status_unit_check.swift
+++ b/scripts/manual_blocker_evidence_status_unit_check.swift
@@ -145,8 +145,10 @@ let backendPRCheck = load("scripts/backend_pr_check.sh")
 
 assertTrue(runnerScript.contains("widget-real-device-evidence"), "runner should support widget evidence directory")
 assertTrue(runnerScript.contains("related-issues"), "runner should print related widget issues")
+assertTrue(runnerScript.contains("next-post-closure-bundle"), "runner should print bundled widget post command")
 assertTrue(doc.contains("#617"), "doc should mention related widget issues")
 assertTrue(doc.contains("widget-real-device-evidence"), "doc should mention widget directory path")
+assertTrue(doc.contains("next-post-closure-bundle"), "doc should describe bundled widget post command")
 assertTrue(readme.contains("docs/manual-blocker-evidence-status-runner-v1.md"), "README should link runner doc")
 assertTrue(iosPRCheck.contains("manual_blocker_evidence_status_unit_check.swift"), "ios_pr_check should run blocker runner check")
 assertTrue(backendPRCheck.contains("manual_blocker_evidence_status_unit_check.swift"), "backend_pr_check should run blocker runner check")
@@ -192,6 +194,7 @@ let completeOutput = runStatus(arguments: ["widget"], environment: [
 ])
 assertTrue(completeOutput.contains("status: complete"), "filled widget evidence should be reported as complete")
 assertTrue(completeOutput.contains("render_closure_comment_from_evidence.sh widget"), "runner should print widget closure render command")
+assertTrue(completeOutput.contains("next-post-closure-bundle: bash scripts/post_closure_comment_from_evidence.sh widget --all-related"), "runner should print bundled widget post command")
 
 let authOutput = runStatus(arguments: ["auth-smtp"], environment: [
     "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,

--- a/scripts/manual_closure_comment_poster_unit_check.swift
+++ b/scripts/manual_closure_comment_poster_unit_check.swift
@@ -184,7 +184,9 @@ let backendPRCheck = load("scripts/backend_pr_check.sh")
 let authTemplate = load("docs/auth-smtp-rollout-evidence-template-v1.md")
 
 assertTrue(posterScript.contains("surface widget must target one of #408, #617, #692, #731"), "poster should allow widget blocker issue bundle")
+assertTrue(posterScript.contains("--all-related"), "poster should support widget bundle posting")
 assertTrue(posterDoc.contains("#617"), "poster doc should mention related widget issues")
+assertTrue(posterDoc.contains("--all-related"), "poster doc should document bundled widget posting")
 assertTrue(rendererDoc.contains("widget-real-device-evidence"), "renderer doc should reference widget bundle path")
 assertTrue(readme.contains("docs/manual-closure-comment-poster-v1.md"), "README should link poster doc")
 assertTrue(iosPRCheck.contains("manual_closure_comment_poster_unit_check.swift"), "ios_pr_check should run poster check")
@@ -222,14 +224,30 @@ let widgetDryRunOutput = runPoster(arguments: ["widget", "--issue", "617", widge
 assertTrue(widgetDryRunOutput.contains("실기기 위젯 blocker 검증을 완료했습니다."), "widget dry-run should print closure comment")
 assertTrue(widgetDryRunOutput.contains("DRY RUN: no GitHub comment was posted."), "widget dry-run should explain posting did not happen")
 
+let widgetBundleDryRunOutput = runPoster(arguments: ["widget", "--all-related", widgetTempDir.path], expectSuccess: true)
+assertTrue(widgetBundleDryRunOutput.contains("실기기 위젯 blocker 검증을 완료했습니다."), "widget bundle dry-run should print closure comment")
+assertTrue(widgetBundleDryRunOutput.contains("issues #408, #617, #692, and #731"), "widget bundle dry-run should mention all target issues")
+
 let widgetMismatchOutput = runPoster(arguments: ["widget", "--issue", "482", widgetTempDir.path], expectSuccess: false)
 assertTrue(widgetMismatchOutput.contains("surface widget must target one of #408, #617, #692, #731"), "widget poster should reject mismatched issue")
+
+let widgetBundleConflictOutput = runPoster(arguments: ["widget", "--issue", "617", "--all-related", widgetTempDir.path], expectSuccess: false)
+assertTrue(widgetBundleConflictOutput.contains("--issue and --all-related cannot be used together"), "widget poster should reject mixed single and bundled modes")
 
 let fakeWidgetGH = makeFakeGH(in: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString))
 let widgetPostOutput = runPoster(arguments: ["widget", "--issue", "731", widgetTempDir.path, "--post"], environment: ["DOGAREA_GH_BIN": fakeWidgetGH.binary.path], expectSuccess: true)
 let widgetGHLog = loadAbsolute(fakeWidgetGH.log)
 assertTrue(widgetGHLog.contains("issue comment 731 --body-file"), "widget post should call gh issue comment with issue 731")
 assertTrue(widgetPostOutput.contains("POSTED issue #731"), "widget post should report successful post")
+
+let fakeWidgetBundleGH = makeFakeGH(in: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString))
+let widgetBundlePostOutput = runPoster(arguments: ["widget", "--all-related", widgetTempDir.path, "--post"], environment: ["DOGAREA_GH_BIN": fakeWidgetBundleGH.binary.path], expectSuccess: true)
+let widgetBundleGHLog = loadAbsolute(fakeWidgetBundleGH.log)
+assertTrue(widgetBundleGHLog.contains("issue comment 408 --body-file"), "widget bundle post should comment on issue 408")
+assertTrue(widgetBundleGHLog.contains("issue comment 617 --body-file"), "widget bundle post should comment on issue 617")
+assertTrue(widgetBundleGHLog.contains("issue comment 692 --body-file"), "widget bundle post should comment on issue 692")
+assertTrue(widgetBundleGHLog.contains("issue comment 731 --body-file"), "widget bundle post should comment on issue 731")
+assertTrue(widgetBundlePostOutput.contains("POSTED issues #408, #617, #692, and #731"), "widget bundle post should report bundled post")
 
 let filledAuth = authTemplate
     .replacingOccurrences(of: "- Date:", with: "- Date: 2026-03-12")

--- a/scripts/post_closure_comment_from_evidence.sh
+++ b/scripts/post_closure_comment_from_evidence.sh
@@ -8,6 +8,7 @@ usage() {
   cat <<'USAGE'
 Usage:
   bash scripts/post_closure_comment_from_evidence.sh widget --issue <408|617|692|731> <evidence-dir> [--post] [--output <path>]
+  bash scripts/post_closure_comment_from_evidence.sh widget --all-related <evidence-dir> [--post] [--output <path>]
   bash scripts/post_closure_comment_from_evidence.sh auth-smtp --issue 482 <evidence-file> --negative-guard <text> --negative-provider-event <text> [--post] [--output <path>]
 USAGE
 }
@@ -38,6 +39,7 @@ issue_number=""
 evidence_path=""
 negative_guard=""
 negative_provider_event=""
+all_related=0
 post_mode=0
 output_path=""
 gh_bin="${DOGAREA_GH_BIN:-gh}"
@@ -53,6 +55,10 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || die "--issue requires a value"
       issue_number="${2#\#}"
       shift 2
+      ;;
+    --all-related)
+      all_related=1
+      shift
       ;;
     --negative-guard)
       [[ $# -ge 2 ]] || die "--negative-guard requires a value"
@@ -89,14 +95,19 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "$kind" ]] || { usage; exit 1; }
-[[ -n "$issue_number" ]] || die "--issue is required"
 [[ -n "$evidence_path" ]] || die "evidence path is required"
 
-if ! issue_allowed_for_surface "$kind" "$issue_number"; then
-  case "$kind" in
-    widget) die "surface widget must target one of #408, #617, #692, #731 (got #$issue_number)" ;;
-    auth-smtp) die "surface auth-smtp must target issue #482 (got #$issue_number)" ;;
-  esac
+if [[ "$all_related" == "1" ]]; then
+  [[ "$kind" == "widget" ]] || die "--all-related is only supported for widget"
+  [[ -z "$issue_number" ]] || die "--issue and --all-related cannot be used together"
+else
+  [[ -n "$issue_number" ]] || die "--issue is required"
+  if ! issue_allowed_for_surface "$kind" "$issue_number"; then
+    case "$kind" in
+      widget) die "surface widget must target one of #408, #617, #692, #731 (got #$issue_number)" ;;
+      auth-smtp) die "surface auth-smtp must target issue #482 (got #$issue_number)" ;;
+    esac
+  fi
 fi
 
 if [[ "$kind" == "auth-smtp" ]]; then
@@ -129,10 +140,22 @@ bash scripts/render_closure_comment_from_evidence.sh "${renderer_args[@]}" >/dev
 if [[ "$post_mode" != "1" ]]; then
   cat "$rendered_output_path"
   printf '\n'
-  printf 'DRY RUN: no GitHub comment was posted. Re-run with --post to publish to issue #%s.\n' "$issue_number" >&2
+  if [[ "$all_related" == "1" ]]; then
+    printf 'DRY RUN: no GitHub comment was posted. Re-run with --post to publish to issues #408, #617, #692, and #731.\n' >&2
+  else
+    printf 'DRY RUN: no GitHub comment was posted. Re-run with --post to publish to issue #%s.\n' "$issue_number" >&2
+  fi
   exit 0
 fi
 
 command -v "$gh_bin" >/dev/null 2>&1 || die "gh binary not found: $gh_bin"
-"$gh_bin" issue comment "$issue_number" --body-file "$rendered_output_path"
-printf 'POSTED issue #%s using %s\n' "$issue_number" "$gh_bin"
+if [[ "$all_related" == "1" ]]; then
+  posted_issues=(408 617 692 731)
+  for posted_issue in "${posted_issues[@]}"; do
+    "$gh_bin" issue comment "$posted_issue" --body-file "$rendered_output_path"
+  done
+  printf 'POSTED issues #408, #617, #692, and #731 using %s\n' "$gh_bin"
+else
+  "$gh_bin" issue comment "$issue_number" --body-file "$rendered_output_path"
+  printf 'POSTED issue #%s using %s\n' "$issue_number" "$gh_bin"
+fi


### PR DESCRIPTION
## Summary
- add `--all-related` support for widget evidence closure posting
- print bundled widget post command from the blocker status runner
- document and statically verify the one-shot multi-issue posting flow

## Related
- closes #752
- refs #408
- refs #617
- refs #692
- refs #731

## Validation
- bash -n scripts/post_closure_comment_from_evidence.sh
- bash -n scripts/manual_blocker_evidence_status.sh
- swift scripts/manual_closure_comment_poster_unit_check.swift
- swift scripts/manual_blocker_evidence_status_unit_check.swift
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh

## Note
- this only reduces repetitive posting once real-device evidence exists
- it does not close #408/#617/#692/#731 by itself
