### PR TITLE
feat: summarize manual blocker evidence gaps

### DIFF
--- a/docs/manual-blocker-evidence-status-runner-v1.md
+++ b/docs/manual-blocker-evidence-status-runner-v1.md
@@ -11,6 +11,7 @@
 - `bash scripts/manual_blocker_evidence_status.sh`
 - `bash scripts/manual_blocker_evidence_status.sh widget`
 - `bash scripts/manual_blocker_evidence_status.sh auth-smtp --write-missing`
+- `bash scripts/manual_blocker_evidence_status.sh widget --raw-errors`
 - `bash scripts/manual_blocker_evidence_status.sh --markdown`
 - `bash scripts/manual_blocker_evidence_status.sh --markdown --output .codex_tmp/manual-blocker-evidence-status.md`
 
@@ -22,6 +23,9 @@
   - `missing`
   - `incomplete`
   - `complete`
+- `incomplete`일 때 gap summary
+  - plain text: `gap-summary`, `next-fill`, `gap-cases`/`gap-files`
+  - markdown: `### Gap Summary`
 - 다음 액션 명령
   - `next-render`
   - `next-validate`
@@ -32,6 +36,8 @@
 - `--markdown` 모드에서는 위 내용을 reviewer 공유용 markdown report로 출력한다.
 - `--output`을 같이 주면 report를 파일로 export하고 `WROTE <path>`를 출력한다.
 - `auth-smtp`의 `next-render`는 `--prefill-from-env`를 포함해 운영 메타데이터 transcription 비용을 줄인다.
+- 기본 출력은 validator raw dump를 숨기고 요약만 보여준다.
+- `--raw-errors`를 주면 validator raw dump도 stderr로 그대로 출력한다.
 
 ## 기본 경로
 - widget: `.codex_tmp/widget-real-device-evidence`
@@ -46,4 +52,5 @@
   - primary issue / related issues
   - evidence pack 경로
   - status
+  - gap summary (`incomplete`일 때만)
   - render / validate / archive / closure post 명령

--- a/scripts/manual_blocker_evidence_status.sh
+++ b/scripts/manual_blocker_evidence_status.sh
@@ -10,6 +10,7 @@ usage() {
 Usage:
   bash scripts/manual_blocker_evidence_status.sh [widget|auth-smtp] [--write-missing]
   bash scripts/manual_blocker_evidence_status.sh [widget|auth-smtp] --markdown [--output <path>] [--write-missing]
+  bash scripts/manual_blocker_evidence_status.sh [widget|auth-smtp] [--raw-errors]
 USAGE
 }
 
@@ -22,6 +23,7 @@ kind_filter=""
 write_missing=0
 markdown_mode=0
 output_path=""
+raw_errors=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -42,6 +44,10 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || die "--output requires a path"
       output_path="$2"
       shift 2
+      ;;
+    --raw-errors)
+      raw_errors=1
+      shift
       ;;
     -h|--help)
       usage
@@ -167,23 +173,252 @@ render_missing_pack_if_needed() {
   fi
 }
 
