### PR TITLE
test: add blocker status markdown export

### DIFF
--- a/docs/manual-blocker-evidence-status-runner-v1.md
+++ b/docs/manual-blocker-evidence-status-runner-v1.md
@@ -11,6 +11,8 @@
 - `bash scripts/manual_blocker_evidence_status.sh`
 - `bash scripts/manual_blocker_evidence_status.sh widget`
 - `bash scripts/manual_blocker_evidence_status.sh auth-smtp --write-missing`
+- `bash scripts/manual_blocker_evidence_status.sh --markdown`
+- `bash scripts/manual_blocker_evidence_status.sh --markdown --output .codex_tmp/manual-blocker-evidence-status.md`
 
 ## 출력 계약
 - canonical issue 번호와 state
@@ -27,7 +29,20 @@
   - `next-archive`
   - `next-post-closure`
   - `next-post-closure-bundle` (`widget`만 제공)
+- `--markdown` 모드에서는 위 내용을 reviewer 공유용 markdown report로 출력한다.
+- `--output`을 같이 주면 report를 파일로 export하고 `WROTE <path>`를 출력한다.
 
 ## 기본 경로
 - widget: `.codex_tmp/widget-real-device-evidence`
 - auth-smtp: `.codex_tmp/auth-smtp-evidence`
+
+## Markdown Report 구조
+- `# Manual Blocker Evidence Status Report`
+- generated timestamp (UTC)
+- scope
+- surface별 섹션
+  - title
+  - primary issue / related issues
+  - evidence pack 경로
+  - status
+  - render / validate / archive / closure post 명령

--- a/scripts/manual_blocker_evidence_status.sh
+++ b/scripts/manual_blocker_evidence_status.sh
@@ -9,6 +9,7 @@ usage() {
   cat <<'USAGE'
 Usage:
   bash scripts/manual_blocker_evidence_status.sh [widget|auth-smtp] [--write-missing]
+  bash scripts/manual_blocker_evidence_status.sh [widget|auth-smtp] --markdown [--output <path>] [--write-missing]
 USAGE
 }
 
