### PR TITLE
test: add manual evidence archive manifest

### DIFF
--- a/docs/manual-evidence-archive-export-v1.md
+++ b/docs/manual-evidence-archive-export-v1.md
@@ -1,6 +1,6 @@
 # Manual Evidence Archive Export v1
 
-- Issue: #762
+- Issue: #764
 - Relates to: #731, #692, #617, #482
 
 ## 목적
@@ -34,6 +34,8 @@
 3. 아래 구조를 staging 디렉터리에 만든다.
    - `README.md`
    - `widget-closure-comment.md` 또는 `auth-smtp-closure-comment.md`
+   - `MANIFEST.md`
+   - `SHA256SUMS`
    - `bundle/`
 4. staging 내용을 zip archive로 묶는다.
 
@@ -41,7 +43,11 @@
 - archive에는 아래만 포함한다.
   - export `README.md`
   - closure comment preview
+  - `MANIFEST.md`
+  - `SHA256SUMS`
   - 원본 evidence bundle 전체 복사본
+- `MANIFEST.md`에는 surface, issue, source bundle, export file 목록, bundle file listing을 기록한다.
+- `SHA256SUMS`에는 `README.md`, closure preview, `MANIFEST.md`, `bundle/` 하위 모든 파일의 sha256을 기록한다.
 - validator 실패 시 archive를 만들지 않는다.
 
 ## 운영 규칙

--- a/scripts/archive_manual_evidence_pack.sh
+++ b/scripts/archive_manual_evidence_pack.sh
@@ -58,6 +58,14 @@ surface_closure_output_name() {
   esac
 }
 
