### PR TITLE
test: target active widget blocker issues only

### DIFF
--- a/docs/manual-blocker-evidence-status-runner-v1.md
+++ b/docs/manual-blocker-evidence-status-runner-v1.md
@@ -1,10 +1,10 @@
 # Manual Blocker Evidence Status Runner v1
 
 ## 목적
-- `#408` widget blocker bundle과 `#482` Auth SMTP blocker의 현재 evidence 상태를 한 번에 점검한다.
+- active widget blocker bundle과 `#482` Auth SMTP blocker의 현재 evidence 상태를 한 번에 점검한다.
 
 ## 대상 surface
-- `widget` -> primary `#408`, related `#617`, `#692`, `#731`
+- `widget` -> primary `#731`, related `#617`, `#692`
 - `auth-smtp` -> `#482`
 
 ## 명령

--- a/docs/manual-closure-comment-poster-v1.md
+++ b/docs/manual-closure-comment-poster-v1.md
@@ -1,7 +1,7 @@
 # Manual Closure Comment Poster v1
 
 - Issue: #684
-- Relates to: #408, #482
+- Relates to: #408 (closed umbrella), #482
 
 ## 목적
 - validator와 renderer를 통과한 evidence를 GitHub issue comment로 바로 게시한다.
@@ -11,7 +11,8 @@
 - 스크립트: `bash scripts/post_closure_comment_from_evidence.sh`
 
 ## 지원 surface / issue 조합
-- `widget` -> `#408`, `#617`, `#692`, `#731`
+- `widget` -> single issue `#408`, `#617`, `#692`, `#731`
+- `widget --all-related` -> active blockers `#731`, `#617`, `#692`
 - `auth-smtp` -> `#482`
 
 ## 사용법

--- a/docs/manual-closure-comment-renderer-v1.md
+++ b/docs/manual-closure-comment-renderer-v1.md
@@ -1,7 +1,7 @@
 # Manual Closure Comment Renderer v1
 
 - Issue: #676
-- Relates to: #408, #482
+- Relates to: #408 (closed umbrella), #482
 
 ## 목적
 - validated evidence를 최종 종료 코멘트 형태로 빠르게 변환한다.
@@ -18,7 +18,7 @@
     - `WL-001` ... `WL-008` complete
     - 모든 케이스가 `Pass`
   - 출력:
-    - `#408`, `#617`, `#692`, `#731`에 공통으로 붙일 수 있는 closure comment 초안
+    - active blocker `#617`, `#692`, `#731`에 공통으로 붙일 수 있는 closure comment 초안
 - `auth-smtp`
   - 입력: validated auth smtp evidence 파일 1개
 

--- a/docs/manual-evidence-helper-v1.md
+++ b/docs/manual-evidence-helper-v1.md
@@ -1,7 +1,7 @@
 # Manual Evidence Helper v1
 
 - Issue: #672
-- Relates to: #408, #482
+- Relates to: #408 (closed umbrella), #482
 
 ## 목적
 - blocker 상태인 manual evidence 이슈를 한 번에 시작할 수 있게 한다.
@@ -13,7 +13,7 @@
 
 ## 지원 모드
 - `widget`
-  - 대상 이슈: `#408`, 관련 blocker `#617`, `#692`, `#731`
+  - 대상 이슈: active blocker `#731`, 관련 blocker `#617`, `#692`
   - 출력: 디렉터리 bundle
   - 포함 문서
     - `docs/widget-action-real-device-evidence-runbook-v1.md`
@@ -52,4 +52,4 @@
 
 ## 운영 규칙
 - 이 helper는 evidence를 대신 채우지 않는다.
-- `#408`, `#617`, `#692`, `#731`, `#482`는 실제 실기기/운영 증적이 들어오기 전까지 닫지 않는다.
+- `#617`, `#692`, `#731`, `#482`는 실제 실기기/운영 증적이 들어오기 전까지 닫지 않는다.

--- a/docs/manual-evidence-validator-v1.md
+++ b/docs/manual-evidence-validator-v1.md
@@ -1,7 +1,7 @@
 # Manual Evidence Validator v1
 
 - Issue: #674
