### PR TITLE
test: validate manual evidence asset paths

### DIFF
--- a/docs/auth-smtp-rollout-evidence-runbook-v1.md
+++ b/docs/auth-smtp-rollout-evidence-runbook-v1.md
@@ -84,14 +84,16 @@
 9. bounce/reject/deferred가 있으면 provider event 캡처를 남긴다.
 10. rollback readiness와 secret rotation 담당자를 기록한다.
 11. `.codex_tmp/auth-smtp-evidence/` bundle 파일을 모두 채운다.
+    - `assets/`
     - `01-dns-verification.md`
     - `02-supabase-smtp-settings.md`
     - `03-live-send-results.md`
     - `04-negative-evidence.md`
     - `05-rollback-rotation.md`
     - `06-final-decision.md`
-12. 코멘트로 올리기 전 `bash scripts/validate_manual_evidence_pack.sh auth-smtp <bundle-dir>` 으로 완결성을 검사한다.
-13. closure comment를 바로 게시하려면 `bash scripts/post_closure_comment_from_evidence.sh auth-smtp --issue 482 <bundle-dir> --post`를 사용한다.
+12. 캡처한 dashboard/mailbox 이미지를 `assets/`에 같은 파일명으로 저장한다.
+13. 코멘트로 올리기 전 `bash scripts/validate_manual_evidence_pack.sh auth-smtp <bundle-dir>` 으로 완결성과 asset 존재를 검사한다.
+14. closure comment를 바로 게시하려면 `bash scripts/post_closure_comment_from_evidence.sh auth-smtp --issue 482 <bundle-dir> --post`를 사용한다.
 
 ## 실수신 시나리오 규칙
 ### Signup confirmation
@@ -119,14 +121,20 @@
 - bounce/reject/deferred가 발생했다면 reason과 retry 여부를 적는다.
 
 ## 스크린샷 규칙
-- 최소 3장
+- 최소 6장
   - provider domain verification
   - Supabase SMTP settings
-  - mailbox 수신 화면
+  - signup mailbox 수신 화면
+  - password reset mailbox 수신 화면
+  - email change mailbox 수신 화면
+  - provider event 또는 dashboard 화면
 - 파일명 예시
-  - `SMTP-001-provider-domain.png`
-  - `SMTP-001-supabase-settings.png`
-  - `SMTP-001-signup-mailbox.png`
+  - `assets/provider-domain.png`
+  - `assets/supabase-smtp-settings.png`
+  - `assets/signup-mailbox.png`
+  - `assets/password-reset-mailbox.png`
+  - `assets/email-change-mailbox.png`
+  - `assets/provider-dashboard-event.png`
 
 ## Pass 기준
 - custom SMTP provider가 production 또는 rollout 대상 project에 실제로 연결돼 있다.

--- a/docs/auth-smtp-rollout-evidence-template-v1.md
+++ b/docs/auth-smtp-rollout-evidence-template-v1.md
@@ -4,6 +4,7 @@
 - Relates to: #482
 
 ## canonical bundle layout
+- `assets/`
 - `01-dns-verification.md`
 - `02-supabase-smtp-settings.md`
 - `03-live-send-results.md`
@@ -24,7 +25,7 @@
 - DKIM:
 - DMARC:
 - Provider Verified Timestamp:
-- Evidence Screenshot:
+- Evidence Screenshot: assets/provider-domain.png
 ```
 
 ## 02-supabase-smtp-settings.md
@@ -38,18 +39,18 @@
 - Sender Email:
 - `email_sent`:
 - `auth.email.max_frequency`:
-- Settings Screenshot:
+- Settings Screenshot: assets/supabase-smtp-settings.png
 ```
 
 ## 03-live-send-results.md
 ```md
 # Live Send Results
 
-| Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | Notes |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| signup confirmation |  |  |  |  |  |  |  |
-| password reset |  |  |  |  |  |  |  |
-| email change |  |  |  |  |  |  |  |
+| Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | evidence_asset | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| signup confirmation |  |  |  |  |  |  | assets/signup-mailbox.png |  |
+| password reset |  |  |  |  |  |  | assets/password-reset-mailbox.png |  |
+| email change |  |  |  |  |  |  | assets/email-change-mailbox.png |  |
 ```
 
 ## 04-negative-evidence.md
@@ -62,7 +63,7 @@
 - reject:
 - deferred:
 - provider_event_id:
-- Dashboard / Webhook Evidence:
+- Dashboard / Webhook Evidence: assets/provider-dashboard-event.png
 ```
 
 ## 05-rollback-rotation.md

--- a/docs/manual-evidence-helper-v1.md
+++ b/docs/manual-evidence-helper-v1.md
@@ -47,10 +47,13 @@
   - auth-smtp: `.codex_tmp/auth-smtp-evidence`
 - widget bundle에는 아래가 생성된다.
   - `README.md`
+  - `assets/action/`
+  - `assets/layout/`
   - `action/WD-001.md` ... `action/WD-008.md`
   - `layout/WL-001.md` ... `layout/WL-008.md`
 - auth-smtp bundle에는 아래가 생성된다.
   - `README.md`
+  - `assets/`
   - `01-dns-verification.md`
   - `02-supabase-smtp-settings.md`
   - `03-live-send-results.md`

--- a/docs/manual-evidence-validator-v1.md
+++ b/docs/manual-evidence-validator-v1.md
@@ -18,8 +18,12 @@
     - `layout/WL-001.md` ... `layout/WL-008.md` 존재 및 완결
     - action 케이스 로그/스크린샷 필드 완결
     - layout 케이스 budget/스크린샷 필드 완결
+    - `assets/action/*`, `assets/layout/*` 참조 경로 실제 존재
 - `auth-smtp`
   - 입력: 운영 증적 bundle 디렉터리
+  - 검사:
+    - `assets/*` 참조 경로 실제 존재
+    - live send `evidence_asset` 열 완결
 
 ## 사용법
 - `bash scripts/render_manual_evidence_pack.sh widget --write`
@@ -35,4 +39,4 @@
   - `PASS: auth-smtp evidence is complete`
 - 실패 시
   - non-zero exit
-  - 누락된 필드/파일/placeholder를 항목별로 출력
+  - 누락된 필드/파일/placeholder/asset 경로를 항목별로 출력

--- a/docs/widget-action-real-device-evidence-runbook-v1.md
+++ b/docs/widget-action-real-device-evidence-runbook-v1.md
@@ -33,6 +33,7 @@
   - 위젯 탭 직후 화면
   - 최종 도착 화면
   - 실패 시 에러/오버레이 상태
+  - asset 경로는 bundle root 기준 `assets/action/*.png`
 
 ## 실행 절차
 1. `docs/widget-action-real-device-validation-matrix-v1.md`에서 대상 케이스를 고른다.
@@ -45,7 +46,8 @@
 8. Xcode console에서 `WidgetAction`, `onOpenURL received`, `consumePendingWidgetActionIfNeeded` 로그를 캡처한다.
 9. 최종 도착 화면에서 `step-2`를 저장한다.
 10. 결과를 `action/WD-*.md`에 기록한다.
-11. 모든 action/layout 케이스를 채운 뒤 `bash scripts/validate_manual_evidence_pack.sh widget <bundle-dir>`로 완결성을 검사한다.
+11. `step-1` / `step-2` / 필요 시 `step-fail` asset을 `assets/action/`에 같은 파일명으로 저장한다.
+12. 모든 action/layout 케이스를 채운 뒤 `bash scripts/validate_manual_evidence_pack.sh widget <bundle-dir>`로 완결성과 asset 존재를 검사한다.
 
 ## Pass 기준
 - 기대한 탭/상세 화면에 도착한다.

--- a/docs/widget-action-real-device-evidence-template-v1.md
+++ b/docs/widget-action-real-device-evidence-template-v1.md
@@ -31,9 +31,9 @@ request_id=...
 ```
 
 ## Screenshot Evidence
-- `step-1`:
-- `step-2`:
-- `step-fail`:
+- `step-1`: assets/action/<case-id>-step-1.png
+- `step-2`: assets/action/<case-id>-step-2.png
+- `step-fail`: n/a
 
 ## Notes
 - defer/replay 여부:

--- a/docs/widget-family-real-device-evidence-runbook-v1.md
+++ b/docs/widget-family-real-device-evidence-runbook-v1.md
@@ -27,6 +27,7 @@
   - `step-1`: 위젯 홈 화면 캡처
   - `step-2`: 길이가 긴 상태 또는 fallback 상태 캡처
   - `step-fail`: 실패 시 추가 캡처
+  - asset 경로는 bundle root 기준 `assets/layout/*.png`
 - budget 판정
   - headline 정책
   - detail 정책
@@ -42,8 +43,9 @@
 4. 첫 화면을 `step-1`로 저장한다.
 5. 상태 전환 또는 worst-case 문구를 만들어 `step-2`를 저장한다.
 6. 위젯 프레임 경계, CTA, badge, metric strip이 깨지지 않는지 확인한다.
-7. `docs/widget-family-real-device-evidence-template-v1.md` 형식으로 기록한다.
-8. `bash scripts/validate_manual_evidence_pack.sh widget <widget-evidence-dir>`로 전체 bundle 완결성을 검사한다.
+7. 캡처한 이미지를 `assets/layout/`에 같은 파일명으로 저장한다.
+8. `docs/widget-family-real-device-evidence-template-v1.md` 형식으로 기록한다.
+9. `bash scripts/validate_manual_evidence_pack.sh widget <widget-evidence-dir>`로 전체 bundle 완결성과 asset 존재를 검사한다.
 
 ## Pass 기준
 - 상단/하단 clipping이 없다.

--- a/docs/widget-family-real-device-evidence-template-v1.md
+++ b/docs/widget-family-real-device-evidence-template-v1.md
@@ -31,9 +31,9 @@
 - Pass / Fail:
 
 ## Screenshot Evidence
-- `step-1`:
-- `step-2`:
-- `step-fail`:
+- `step-1`: assets/layout/<case-id>-step-1.png
+- `step-2`: assets/layout/<case-id>-step-2.png
+- `step-fail`: n/a
 
 ## Notes
 - clipping 여부:

--- a/scripts/auth_smtp_live_send_validation_matrix_unit_check.swift
+++ b/scripts/auth_smtp_live_send_validation_matrix_unit_check.swift
@@ -52,6 +52,8 @@ assertTrue(runbook.contains("docs/auth-smtp-live-send-validation-matrix-v1.md"),
 assertTrue(template.contains("signup confirmation"), "template should still include signup confirmation scenario")
 assertTrue(template.contains("password reset"), "template should still include password reset scenario")
 assertTrue(template.contains("email change"), "template should still include email change scenario")
+assertTrue(template.contains("evidence_asset"), "template should include mailbox evidence asset column")
+assertTrue(template.contains("assets/signup-mailbox.png"), "template should include signup mailbox asset path")
 assertTrue(readme.contains("docs/auth-smtp-live-send-validation-matrix-v1.md"), "README should link live-send validation matrix")
 assertTrue(backendPRCheck.contains("auth_smtp_live_send_validation_matrix_unit_check.swift"), "backend_pr_check should run live-send validation matrix check")
 assertTrue(iosPRCheck.contains("auth_smtp_live_send_validation_matrix_unit_check.swift"), "ios_pr_check should run live-send validation matrix check")

--- a/scripts/auth_smtp_rollout_evidence_unit_check.swift
+++ b/scripts/auth_smtp_rollout_evidence_unit_check.swift
@@ -54,12 +54,17 @@ assertTrue(runbook.contains("01-dns-verification.md"), "runbook should define dn
 assertTrue(runbook.contains("06-final-decision.md"), "runbook should define final decision bundle file")
 
 assertTrue(template.contains("# Auth SMTP Rollout Evidence Template v1"), "template title should exist")
+assertTrue(template.contains("assets/"), "template should include assets directory")
 assertTrue(template.contains("01-dns-verification.md"), "template should include dns file")
 assertTrue(template.contains("02-supabase-smtp-settings.md"), "template should include settings file")
 assertTrue(template.contains("03-live-send-results.md"), "template should include live send file")
 assertTrue(template.contains("04-negative-evidence.md"), "template should include negative evidence file")
 assertTrue(template.contains("05-rollback-rotation.md"), "template should include rollback file")
 assertTrue(template.contains("06-final-decision.md"), "template should include final decision file")
+assertTrue(template.contains("assets/provider-domain.png"), "template should include dns asset path")
+assertTrue(template.contains("assets/supabase-smtp-settings.png"), "template should include settings asset path")
+assertTrue(template.contains("evidence_asset"), "template should include mailbox asset column")
+assertTrue(template.contains("assets/provider-dashboard-event.png"), "template should include provider event asset path")
 
 assertTrue(checklist.contains("## DNS 체크리스트"), "existing provider checklist should still define DNS checklist")
 assertTrue(observability.contains("provider_message_id"), "observability doc should still define provider message id")

--- a/scripts/auth_smtp_rollout_readiness_preflight_unit_check.swift
+++ b/scripts/auth_smtp_rollout_readiness_preflight_unit_check.swift
@@ -29,6 +29,12 @@ func write(_ url: URL, content: String) {
     }
 }
 
+/// Writes a placeholder asset file for auth SMTP evidence tests.
+/// - Parameter url: Asset file URL to create.
+func writeAsset(_ url: URL) {
+    write(url, content: "placeholder-asset")
+}
+
 /// Writes a filled auth smtp evidence bundle into the provided directory.
 /// - Parameter directory: Bundle root directory that will receive the evidence files.
 func writeFilledAuthBundle(at directory: URL) {
@@ -44,7 +50,7 @@ func writeFilledAuthBundle(at directory: URL) {
     - DKIM: verified
     - DMARC: present
     - Provider Verified Timestamp: 2026-03-12T12:00:00Z
-    - Evidence Screenshot: smtp-domain.png
+    - Evidence Screenshot: assets/provider-domain.png
     """)
 
     write(directory.appendingPathComponent("02-supabase-smtp-settings.md"), content: """
@@ -57,17 +63,17 @@ func writeFilledAuthBundle(at directory: URL) {
     - Sender Email: auth@auth.dogarea.app
     - `email_sent`: 2
     - `auth.email.max_frequency`: 60
-    - Settings Screenshot: smtp-settings.png
+    - Settings Screenshot: assets/supabase-smtp-settings.png
     """)
 
     write(directory.appendingPathComponent("03-live-send-results.md"), content: """
     # Live Send Results
 
-    | Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | Notes |
-    | --- | --- | --- | --- | --- | --- | --- | --- |
-    | signup confirmation | a***@dogarea.test | 2026-03-12 12:00 | yes | yes | req-1 | msg-1 | ok |
-    | password reset | a***@dogarea.test | 2026-03-12 12:05 | yes | yes | req-2 | msg-2 | ok |
-    | email change | a***@dogarea.test | 2026-03-12 12:10 | yes | yes | req-3 | msg-3 | ok |
+    | Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | evidence_asset | Notes |
+    | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+    | signup confirmation | a***@dogarea.test | 2026-03-12 12:00 | yes | yes | req-1 | msg-1 | assets/signup-mailbox.png | ok |
+    | password reset | a***@dogarea.test | 2026-03-12 12:05 | yes | yes | req-2 | msg-2 | assets/password-reset-mailbox.png | ok |
+    | email change | a***@dogarea.test | 2026-03-12 12:10 | yes | yes | req-3 | msg-3 | assets/email-change-mailbox.png | ok |
     """)
 
     write(directory.appendingPathComponent("04-negative-evidence.md"), content: """
@@ -79,7 +85,7 @@ func writeFilledAuthBundle(at directory: URL) {
     - reject: none observed
     - deferred: none observed
     - provider_event_id: evt-1
-    - Dashboard / Webhook Evidence: resend-dashboard.png
+    - Dashboard / Webhook Evidence: assets/provider-dashboard-event.png
     """)
 
     write(directory.appendingPathComponent("05-rollback-rotation.md"), content: """
@@ -98,6 +104,13 @@ func writeFilledAuthBundle(at directory: URL) {
     - Remaining Blockers: none
     - Linked Issue / PR Comment: issue comment url
     """)
+
+    writeAsset(directory.appendingPathComponent("assets/provider-domain.png"))
+    writeAsset(directory.appendingPathComponent("assets/supabase-smtp-settings.png"))
+    writeAsset(directory.appendingPathComponent("assets/signup-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/password-reset-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/email-change-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/provider-dashboard-event.png"))
 }
 
 /// Asserts that a condition holds for the readiness preflight contract.

--- a/scripts/lib/auth_smtp_evidence_bundle.sh
+++ b/scripts/lib/auth_smtp_evidence_bundle.sh
@@ -39,6 +39,10 @@ auth_smtp_bundle_decision_path() {
   printf '%s/06-final-decision.md' "$1"
 }
 
+auth_smtp_bundle_assets_dir() {
+  printf '%s/assets' "$1"
+}
+
 auth_smtp_bundle_render_overview() {
   cat <<'EOF'
 # Auth SMTP Evidence Bundle v2
@@ -51,6 +55,7 @@ auth_smtp_bundle_render_overview() {
 - Closure comment template: `docs/auth-smtp-closure-comment-template-v1.md`
 - Generated directory layout:
   - `README.md`
+  - `assets/`
   - `01-dns-verification.md`
   - `02-supabase-smtp-settings.md`
   - `03-live-send-results.md`
@@ -64,7 +69,7 @@ EOF
 
 auth_smtp_bundle_write() {
   local dir="$1"
-  mkdir -p "$dir"
+  mkdir -p "$dir" "$(auth_smtp_bundle_assets_dir "$dir")"
 
   cat > "$(auth_smtp_bundle_readme_path "$dir")" <<'EOF'
 # Auth SMTP Evidence Bundle v2
@@ -77,12 +82,24 @@ auth_smtp_bundle_write() {
 - Closure comment template: `docs/auth-smtp-closure-comment-template-v1.md`
 
 ## Files
+- `assets/`
 - `01-dns-verification.md`
 - `02-supabase-smtp-settings.md`
 - `03-live-send-results.md`
 - `04-negative-evidence.md`
 - `05-rollback-rotation.md`
 - `06-final-decision.md`
+EOF
+
+  cat > "$(auth_smtp_bundle_assets_dir "$dir")/README.md" <<'EOF'
+# Auth SMTP Evidence Assets
+
+- `provider-domain.png`
+- `supabase-smtp-settings.png`
+- `signup-mailbox.png`
+- `password-reset-mailbox.png`
+- `email-change-mailbox.png`
+- `provider-dashboard-event.png`
 EOF
 
   cat > "$(auth_smtp_bundle_dns_path "$dir")" <<'EOF'
@@ -97,7 +114,7 @@ EOF
 - DKIM:
 - DMARC:
 - Provider Verified Timestamp:
-- Evidence Screenshot:
+- Evidence Screenshot: assets/provider-domain.png
 EOF
 
   cat > "$(auth_smtp_bundle_settings_path "$dir")" <<'EOF'
@@ -110,17 +127,17 @@ EOF
 - Sender Email:
 - `email_sent`:
 - `auth.email.max_frequency`:
-- Settings Screenshot:
+- Settings Screenshot: assets/supabase-smtp-settings.png
 EOF
 
   cat > "$(auth_smtp_bundle_live_send_path "$dir")" <<'EOF'
 # Live Send Results
 
-| Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | Notes |
+| Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | evidence_asset | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| signup confirmation |  |  |  |  |  |  |  |
-| password reset |  |  |  |  |  |  |  |
-| email change |  |  |  |  |  |  |  |
+| signup confirmation |  |  |  |  |  |  | assets/signup-mailbox.png |  |
+| password reset |  |  |  |  |  |  | assets/password-reset-mailbox.png |  |
+| email change |  |  |  |  |  |  | assets/email-change-mailbox.png |  |
 EOF
 
   cat > "$(auth_smtp_bundle_negative_path "$dir")" <<'EOF'
@@ -132,7 +149,7 @@ EOF
 - reject:
 - deferred:
 - provider_event_id:
-- Dashboard / Webhook Evidence:
+- Dashboard / Webhook Evidence: assets/provider-dashboard-event.png
 EOF
 
   cat > "$(auth_smtp_bundle_ops_path "$dir")" <<'EOF'

--- a/scripts/manual_blocker_evidence_status_unit_check.swift
+++ b/scripts/manual_blocker_evidence_status_unit_check.swift
@@ -79,6 +79,12 @@ func write(_ url: URL, content: String) {
     }
 }
 
+/// Writes a placeholder asset file for status-runner-backed evidence tests.
+/// - Parameter url: Asset file URL to create.
+func writeAsset(_ url: URL) {
+    write(url, content: "placeholder-asset")
+}
+
 /// Builds a filled widget action case from the shared template.
 /// - Parameters:
 ///   - caseID: Canonical action case identifier.
@@ -104,8 +110,8 @@ func filledWidgetAction(caseID: String, summary: String) -> String {
         .replacingOccurrences(of: "onOpenURL received: ...", with: "onOpenURL received: widget://\(caseID.lowercased())")
         .replacingOccurrences(of: "consumePendingWidgetActionIfNeeded ...", with: "consumePendingWidgetActionIfNeeded consumed=\(caseID)")
         .replacingOccurrences(of: "request_id=...", with: "request_id=req-\(caseID)")
-        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
-        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+        .replacingOccurrences(of: "- `step-1`: assets/action/<case-id>-step-1.png", with: "- `step-1`: assets/action/\(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`: assets/action/<case-id>-step-2.png", with: "- `step-2`: assets/action/\(caseID)-step-2.png")
 }
 
 /// Builds a filled widget layout case from the shared template.
@@ -133,8 +139,8 @@ func filledWidgetLayout(caseID: String, surface: String) -> String {
         .replacingOccurrences(of: "- Expected Result:", with: "- Expected Result: no clipping")
         .replacingOccurrences(of: "- Summary:", with: "- Summary: \(surface) layout stayed within bounds")
         .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
-        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
-        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+        .replacingOccurrences(of: "- `step-1`: assets/layout/<case-id>-step-1.png", with: "- `step-1`: assets/layout/\(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`: assets/layout/<case-id>-step-2.png", with: "- `step-2`: assets/layout/\(caseID)-step-2.png")
 }
 
 let runnerScript = load("scripts/manual_blocker_evidence_status.sh")
@@ -175,6 +181,8 @@ assertTrue(generatedOutput.contains("status: incomplete"), "generated widget bun
 
 for caseID in ["WD-001", "WD-002", "WD-003", "WD-004", "WD-005", "WD-006", "WD-007", "WD-008"] {
     write(widgetPath.appendingPathComponent("action/\(caseID).md"), content: filledWidgetAction(caseID: caseID, summary: "\(caseID) converged"))
+    writeAsset(widgetPath.appendingPathComponent("assets/action/\(caseID)-step-1.png"))
+    writeAsset(widgetPath.appendingPathComponent("assets/action/\(caseID)-step-2.png"))
 }
 let layoutSurfaces = [
     "WL-001": "WalkControlWidget",
@@ -188,6 +196,8 @@ let layoutSurfaces = [
 ]
 for (caseID, surface) in layoutSurfaces {
     write(widgetPath.appendingPathComponent("layout/\(caseID).md"), content: filledWidgetLayout(caseID: caseID, surface: surface))
+    writeAsset(widgetPath.appendingPathComponent("assets/layout/\(caseID)-step-1.png"))
+    writeAsset(widgetPath.appendingPathComponent("assets/layout/\(caseID)-step-2.png"))
 }
 let completeOutput = runStatus(arguments: ["widget"], environment: [
     "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,

--- a/scripts/manual_closure_comment_poster_unit_check.swift
+++ b/scripts/manual_closure_comment_poster_unit_check.swift
@@ -94,6 +94,12 @@ func write(_ url: URL, content: String) {
     }
 }
 
+/// Writes a placeholder asset file for poster-backed evidence tests.
+/// - Parameter url: Asset file URL to create.
+func writeAsset(_ url: URL) {
+    write(url, content: "placeholder-asset")
+}
+
 /// Creates a fake gh binary that records its arguments.
 /// - Parameter directory: Temporary directory that owns the fake binary.
 /// - Returns: URLs for the fake binary and captured log.
@@ -138,8 +144,8 @@ func filledWidgetAction(caseID: String, summary: String) -> String {
         .replacingOccurrences(of: "- Summary:", with: "- Summary: \(summary)")
         .replacingOccurrences(of: "- Final Screen:", with: "- Final Screen: expected destination")
         .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
-        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
-        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+        .replacingOccurrences(of: "- `step-1`: assets/action/<case-id>-step-1.png", with: "- `step-1`: assets/action/\(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`: assets/action/<case-id>-step-2.png", with: "- `step-2`: assets/action/\(caseID)-step-2.png")
         .replacingOccurrences(of: "[WidgetAction] ...", with: "[WidgetAction] route=\(caseID.lowercased())")
         .replacingOccurrences(of: "onOpenURL received: ...", with: "onOpenURL received: dogarea://widget/\(caseID.lowercased())")
         .replacingOccurrences(of: "consumePendingWidgetActionIfNeeded ...", with: "consumePendingWidgetActionIfNeeded action=\(caseID.lowercased())")
@@ -171,8 +177,8 @@ func filledWidgetLayout(caseID: String, surface: String) -> String {
         .replacingOccurrences(of: "- Expected Result:", with: "- Expected Result: no clipping")
         .replacingOccurrences(of: "- Summary:", with: "- Summary: \(surface) layout stayed within bounds")
         .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
-        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
-        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+        .replacingOccurrences(of: "- `step-1`: assets/layout/<case-id>-step-1.png", with: "- `step-1`: assets/layout/\(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`: assets/layout/<case-id>-step-2.png", with: "- `step-2`: assets/layout/\(caseID)-step-2.png")
 }
 
 /// Writes a filled auth smtp evidence bundle into the provided directory.
@@ -190,7 +196,7 @@ func writeFilledAuthBundle(at directory: URL) {
     - DKIM: verified
     - DMARC: present
     - Provider Verified Timestamp: 2026-03-12T12:00:00Z
-    - Evidence Screenshot: smtp-domain.png
+    - Evidence Screenshot: assets/provider-domain.png
     """)
 
     write(directory.appendingPathComponent("02-supabase-smtp-settings.md"), content: """
@@ -203,17 +209,17 @@ func writeFilledAuthBundle(at directory: URL) {
     - Sender Email: auth@auth.dogarea.app
     - `email_sent`: true
     - `auth.email.max_frequency`: 60
-    - Settings Screenshot: smtp-settings.png
+    - Settings Screenshot: assets/supabase-smtp-settings.png
     """)
 
     write(directory.appendingPathComponent("03-live-send-results.md"), content: """
     # Live Send Results
 
-    | Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | Notes |
-    | --- | --- | --- | --- | --- | --- | --- | --- |
-    | signup confirmation | a***@dogarea.test | 2026-03-12 12:00 | yes | yes | req-1 | msg-1 | ok |
-    | password reset | a***@dogarea.test | 2026-03-12 12:05 | yes | yes | req-2 | msg-2 | ok |
-    | email change | a***@dogarea.test | 2026-03-12 12:10 | yes | yes | req-3 | msg-3 | ok |
+    | Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | evidence_asset | Notes |
+    | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+    | signup confirmation | a***@dogarea.test | 2026-03-12 12:00 | yes | yes | req-1 | msg-1 | assets/signup-mailbox.png | ok |
+    | password reset | a***@dogarea.test | 2026-03-12 12:05 | yes | yes | req-2 | msg-2 | assets/password-reset-mailbox.png | ok |
+    | email change | a***@dogarea.test | 2026-03-12 12:10 | yes | yes | req-3 | msg-3 | assets/email-change-mailbox.png | ok |
     """)
 
     write(directory.appendingPathComponent("04-negative-evidence.md"), content: """
@@ -225,7 +231,7 @@ func writeFilledAuthBundle(at directory: URL) {
     - reject: none observed
     - deferred: none observed
     - provider_event_id: evt-1
-    - Dashboard / Webhook Evidence: resend-dashboard.png
+    - Dashboard / Webhook Evidence: assets/provider-dashboard-event.png
     """)
 
     write(directory.appendingPathComponent("05-rollback-rotation.md"), content: """
@@ -244,6 +250,13 @@ func writeFilledAuthBundle(at directory: URL) {
     - Remaining Blockers: none
     - Linked Issue / PR Comment: issue comment url
     """)
+
+    writeAsset(directory.appendingPathComponent("assets/provider-domain.png"))
+    writeAsset(directory.appendingPathComponent("assets/supabase-smtp-settings.png"))
+    writeAsset(directory.appendingPathComponent("assets/signup-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/password-reset-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/email-change-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/provider-dashboard-event.png"))
 }
 
 let posterScript = load("scripts/post_closure_comment_from_evidence.sh")
@@ -275,6 +288,8 @@ let widgetCases: [(String, String)] = [
 ]
 for (caseID, summary) in widgetCases {
     write(widgetTempDir.appendingPathComponent("action/\(caseID).md"), content: filledWidgetAction(caseID: caseID, summary: summary))
+    writeAsset(widgetTempDir.appendingPathComponent("assets/action/\(caseID)-step-1.png"))
+    writeAsset(widgetTempDir.appendingPathComponent("assets/action/\(caseID)-step-2.png"))
 }
 let widgetLayouts = [
     "WL-001": "WalkControlWidget",
@@ -288,6 +303,8 @@ let widgetLayouts = [
 ]
 for (caseID, surface) in widgetLayouts {
     write(widgetTempDir.appendingPathComponent("layout/\(caseID).md"), content: filledWidgetLayout(caseID: caseID, surface: surface))
+    writeAsset(widgetTempDir.appendingPathComponent("assets/layout/\(caseID)-step-1.png"))
+    writeAsset(widgetTempDir.appendingPathComponent("assets/layout/\(caseID)-step-2.png"))
 }
 
 let widgetDryRunOutput = runPoster(arguments: ["widget", "--issue", "617", widgetTempDir.path], expectSuccess: true)

--- a/scripts/manual_closure_comment_renderer_unit_check.swift
+++ b/scripts/manual_closure_comment_renderer_unit_check.swift
@@ -77,6 +77,12 @@ func write(_ url: URL, content: String) {
     }
 }
 
+/// Writes a placeholder asset file for renderer-backed evidence tests.
+/// - Parameter url: Asset file URL to create.
+func writeAsset(_ url: URL) {
+    write(url, content: "placeholder-asset")
+}
+
 /// Builds a filled widget action case from the shared template.
 /// - Parameters:
 ///   - caseID: Canonical action case identifier.
@@ -98,8 +104,8 @@ func filledWidgetAction(caseID: String, summary: String) -> String {
         .replacingOccurrences(of: "- Summary:", with: "- Summary: \(summary)")
         .replacingOccurrences(of: "- Final Screen:", with: "- Final Screen: expected destination")
         .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
-        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
-        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+        .replacingOccurrences(of: "- `step-1`: assets/action/<case-id>-step-1.png", with: "- `step-1`: assets/action/\(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`: assets/action/<case-id>-step-2.png", with: "- `step-2`: assets/action/\(caseID)-step-2.png")
         .replacingOccurrences(of: "[WidgetAction] ...", with: "[WidgetAction] route=\(caseID.lowercased())")
         .replacingOccurrences(of: "onOpenURL received: ...", with: "onOpenURL received: widget://\(caseID.lowercased())")
         .replacingOccurrences(of: "consumePendingWidgetActionIfNeeded ...", with: "consumePendingWidgetActionIfNeeded action=\(caseID.lowercased())")
@@ -131,8 +137,8 @@ func filledWidgetLayout(caseID: String, surface: String) -> String {
         .replacingOccurrences(of: "- Expected Result:", with: "- Expected Result: no clipping")
         .replacingOccurrences(of: "- Summary:", with: "- Summary: \(surface) layout stayed within bounds")
         .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
-        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
-        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+        .replacingOccurrences(of: "- `step-1`: assets/layout/<case-id>-step-1.png", with: "- `step-1`: assets/layout/\(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`: assets/layout/<case-id>-step-2.png", with: "- `step-2`: assets/layout/\(caseID)-step-2.png")
 }
 
 /// Writes a filled auth smtp evidence bundle into the provided directory.
@@ -150,7 +156,7 @@ func writeFilledAuthBundle(at directory: URL) {
     - DKIM: verified
     - DMARC: present
     - Provider Verified Timestamp: 2026-03-12T12:00:00Z
-    - Evidence Screenshot: smtp-domain.png
+    - Evidence Screenshot: assets/provider-domain.png
     """)
 
     write(directory.appendingPathComponent("02-supabase-smtp-settings.md"), content: """
@@ -163,17 +169,17 @@ func writeFilledAuthBundle(at directory: URL) {
     - Sender Email: auth@auth.dogarea.app
     - `email_sent`: true
     - `auth.email.max_frequency`: 60
-    - Settings Screenshot: smtp-settings.png
+    - Settings Screenshot: assets/supabase-smtp-settings.png
     """)
 
     write(directory.appendingPathComponent("03-live-send-results.md"), content: """
     # Live Send Results
 
-    | Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | Notes |
-    | --- | --- | --- | --- | --- | --- | --- | --- |
-    | signup confirmation | a***@dogarea.test | 2026-03-12 12:00 | yes | yes | req-1 | msg-1 | ok |
-    | password reset | a***@dogarea.test | 2026-03-12 12:05 | yes | yes | req-2 | msg-2 | ok |
-    | email change | a***@dogarea.test | 2026-03-12 12:10 | yes | yes | req-3 | msg-3 | ok |
+    | Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | evidence_asset | Notes |
+    | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+    | signup confirmation | a***@dogarea.test | 2026-03-12 12:00 | yes | yes | req-1 | msg-1 | assets/signup-mailbox.png | ok |
+    | password reset | a***@dogarea.test | 2026-03-12 12:05 | yes | yes | req-2 | msg-2 | assets/password-reset-mailbox.png | ok |
+    | email change | a***@dogarea.test | 2026-03-12 12:10 | yes | yes | req-3 | msg-3 | assets/email-change-mailbox.png | ok |
     """)
 
     write(directory.appendingPathComponent("04-negative-evidence.md"), content: """
@@ -185,7 +191,7 @@ func writeFilledAuthBundle(at directory: URL) {
     - reject: none observed
     - deferred: none observed
     - provider_event_id: evt-1
-    - Dashboard / Webhook Evidence: resend-dashboard.png
+    - Dashboard / Webhook Evidence: assets/provider-dashboard-event.png
     """)
 
     write(directory.appendingPathComponent("05-rollback-rotation.md"), content: """
@@ -204,6 +210,13 @@ func writeFilledAuthBundle(at directory: URL) {
     - Remaining Blockers: none
     - Linked Issue / PR Comment: issue comment url
     """)
+
+    writeAsset(directory.appendingPathComponent("assets/provider-domain.png"))
+    writeAsset(directory.appendingPathComponent("assets/supabase-smtp-settings.png"))
+    writeAsset(directory.appendingPathComponent("assets/signup-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/password-reset-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/email-change-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/provider-dashboard-event.png"))
 }
 
 let rendererScript = load("scripts/render_closure_comment_from_evidence.sh")
@@ -232,6 +245,8 @@ let widgetCases = [
 ]
 for (caseID, summary) in widgetCases {
     write(widgetDirectory.appendingPathComponent("action/\(caseID).md"), content: filledWidgetAction(caseID: caseID, summary: summary))
+    writeAsset(widgetDirectory.appendingPathComponent("assets/action/\(caseID)-step-1.png"))
+    writeAsset(widgetDirectory.appendingPathComponent("assets/action/\(caseID)-step-2.png"))
 }
 let layoutCases = [
     "WL-001": "WalkControlWidget",
@@ -245,6 +260,8 @@ let layoutCases = [
 ]
 for (caseID, surface) in layoutCases {
     write(widgetDirectory.appendingPathComponent("layout/\(caseID).md"), content: filledWidgetLayout(caseID: caseID, surface: surface))
+    writeAsset(widgetDirectory.appendingPathComponent("assets/layout/\(caseID)-step-1.png"))
+    writeAsset(widgetDirectory.appendingPathComponent("assets/layout/\(caseID)-step-2.png"))
 }
 
 let widgetOutput = runRenderer(arguments: ["widget", widgetDirectory.path], expectSuccess: true)

--- a/scripts/manual_evidence_helper_unit_check.swift
+++ b/scripts/manual_evidence_helper_unit_check.swift
@@ -98,6 +98,8 @@ let bundleReadme = (try? String(contentsOf: tempDirectory.appendingPathComponent
 assertTrue(bundleReadme.contains("Widget Real-Device Evidence Pack v2"), "written widget bundle should include readme")
 assertTrue(FileManager.default.fileExists(atPath: tempDirectory.appendingPathComponent("action/WD-001.md").path), "written widget bundle should include WD-001")
 assertTrue(FileManager.default.fileExists(atPath: tempDirectory.appendingPathComponent("layout/WL-008.md").path), "written widget bundle should include WL-008")
+assertTrue(FileManager.default.fileExists(atPath: tempDirectory.appendingPathComponent("assets/action").path), "written widget bundle should include action assets directory")
+assertTrue(FileManager.default.fileExists(atPath: tempDirectory.appendingPathComponent("assets/layout").path), "written widget bundle should include layout assets directory")
 
 let authDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
 let authWriteOutput = runHelper(arguments: ["auth-smtp", "--output", authDirectory.path])
@@ -106,5 +108,6 @@ let authReadme = (try? String(contentsOf: authDirectory.appendingPathComponent("
 assertTrue(authReadme.contains("Auth SMTP Evidence Bundle v2"), "written auth bundle should include readme")
 assertTrue(FileManager.default.fileExists(atPath: authDirectory.appendingPathComponent("01-dns-verification.md").path), "written auth bundle should include dns file")
 assertTrue(FileManager.default.fileExists(atPath: authDirectory.appendingPathComponent("06-final-decision.md").path), "written auth bundle should include final decision file")
+assertTrue(FileManager.default.fileExists(atPath: authDirectory.appendingPathComponent("assets/README.md").path), "written auth bundle should include assets readme")
 
 print("PASS: manual evidence helper contract checks")

--- a/scripts/manual_evidence_validator_unit_check.swift
+++ b/scripts/manual_evidence_validator_unit_check.swift
@@ -79,6 +79,12 @@ func write(_ url: URL, content: String) {
     }
 }
 
+/// Writes a placeholder asset file for validator-backed evidence tests.
+/// - Parameter url: Asset file URL to create.
+func writeAsset(_ url: URL) {
+    write(url, content: "placeholder-asset")
+}
+
 /// Builds a filled widget action case from the shared template.
 /// - Parameters:
 ///   - caseID: Canonical action case identifier.
@@ -104,8 +110,8 @@ func filledWidgetAction(caseID: String, summary: String) -> String {
         .replacingOccurrences(of: "onOpenURL received: ...", with: "onOpenURL received: widget://\(caseID.lowercased())")
         .replacingOccurrences(of: "consumePendingWidgetActionIfNeeded ...", with: "consumePendingWidgetActionIfNeeded consumed=\(caseID)")
         .replacingOccurrences(of: "request_id=...", with: "request_id=req-\(caseID)")
-        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
-        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+        .replacingOccurrences(of: "- `step-1`: assets/action/<case-id>-step-1.png", with: "- `step-1`: assets/action/\(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`: assets/action/<case-id>-step-2.png", with: "- `step-2`: assets/action/\(caseID)-step-2.png")
 }
 
 /// Builds a filled widget layout case from the shared template.
@@ -133,8 +139,8 @@ func filledWidgetLayout(caseID: String, surface: String) -> String {
         .replacingOccurrences(of: "- Expected Result:", with: "- Expected Result: no clipping")
         .replacingOccurrences(of: "- Summary:", with: "- Summary: \(surface) layout stayed within bounds")
         .replacingOccurrences(of: "- Pass / Fail:", with: "- Pass / Fail: Pass")
-        .replacingOccurrences(of: "- `step-1`:", with: "- `step-1`: \(caseID)-step-1.png")
-        .replacingOccurrences(of: "- `step-2`:", with: "- `step-2`: \(caseID)-step-2.png")
+        .replacingOccurrences(of: "- `step-1`: assets/layout/<case-id>-step-1.png", with: "- `step-1`: assets/layout/\(caseID)-step-1.png")
+        .replacingOccurrences(of: "- `step-2`: assets/layout/<case-id>-step-2.png", with: "- `step-2`: assets/layout/\(caseID)-step-2.png")
 }
 
 /// Writes a filled auth smtp evidence bundle into the provided directory.
@@ -152,7 +158,7 @@ func writeFilledAuthBundle(at directory: URL) {
     - DKIM: verified
     - DMARC: present
     - Provider Verified Timestamp: 2026-03-12T12:00:00Z
-    - Evidence Screenshot: smtp-domain.png
+    - Evidence Screenshot: assets/provider-domain.png
     """)
 
     write(directory.appendingPathComponent("02-supabase-smtp-settings.md"), content: """
@@ -165,17 +171,17 @@ func writeFilledAuthBundle(at directory: URL) {
     - Sender Email: auth@auth.dogarea.app
     - `email_sent`: true
     - `auth.email.max_frequency`: 60
-    - Settings Screenshot: smtp-settings.png
+    - Settings Screenshot: assets/supabase-smtp-settings.png
     """)
 
     write(directory.appendingPathComponent("03-live-send-results.md"), content: """
     # Live Send Results
 
-    | Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | Notes |
-    | --- | --- | --- | --- | --- | --- | --- | --- |
-    | signup confirmation | a***@dogarea.test | 2026-03-12 12:00 | yes | yes | req-1 | msg-1 | ok |
-    | password reset | a***@dogarea.test | 2026-03-12 12:05 | yes | yes | req-2 | msg-2 | ok |
-    | email change | a***@dogarea.test | 2026-03-12 12:10 | yes | yes | req-3 | msg-3 | ok |
+    | Scenario | Recipient Mask | Request Time | Accepted | Mailbox Received | request_id | provider_message_id | evidence_asset | Notes |
+    | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+    | signup confirmation | a***@dogarea.test | 2026-03-12 12:00 | yes | yes | req-1 | msg-1 | assets/signup-mailbox.png | ok |
+    | password reset | a***@dogarea.test | 2026-03-12 12:05 | yes | yes | req-2 | msg-2 | assets/password-reset-mailbox.png | ok |
+    | email change | a***@dogarea.test | 2026-03-12 12:10 | yes | yes | req-3 | msg-3 | assets/email-change-mailbox.png | ok |
     """)
 
     write(directory.appendingPathComponent("04-negative-evidence.md"), content: """
@@ -187,7 +193,7 @@ func writeFilledAuthBundle(at directory: URL) {
     - reject: none observed
     - deferred: none observed
     - provider_event_id: evt-1
-    - Dashboard / Webhook Evidence: resend-dashboard.png
+    - Dashboard / Webhook Evidence: assets/provider-dashboard-event.png
     """)
 
     write(directory.appendingPathComponent("05-rollback-rotation.md"), content: """
@@ -206,6 +212,13 @@ func writeFilledAuthBundle(at directory: URL) {
     - Remaining Blockers: none
     - Linked Issue / PR Comment: issue comment url
     """)
+
+    writeAsset(directory.appendingPathComponent("assets/provider-domain.png"))
+    writeAsset(directory.appendingPathComponent("assets/supabase-smtp-settings.png"))
+    writeAsset(directory.appendingPathComponent("assets/signup-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/password-reset-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/email-change-mailbox.png"))
+    writeAsset(directory.appendingPathComponent("assets/provider-dashboard-event.png"))
 }
 
 let validatorScript = load("scripts/validate_manual_evidence_pack.sh")
@@ -246,6 +259,8 @@ assertTrue(rawWidgetOutput.contains("missing layout file"), "raw widget bundle s
 let filledBundleURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
 for caseID in ["WD-001", "WD-002", "WD-003", "WD-004", "WD-005", "WD-006", "WD-007", "WD-008"] {
     write(filledBundleURL.appendingPathComponent("action/\(caseID).md"), content: filledWidgetAction(caseID: caseID, summary: "\(caseID) converged"))
+    writeAsset(filledBundleURL.appendingPathComponent("assets/action/\(caseID)-step-1.png"))
+    writeAsset(filledBundleURL.appendingPathComponent("assets/action/\(caseID)-step-2.png"))
 }
 let layoutSurfaces = [
     "WL-001": "WalkControlWidget",
@@ -259,6 +274,8 @@ let layoutSurfaces = [
 ]
 for (caseID, surface) in layoutSurfaces {
     write(filledBundleURL.appendingPathComponent("layout/\(caseID).md"), content: filledWidgetLayout(caseID: caseID, surface: surface))
+    writeAsset(filledBundleURL.appendingPathComponent("assets/layout/\(caseID)-step-1.png"))
+    writeAsset(filledBundleURL.appendingPathComponent("assets/layout/\(caseID)-step-2.png"))
 }
 let filledWidgetOutput = runValidator(arguments: ["widget", filledBundleURL.path], expectSuccess: true)
 assertTrue(filledWidgetOutput.contains("PASS: widget evidence is complete"), "filled widget bundle should pass")

--- a/scripts/render_manual_evidence_pack.sh
+++ b/scripts/render_manual_evidence_pack.sh
@@ -71,6 +71,8 @@ render_widget_overview() {
 - Closure checklist:
   - `docs/widget-action-closure-checklist-v1.md`
 - Generated directory layout:
+  - `assets/action/`
+  - `assets/layout/`
   - `action/WD-001.md` ... `action/WD-008.md`
   - `layout/WL-001.md` ... `layout/WL-008.md`
   - `README.md`
@@ -94,7 +96,9 @@ widget_action_file_content() {
     | sed "s#^- 앱 상태:#- 앱 상태: ${app_state}#" \
     | sed "s#^- 인증 상태:#- 인증 상태: ${auth_state}#" \
     | sed "s#^- Action Route:#- Action Route: ${route}#" \
-    | sed "s#^- Expected Result:#- Expected Result: ${expected}#"
+    | sed "s#^- Expected Result:#- Expected Result: ${expected}#" \
+    | sed "s#^- \`step-1\`: assets/action/<case-id>-step-1.png#- \`step-1\`: assets/action/${case_id}-step-1.png#" \
+    | sed "s#^- \`step-2\`: assets/action/<case-id>-step-2.png#- \`step-2\`: assets/action/${case_id}-step-2.png#"
 }
 
 widget_layout_file_content() {
@@ -122,12 +126,14 @@ widget_layout_file_content() {
     | sed "s#^- CTA Height Rule:#- CTA Height Rule: ${cta_rule}#" \
     | sed "s#^- Metric Tile Rule:#- Metric Tile Rule: ${metric_rule}#" \
     | sed "s#^- Compact Formatting Rule:#- Compact Formatting Rule: ${compact_rule}#" \
-    | sed "s#^- Expected Result:#- Expected Result: ${expected}#"
+    | sed "s#^- Expected Result:#- Expected Result: ${expected}#" \
+    | sed "s#^- \`step-1\`: assets/layout/<case-id>-step-1.png#- \`step-1\`: assets/layout/${case_id}-step-1.png#" \
+    | sed "s#^- \`step-2\`: assets/layout/<case-id>-step-2.png#- \`step-2\`: assets/layout/${case_id}-step-2.png#"
 }
 
 write_widget_bundle() {
   local dir="$1"
-  mkdir -p "$dir/action" "$dir/layout"
+  mkdir -p "$dir/action" "$dir/layout" "$dir/assets/action" "$dir/assets/layout"
 
   cat > "$dir/README.md" <<'README'
 # Widget Real-Device Evidence Pack v2
@@ -140,6 +146,7 @@ write_widget_bundle() {
 - Closure checklist: `docs/widget-action-closure-checklist-v1.md`
 
 ## Action Cases
+- assets/action/
 - action/WD-001.md
 - action/WD-002.md
 - action/WD-003.md
@@ -150,6 +157,7 @@ write_widget_bundle() {
 - action/WD-008.md
 
 ## Layout Cases
+- assets/layout/
 - layout/WL-001.md
 - layout/WL-002.md
 - layout/WL-003.md
@@ -158,6 +166,13 @@ write_widget_bundle() {
 - layout/WL-006.md
 - layout/WL-007.md
 - layout/WL-008.md
+README
+
+  cat > "$dir/assets/README.md" <<'README'
+# Widget Real-Device Evidence Assets
+
+- `action/WD-001-step-1.png` ... `action/WD-008-step-2.png`
+- `layout/WL-001-step-1.png` ... `layout/WL-008-step-2.png`
 README
 
   widget_action_file_content "WD-001" "systemSmall" "cold start" "로그인" "open_rival_tab" "라이벌 탭으로 직접 진입하고 기본 상태가 보인다." > "$dir/action/WD-001.md"

--- a/scripts/validate_manual_evidence_pack.sh
+++ b/scripts/validate_manual_evidence_pack.sh
@@ -53,6 +53,43 @@ require_nonempty_prefixed_line() {
   fi
 }
 
+extract_prefixed_value() {
+  local prefix="$1"
+  local file="$2"
+  local line value
+
+  line="$(line_by_prefix "$prefix" "$file")"
+  [[ -n "$line" ]] || return 1
+  value="${line#"$prefix"}"
+  trim "$value"
+}
+
+require_existing_relative_asset() {
+  local base_dir="$1"
+  local relative_path="$2"
+  local source_label="$3"
+  local normalized
+
+  normalized="$(trim "$relative_path")"
+  if [[ -z "$normalized" ]]; then
+    add_error "empty asset path: $source_label"
+    return
+  fi
+
+  if [[ "$normalized" == "n/a" || "$normalized" == "N/A" ]]; then
+    return
+  fi
+
+  if [[ "$normalized" = /* ]]; then
+    add_error "asset path must be relative: $source_label :: $normalized"
+    return
+  fi
+
+  if [[ ! -e "$base_dir/$normalized" ]]; then
+    add_error "missing asset file: $source_label :: $normalized"
+  fi
+}
+
 require_contains() {
   local literal="$1"
   local file="$2"
@@ -83,6 +120,8 @@ require_pass_outcome() {
 validate_widget_action_case() {
   local file="$1"
   local expected_case="$2"
+  local bundle_root="$3"
+  local step1_path step2_path step_fail_path
 
   [[ -f "$file" ]] || {
     add_error "missing action file: $file"
@@ -106,6 +145,16 @@ validate_widget_action_case() {
   require_nonempty_prefixed_line '- `step-2`:' "$file"
   require_pass_outcome "$file"
 
+  step1_path="$(extract_prefixed_value '- `step-1`:' "$file" || true)"
+  step2_path="$(extract_prefixed_value '- `step-2`:' "$file" || true)"
+  step_fail_path="$(extract_prefixed_value '- `step-fail`:' "$file" || true)"
+
+  [[ -n "$step1_path" ]] && require_existing_relative_asset "$bundle_root" "$step1_path" "$file :: step-1"
+  [[ -n "$step2_path" ]] && require_existing_relative_asset "$bundle_root" "$step2_path" "$file :: step-2"
+  if [[ -n "$step_fail_path" && "$step_fail_path" != "n/a" && "$step_fail_path" != "N/A" ]]; then
+    require_existing_relative_asset "$bundle_root" "$step_fail_path" "$file :: step-fail"
+  fi
+
   require_contains "[WidgetAction]" "$file"
   require_contains "onOpenURL received" "$file"
   require_contains "consumePendingWidgetActionIfNeeded" "$file"
@@ -124,6 +173,8 @@ validate_widget_action_case() {
 validate_widget_layout_case() {
   local file="$1"
   local expected_case="$2"
+  local bundle_root="$3"
+  local step1_path step2_path step_fail_path
 
   [[ -f "$file" ]] || {
     add_error "missing layout file: $file"
@@ -151,6 +202,16 @@ validate_widget_layout_case() {
   require_nonempty_prefixed_line '- `step-2`:' "$file"
   require_pass_outcome "$file"
 
+  step1_path="$(extract_prefixed_value '- `step-1`:' "$file" || true)"
+  step2_path="$(extract_prefixed_value '- `step-2`:' "$file" || true)"
+  step_fail_path="$(extract_prefixed_value '- `step-fail`:' "$file" || true)"
+
+  [[ -n "$step1_path" ]] && require_existing_relative_asset "$bundle_root" "$step1_path" "$file :: step-1"
+  [[ -n "$step2_path" ]] && require_existing_relative_asset "$bundle_root" "$step2_path" "$file :: step-2"
+  if [[ -n "$step_fail_path" && "$step_fail_path" != "n/a" && "$step_fail_path" != "N/A" ]]; then
+    require_existing_relative_asset "$bundle_root" "$step_fail_path" "$file :: step-fail"
+  fi
+
   if ! grep -Fq -- "- Case ID: ${expected_case}" "$file"; then
     add_error "unexpected layout case id: $file :: expected ${expected_case}"
   fi
@@ -168,11 +229,11 @@ validate_widget_bundle() {
   }
 
   for id in "${action_ids[@]}"; do
-    validate_widget_action_case "$dir/action/${id}.md" "$id"
+    validate_widget_action_case "$dir/action/${id}.md" "$id" "$dir"
   done
 
   for id in "${layout_ids[@]}"; do
-    validate_widget_layout_case "$dir/layout/${id}.md" "$id"
+    validate_widget_layout_case "$dir/layout/${id}.md" "$id" "$dir"
   done
 }
 
@@ -201,7 +262,7 @@ require_auth_row_filled() {
     BEGIN {
       split(row, cells, "|")
       fail = 0
-      for (i = 3; i <= 9; i++) {
+      for (i = 3; i <= 10; i++) {
         value = cells[i]
         gsub(/^[ \t]+|[ \t]+$/, "", value)
         if (value == "") {
@@ -215,9 +276,29 @@ require_auth_row_filled() {
   ' || add_error "incomplete scenario row: $scenario"
 }
 
+auth_row_cell() {
+  local scenario="$1"
+  local file="$2"
+  local column="$3"
+
+  awk -F'|' -v scenario="$scenario" -v column="$column" '
+    {
+      first = $2
+      gsub(/^[ \t]+|[ \t]+$/, "", first)
+      if (first == scenario) {
+        value = $column
+        gsub(/^[ \t]+|[ \t]+$/, "", value)
+        print value
+        exit
+      }
+    }
+  ' "$file"
+}
+
 validate_auth_smtp_bundle() {
   local dir="$1"
   local dns_path settings_path live_send_path negative_path ops_path decision_path
+  local dns_asset settings_asset negative_asset live_signup_asset live_reset_asset live_change_asset
 
   [[ -d "$dir" ]] || {
     add_error "auth-smtp evidence must be a directory: $dir"
@@ -249,6 +330,8 @@ validate_auth_smtp_bundle() {
     require_nonempty_prefixed_line "- DMARC:" "$dns_path"
     require_nonempty_prefixed_line "- Provider Verified Timestamp:" "$dns_path"
     require_nonempty_prefixed_line "- Evidence Screenshot:" "$dns_path"
+    dns_asset="$(extract_prefixed_value "- Evidence Screenshot:" "$dns_path" || true)"
+    [[ -n "$dns_asset" ]] && require_existing_relative_asset "$dir" "$dns_asset" "$dns_path :: Evidence Screenshot"
   fi
 
   if [[ -f "$settings_path" ]]; then
@@ -260,12 +343,22 @@ validate_auth_smtp_bundle() {
     require_nonempty_prefixed_line '- `email_sent`:' "$settings_path"
     require_nonempty_prefixed_line '- `auth.email.max_frequency`:' "$settings_path"
     require_nonempty_prefixed_line "- Settings Screenshot:" "$settings_path"
+    settings_asset="$(extract_prefixed_value "- Settings Screenshot:" "$settings_path" || true)"
+    [[ -n "$settings_asset" ]] && require_existing_relative_asset "$dir" "$settings_asset" "$settings_path :: Settings Screenshot"
   fi
 
   if [[ -f "$live_send_path" ]]; then
     require_auth_row_filled "signup confirmation" "$live_send_path"
     require_auth_row_filled "password reset" "$live_send_path"
     require_auth_row_filled "email change" "$live_send_path"
+
+    live_signup_asset="$(auth_row_cell "signup confirmation" "$live_send_path" 9)"
+    live_reset_asset="$(auth_row_cell "password reset" "$live_send_path" 9)"
+    live_change_asset="$(auth_row_cell "email change" "$live_send_path" 9)"
+
+    [[ -n "$live_signup_asset" ]] && require_existing_relative_asset "$dir" "$live_signup_asset" "$live_send_path :: signup confirmation evidence_asset"
+    [[ -n "$live_reset_asset" ]] && require_existing_relative_asset "$dir" "$live_reset_asset" "$live_send_path :: password reset evidence_asset"
+    [[ -n "$live_change_asset" ]] && require_existing_relative_asset "$dir" "$live_change_asset" "$live_send_path :: email change evidence_asset"
   fi
 
   if [[ -f "$negative_path" ]]; then
@@ -276,6 +369,8 @@ validate_auth_smtp_bundle() {
     require_nonempty_prefixed_line "- deferred:" "$negative_path"
     require_nonempty_prefixed_line "- provider_event_id:" "$negative_path"
     require_nonempty_prefixed_line "- Dashboard / Webhook Evidence:" "$negative_path"
+    negative_asset="$(extract_prefixed_value "- Dashboard / Webhook Evidence:" "$negative_path" || true)"
+    [[ -n "$negative_asset" ]] && require_existing_relative_asset "$dir" "$negative_asset" "$negative_path :: Dashboard / Webhook Evidence"
   fi
 
   if [[ -f "$ops_path" ]]; then


### PR DESCRIPTION
## Summary
- require referenced manual evidence asset files to exist
- generate widget/auth evidence bundles with canonical asset paths
- update validator-backed unit checks to create matching asset fixtures

Closes #760

## Verification
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 DOGAREA_SKIP_WATCH_BUILD=1 bash scripts/ios_pr_check.sh