### PR TITLE
feat: add apply-prefill mode to blocker status runner

### DIFF
--- a/docs/manual-blocker-evidence-status-runner-v1.md
+++ b/docs/manual-blocker-evidence-status-runner-v1.md
@@ -12,6 +12,7 @@
 - `bash scripts/manual_blocker_evidence_status.sh widget`
 - `bash scripts/manual_blocker_evidence_status.sh auth-smtp --write-missing`
 - `bash scripts/manual_blocker_evidence_status.sh widget --raw-errors`
+- `bash scripts/manual_blocker_evidence_status.sh widget --apply-prefill`
 - `bash scripts/manual_blocker_evidence_status.sh --markdown`
 - `bash scripts/manual_blocker_evidence_status.sh --markdown --output .codex_tmp/manual-blocker-evidence-status.md`
 
@@ -37,6 +38,7 @@
   - `next-post-closure-bundle` (`widget`만 제공)
 - `--markdown` 모드에서는 위 내용을 reviewer 공유용 markdown report로 출력한다.
 - `--output`을 같이 주면 report를 파일로 export하고 `WROTE <path>`를 출력한다.
+- `--apply-prefill`를 주면 existing bundle에 대해 `prefill_manual_evidence_pack.sh`를 먼저 적용한 뒤 status를 계산한다.
 - `auth-smtp`의 `next-render`는 `--prefill-from-env`를 포함해 운영 메타데이터 transcription 비용을 줄인다.
 - `widget`의 `next-render`도 `--prefill-from-env`를 포함해 공통 기록 메타 transcription 비용을 줄인다.
 - 기존 bundle이 이미 있으면 `next-prefill-existing` -> `next-validate` 순서가 더 안전한 기본 경로다.

--- a/scripts/manual_blocker_evidence_status.sh
+++ b/scripts/manual_blocker_evidence_status.sh
@@ -11,6 +11,7 @@ Usage:
   bash scripts/manual_blocker_evidence_status.sh [widget|auth-smtp] [--write-missing]
   bash scripts/manual_blocker_evidence_status.sh [widget|auth-smtp] --markdown [--output <path>] [--write-missing]
   bash scripts/manual_blocker_evidence_status.sh [widget|auth-smtp] [--raw-errors]
+  bash scripts/manual_blocker_evidence_status.sh [widget|auth-smtp] [--apply-prefill]
 USAGE
 }
 
@@ -24,6 +25,7 @@ write_missing=0
 markdown_mode=0
 output_path=""
 raw_errors=0
+apply_prefill=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -47,6 +49,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --raw-errors)
       raw_errors=1
+      shift
+      ;;
+    --apply-prefill)
+      apply_prefill=1
       shift
       ;;
     -h|--help)