-- Relates to: #408, #482
+- Relates to: #408 (closed umbrella), #482
 
 ## 목적
 - helper로 만든 evidence pack이 실제 closure 용도로 충분히 채워졌는지 빠르게 확인한다.
@@ -25,7 +25,7 @@
 - `bash scripts/render_manual_evidence_pack.sh widget --write`
 - `bash scripts/validate_manual_evidence_pack.sh widget .codex_tmp/widget-real-device-evidence`
 - `bash scripts/render_closure_comment_from_evidence.sh widget .codex_tmp/widget-real-device-evidence --write`
-- `bash scripts/post_closure_comment_from_evidence.sh widget --issue 408 .codex_tmp/widget-real-device-evidence --post`
+- `bash scripts/post_closure_comment_from_evidence.sh widget --all-related .codex_tmp/widget-real-device-evidence --post`
 
 ## 출력 규칙
 - 성공 시

--- a/docs/widget-action-closure-checklist-v1.md
+++ b/docs/widget-action-closure-checklist-v1.md
@@ -1,10 +1,10 @@
 # Widget Action Closure Checklist v1
 
 - Issue: #668
-- Relates to: #408, #617, #692, #731
+- Relates to: #408 (closed umbrella), #617, #692, #731
 
 ## 목적
-- `#408`을 닫기 전에 실제로 채워져야 하는 증적 항목을 한 문서에 고정한다.
+- active widget blocker `#617`, `#692`, `#731`을 닫기 전에 실제로 채워져야 하는 증적 항목을 한 문서에 고정한다.
 - action convergence와 layout/clipping evidence가 분리돼 누락되는 일을 막는다.
 
 ## 선행 문서
@@ -62,5 +62,5 @@
 - 남은 실패 케이스가 있으면 blocker와 owner가 적혀 있다.
 
 ## 종료 판정
-- 위 항목이 모두 채워졌고 실패 케이스가 없다면 `#408`, `#617`, `#692`, `#731`을 닫아도 된다.
+- 위 항목이 모두 채워졌고 실패 케이스가 없다면 active blocker `#617`, `#692`, `#731`을 닫아도 된다.
 - 실패 케이스가 남아 있으면 blocker를 닫지 않는다.

--- a/docs/widget-action-closure-comment-template-v1.md
+++ b/docs/widget-action-closure-comment-template-v1.md
@@ -1,7 +1,7 @@
 # Widget Action Closure Comment Template v1
 
 - Issue: #668
-- Relates to: #408, #617, #692, #731
+- Relates to: #408 (closed umbrella), #617, #692, #731
 
 ```md
 실기기 위젯 blocker 검증을 완료했습니다.
@@ -47,5 +47,5 @@ layout / clipping 케이스
 - 없음
 
 결론
-- `#408`, `#617`, `#692`, `#731` DoD를 충족했으므로 종료합니다.
+- active widget blocker `#617`, `#692`, `#731` DoD를 충족했으므로 종료합니다.
 ```

--- a/docs/widget-action-real-device-evidence-runbook-v1.md
+++ b/docs/widget-action-real-device-evidence-runbook-v1.md
@@ -1,12 +1,12 @@
 # Widget Action Real-Device Evidence Runbook v1
 
 - Issue: #662
-- Relates to: #408, #617, #731
+- Relates to: #408 (closed umbrella), #617, #731
 
 ## 목적
 - 실기기 위젯 액션 검증 결과를 저장소 기준으로 일관되게 남긴다.
 - `pass/fail`만 적는 대신 로그, 스크린샷, request_id, 앱 상태를 함께 남긴다.
-- `#408`, `#617`, `#731` 종료에 필요한 manual QA evidence를 재현 가능한 형식으로 고정한다.
+- active blocker `#617`, `#731` 종료에 필요한 manual QA evidence를 재현 가능한 형식으로 고정한다.
 
 ## 선행 문서
 - 검증 축 정의: `docs/widget-action-real-device-validation-matrix-v1.md`
@@ -60,5 +60,5 @@
 - `auth overlay`가 필요한데 요청이 소실되거나 잘못된 상태로 종료된다.
 
 ## 운영 규칙