-surface_status() {
+surface_status_and_capture() {
   local surface="$1"
   local pack_path="$2"
+  local capture_path="$3"
   if [[ ! -e "$pack_path" ]]; then
     printf 'missing'
     return
   fi
 
-  if bash scripts/validate_manual_evidence_pack.sh "$surface" "$pack_path" >/tmp/dogarea_manual_blocker_status.$$ 2>&1; then
-    rm -f /tmp/dogarea_manual_blocker_status.$$
+  if bash scripts/validate_manual_evidence_pack.sh "$surface" "$pack_path" >"$capture_path" 2>&1; then
     printf 'complete'
     return
   fi
 
-  cat /tmp/dogarea_manual_blocker_status.$$ >&2
-  rm -f /tmp/dogarea_manual_blocker_status.$$
+  if [[ "$raw_errors" == "1" ]]; then
+    cat "$capture_path" >&2
+  fi
   printf 'incomplete'
+}
+
+surface_gap_summary_plain() {
+  local surface="$1"
+  local capture_path="$2"
+  case "$surface" in
+    widget)
+      awk '
+        function append_bucket(key, value, composite, current) {
+          composite = key SUBSEP value
+          if (seenBuckets[composite]) return
+          seenBuckets[composite] = 1
+          current = categories[key]
+          if (current == "") {
+            categories[key] = value
+          } else {
+            categories[key] = current ", " value
+          }
+        }
+        /^ - / {
+          errorCount++
+          line = substr($0, 4)
+          split(line, headParts, ": ")
+          kind = headParts[1]
+          remainder = substr(line, length(kind) + 3)
+
+          split(remainder, detailParts, " :: ")
+          filePath = detailParts[1]
+          if (filePath == "") next
+
+          caseRef = filePath
+          sub(/^.*\//, "", caseRef)
+          sub(/\.md$/, "", caseRef)
+          if (caseRef !~ /^(WD|WL)-[0-9][0-9][0-9]$/) next
+
+          if (!(caseRef in seen)) {
+            seen[caseRef] = 1
+            order[++orderCount] = caseRef
+            if (caseRef ~ /^WD-/) {
+              actionCount++
+            } else {
+              layoutCount++
+            }
+          }
+
+          bucket = "other"
+          if (kind == "empty value" || kind == "missing line") {
+            field = detailParts[2]
+            if (field ~ /Date|Tester|Device \/ OS|App Build/) {
+              bucket = "metadata"
+            } else if (field ~ /Summary|Final Screen|Pass \/ Fail/) {
+              bucket = "result"
+            } else {
+              bucket = "fields"
+            }
+          } else if (kind == "missing asset file") {
+            bucket = "assets"
+          } else if (kind == "placeholder literal remains") {
+            bucket = "placeholder logs"
+          } else if (kind == "non-pass outcome") {
+            bucket = "result"
+          }
+          append_bucket(caseRef, bucket)
+        }
+        END {
+          if (orderCount == 0) exit
+          printf "gap-summary: %d incomplete cases (action %d, layout %d, total-errors %d)\n", orderCount, actionCount, layoutCount, errorCount
+          nextFill = order[1]
+          if (nextFill ~ /^WD-/) {
+            printf "next-fill: action/%s.md\n", nextFill
+          } else {
+            printf "next-fill: layout/%s.md\n", nextFill
+          }
+          printf "gap-cases:\n"
+          for (i = 1; i <= orderCount; i++) {
+            current = order[i]
+            printf "  - %s: %s\n", current, categories[current]
+          }
+        }
+      ' "$capture_path"
+      ;;
+    auth-smtp)
+      awk '
+        /^ - / {
+          errorCount++
+          line = substr($0, 4)
+          split(line, headParts, ": ")
+          remainder = substr(line, length(headParts[1]) + 3)
+          split(remainder, detailParts, " :: ")
+          filePath = detailParts[1]
+          if (filePath == "") next
+
+          fileRef = filePath
+          sub(/^.*\//, "", fileRef)
+          fileErrors[fileRef]++
+          if (!(fileRef in seen)) {
+            seen[fileRef] = 1
+            order[++orderCount] = fileRef
+          }
+        }
+        END {
+          if (orderCount == 0) exit
+          printf "gap-summary: %d incomplete files (total-errors %d)\n", orderCount, errorCount
+          printf "next-fill: %s\n", order[1]
+          printf "gap-files:\n"
+          for (i = 1; i <= orderCount; i++) {
+            current = order[i]
+            printf "  - %s: %d gaps\n", current, fileErrors[current]
+          }
+        }
+      ' "$capture_path"
+      ;;
+  esac
+}
+
+surface_gap_summary_markdown() {
+  local surface="$1"
+  local capture_path="$2"
+  case "$surface" in
+    widget)
+      awk '
+        function append_bucket(key, value, composite, current) {
+          composite = key SUBSEP value
+          if (seenBuckets[composite]) return
+          seenBuckets[composite] = 1
+          current = categories[key]
+          if (current == "") {
+            categories[key] = value
+          } else {
+            categories[key] = current ", " value
+          }
+        }
+        /^ - / {
+          errorCount++
+          line = substr($0, 4)
+          split(line, headParts, ": ")
+          kind = headParts[1]
+          remainder = substr(line, length(kind) + 3)
+
+          split(remainder, detailParts, " :: ")
+          filePath = detailParts[1]
+          if (filePath == "") next
+
+          caseRef = filePath
+          sub(/^.*\//, "", caseRef)
+          sub(/\.md$/, "", caseRef)
+          if (caseRef !~ /^(WD|WL)-[0-9][0-9][0-9]$/) next
+
+          if (!(caseRef in seen)) {
+            seen[caseRef] = 1
+            order[++orderCount] = caseRef
+            if (caseRef ~ /^WD-/) {
+              actionCount++
+            } else {
+              layoutCount++
+            }
+          }
+
+          bucket = "other"
+          if (kind == "empty value" || kind == "missing line") {
+            field = detailParts[2]
+            if (field ~ /Date|Tester|Device \/ OS|App Build/) {
+              bucket = "metadata"
+            } else if (field ~ /Summary|Final Screen|Pass \/ Fail/) {
+              bucket = "result"
+            } else {
+              bucket = "fields"
+            }
+          } else if (kind == "missing asset file") {
+            bucket = "assets"
+          } else if (kind == "placeholder literal remains") {
+            bucket = "placeholder logs"
+          } else if (kind == "non-pass outcome") {
+            bucket = "result"
+          }
+          append_bucket(caseRef, bucket)
+        }
+        END {
+          if (orderCount == 0) exit
+          printf "### Gap Summary\n"
+          printf "- Incomplete Cases: `%d` (`action %d`, `layout %d`, `errors %d`)\n", orderCount, actionCount, layoutCount, errorCount
+          nextFill = order[1]
+          if (nextFill ~ /^WD-/) {
+            printf "- Next Fill: `action/%s.md`\n", nextFill
+          } else {
+            printf "- Next Fill: `layout/%s.md`\n", nextFill
+          }
+          printf "- Case Buckets:\n"
+          for (i = 1; i <= orderCount; i++) {
+            current = order[i]
+            printf "  - `%s`: %s\n", current, categories[current]
+          }
+        }
+      ' "$capture_path"
+      ;;
+    auth-smtp)
+      awk '
+        /^ - / {
+          errorCount++
+          line = substr($0, 4)
+          split(line, headParts, ": ")
+          remainder = substr(line, length(headParts[1]) + 3)
+          split(remainder, detailParts, " :: ")
+          filePath = detailParts[1]
+          if (filePath == "") next
+
+          fileRef = filePath
+          sub(/^.*\//, "", fileRef)
+          fileErrors[fileRef]++
+          if (!(fileRef in seen)) {
+            seen[fileRef] = 1
+            order[++orderCount] = fileRef
+          }
+        }
+        END {
+          if (orderCount == 0) exit
+          printf "### Gap Summary\n"
+          printf "- Incomplete Files: `%d` (`errors %d`)\n", orderCount, errorCount
+          printf "- Next Fill: `%s`\n", order[1]
+          printf "- File Buckets:\n"
+          for (i = 1; i <= orderCount; i++) {
+            current = order[i]
+            printf "  - `%s`: %d gaps\n", current, fileErrors[current]
+          }
+        }
+      ' "$capture_path"
+      ;;
+  esac
 }
 
 print_surface_status() {
@@ -191,8 +426,9 @@ print_surface_status() {
   local issue_number="$(surface_issue_number "$surface")"
   local issue_state="$(surface_issue_state "$issue_number")"
   local pack_path="$(surface_pack_path "$surface")"
+  local capture_path="/tmp/dogarea_manual_blocker_status_${surface}_$$"
   render_missing_pack_if_needed "$surface" "$pack_path"
-  local status="$(surface_status "$surface" "$pack_path")"
+  local status="$(surface_status_and_capture "$surface" "$pack_path" "$capture_path")"
 
   printf '== %s ==\n' "$surface"
   printf 'title: %s\n' "$(surface_title "$surface")"
@@ -208,7 +444,11 @@ print_surface_status() {
   if [[ "$surface" == "widget" ]]; then
     printf 'next-post-closure-bundle: %s\n' "$(surface_bundle_post_command "$surface" "$pack_path")"
   fi
+  if [[ "$status" == "incomplete" ]]; then
+    surface_gap_summary_plain "$surface" "$capture_path"
+  fi
   printf '\n'
+  rm -f "$capture_path"
 }
 
 print_surface_status_markdown() {
@@ -216,8 +456,9 @@ print_surface_status_markdown() {
   local issue_number="$(surface_issue_number "$surface")"
   local issue_state="$(surface_issue_state "$issue_number")"
   local pack_path="$(surface_pack_path "$surface")"
+  local capture_path="/tmp/dogarea_manual_blocker_status_${surface}_$$"
   render_missing_pack_if_needed "$surface" "$pack_path"
-  local status="$(surface_status "$surface" "$pack_path")"
+  local status="$(surface_status_and_capture "$surface" "$pack_path" "$capture_path")"
 
   printf '## %s\n' "$surface"
   printf -- '- Title: %s\n' "$(surface_title "$surface")"
@@ -239,6 +480,11 @@ print_surface_status_markdown() {
     printf -- '- Post Closure Bundle: `%s`\n' "$(surface_bundle_post_command "$surface" "$pack_path")"
   fi
   printf '\n'
+  if [[ "$status" == "incomplete" ]]; then
+    surface_gap_summary_markdown "$surface" "$capture_path"
+  fi
+  printf '\n'
+  rm -f "$capture_path"
 }
 
 surfaces=(widget auth-smtp)

--- a/scripts/manual_blocker_evidence_status_unit_check.swift
+++ b/scripts/manual_blocker_evidence_status_unit_check.swift
@@ -167,6 +167,10 @@ assertTrue(runnerScript.contains("next-archive"), "runner should print archive c
 assertTrue(runnerScript.contains("next-post-closure-bundle"), "runner should print bundled widget post command")
 assertTrue(runnerScript.contains("--markdown"), "runner should support markdown mode")
 assertTrue(runnerScript.contains("--output"), "runner should support output path")
+assertTrue(runnerScript.contains("--raw-errors"), "runner should support raw error output mode")
+assertTrue(runnerScript.contains("gap-summary:"), "runner should print plain gap summaries for incomplete packs")
+assertTrue(runnerScript.contains("next-fill:"), "runner should print next-fill guidance")
+assertTrue(runnerScript.contains("### Gap Summary"), "runner should print markdown gap summaries for incomplete packs")
 assertTrue(runnerScript.contains("--prefill-from-env"), "runner should use auth smtp env prefill render path")
 assertTrue(doc.contains("primary `#731`, related `#617`, `#692`"), "doc should describe active widget blocker routing")
 assertTrue(doc.contains("widget-real-device-evidence"), "doc should mention widget directory path")
@@ -175,6 +179,10 @@ assertTrue(doc.contains("next-post-closure-bundle"), "doc should describe bundle
 assertTrue(doc.contains("Manual Blocker Evidence Status Report"), "doc should describe markdown report title")
 assertTrue(doc.contains("--markdown"), "doc should describe markdown mode")
 assertTrue(doc.contains("--output"), "doc should describe output export")
+assertTrue(doc.contains("--raw-errors"), "doc should describe raw error output mode")
+assertTrue(doc.contains("gap-summary"), "doc should describe plain gap summary output")
+assertTrue(doc.contains("next-fill"), "doc should describe next-fill guidance")
+assertTrue(doc.contains("### Gap Summary"), "doc should describe markdown gap summary heading")
 assertTrue(doc.contains("--prefill-from-env"), "doc should describe auth smtp prefill render command")
 assertTrue(readme.contains("docs/manual-blocker-evidence-status-runner-v1.md"), "README should link runner doc")
 assertTrue(iosPRCheck.contains("manual_blocker_evidence_status_unit_check.swift"), "ios_pr_check should run blocker runner check")
@@ -199,6 +207,11 @@ let generatedOutput = runStatus(arguments: ["widget", "--write-missing"], enviro
 ])
 assertTrue(FileManager.default.fileExists(atPath: widgetPath.appendingPathComponent("action/WD-001.md").path), "write-missing should create widget action cases")
 assertTrue(generatedOutput.contains("status: incomplete"), "generated widget bundle should still be incomplete until filled")
+assertTrue(generatedOutput.contains("gap-summary: 16 incomplete cases"), "generated widget bundle should summarize incomplete case counts")
+assertTrue(generatedOutput.contains("next-fill: action/WD-001.md"), "generated widget bundle should point at the first case to fill")
+assertTrue(generatedOutput.contains("gap-cases:"), "generated widget bundle should print case bucket list")
+assertTrue(generatedOutput.contains("WD-001: metadata, result, assets, placeholder logs"), "generated widget bundle should dedupe case buckets")
+assertTrue(!generatedOutput.contains("empty value:"), "generated widget bundle should hide raw validator errors by default")
 
 for caseID in ["WD-001", "WD-002", "WD-003", "WD-004", "WD-005", "WD-006", "WD-007", "WD-008"] {
     write(widgetPath.appendingPathComponent("action/\(caseID).md"), content: filledWidgetAction(caseID: caseID, summary: "\(caseID) converged"))
@@ -228,6 +241,7 @@ assertTrue(completeOutput.contains("status: complete"), "filled widget evidence 
 assertTrue(completeOutput.contains("render_closure_comment_from_evidence.sh widget"), "runner should print widget closure render command")
 assertTrue(completeOutput.contains("archive_manual_evidence_pack.sh widget"), "runner should print widget archive command")
 assertTrue(completeOutput.contains("next-post-closure-bundle: bash scripts/post_closure_comment_from_evidence.sh widget --all-related"), "runner should print bundled widget post command")
+assertTrue(!completeOutput.contains("gap-summary:"), "complete widget evidence should not print a gap summary")
 
 let markdownOutput = runStatus(arguments: ["widget", "--markdown"], environment: [
     "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,
@@ -237,6 +251,14 @@ assertTrue(markdownOutput.contains("# Manual Blocker Evidence Status Report"), "
 assertTrue(markdownOutput.contains("## widget"), "markdown mode should render widget section")
 assertTrue(markdownOutput.contains("- Primary Issue: [#731]"), "markdown mode should render primary issue link")
 assertTrue(markdownOutput.contains("- Post Closure Bundle: `bash scripts/post_closure_comment_from_evidence.sh widget --all-related"), "markdown mode should render bundled post command")
+assertTrue(!markdownOutput.contains("### Gap Summary"), "complete widget markdown should not print a gap summary")
+
+let incompleteMarkdownOutput = runStatus(arguments: ["widget", "--markdown", "--write-missing"], environment: [
+    "DOGAREA_WIDGET_EVIDENCE_PATH": tempRoot.appendingPathComponent("widget-incomplete").path,
+    "DOGAREA_AUTH_SMTP_EVIDENCE_PATH": authPath.path,
+])
+assertTrue(incompleteMarkdownOutput.contains("### Gap Summary"), "incomplete widget markdown should print a gap summary")
+assertTrue(incompleteMarkdownOutput.contains("- Next Fill: `action/WD-001.md`"), "incomplete widget markdown should print next-fill guidance")
 
 let markdownPath = tempRoot.appendingPathComponent("manual-blocker-status.md")
 let markdownWriteOutput = runStatus(arguments: ["auth-smtp", "--markdown", "--output", markdownPath.path], environment: [


### PR DESCRIPTION
## Summary
- add concise gap summaries to manual blocker evidence status output
- add markdown gap summaries and opt-in raw validator dumps
- document and test the new runner contract

## Validation
- swift scripts/manual_blocker_evidence_status_unit_check.swift
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

## Related
- supports #731
- supports #692