### PR TITLE
fix: guard territory widget remaining area fallback

### DIFF
--- a/dogAreaWidgetExtension/Widgets/TerritoryStatusWidget.swift
+++ b/dogAreaWidgetExtension/Widgets/TerritoryStatusWidget.swift
@@ -353,7 +353,7 @@ struct TerritoryStatusWidgetEntryView: View {
         }
         switch goalContext.status {
         case .ready:
-            let remainingText = layoutBudget.areaText(goalContext.remainingAreaM2)
+            let remainingText = layoutBudget.areaText(goalContext.remainingAreaM2 ?? 0.0)
             return "\(goalContext.nextGoalName)까지 \(remainingText) 남았어요."
         case .completed:
             return "현재 비교 구역 기준을 모두 달성했어요."


### PR DESCRIPTION
## Summary
- avoid passing a nil remaining-area value into the territory widget compact formatter
- keep the compact next-goal sentence stable when the remaining metric is temporarily absent

## Testing
- swift scripts/territory_status_widget_unit_check.swift
- bash scripts/run_pr_fast_smoke_widget_layout_checks.sh
- xcodebuild -project dogArea.xcodeproj -scheme dogArea -configuration Debug -destination "generic/platform=iOS Simulator" -derivedDataPath .build/codex-buildable-check CODE_SIGNING_ALLOWED=NO build

Refs #692
Refs #731