-- `#408`을 닫을 때는 action evidence만 complete여도 부족하다. layout evidence `WL-*`까지 complete여야 한다.
+- active blocker를 닫을 때는 action evidence만 complete여도 부족하다. layout evidence `WL-*`까지 complete여야 한다.
 - simulator 결과는 참고 자료일 뿐, `real-device evidence` 대체물이 아니다.

--- a/docs/widget-action-real-device-evidence-template-v1.md
+++ b/docs/widget-action-real-device-evidence-template-v1.md
@@ -1,7 +1,7 @@
 # Widget Action Real-Device Evidence Template v1
 
 - Issue: #662
-- Relates to: #408
+- Relates to: #408 (closed umbrella), #617, #731
 
 ## 기록 메타
 - Date:

--- a/docs/widget-action-real-device-validation-matrix-v1.md
+++ b/docs/widget-action-real-device-validation-matrix-v1.md
@@ -1,13 +1,13 @@
 # Widget Action Real-Device Validation Matrix v1
 
 - Issue: #660
-- Relates to: #408, #617, #731
+- Relates to: #408 (closed umbrella), #617, #731
 
 ## 목적
 - 위젯 액션 경로의 실기기 검증 결과를 한 문서에 남긴다.
 - simulator 자동 회귀와 분리된 real-device evidence 포맷을 고정한다.
 - cold start / background / foreground / auth state / action 축을 누락 없이 기록한다.
-- `#617`, `#731`에서 요구한 action convergence evidence를 `#408` closure pack으로 연결한다.
+- `#617`, `#731`에서 요구한 action convergence evidence를 active blocker closure pack으로 연결한다.
 
 ## 자동 회귀 진입점
 - 전용 위젯 액션 UI 러너: `bash scripts/run_widget_action_regression_ui_tests.sh`
@@ -61,6 +61,6 @@
 - 필요하면 `request_id` 또는 위젯 action route 문자열을 함께 남긴다.
 
 ## 운영 규칙
-- `#408`을 닫을 때는 `WD-001` ... `WD-008` action evidence와 `WL-001` ... `WL-008` layout evidence가 모두 complete여야 한다.
+- active blocker를 닫을 때는 `WD-001` ... `WD-008` action evidence와 `WL-001` ... `WL-008` layout evidence가 모두 complete여야 한다.
 - simulator 결과만으로는 `real-device validation` DoD를 충족하지 않는다.
 - 새 widget action route를 추가하면 자동 회귀 스크립트와 이 문서, bundle skeleton을 같이 갱신한다.

--- a/docs/widget-family-real-device-evidence-runbook-v1.md
+++ b/docs/widget-family-real-device-evidence-runbook-v1.md
@@ -1,7 +1,7 @@
 # Widget Family Real-Device Evidence Runbook v1
 
 - Issue: #751
-- Relates to: #692, #731, #408
+- Relates to: #692, #731, #408 (closed umbrella)
 
 ## 목적
 - 위젯 family별 실기기 clipping / overflow / CTA 충돌 증적을 일관되게 남긴다.
@@ -60,4 +60,4 @@
 
 ## 운영 규칙
 - `WL-001` ... `WL-008`이 모두 채워져야 `#692`, `#731`의 실기기 layout evidence가 complete로 본다.
-- 이 문서만으로는 충분하지 않고, action 수렴 evidence `WD-001` ... `WD-008`도 함께 complete여야 `#408`을 닫을 수 있다.
+- 이 문서만으로는 충분하지 않고, action 수렴 evidence `WD-001` ... `WD-008`도 함께 complete여야 active blocker를 닫을 수 있다.

--- a/docs/widget-family-real-device-evidence-template-v1.md
+++ b/docs/widget-family-real-device-evidence-template-v1.md
@@ -1,7 +1,7 @@
 # Widget Family Real-Device Evidence Template v1
 
 - Issue: #751
-- Relates to: #692, #731, #408
+- Relates to: #692, #731, #408 (closed umbrella)
 
 ## 기록 메타
 - Date:

--- a/docs/widget-family-real-device-validation-matrix-v1.md
+++ b/docs/widget-family-real-device-validation-matrix-v1.md
@@ -1,7 +1,7 @@
 # Widget Family Real-Device Validation Matrix v1
 
 - Issue: #751
