### PR TITLE
feat: normalize auth smtp evidence gap summaries

### DIFF
--- a/docs/manual-blocker-evidence-status-runner-v1.md
+++ b/docs/manual-blocker-evidence-status-runner-v1.md
@@ -26,6 +26,7 @@
 - `incomplete`일 때 gap summary
   - plain text: `gap-summary`, `next-fill`, `gap-cases`/`gap-files`
   - markdown: `### Gap Summary`
+  - `auth-smtp`는 scenario row 오류를 `03-live-send-results.md`로 접어서 실제 작성 파일 기준으로 보여준다.
 - 다음 액션 명령
   - `next-render`
   - `next-validate`

--- a/scripts/manual_blocker_evidence_status.sh
+++ b/scripts/manual_blocker_evidence_status.sh
@@ -274,22 +274,78 @@ surface_gap_summary_plain() {
       ;;
     auth-smtp)
       awk '
+        function append_bucket(key, value, composite, current) {
+          composite = key SUBSEP value
+          if (seenBuckets[composite]) return
+          seenBuckets[composite] = 1
+          current = categories[key]
+          if (current == "") {
+            categories[key] = value
+          } else {
+            categories[key] = current ", " value
+          }
+        }
         /^ - / {
           errorCount++
           line = substr($0, 4)
           split(line, headParts, ": ")
-          remainder = substr(line, length(headParts[1]) + 3)
-          split(remainder, detailParts, " :: ")
-          filePath = detailParts[1]
-          if (filePath == "") next
+          kind = headParts[1]
+          remainder = substr(line, length(kind) + 3)
+          fileRef = ""
+          bucket = "other"
 
-          fileRef = filePath
-          sub(/^.*\//, "", fileRef)
-          fileErrors[fileRef]++
+          if (kind == "incomplete scenario row") {
+            fileRef = "03-live-send-results.md"
+            bucket = "scenario rows"
+          } else {
+            split(remainder, detailParts, " :: ")
+            filePath = detailParts[1]
+            if (filePath == "") next
+
+            fileRef = filePath
+            sub(/^.*\//, "", fileRef)
+
+            field = detailParts[2]
+            if (fileRef == "01-dns-verification.md") {
+              if (kind == "missing asset file") {
+                bucket = "asset"
+              } else {
+                bucket = "dns metadata"
+              }
+            } else if (fileRef == "02-supabase-smtp-settings.md") {
+              if (kind == "missing asset file") {
+                bucket = "asset"
+              } else {
+                bucket = "smtp settings"
+              }
+            } else if (fileRef == "03-live-send-results.md") {
+              if (kind == "missing asset file") {
+                bucket = "mailbox assets"
+              } else {
+                bucket = "scenario rows"
+              }
+            } else if (fileRef == "04-negative-evidence.md") {
+              if (kind == "missing asset file") {
+                bucket = "asset"
+              } else {
+                bucket = "negative evidence"
+              }
+            } else if (fileRef == "05-rollback-rotation.md") {
+              bucket = "rollback readiness"
+            } else if (fileRef == "06-final-decision.md") {
+              if (kind == "non-pass outcome") {
+                bucket = "final decision"
+              } else {
+                bucket = "closure fields"
+              }
+            }
+          }
+
           if (!(fileRef in seen)) {
             seen[fileRef] = 1
             order[++orderCount] = fileRef
           }
+          append_bucket(fileRef, bucket)
         }
         END {
           if (orderCount == 0) exit
@@ -298,7 +354,7 @@ surface_gap_summary_plain() {
           printf "gap-files:\n"
           for (i = 1; i <= orderCount; i++) {
             current = order[i]
-            printf "  - %s: %d gaps\n", current, fileErrors[current]
+            printf "  - %s: %s\n", current, categories[current]
           }
         }
       ' "$capture_path"
@@ -388,22 +444,78 @@ surface_gap_summary_markdown() {
       ;;
     auth-smtp)
       awk '
+        function append_bucket(key, value, composite, current) {
+          composite = key SUBSEP value
+          if (seenBuckets[composite]) return
+          seenBuckets[composite] = 1
+          current = categories[key]
+          if (current == "") {
+            categories[key] = value
+          } else {
+            categories[key] = current ", " value
+          }
+        }
         /^ - / {
           errorCount++
           line = substr($0, 4)
           split(line, headParts, ": ")
-          remainder = substr(line, length(headParts[1]) + 3)
-          split(remainder, detailParts, " :: ")
-          filePath = detailParts[1]
-          if (filePath == "") next
+          kind = headParts[1]
+          remainder = substr(line, length(kind) + 3)
+          fileRef = ""
+          bucket = "other"
 
-          fileRef = filePath
-          sub(/^.*\//, "", fileRef)
-          fileErrors[fileRef]++
+          if (kind == "incomplete scenario row") {
+            fileRef = "03-live-send-results.md"
+            bucket = "scenario rows"
+          } else {
+            split(remainder, detailParts, " :: ")
+            filePath = detailParts[1]
+            if (filePath == "") next
+
+            fileRef = filePath
+            sub(/^.*\//, "", fileRef)
+
+            field = detailParts[2]
+            if (fileRef == "01-dns-verification.md") {
+              if (kind == "missing asset file") {
+                bucket = "asset"
+              } else {
+                bucket = "dns metadata"
+              }
+            } else if (fileRef == "02-supabase-smtp-settings.md") {
+              if (kind == "missing asset file") {
+                bucket = "asset"
+              } else {
+                bucket = "smtp settings"
+              }
+            } else if (fileRef == "03-live-send-results.md") {
+              if (kind == "missing asset file") {
+                bucket = "mailbox assets"
+              } else {
+                bucket = "scenario rows"
+              }
+            } else if (fileRef == "04-negative-evidence.md") {
+              if (kind == "missing asset file") {
+                bucket = "asset"
+              } else {
+                bucket = "negative evidence"
+              }
+            } else if (fileRef == "05-rollback-rotation.md") {
+              bucket = "rollback readiness"
+            } else if (fileRef == "06-final-decision.md") {
+              if (kind == "non-pass outcome") {
+                bucket = "final decision"
+              } else {
+                bucket = "closure fields"
+              }
+            }
+          }
+
           if (!(fileRef in seen)) {
             seen[fileRef] = 1
             order[++orderCount] = fileRef
           }
+          append_bucket(fileRef, bucket)
         }
         END {
           if (orderCount == 0) exit
@@ -413,7 +525,7 @@ surface_gap_summary_markdown() {
           printf "- File Buckets:\n"
           for (i = 1; i <= orderCount; i++) {
             current = order[i]
-            printf "  - `%s`: %d gaps\n", current, fileErrors[current]
+            printf "  - `%s`: %s\n", current, categories[current]
           }
         }
       ' "$capture_path"

--- a/scripts/manual_blocker_evidence_status_unit_check.swift
+++ b/scripts/manual_blocker_evidence_status_unit_check.swift
@@ -183,6 +183,7 @@ assertTrue(doc.contains("--raw-errors"), "doc should describe raw error output m
 assertTrue(doc.contains("gap-summary"), "doc should describe plain gap summary output")
 assertTrue(doc.contains("next-fill"), "doc should describe next-fill guidance")
 assertTrue(doc.contains("### Gap Summary"), "doc should describe markdown gap summary heading")
+assertTrue(doc.contains("03-live-send-results.md"), "doc should describe auth-smtp file-level scenario row grouping")
 assertTrue(doc.contains("--prefill-from-env"), "doc should describe auth smtp prefill render command")
 assertTrue(readme.contains("docs/manual-blocker-evidence-status-runner-v1.md"), "README should link runner doc")
 assertTrue(iosPRCheck.contains("manual_blocker_evidence_status_unit_check.swift"), "ios_pr_check should run blocker runner check")
@@ -280,6 +281,15 @@ assertTrue(authOutput.contains("pack: \(authPath.path)"), "auth runner should pr
 assertTrue(authOutput.contains("render_manual_evidence_pack.sh auth-smtp --output"), "auth runner should print auth render command")
 assertTrue(authOutput.contains("--prefill-from-env"), "auth runner should prefer prefilled auth render command")
 assertTrue(!authOutput.contains("--negative-guard"), "auth next command should not require negative guard flag")
+
+let authGeneratedOutput = runStatus(arguments: ["auth-smtp", "--write-missing"], environment: [
+    "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,
+    "DOGAREA_AUTH_SMTP_EVIDENCE_PATH": authPath.path,
+])
+assertTrue(authGeneratedOutput.contains("gap-summary: 6 incomplete files"), "auth runner should summarize auth evidence by file count")
+assertTrue(authGeneratedOutput.contains("next-fill: 01-dns-verification.md"), "auth runner should point to the first auth file to fill")
+assertTrue(authGeneratedOutput.contains("03-live-send-results.md: scenario rows, mailbox assets"), "auth runner should fold live-send scenario row errors into the live-send file")
+assertTrue(!authGeneratedOutput.contains("signup confirmation: 1 gaps"), "auth runner should avoid scenario-only pseudo-file output")
 assertTrue(!authOutput.contains("--negative-provider-event"), "auth next command should not require provider event flag")
 
 print("PASS: manual blocker evidence status runner contract checks")


### PR DESCRIPTION
## Summary
- fold auth-smtp validator errors into file-level gap summaries
- map live-send scenario row failures back to 03-live-send-results.md
- document and test the refined blocker runner contract

## Validation
- swift scripts/manual_blocker_evidence_status_unit_check.swift
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

## Related
- supports #482