@@ -19,6 +20,8 @@ die() {
 
 kind_filter=""
 write_missing=0
+markdown_mode=0
+output_path=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -31,6 +34,15 @@ while [[ $# -gt 0 ]]; do
       write_missing=1
       shift
       ;;
+    --markdown)
+      markdown_mode=1
+      shift
+      ;;
+    --output|-o)
+      [[ $# -ge 2 ]] || die "--output requires a path"
+      output_path="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -40,6 +52,8 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+[[ -z "$output_path" || "$markdown_mode" == "1" ]] || die "--output requires --markdown"
 
 surface_pack_path() {
   case "$1" in
@@ -55,6 +69,10 @@ surface_issue_number() {
     auth-smtp) printf '482' ;;
     *) die "unsupported surface: $1" ;;
   esac
+}
+
+surface_issue_url() {
+  printf 'https://github.com/iAmSomething/dogArea/issues/%s' "$1"
 }
 
 surface_related_issues() {
@@ -185,9 +203,62 @@ print_surface_status() {
   printf '\n'
 }
 
+print_surface_status_markdown() {
+  local surface="$1"
+  local issue_number="$(surface_issue_number "$surface")"
+  local issue_state="$(surface_issue_state "$issue_number")"
+  local pack_path="$(surface_pack_path "$surface")"
+  render_missing_pack_if_needed "$surface" "$pack_path"
+  local status="$(surface_status "$surface" "$pack_path")"
+
+  printf '## %s\n' "$surface"
+  printf -- '- Title: %s\n' "$(surface_title "$surface")"
+  printf -- '- Primary Issue: [#%s](%s) (`%s`)\n' "$issue_number" "$(surface_issue_url "$issue_number")" "$issue_state"
+  if [[ "$surface" == "widget" ]]; then
+    printf -- '- Related Issues: [#617](%s), [#692](%s)\n' "$(surface_issue_url 617)" "$(surface_issue_url 692)"
+  else
+    printf -- '- Related Issues: none\n'
+  fi
+  printf -- '- Evidence Pack: `%s`\n' "$pack_path"
+  printf -- '- Status: `%s`\n\n' "$status"
+  printf '### Next Commands\n'
+  printf -- '- Render: `%s`\n' "$(surface_render_command "$surface" "$pack_path")"
+  printf -- '- Validate: `%s`\n' "$(surface_validate_command "$surface" "$pack_path")"
+  printf -- '- Render Closure: `%s`\n' "$(surface_closure_render_command "$surface" "$pack_path")"
+  printf -- '- Archive: `%s`\n' "$(surface_archive_command "$surface" "$pack_path")"
+  printf -- '- Post Closure: `%s`\n' "$(surface_closure_post_command "$surface" "$issue_number" "$pack_path")"
+  if [[ "$surface" == "widget" ]]; then
+    printf -- '- Post Closure Bundle: `%s`\n' "$(surface_bundle_post_command "$surface" "$pack_path")"
+  fi
+  printf '\n'
+}
+
 surfaces=(widget auth-smtp)
 [[ -n "$kind_filter" ]] && surfaces=("$kind_filter")
 
-for surface in "${surfaces[@]}"; do
-  print_surface_status "$surface"
-done
+if [[ "$markdown_mode" == "1" ]]; then
+  report_path="${output_path:-/tmp/dogarea_manual_blocker_status_report.$$}"
+  if [[ -n "$output_path" ]]; then
+    mkdir -p "$(dirname "$output_path")"
+  fi
+  {
+    printf '# Manual Blocker Evidence Status Report\n\n'
+    printf -- '- Generated At (UTC): %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf -- '- Repository: dogArea\n'
+    printf -- '- Scope: %s\n\n' "${kind_filter:-widget + auth-smtp}"
+    for surface in "${surfaces[@]}"; do
+      print_surface_status_markdown "$surface"
+    done
+  } > "$report_path"
+
+  if [[ -n "$output_path" ]]; then
+    printf 'WROTE %s\n' "$output_path"
+  else
+    cat "$report_path"
+    rm -f "$report_path"
+  fi
+else
+  for surface in "${surfaces[@]}"; do
+    print_surface_status "$surface"
+  done
+fi

--- a/scripts/manual_blocker_evidence_status_unit_check.swift
+++ b/scripts/manual_blocker_evidence_status_unit_check.swift
@@ -85,6 +85,18 @@ func writeAsset(_ url: URL) {
     write(url, content: "placeholder-asset")
 }
 
+/// Loads a UTF-8 text file from an absolute file URL.
+/// - Parameter url: Absolute file URL to read.
+/// - Returns: Decoded file contents.
+func loadFile(_ url: URL) -> String {
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .utf8) else {
+        fputs("Failed to load file \(url.path)\n", stderr)
+        exit(1)
+    }
+    return text
+}
+
 /// Builds a filled widget action case from the shared template.
 /// - Parameters:
 ///   - caseID: Canonical action case identifier.
@@ -153,10 +165,15 @@ assertTrue(runnerScript.contains("widget-real-device-evidence"), "runner should 
 assertTrue(runnerScript.contains("related-issues"), "runner should print related widget issues")
 assertTrue(runnerScript.contains("next-archive"), "runner should print archive command")
 assertTrue(runnerScript.contains("next-post-closure-bundle"), "runner should print bundled widget post command")
+assertTrue(runnerScript.contains("--markdown"), "runner should support markdown mode")
+assertTrue(runnerScript.contains("--output"), "runner should support output path")
 assertTrue(doc.contains("primary `#731`, related `#617`, `#692`"), "doc should describe active widget blocker routing")
 assertTrue(doc.contains("widget-real-device-evidence"), "doc should mention widget directory path")
 assertTrue(doc.contains("next-archive"), "doc should describe archive command")
 assertTrue(doc.contains("next-post-closure-bundle"), "doc should describe bundled widget post command")
+assertTrue(doc.contains("Manual Blocker Evidence Status Report"), "doc should describe markdown report title")
+assertTrue(doc.contains("--markdown"), "doc should describe markdown mode")
+assertTrue(doc.contains("--output"), "doc should describe output export")
 assertTrue(readme.contains("docs/manual-blocker-evidence-status-runner-v1.md"), "README should link runner doc")
 assertTrue(iosPRCheck.contains("manual_blocker_evidence_status_unit_check.swift"), "ios_pr_check should run blocker runner check")
 assertTrue(backendPRCheck.contains("manual_blocker_evidence_status_unit_check.swift"), "backend_pr_check should run blocker runner check")
@@ -209,6 +226,26 @@ assertTrue(completeOutput.contains("status: complete"), "filled widget evidence 
 assertTrue(completeOutput.contains("render_closure_comment_from_evidence.sh widget"), "runner should print widget closure render command")
 assertTrue(completeOutput.contains("archive_manual_evidence_pack.sh widget"), "runner should print widget archive command")
 assertTrue(completeOutput.contains("next-post-closure-bundle: bash scripts/post_closure_comment_from_evidence.sh widget --all-related"), "runner should print bundled widget post command")
+
+let markdownOutput = runStatus(arguments: ["widget", "--markdown"], environment: [
+    "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,
+    "DOGAREA_AUTH_SMTP_EVIDENCE_PATH": authPath.path,
+])
+assertTrue(markdownOutput.contains("# Manual Blocker Evidence Status Report"), "markdown mode should print report title")
+assertTrue(markdownOutput.contains("## widget"), "markdown mode should render widget section")
+assertTrue(markdownOutput.contains("- Primary Issue: [#731]"), "markdown mode should render primary issue link")
+assertTrue(markdownOutput.contains("- Post Closure Bundle: `bash scripts/post_closure_comment_from_evidence.sh widget --all-related"), "markdown mode should render bundled post command")
+
+let markdownPath = tempRoot.appendingPathComponent("manual-blocker-status.md")
+let markdownWriteOutput = runStatus(arguments: ["auth-smtp", "--markdown", "--output", markdownPath.path], environment: [
+    "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,
+    "DOGAREA_AUTH_SMTP_EVIDENCE_PATH": authPath.path,
+])
+assertTrue(markdownWriteOutput.contains("WROTE \(markdownPath.path)"), "markdown output mode should report written file")
+let markdownFile = loadFile(markdownPath)
+assertTrue(markdownFile.contains("## auth-smtp"), "written markdown report should render auth surface section")
+assertTrue(markdownFile.contains("- Primary Issue: [#482]"), "written markdown report should render auth primary issue link")
+assertTrue(markdownFile.contains("- Archive: `bash scripts/archive_manual_evidence_pack.sh auth-smtp"), "written markdown report should render archive command")
 
 let authOutput = runStatus(arguments: ["auth-smtp"], environment: [
     "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,


### PR DESCRIPTION
Closes #766

## Summary
- add markdown report export mode to the manual blocker status runner
- document the markdown report contract and file export flow
- extend status runner checks to cover markdown stdout and file export