-- Relates to: #692, #731, #408
+- Relates to: #692, #731, #408 (closed umbrella)
 
 ## 목적
 - 홈 화면 위젯 4종의 `systemSmall`, `systemMedium` family를 실기기 기준으로 전수 조사한다.
@@ -55,4 +55,4 @@
 ## 완료 규칙
 - `WL-001` ... `WL-008`이 모두 채워져야 `#692`, `#731` 실기기 layout 증적이 충족된다.
 - `Pass`가 아닌 케이스가 하나라도 있으면 blocker를 닫지 않는다.
-- action 수렴 케이스 `WD-001` ... `WD-008`과 layout 케이스 `WL-001` ... `WL-008`을 함께 봐야 `#408` 종료 판단이 가능하다.
+- action 수렴 케이스 `WD-001` ... `WD-008`과 layout 케이스 `WL-001` ... `WL-008`을 함께 봐야 active blocker 종료 판단이 가능하다.

--- a/scripts/manual_blocker_evidence_status.sh
+++ b/scripts/manual_blocker_evidence_status.sh
@@ -50,7 +50,7 @@ surface_pack_path() {
 
 surface_issue_number() {
   case "$1" in
-    widget) printf '408' ;;
+    widget) printf '731' ;;
     auth-smtp) printf '482' ;;
     *) die "unsupported surface: $1" ;;
   esac
@@ -58,7 +58,7 @@ surface_issue_number() {
 
 surface_related_issues() {
   case "$1" in
-    widget) printf '#617 #692 #731' ;;
+    widget) printf '#617 #692' ;;
     auth-smtp) printf 'none' ;;
     *) die "unsupported surface: $1" ;;
   esac

--- a/scripts/manual_blocker_evidence_status_unit_check.swift
+++ b/scripts/manual_blocker_evidence_status_unit_check.swift
@@ -146,7 +146,7 @@ let backendPRCheck = load("scripts/backend_pr_check.sh")
 assertTrue(runnerScript.contains("widget-real-device-evidence"), "runner should support widget evidence directory")
 assertTrue(runnerScript.contains("related-issues"), "runner should print related widget issues")
 assertTrue(runnerScript.contains("next-post-closure-bundle"), "runner should print bundled widget post command")
-assertTrue(doc.contains("#617"), "doc should mention related widget issues")
+assertTrue(doc.contains("primary `#731`, related `#617`, `#692`"), "doc should describe active widget blocker routing")
 assertTrue(doc.contains("widget-real-device-evidence"), "doc should mention widget directory path")
 assertTrue(doc.contains("next-post-closure-bundle"), "doc should describe bundled widget post command")
 assertTrue(readme.contains("docs/manual-blocker-evidence-status-runner-v1.md"), "README should link runner doc")
@@ -163,7 +163,8 @@ let missingOutput = runStatus(arguments: ["widget"], environment: [
 ])
 assertTrue(missingOutput.contains("== widget =="), "runner should print widget header")
 assertTrue(missingOutput.contains("status: missing"), "runner should mark missing widget evidence")