@@ -175,6 +181,15 @@ render_missing_pack_if_needed() {
   else
     bash scripts/render_manual_evidence_pack.sh "$surface" --output "$pack_path" --prefill-from-env >/dev/null
   fi
+}
+
+apply_prefill_if_requested() {
+  local surface="$1"
+  local pack_path="$2"
+  if [[ "$apply_prefill" != "1" || ! -e "$pack_path" ]]; then
+    return
+  fi
+  bash scripts/prefill_manual_evidence_pack.sh "$surface" "$pack_path" >/dev/null
 }
 
 surface_status_and_capture() {
@@ -544,6 +559,7 @@ print_surface_status() {
   local pack_path="$(surface_pack_path "$surface")"
   local capture_path="/tmp/dogarea_manual_blocker_status_${surface}_$$"
   render_missing_pack_if_needed "$surface" "$pack_path"
+  apply_prefill_if_requested "$surface" "$pack_path"
   local status="$(surface_status_and_capture "$surface" "$pack_path" "$capture_path")"
 
   printf '== %s ==\n' "$surface"
@@ -575,6 +591,7 @@ print_surface_status_markdown() {
   local pack_path="$(surface_pack_path "$surface")"
   local capture_path="/tmp/dogarea_manual_blocker_status_${surface}_$$"
   render_missing_pack_if_needed "$surface" "$pack_path"
+  apply_prefill_if_requested "$surface" "$pack_path"
   local status="$(surface_status_and_capture "$surface" "$pack_path" "$capture_path")"
 
   printf '## %s\n' "$surface"

--- a/scripts/manual_blocker_evidence_status_unit_check.swift
+++ b/scripts/manual_blocker_evidence_status_unit_check.swift
@@ -169,6 +169,7 @@ assertTrue(runnerScript.contains("next-post-closure-bundle"), "runner should pri
 assertTrue(runnerScript.contains("--markdown"), "runner should support markdown mode")
 assertTrue(runnerScript.contains("--output"), "runner should support output path")
 assertTrue(runnerScript.contains("--raw-errors"), "runner should support raw error output mode")
+assertTrue(runnerScript.contains("--apply-prefill"), "runner should support one-shot prefill application")
 assertTrue(runnerScript.contains("gap-summary:"), "runner should print plain gap summaries for incomplete packs")
 assertTrue(runnerScript.contains("next-fill:"), "runner should print next-fill guidance")
 assertTrue(runnerScript.contains("### Gap Summary"), "runner should print markdown gap summaries for incomplete packs")
@@ -183,6 +184,7 @@ assertTrue(doc.contains("Manual Blocker Evidence Status Report"), "doc should de
 assertTrue(doc.contains("--markdown"), "doc should describe markdown mode")
 assertTrue(doc.contains("--output"), "doc should describe output export")
 assertTrue(doc.contains("--raw-errors"), "doc should describe raw error output mode")
+assertTrue(doc.contains("--apply-prefill"), "doc should describe one-shot prefill application")
 assertTrue(doc.contains("gap-summary"), "doc should describe plain gap summary output")
 assertTrue(doc.contains("next-fill"), "doc should describe next-fill guidance")
 assertTrue(doc.contains("### Gap Summary"), "doc should describe markdown gap summary heading")
@@ -223,6 +225,22 @@ assertTrue(generatedOutput.contains("gap-cases:"), "generated widget bundle shou
 assertTrue(generatedOutput.contains("WD-001: result, assets, placeholder logs"), "generated widget bundle should dedupe case buckets after metadata prefill")
 assertTrue(generatedOutput.contains("WL-001: result, assets"), "generated widget bundle should reduce layout gaps after metadata prefill")
 assertTrue(!generatedOutput.contains("empty value:"), "generated widget bundle should hide raw validator errors by default")
+
+let widgetExistingPath = tempRoot.appendingPathComponent("widget-existing")
+_ = runStatus(arguments: ["widget", "--write-missing"], environment: [
+    "DOGAREA_WIDGET_EVIDENCE_PATH": widgetExistingPath.path,
+    "DOGAREA_AUTH_SMTP_EVIDENCE_PATH": authPath.path,
+])
+let widgetAppliedPrefillOutput = runStatus(arguments: ["widget", "--apply-prefill"], environment: [
+    "DOGAREA_WIDGET_EVIDENCE_PATH": widgetExistingPath.path,
+    "DOGAREA_AUTH_SMTP_EVIDENCE_PATH": authPath.path,
+    "DOGAREA_WIDGET_EVIDENCE_DATE": "2026-03-12",
+    "DOGAREA_WIDGET_EVIDENCE_TESTER": "codex",
+    "DOGAREA_WIDGET_EVIDENCE_DEVICE_OS": "iPhone 16 / iOS 18.5",
+    "DOGAREA_WIDGET_EVIDENCE_APP_BUILD": "2026.03.12.1",
+])
+assertTrue(widgetAppliedPrefillOutput.contains("gap-summary: 16 incomplete cases (action 8, layout 8, total-errors 120)"), "apply-prefill should reduce widget error counts for existing bundles")
+assertTrue(widgetAppliedPrefillOutput.contains("WD-001: result, assets, placeholder logs"), "apply-prefill should remove metadata gaps from widget bundles")
 
 for caseID in ["WD-001", "WD-002", "WD-003", "WD-004", "WD-005", "WD-006", "WD-007", "WD-008"] {
     write(widgetPath.appendingPathComponent("action/\(caseID).md"), content: filledWidgetAction(caseID: caseID, summary: "\(caseID) converged"))
@@ -307,6 +325,37 @@ assertTrue(authGeneratedOutput.contains("gap-summary: 6 incomplete files"), "aut
 assertTrue(authGeneratedOutput.contains("next-fill: 01-dns-verification.md"), "auth runner should point to the first auth file to fill")
 assertTrue(authGeneratedOutput.contains("03-live-send-results.md: scenario rows, mailbox assets"), "auth runner should fold live-send scenario row errors into the live-send file")
 assertTrue(!authGeneratedOutput.contains("signup confirmation: 1 gaps"), "auth runner should avoid scenario-only pseudo-file output")
+
+let authExistingPath = tempRoot.appendingPathComponent("auth-existing")
+_ = runStatus(arguments: ["auth-smtp", "--write-missing"], environment: [
+    "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,
+    "DOGAREA_AUTH_SMTP_EVIDENCE_PATH": authExistingPath.path,
+])
+let authAppliedPrefillOutput = runStatus(arguments: ["auth-smtp", "--apply-prefill"], environment: [
+    "DOGAREA_WIDGET_EVIDENCE_PATH": widgetPath.path,
+    "DOGAREA_AUTH_SMTP_EVIDENCE_PATH": authExistingPath.path,
+    "DOGAREA_AUTH_SMTP_PROJECT": "ttjiknenynbhbpoqoesq",
+    "DOGAREA_AUTH_SMTP_PROVIDER": "Resend",
+    "DOGAREA_AUTH_SMTP_SENDER_DOMAIN": "auth.dogarea.app",
+    "DOGAREA_AUTH_SMTP_DNS_SPF": "pass",
+    "DOGAREA_AUTH_SMTP_DNS_DKIM": "verified",
+    "DOGAREA_AUTH_SMTP_DNS_DMARC": "present",
+    "DOGAREA_AUTH_SMTP_PROVIDER_VERIFIED_AT": "2026-03-12T08:00:00Z",
+    "DOGAREA_AUTH_SMTP_HOST": "smtp.resend.com",
+    "DOGAREA_AUTH_SMTP_PORT": "587",
+    "DOGAREA_AUTH_SMTP_USER_MASK": "re_***",
+    "DOGAREA_AUTH_SMTP_SENDER_NAME": "DogArea Auth",
+    "DOGAREA_AUTH_SMTP_SENDER_EMAIL": "auth@auth.dogarea.app",
+    "DOGAREA_AUTH_SMTP_EMAIL_SENT": "12",
+    "DOGAREA_AUTH_SMTP_MAX_FREQUENCY": "90",
+    "DOGAREA_AUTH_SMTP_CONFIRM_EMAIL_POLICY": "required",
+    "DOGAREA_AUTH_SMTP_PASSWORD_RESET_POLICY": "enabled / app deep link",
+    "DOGAREA_AUTH_SMTP_EMAIL_CHANGE_POLICY": "double confirmation",
+    "DOGAREA_AUTH_SMTP_INVITE_POLICY": "disabled in product",
+])
+assertTrue(authAppliedPrefillOutput.contains("01-dns-verification.md: asset"), "apply-prefill should reduce auth metadata gaps for existing bundles")
+assertTrue(authAppliedPrefillOutput.contains("02-supabase-smtp-settings.md: asset"), "apply-prefill should reduce auth smtp settings gaps for existing bundles")
+assertTrue(!authAppliedPrefillOutput.contains("01-dns-verification.md: dns metadata, asset"), "apply-prefill should remove auth dns metadata gaps for existing bundles")
 assertTrue(!authOutput.contains("--negative-provider-event"), "auth next command should not require provider event flag")
 
 print("PASS: manual blocker evidence status runner contract checks")


### PR DESCRIPTION
## Summary
- add `--apply-prefill` to `manual_blocker_evidence_status.sh` for one-shot existing bundle prefill
- document the new flow and cover widget/auth-smtp existing bundle cases in unit checks
- keep blocker evidence workflows for `#731`, `#692`, and `#482` on the same runner path

## Verification
- swift scripts/manual_blocker_evidence_status_unit_check.swift
- swift scripts/manual_evidence_prefill_unit_check.swift
- swift scripts/manual_evidence_helper_unit_check.swift
- bash scripts/backend_pr_check.sh
- DOGAREA_SKIP_BUILD=1 bash scripts/ios_pr_check.sh

Closes #780