+surface_manifest_name() {
+  printf 'MANIFEST.md'
+}
+
+surface_checksum_name() {
+  printf 'SHA256SUMS'
+}
+
 write_export_readme() {
   local surface="$1"
   local bundle_path="$2"
@@ -81,6 +89,55 @@ write_export_readme() {
 - $closure_name
 - bundle/
 EOF
+}
+
+write_manifest() {
+  local surface="$1"
+  local bundle_path="$2"
+  local export_root="$3"
+  local closure_name="$4"
+  local manifest_path="$export_root/$(surface_manifest_name)"
+  local file_count asset_count
+
+  file_count="$(find "$export_root/bundle" -type f | wc -l | tr -d ' ')"
+  asset_count="$(find "$export_root/bundle/assets" -type f 2>/dev/null | wc -l | tr -d ' ')"
+
+  {
+    printf '# Manual Evidence Export Manifest\n\n'
+    printf -- '- Surface: %s\n' "$surface"
+    printf -- '- Bundle Label: %s\n' "$(surface_bundle_label "$surface")"
+    printf -- '- Primary Issue: %s\n' "$(surface_primary_issue "$surface")"
+    printf -- '- Related Issues: %s\n' "$(surface_related_issues "$surface")"
+    printf -- '- Source Bundle: %s\n' "$bundle_path"
+    printf -- '- Closure Preview: %s\n' "$closure_name"
+    printf -- '- Bundle File Count: %s\n' "$file_count"
+    printf -- '- Bundle Asset Count: %s\n\n' "$asset_count"
+    printf '## Export Files\n'
+    printf -- '- README.md\n'
+    printf -- '- %s\n' "$closure_name"
+    printf -- '- %s\n\n' "$(surface_manifest_name)"
+    printf '## Bundle Files\n'
+    (
+      cd "$export_root/bundle"
+      find . -type f | sort | sed 's#^\./#- #'
+    )
+  } > "$manifest_path"
+}
+
+write_checksums() {
+  local export_root="$1"
+  local closure_name="$2"
+  local checksum_path="$export_root/$(surface_checksum_name)"
+
+  (
+    cd "$export_root"
+    shasum -a 256 "README.md"
+    shasum -a 256 "$closure_name"
+    shasum -a 256 "$(surface_manifest_name)"
+    find bundle -type f | sort | while IFS= read -r file; do
+      shasum -a 256 "$file"
+    done
+  ) > "$checksum_path"
 }
 
 surface="${1:-}"
@@ -152,8 +209,10 @@ cp -R "$bundle_dir"/. "$export_root/bundle/"
 closure_name="$(surface_closure_output_name "$surface")"
 bash scripts/render_closure_comment_from_evidence.sh "$surface" "$bundle_dir" --output "$export_root/$closure_name" >/dev/null
 write_export_readme "$surface" "$bundle_dir" "$archive_abs" "$export_root" "$closure_name"
+write_manifest "$surface" "$bundle_dir" "$export_root" "$closure_name"
+write_checksums "$export_root" "$closure_name"
 
 rm -f "$archive_abs"
-(cd "$export_root" && zip -qr "$archive_abs" README.md "$closure_name" bundle)
+(cd "$export_root" && zip -qr "$archive_abs" README.md "$closure_name" "$(surface_manifest_name)" "$(surface_checksum_name)" bundle)
 
 printf 'WROTE %s\n' "$archive_abs"

--- a/scripts/manual_evidence_archive_export_unit_check.swift
+++ b/scripts/manual_evidence_archive_export_unit_check.swift
@@ -229,6 +229,15 @@ func listArchive(_ archiveURL: URL) -> String {
     runProcess("/usr/bin/unzip", arguments: ["-l", archiveURL.path], expectSuccess: true)
 }
 
+/// Reads a UTF-8 file entry from a zip archive.
+/// - Parameters:
+///   - archiveURL: Zip archive file URL.
+///   - entryPath: Relative entry path inside the archive.
+/// - Returns: Decoded archive entry contents.
+func readArchiveEntry(_ archiveURL: URL, entryPath: String) -> String {
+    runProcess("/usr/bin/unzip", arguments: ["-p", archiveURL.path, entryPath], expectSuccess: true)
+}
+
 let script = load("scripts/archive_manual_evidence_pack.sh")
 let doc = load("docs/manual-evidence-archive-export-v1.md")
 let readme = load("README.md")
@@ -239,8 +248,12 @@ assertTrue(script.contains("validate_manual_evidence_pack.sh"), "archive script 
 assertTrue(script.contains("render_closure_comment_from_evidence.sh"), "archive script should render closure preview")
 assertTrue(script.contains("widget-real-device-evidence-export.zip"), "archive script should define widget default export path")
 assertTrue(script.contains("auth-smtp-evidence-export.zip"), "archive script should define auth default export path")
+assertTrue(script.contains("MANIFEST.md"), "archive script should export manifest")
+assertTrue(script.contains("SHA256SUMS"), "archive script should export checksums")
 assertTrue(doc.contains("# Manual Evidence Archive Export v1"), "archive export doc title should exist")
 assertTrue(doc.contains("closure comment preview"), "archive export doc should describe closure preview")
+assertTrue(doc.contains("MANIFEST.md"), "archive export doc should describe manifest")
+assertTrue(doc.contains("SHA256SUMS"), "archive export doc should describe checksums")
 assertTrue(readme.contains("docs/manual-evidence-archive-export-v1.md"), "README should link archive export doc")
 assertTrue(iosPRCheck.contains("manual_evidence_archive_export_unit_check.swift"), "ios_pr_check should run archive export check")
 assertTrue(backendPRCheck.contains("manual_evidence_archive_export_unit_check.swift"), "backend_pr_check should run archive export check")
@@ -273,8 +286,17 @@ assertTrue(widgetArchiveOutput.contains("WROTE"), "widget archive export should 
 assertTrue(FileManager.default.fileExists(atPath: widgetArchiveURL.path), "widget archive should exist")
 let widgetArchiveListing = listArchive(widgetArchiveURL)
 assertTrue(widgetArchiveListing.contains("widget-closure-comment.md"), "widget archive should include closure preview")
+assertTrue(widgetArchiveListing.contains("MANIFEST.md"), "widget archive should include manifest")
+assertTrue(widgetArchiveListing.contains("SHA256SUMS"), "widget archive should include checksums")
 assertTrue(widgetArchiveListing.contains("bundle/action/WD-001.md"), "widget archive should include evidence bundle files")
 assertTrue(widgetArchiveListing.contains("bundle/assets/action/WD-001-step-1.png"), "widget archive should include action assets")
+let widgetManifest = readArchiveEntry(widgetArchiveURL, entryPath: "MANIFEST.md")
+assertTrue(widgetManifest.contains("- Surface: widget"), "widget manifest should describe the widget surface")
+assertTrue(widgetManifest.contains("- Bundle File Count:"), "widget manifest should include bundle file count")
+let widgetChecksums = readArchiveEntry(widgetArchiveURL, entryPath: "SHA256SUMS")
+assertTrue(widgetChecksums.contains(" README.md"), "widget checksums should include README")
+assertTrue(widgetChecksums.contains(" MANIFEST.md"), "widget checksums should include manifest")
+assertTrue(widgetChecksums.contains(" bundle/action/WD-001.md"), "widget checksums should include bundle files")
 
 let authBundleURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
 writeFilledAuthBundle(at: authBundleURL)
@@ -284,7 +306,15 @@ assertTrue(authArchiveOutput.contains("WROTE"), "auth archive export should repo
 assertTrue(FileManager.default.fileExists(atPath: authArchiveURL.path), "auth archive should exist")
 let authArchiveListing = listArchive(authArchiveURL)
 assertTrue(authArchiveListing.contains("auth-smtp-closure-comment.md"), "auth archive should include closure preview")
+assertTrue(authArchiveListing.contains("MANIFEST.md"), "auth archive should include manifest")
+assertTrue(authArchiveListing.contains("SHA256SUMS"), "auth archive should include checksums")
 assertTrue(authArchiveListing.contains("bundle/03-live-send-results.md"), "auth archive should include evidence bundle files")
 assertTrue(authArchiveListing.contains("bundle/assets/provider-dashboard-event.png"), "auth archive should include evidence assets")
+let authManifest = readArchiveEntry(authArchiveURL, entryPath: "MANIFEST.md")
+assertTrue(authManifest.contains("- Surface: auth-smtp"), "auth manifest should describe the auth smtp surface")
+assertTrue(authManifest.contains("- Bundle Asset Count:"), "auth manifest should include asset count")
+let authChecksums = readArchiveEntry(authArchiveURL, entryPath: "SHA256SUMS")
+assertTrue(authChecksums.contains(" auth-smtp-closure-comment.md"), "auth checksums should include closure preview")
+assertTrue(authChecksums.contains(" bundle/assets/provider-dashboard-event.png"), "auth checksums should include bundle assets")
 
 print("PASS: manual evidence archive export checks")


### PR DESCRIPTION
Closes #764

## Summary
- add MANIFEST.md and SHA256SUMS to exported manual evidence archives
- extend archive export checks to inspect manifest/checksum contents
- document the manifest/checksum export contract