-assertTrue(missingOutput.contains("related-issues: #617 #692 #731"), "runner should print related widget issues")
+assertTrue(missingOutput.contains("issue: #731 (skipped)"), "runner should print active widget primary issue")
+assertTrue(missingOutput.contains("related-issues: #617 #692"), "runner should print related widget issues")
 
 let generatedOutput = runStatus(arguments: ["widget", "--write-missing"], environment: [
     "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,

--- a/scripts/manual_closure_comment_poster_unit_check.swift
+++ b/scripts/manual_closure_comment_poster_unit_check.swift
@@ -226,7 +226,7 @@ assertTrue(widgetDryRunOutput.contains("DRY RUN: no GitHub comment was posted.")
 
 let widgetBundleDryRunOutput = runPoster(arguments: ["widget", "--all-related", widgetTempDir.path], expectSuccess: true)
 assertTrue(widgetBundleDryRunOutput.contains("실기기 위젯 blocker 검증을 완료했습니다."), "widget bundle dry-run should print closure comment")
-assertTrue(widgetBundleDryRunOutput.contains("issues #408, #617, #692, and #731"), "widget bundle dry-run should mention all target issues")
+assertTrue(widgetBundleDryRunOutput.contains("issues #731, #617, and #692"), "widget bundle dry-run should mention active target issues")
 
 let widgetMismatchOutput = runPoster(arguments: ["widget", "--issue", "482", widgetTempDir.path], expectSuccess: false)
 assertTrue(widgetMismatchOutput.contains("surface widget must target one of #408, #617, #692, #731"), "widget poster should reject mismatched issue")
@@ -243,11 +243,11 @@ assertTrue(widgetPostOutput.contains("POSTED issue #731"), "widget post should r
 let fakeWidgetBundleGH = makeFakeGH(in: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString))
 let widgetBundlePostOutput = runPoster(arguments: ["widget", "--all-related", widgetTempDir.path, "--post"], environment: ["DOGAREA_GH_BIN": fakeWidgetBundleGH.binary.path], expectSuccess: true)
 let widgetBundleGHLog = loadAbsolute(fakeWidgetBundleGH.log)
-assertTrue(widgetBundleGHLog.contains("issue comment 408 --body-file"), "widget bundle post should comment on issue 408")
+assertTrue(!widgetBundleGHLog.contains("issue comment 408 --body-file"), "widget bundle post should skip closed issue 408")
+assertTrue(widgetBundleGHLog.contains("issue comment 731 --body-file"), "widget bundle post should comment on issue 731")
 assertTrue(widgetBundleGHLog.contains("issue comment 617 --body-file"), "widget bundle post should comment on issue 617")
 assertTrue(widgetBundleGHLog.contains("issue comment 692 --body-file"), "widget bundle post should comment on issue 692")
-assertTrue(widgetBundleGHLog.contains("issue comment 731 --body-file"), "widget bundle post should comment on issue 731")
-assertTrue(widgetBundlePostOutput.contains("POSTED issues #408, #617, #692, and #731"), "widget bundle post should report bundled post")
+assertTrue(widgetBundlePostOutput.contains("POSTED issues #731, #617, and #692"), "widget bundle post should report bundled post")
 
 let filledAuth = authTemplate
     .replacingOccurrences(of: "- Date:", with: "- Date: 2026-03-12")

--- a/scripts/manual_closure_comment_renderer_unit_check.swift
+++ b/scripts/manual_closure_comment_renderer_unit_check.swift
@@ -181,7 +181,7 @@ let widgetOutput = runRenderer(arguments: ["widget", widgetDirectory.path], expe
 assertTrue(widgetOutput.contains("실기기 위젯 blocker 검증을 완료했습니다."), "widget comment should include intro")
 assertTrue(widgetOutput.contains("`WD-001`: Pass - member rival route converged"), "widget comment should include WD-001 summary")
 assertTrue(widgetOutput.contains("`WL-008`: Pass - HotspotStatusWidget layout stayed within bounds"), "widget comment should include WL-008 summary")
-assertTrue(widgetOutput.contains("`#408`, `#617`, `#692`, `#731` DoD를 충족했으므로 종료합니다."), "widget comment should include bundled closure line")
+assertTrue(widgetOutput.contains("active widget blocker `#617`, `#692`, `#731` DoD를 충족했으므로 종료합니다."), "widget comment should include active blocker closure line")
 
 let incompleteWidgetDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
 write(incompleteWidgetDirectory.appendingPathComponent("action/WD-001.md"), content: filledWidgetAction(caseID: "WD-001", summary: "only one case"))

--- a/scripts/post_closure_comment_from_evidence.sh
+++ b/scripts/post_closure_comment_from_evidence.sh
@@ -141,7 +141,7 @@ if [[ "$post_mode" != "1" ]]; then
   cat "$rendered_output_path"
   printf '\n'
   if [[ "$all_related" == "1" ]]; then
-    printf 'DRY RUN: no GitHub comment was posted. Re-run with --post to publish to issues #408, #617, #692, and #731.\n' >&2
+    printf 'DRY RUN: no GitHub comment was posted. Re-run with --post to publish to issues #731, #617, and #692.\n' >&2
   else
     printf 'DRY RUN: no GitHub comment was posted. Re-run with --post to publish to issue #%s.\n' "$issue_number" >&2
   fi
@@ -150,11 +150,11 @@ fi
 
 command -v "$gh_bin" >/dev/null 2>&1 || die "gh binary not found: $gh_bin"
 if [[ "$all_related" == "1" ]]; then
-  posted_issues=(408 617 692 731)
+  posted_issues=(731 617 692)
   for posted_issue in "${posted_issues[@]}"; do
     "$gh_bin" issue comment "$posted_issue" --body-file "$rendered_output_path"
   done
-  printf 'POSTED issues #408, #617, #692, and #731 using %s\n' "$gh_bin"
+  printf 'POSTED issues #731, #617, and #692 using %s\n' "$gh_bin"
 else
   "$gh_bin" issue comment "$issue_number" --body-file "$rendered_output_path"
   printf 'POSTED issue #%s using %s\n' "$issue_number" "$gh_bin"

--- a/scripts/render_closure_comment_from_evidence.sh
+++ b/scripts/render_closure_comment_from_evidence.sh
@@ -164,12 +164,13 @@ HEADER
 - `#617` start/end 액션 후 위젯·Live Activity·앱 상태 수렴 규칙
 - `#692` 홈 화면 위젯 family별 clipping zero-base 정리
 - `#731` WalkControlWidget 실기기 clipping과 start/end 액션 불능 회귀
+- `#408` umbrella epic은 이미 종료되어, 이번 closure comment는 active blocker 기준으로만 게시합니다.
 
 남은 blocker
 - 없음
 
 결론
-- `#408`, `#617`, `#692`, `#731` DoD를 충족했으므로 종료합니다.
+- active widget blocker `#617`, `#692`, `#731` DoD를 충족했으므로 종료합니다.
 FOOTER
 }
 

--- a/scripts/widget_action_closure_pack_unit_check.swift
+++ b/scripts/widget_action_closure_pack_unit_check.swift
@@ -33,7 +33,7 @@ let layoutMatrix = load("docs/widget-family-real-device-validation-matrix-v1.md"
 let readme = load("README.md")
 let iosPRCheck = load("scripts/ios_pr_check.sh")
 
-assertTrue(checklist.contains("#408, #617, #692, #731"), "checklist should reference bundled widget issues")
+assertTrue(checklist.contains("#408 (closed umbrella), #617, #692, #731"), "checklist should reference widget issue set with closed umbrella context")
 for caseID in ["WD-001", "WD-008", "WL-001", "WL-008"] {
     assertTrue(checklist.contains(caseID), "checklist should require \(caseID)")
 }
@@ -45,7 +45,7 @@ assertTrue(template.contains("실기기 위젯 blocker 검증을 완료했습니
 assertTrue(template.contains("layout / clipping 케이스"), "template should include layout section")
 assertTrue(template.contains("#617"), "template should mention #617")
 assertTrue(template.contains("#731"), "template should mention #731")
-assertTrue(template.contains("#408`, `#617`, `#692`, `#731"), "template should close bundled issues")
+assertTrue(template.contains("active widget blocker `#617`, `#692`, `#731`"), "template should close active widget blockers")
 
 assertTrue(actionMatrix.contains("docs/widget-action-closure-checklist-v1.md"), "action matrix should reference closure checklist")
 assertTrue(layoutMatrix.contains("docs/widget-action-closure-checklist-v1.md"), "layout matrix should reference closure checklist")


### PR DESCRIPTION
## Summary
- retarget widget bundled closure flow to active blocker issues only
- make widget blocker status runner use `#731` as primary and `#617/#692` as related issues
- align closure docs/templates/runbooks with the current active blocker set while keeping `#408` as closed umbrella context

## Related
- closes #754
- refs #617
- refs #692
- refs #731

## Validation
- bash -n scripts/post_closure_comment_from_evidence.sh
- bash -n scripts/manual_blocker_evidence_status.sh
- bash -n scripts/render_closure_comment_from_evidence.sh
- swift scripts/widget_action_real_device_evidence_unit_check.swift
- swift scripts/widget_action_closure_pack_unit_check.swift
- swift scripts/manual_closure_comment_renderer_unit_check.swift
- swift scripts/manual_closure_comment_poster_unit_check.swift
- swift scripts/manual_blocker_evidence_status_unit_check.swift
- swift scripts/manual_evidence_helper_unit_check.swift
- swift scripts/manual_evidence_validator_unit_check.swift
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh
